### PR TITLE
Add `SamReaderFactory` as a new facility for reading from SAM files.

### DIFF
--- a/src/java/htsjdk/samtools/BAMIndexMetaData.java
+++ b/src/java/htsjdk/samtools/BAMIndexMetaData.java
@@ -190,7 +190,7 @@ public class BAMIndexMetaData {
      */
     static public void printIndexStats(final File inputBamFile) {
         try {
-            final BAMFileReader bam = new BAMFileReader(inputBamFile, null, false, SAMFileReader.ValidationStringency.SILENT, new DefaultSAMRecordFactory());
+            final BAMFileReader bam = new BAMFileReader(inputBamFile, null, false, ValidationStringency.SILENT, new DefaultSAMRecordFactory());
             if (!bam.hasIndex()) {
                 throw new SAMException("No index for bam file " + inputBamFile);
             }

--- a/src/java/htsjdk/samtools/BAMRecord.java
+++ b/src/java/htsjdk/samtools/BAMRecord.java
@@ -242,7 +242,7 @@ public class BAMRecord extends SAMRecord {
             byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
             super.initializeCigar(BinaryCigarCodec.getSingleton().decode(byteBuffer));
             mCigarDecoded = true;
-            if (getValidationStringency() != SAMFileReader.ValidationStringency.SILENT && !this.getReadUnmappedFlag()) {
+            if (getValidationStringency() != ValidationStringency.SILENT && !this.getReadUnmappedFlag()) {
                 // Don't know line number, and don't want to force read name to be decoded.
                 SAMUtils.processValidationErrors(validateCigar(-1L), -1, getValidationStringency());
             }

--- a/src/java/htsjdk/samtools/BinaryTagCodec.java
+++ b/src/java/htsjdk/samtools/BinaryTagCodec.java
@@ -267,7 +267,7 @@ class BinaryTagCodec {
      * @param length How many bytes in binaryRep are tag storage.
      */
     static SAMBinaryTagAndValue readTags(final byte[] binaryRep, final int offset,
-                                         final int length, final SAMFileReader.ValidationStringency validationStringency) {
+                                         final int length, final ValidationStringency validationStringency) {
         final ByteBuffer byteBuffer = ByteBuffer.wrap(binaryRep, offset, length);
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
 
@@ -312,7 +312,7 @@ class BinaryTagCodec {
      * @return Value in in-memory Object form.
      */
     private static  Object readSingleValue(final byte tagType, final ByteBuffer byteBuffer,
-                                           final SAMFileReader.ValidationStringency validationStringency) {
+                                           final ValidationStringency validationStringency) {
         switch (tagType) {
             case 'Z':
                 return readNullTerminatedString(byteBuffer);
@@ -358,7 +358,7 @@ class BinaryTagCodec {
      * @return CVO containing the value in in-memory Object form, and a flag indicating whether it is unsigned or not.
      */
     private static TagValueAndUnsignedArrayFlag readArray(final ByteBuffer byteBuffer,
-                                                          final SAMFileReader.ValidationStringency validationStringency) {
+                                                          final ValidationStringency validationStringency) {
         final byte arrayType = byteBuffer.get();
         final boolean isUnsigned = Character.isUpperCase(arrayType);
         final int length = byteBuffer.getInt();

--- a/src/java/htsjdk/samtools/DefaultSAMRecordFactory.java
+++ b/src/java/htsjdk/samtools/DefaultSAMRecordFactory.java
@@ -7,6 +7,12 @@ package htsjdk.samtools;
  */
 public class DefaultSAMRecordFactory implements SAMRecordFactory {
 
+    private static final DefaultSAMRecordFactory INSTANCE = new DefaultSAMRecordFactory();
+    
+    public static DefaultSAMRecordFactory getInstance() {
+        return INSTANCE;   
+    }
+
     /** Create a new SAMRecord to be filled in */
     public SAMRecord createSAMRecord(final SAMFileHeader header) {
         return new SAMRecord(header);

--- a/src/java/htsjdk/samtools/FixBAMFile.java
+++ b/src/java/htsjdk/samtools/FixBAMFile.java
@@ -22,7 +22,6 @@
  */
 package htsjdk.samtools;
 
-import htsjdk.samtools.SAMFileReader.ValidationStringency;
 
 import java.io.File;
 

--- a/src/java/htsjdk/samtools/QueryInterval.java
+++ b/src/java/htsjdk/samtools/QueryInterval.java
@@ -1,0 +1,96 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.util.CoordMath;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Interval relative to a reference, for querying a BAM file.
+ */
+public class QueryInterval implements Comparable<QueryInterval> {
+
+    /** Index of reference sequence, based on the sequence dictionary of the BAM file being queried. */
+    public final int referenceIndex;
+    /** 1-based, inclusive */
+    public final int start;
+    /** 1-based, inclusive.  If <= 0, implies that the interval goes to the end of the reference sequence */
+    public final int end;
+
+
+    public QueryInterval(final int referenceIndex, final int start, final int end) {
+        if (referenceIndex < 0) {
+            throw new IllegalArgumentException("Invalid reference index " + referenceIndex);
+        }
+        this.referenceIndex = referenceIndex;
+        this.start = start;
+        this.end = end;
+    }
+
+
+    public int compareTo(final QueryInterval other) {
+        int comp = this.referenceIndex - other.referenceIndex;
+        if (comp != 0) return comp;
+        comp = this.start - other.start;
+        if (comp != 0) return comp;
+        else if (this.end == other.end) return 0;
+        else if (this.end == 0) return 1;
+        else if (other.end == 0) return -1;
+        else return this.end - other.end;
+    }
+
+    /**
+     * @return true if both are on same reference, and other starts exactly where this ends.
+     */
+    public boolean abuts(final QueryInterval other) {
+        return this.referenceIndex == other.referenceIndex && this.end == other.start;
+    }
+
+    /**
+     * @return true if both are on same reference, and the overlap.
+     */
+    public boolean overlaps(final QueryInterval other) {
+        if (this.referenceIndex != other.referenceIndex) {
+            return false;
+        }
+        final int thisEnd = (this.end == 0 ? Integer.MAX_VALUE : this.end);
+        final int otherEnd = (other.end == 0 ? Integer.MAX_VALUE : other.end);
+        return CoordMath.overlaps(this.start, thisEnd, other.start, otherEnd);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d:%d-%d", referenceIndex, start, end);
+    }
+
+    private static final QueryInterval[] EMPTY_QUERY_INTERVAL_ARRAY = new QueryInterval[0];
+
+    /**
+     * @param inputIntervals WARNING: This list is modified (sorted) by this method.
+     * @return Ordered list of intervals in which abutting and overlapping intervals are merged.
+     */
+    public static QueryInterval[] optimizeIntervals(final QueryInterval[] inputIntervals) {
+        if (inputIntervals.length == 0) return EMPTY_QUERY_INTERVAL_ARRAY;
+        Arrays.sort(inputIntervals);
+
+        final List<QueryInterval> unique = new ArrayList<QueryInterval>();
+        QueryInterval previous = inputIntervals[0];
+
+
+        for (int i = 1; i < inputIntervals.length; ++i) {
+            final QueryInterval next = inputIntervals[i];
+            if (previous.abuts(next) || previous.overlaps(next)) {
+                final int newEnd = ((previous.end == 0 || next.end == 0) ? 0 : Math.max(previous.end, next.end));
+                previous = new QueryInterval(previous.referenceIndex, previous.start, newEnd);
+            } else {
+                unique.add(previous);
+                previous = next;
+            }
+        }
+
+        if (previous != null) unique.add(previous);
+
+        return unique.toArray(EMPTY_QUERY_INTERVAL_ARRAY);
+    }
+}

--- a/src/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/java/htsjdk/samtools/SAMFileHeader.java
@@ -348,7 +348,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
 
     public final SAMFileHeader clone() {
         final SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
-        codec.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        codec.setValidationStringency(ValidationStringency.SILENT);
         final StringWriter stringWriter = new StringWriter();
         codec.encode(stringWriter, this);
         return codec.decode(new StringLineReader(stringWriter.toString()), "SAMFileHeader.clone");

--- a/src/java/htsjdk/samtools/SAMFileSource.java
+++ b/src/java/htsjdk/samtools/SAMFileSource.java
@@ -33,7 +33,7 @@ public class SAMFileSource {
     /**
      * The reader originating this SAM record.
      */
-    private SAMFileReader mReader;
+    private SamReader mReader;
 
     /**
      * The point on disk from which a record originates.
@@ -45,7 +45,7 @@ public class SAMFileSource {
      * @param reader reader.
      * @param filePointer File pointer.
      */
-    public SAMFileSource(final SAMFileReader reader, final SAMFileSpan filePointer) {
+    public SAMFileSource(final SamReader reader, final SAMFileSpan filePointer) {
         this.mReader = reader;
         this.mFilePointer = filePointer;
     }
@@ -54,7 +54,7 @@ public class SAMFileSource {
      * Retrieves the reader from which this read was initially retrieved.
      * @return The reader.
      */
-    public SAMFileReader getReader() {
+    public SamReader getReader() {
         return mReader;
     }
 

--- a/src/java/htsjdk/samtools/SAMLineParser.java
+++ b/src/java/htsjdk/samtools/SAMLineParser.java
@@ -64,9 +64,9 @@ public class SAMLineParser {
     /**
      * Add information about the origin (reader and position) to SAM records.
      */
-    private final SAMFileReader mParentReader;
+    private final SamReader mParentReader;
     private final SAMRecordFactory samRecordFactory;
-    private final SAMFileReader.ValidationStringency validationStringency;
+    private final ValidationStringency validationStringency;
     private final SAMFileHeader mFileHeader;
     private final File mFile;
 
@@ -86,7 +86,7 @@ public class SAMLineParser {
     public SAMLineParser(final SAMFileHeader samFileHeader) {
 
         this(new DefaultSAMRecordFactory(),
-                SAMFileReader.ValidationStringency.DEFAULT_STRINGENCY, samFileHeader,
+                ValidationStringency.DEFAULT_STRINGENCY, samFileHeader,
                 null, null);
     }
 
@@ -100,7 +100,7 @@ public class SAMLineParser {
                          final SAMFileReader samFileReader, final File samFile) {
 
         this(new DefaultSAMRecordFactory(),
-                SAMFileReader.ValidationStringency.DEFAULT_STRINGENCY, samFileHeader,
+                ValidationStringency.DEFAULT_STRINGENCY, samFileHeader,
                 samFileReader, samFile);
     }
 
@@ -113,8 +113,8 @@ public class SAMLineParser {
      * @param samFile SAM file being read (for error message only, may be null)
      */
     public SAMLineParser(final SAMRecordFactory samRecordFactory,
-                         final SAMFileReader.ValidationStringency validationStringency,
-                         final SAMFileHeader samFileHeader, final SAMFileReader samFileReader,
+                         final ValidationStringency validationStringency,
+                         final SAMFileHeader samFileHeader, final SamReader samFileReader,
                          final File samFile) {
 
         if (samRecordFactory == null)
@@ -150,7 +150,7 @@ public class SAMLineParser {
      * Get validation stringency.
      * @return validation stringency
      */
-    public SAMFileReader.ValidationStringency getValidationStringency() {
+    public ValidationStringency getValidationStringency() {
 
         return this.validationStringency;
     }
@@ -423,9 +423,9 @@ public class SAMLineParser {
     private void reportErrorParsingLine(final String reason) {
         final String errorMessage = makeErrorString(reason);
 
-        if (validationStringency == SAMFileReader.ValidationStringency.STRICT) {
+        if (validationStringency == ValidationStringency.STRICT) {
             throw new SAMFormatException(errorMessage);
-        } else if (validationStringency == SAMFileReader.ValidationStringency.LENIENT) {
+        } else if (validationStringency == ValidationStringency.LENIENT) {
             System.err
                     .println("Ignoring SAM validation error due to lenient parsing:");
             System.err.println(errorMessage);
@@ -434,9 +434,9 @@ public class SAMLineParser {
 
     private void reportErrorParsingLine(final Exception e) {
         final String errorMessage = makeErrorString(e.getMessage());
-        if (validationStringency == SAMFileReader.ValidationStringency.STRICT) {
+        if (validationStringency == ValidationStringency.STRICT) {
             throw new SAMFormatException(errorMessage);
-        } else if (validationStringency == SAMFileReader.ValidationStringency.LENIENT) {
+        } else if (validationStringency == ValidationStringency.LENIENT) {
             System.err
                     .println("Ignoring SAM validation error due to lenient parsing:");
             System.err.println(errorMessage);

--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -172,7 +172,7 @@ public class SAMRecord implements Cloneable
     /**
      * Some attributes (e.g. CIGAR) are not decoded immediately.  Use this to decide how to validate when decoded.
      */
-    private SAMFileReader.ValidationStringency mValidationStringency = SAMFileReader.ValidationStringency.SILENT;
+    private ValidationStringency mValidationStringency = ValidationStringency.SILENT;
 
     private SAMFileSource mFileSource;
     private SAMFileHeader mHeader = null;
@@ -579,7 +579,7 @@ public class SAMRecord implements Cloneable
     public Cigar getCigar() {
         if (mCigar == null && mCigarString != null) {
             mCigar = TextCigarCodec.getSingleton().decode(mCigarString);
-            if (getValidationStringency() != SAMFileReader.ValidationStringency.SILENT && !this.getReadUnmappedFlag()) {
+            if (getValidationStringency() != ValidationStringency.SILENT && !this.getReadUnmappedFlag()) {
                 // Don't know line number, and don't want to force read name to be decoded.
                 SAMUtils.processValidationErrors(this.validateCigar(-1L), -1L, getValidationStringency());
             }
@@ -868,14 +868,14 @@ public class SAMRecord implements Cloneable
         }
     }
 
-    public SAMFileReader.ValidationStringency getValidationStringency() {
+    public ValidationStringency getValidationStringency() {
         return mValidationStringency;
     }
 
     /**
      * Control validation of lazily-decoded elements.
      */
-    public void setValidationStringency(final SAMFileReader.ValidationStringency validationStringency) {
+    public void setValidationStringency(final ValidationStringency validationStringency) {
         this.mValidationStringency = validationStringency;
     }
 
@@ -1377,7 +1377,7 @@ public class SAMRecord implements Cloneable
     public List<SAMValidationError> validateCigar(final long recordNumber) {
         List<SAMValidationError> ret = null;
 
-        if (getValidationStringency() != SAMFileReader.ValidationStringency.SILENT && !this.getReadUnmappedFlag()) {
+        if (getValidationStringency() != ValidationStringency.SILENT && !this.getReadUnmappedFlag()) {
             ret = SAMUtils.validateCigar(this, getCigar(), getReferenceIndex(), getAlignmentBlocks(), recordNumber, "Read CIGAR");
         }
         return ret;

--- a/src/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -57,7 +57,7 @@ public class SAMTextHeaderCodec {
     private final StringBuilder textHeader = new StringBuilder();
 
     // For error reporting when parsing
-    private SAMFileReader.ValidationStringency validationStringency = SAMFileReader.ValidationStringency.SILENT;
+    private ValidationStringency validationStringency = ValidationStringency.SILENT;
 
     // These attributes are populated when generating text
     private BufferedWriter writer;
@@ -225,7 +225,7 @@ public class SAMTextHeaderCodec {
 
     private void reportErrorParsingLine(String reason, final SAMValidationError.Type type, final Throwable nestedException) {
         reason = "Error parsing SAM header. " + reason + ". Line:\n" + mCurrentLine;
-        if (validationStringency != SAMFileReader.ValidationStringency.STRICT) {
+        if (validationStringency != ValidationStringency.STRICT) {
             final SAMValidationError error = new SAMValidationError(type, reason, null, mReader.getLineNumber());
             error.setSource(mSource);
             mFileHeader.addValidationError(error);
@@ -459,7 +459,7 @@ public class SAMTextHeaderCodec {
         }
     }
 
-    public void setValidationStringency(final SAMFileReader.ValidationStringency validationStringency) {
+    public void setValidationStringency(final ValidationStringency validationStringency) {
         if (validationStringency == null) {
             throw new IllegalArgumentException("null validationStringency not allowed");
         }

--- a/src/java/htsjdk/samtools/SAMTextReader.java
+++ b/src/java/htsjdk/samtools/SAMTextReader.java
@@ -44,18 +44,18 @@ class SAMTextReader extends SAMFileReader.ReaderImplementation {
     private RecordIterator mIterator = null;
     private File mFile = null;
 
-    private SAMFileReader.ValidationStringency validationStringency = SAMFileReader.ValidationStringency.DEFAULT_STRINGENCY;
+    private ValidationStringency validationStringency = ValidationStringency.DEFAULT_STRINGENCY;
 
     /**
      * Add information about the origin (reader and position) to SAM records.
      */
-    private SAMFileReader mParentReader;
+    private SamReader mParentReader;
 
     /**
      * Prepare to read a SAM text file.
      * @param stream Need not be buffered, as this class provides buffered reading.
      */
-    SAMTextReader(final InputStream stream, final SAMFileReader.ValidationStringency validationStringency, final SAMRecordFactory factory) {
+    public SAMTextReader(final InputStream stream, final ValidationStringency validationStringency, final SAMRecordFactory factory) {
         mReader = new BufferedLineReader(stream);
         this.validationStringency = validationStringency;
         this.samRecordFactory = factory;
@@ -67,7 +67,7 @@ class SAMTextReader extends SAMFileReader.ReaderImplementation {
      * @param stream Need not be buffered, as this class provides buffered reading.
      * @param file For error reporting only.
      */
-    SAMTextReader(final InputStream stream, final File file, final SAMFileReader.ValidationStringency validationStringency, final SAMRecordFactory factory) {
+    public SAMTextReader(final InputStream stream, final File file, final ValidationStringency validationStringency, final SAMRecordFactory factory) {
         this(stream, validationStringency, factory);
         mFile = file;
     }
@@ -76,7 +76,7 @@ class SAMTextReader extends SAMFileReader.ReaderImplementation {
      * If true, writes the source of every read into the source SAMRecords.
      * @param enabled true to write source information into each SAMRecord.
      */
-    void enableFileSource(final SAMFileReader reader, final boolean enabled) {
+    public void enableFileSource(final SamReader reader, final boolean enabled) {
         this.mParentReader = enabled ? reader : null;
     }
 
@@ -96,15 +96,20 @@ class SAMTextReader extends SAMFileReader.ReaderImplementation {
         this.samRecordFactory = factory;
     }
 
-    boolean hasIndex() {
+    @Override
+    public SamReader.Type type() {
+        return SamReader.Type.SAM_TYPE;
+    }
+
+    public boolean hasIndex() {
         return false;
     }
 
-    BAMIndex getIndex() {
+    public BAMIndex getIndex() {
         throw new UnsupportedOperationException();
     }
 
-    void close() {
+    public void close() {
         if (mReader != null) {
             try {
                 mReader.close();
@@ -114,15 +119,15 @@ class SAMTextReader extends SAMFileReader.ReaderImplementation {
         }
     }
 
-    SAMFileHeader getFileHeader() {
+    public SAMFileHeader getFileHeader() {
         return mFileHeader;
     }
 
-    public SAMFileReader.ValidationStringency getValidationStringency() {
+    public ValidationStringency getValidationStringency() {
         return validationStringency;
     }
 
-    public void setValidationStringency(final SAMFileReader.ValidationStringency stringency) {
+    public void setValidationStringency(final ValidationStringency stringency) {
         this.validationStringency = stringency;
     }
 
@@ -133,7 +138,7 @@ class SAMTextReader extends SAMFileReader.ReaderImplementation {
      *
      * @return Iterator of SAMRecords in file order.
      */
-    CloseableIterator<SAMRecord> getIterator() {
+    public CloseableIterator<SAMRecord> getIterator() {
         if (mReader == null) {
             throw new IllegalStateException("File reader is closed");
         }
@@ -149,7 +154,7 @@ class SAMTextReader extends SAMFileReader.ReaderImplementation {
      * @param fileSpan The file span.
      * @return An iterator over the given file span.
      */
-    CloseableIterator<SAMRecord> getIterator(final SAMFileSpan fileSpan) {
+    public CloseableIterator<SAMRecord> getIterator(final SAMFileSpan fileSpan) {
         throw new UnsupportedOperationException("Cannot directly iterate over regions within SAM text files.");
     }
 
@@ -157,26 +162,26 @@ class SAMTextReader extends SAMFileReader.ReaderImplementation {
      * Generally gets a pointer to the first read in the file.  Unsupported for SAMTextReaders.
      * @return An pointer to the first read in the file.
      */
-    SAMFileSpan getFilePointerSpanningReads() {
+    public SAMFileSpan getFilePointerSpanningReads() {
         throw new UnsupportedOperationException("Cannot retrieve file pointers within SAM text files.");
     }
 
     /**
      * Unsupported for SAM text files.
      */
-    CloseableIterator<SAMRecord> query(final String sequence, final int start, final int end, final boolean contained) {
+    public CloseableIterator<SAMRecord> query(final String sequence, final int start, final int end, final boolean contained) {
         throw new UnsupportedOperationException("Cannot query SAM text files");
     }
 
     @Override
-    CloseableIterator<SAMRecord> query(final SAMFileReader.QueryInterval[] intervals, final boolean contained) {
+    public CloseableIterator<SAMRecord> query(final QueryInterval[] intervals, final boolean contained) {
         throw new UnsupportedOperationException("Cannot query SAM text files");
     }
 
     /**
      * Unsupported for SAM text files.
      */
-    CloseableIterator<SAMRecord> queryAlignmentStart(final String sequence, final int start) {
+    public CloseableIterator<SAMRecord> queryAlignmentStart(final String sequence, final int start) {
         throw new UnsupportedOperationException("Cannot query SAM text files");
     }
 

--- a/src/java/htsjdk/samtools/SAMUtils.java
+++ b/src/java/htsjdk/samtools/SAMUtils.java
@@ -443,15 +443,15 @@ public final class SAMUtils
      */
     static void processValidationErrors(final List<SAMValidationError> validationErrors,
                                         final long samRecordIndex,
-                                        final SAMFileReader.ValidationStringency validationStringency) {
+                                        final ValidationStringency validationStringency) {
         if (validationErrors != null && validationErrors.size() > 0) {
             for (final SAMValidationError validationError : validationErrors) {
                 validationError.setRecordNumber(samRecordIndex);
             }
-            if (validationStringency == SAMFileReader.ValidationStringency.STRICT) {
+            if (validationStringency == ValidationStringency.STRICT) {
                 throw new SAMFormatException("SAM validation error: " + validationErrors.get(0));
             }
-            else if (validationStringency == SAMFileReader.ValidationStringency.LENIENT) {
+            else if (validationStringency == ValidationStringency.LENIENT) {
                 for (final SAMValidationError error : validationErrors) {
                     System.err.println("Ignoring SAM validation error: " + error);
                 }
@@ -460,11 +460,11 @@ public final class SAMUtils
     }
 
     public static void processValidationError(final SAMValidationError validationError,
-                                       final SAMFileReader.ValidationStringency validationStringency) {
-        if (validationStringency == SAMFileReader.ValidationStringency.STRICT) {
+                                       final ValidationStringency validationStringency) {
+        if (validationStringency == ValidationStringency.STRICT) {
             throw new SAMFormatException("SAM validation error: " + validationError);
         }
-        else if (validationStringency == SAMFileReader.ValidationStringency.LENIENT) {
+        else if (validationStringency == ValidationStringency.LENIENT) {
             System.err.println("Ignoring SAM validation error: " + validationError);
         }
         
@@ -752,7 +752,7 @@ public final class SAMUtils
         Cigar mateCigar = null;
         if (mateCigarString != null) {
             mateCigar = TextCigarCodec.getSingleton().decode(mateCigarString);
-            if (withValidation && rec.getValidationStringency() != SAMFileReader.ValidationStringency.SILENT) {
+            if (withValidation && rec.getValidationStringency() != ValidationStringency.SILENT) {
                 final List<AlignmentBlock> alignmentBlocks = getAlignmentBlocks(mateCigar, rec.getMateAlignmentStart(), "mate cigar");
                 SAMUtils.processValidationErrors(validateCigar(rec, mateCigar, rec.getMateReferenceIndex(), alignmentBlocks, -1, "Mate CIGAR"), -1L, rec.getValidationStringency());
             }
@@ -887,7 +887,7 @@ public final class SAMUtils
     public static List<SAMValidationError> validateMateCigar(final SAMRecord rec, final long recordNumber) {
         List<SAMValidationError> ret = null;
 
-        if (rec.getValidationStringency() != SAMFileReader.ValidationStringency.SILENT) {
+        if (rec.getValidationStringency() != ValidationStringency.SILENT) {
             if (rec.getReadPairedFlag() && !rec.getMateUnmappedFlag()) {      // The mateCigar will be defined if the mate is mapped
                 if (getMateCigarString(rec) != null) {
                     ret = SAMUtils.validateCigar(rec, getMateCigar(rec), rec.getMateReferenceIndex(), getMateAlignmentBlocks(rec), recordNumber, "Mate CIGAR");

--- a/src/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/java/htsjdk/samtools/SamFileValidator.java
@@ -24,7 +24,7 @@
 
 package htsjdk.samtools;
 
-import htsjdk.samtools.SAMFileReader.ValidationStringency;
+import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.SAMValidationError.Type;
 import htsjdk.samtools.metrics.MetricBase;
 import htsjdk.samtools.metrics.MetricsFile;

--- a/src/java/htsjdk/samtools/SamFiles.java
+++ b/src/java/htsjdk/samtools/SamFiles.java
@@ -1,0 +1,34 @@
+package htsjdk.samtools;
+
+import java.io.File;
+
+/**
+ * @author mccowan
+ */
+public class SamFiles {
+    /**
+     * Finds the index file associated with the provided SAM file.  The index file must exist and be reachable to be found. 
+     *
+     * @return The index for the provided SAM, or null if one was not found.
+     */
+    public static File findIndex(final File samFile) {
+        // If input is foo.bam, look for foo.bai
+        File indexFile;
+        final String fileName = samFile.getName();
+        if (fileName.endsWith(BamFileIoUtils.BAM_FILE_EXTENSION)) {
+            final String bai = fileName.substring(0, fileName.length() - BamFileIoUtils.BAM_FILE_EXTENSION.length()) + BAMIndex.BAMIndexSuffix;
+            indexFile = new File(samFile.getParent(), bai);
+            if (indexFile.isFile()) {
+                return indexFile;
+            }
+        }
+
+        // If foo.bai doesn't exist look for foo.bam.bai
+        indexFile = new File(samFile.getParent(), samFile.getName() + BAMIndex.BAMIndexSuffix);
+        if (indexFile.isFile()) {
+            return indexFile;
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/java/htsjdk/samtools/SamInputResource.java
+++ b/src/java/htsjdk/samtools/SamInputResource.java
@@ -1,0 +1,282 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.seekablestream.SeekableFileStream;
+import htsjdk.samtools.seekablestream.SeekableHTTPStream;
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.Lazy;
+import htsjdk.samtools.util.RuntimeIOException;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * Describes a SAM-like resource, including its data (where the records are), and optionally an index.
+ * <p/>
+ * A data or index source may originate from a {@link java.io.File}, {@link java.io.InputStream}, {@link URL}, or
+ * {@link htsjdk.samtools.seekablestream.SeekableStream}; look for the appropriate overload for
+ * {@code htsjdk.samtools.SamInputResource#of()}.
+ *
+ * @author mccowan
+ */
+public class SamInputResource {
+    private final InputResource source;
+    private InputResource index;
+
+    SamInputResource(final InputResource data) {
+        this(data, null);
+    }
+
+    SamInputResource(final InputResource source, final InputResource index) {
+        if (source == null) throw new NullPointerException("source");
+        this.source = source;
+        this.index = index;
+    }
+
+    /** The resource that is the SAM data (e.g., records) */
+    InputResource data() {
+        return source;
+    }
+
+    /**
+     * The resource that is the SAM index
+     *
+     * @return null, if no index is defined for this resource
+     */
+    InputResource indexMaybe() {
+        return index;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("data=%s;index=%s", source, index);
+    }
+
+    /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
+    public static SamInputResource of(final File file) { return new SamInputResource(new FileInputResource(file)); }
+
+    /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
+    public static SamInputResource of(final InputStream inputStream) { return new SamInputResource(new InputStreamInputResource(inputStream)); }
+
+    /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
+    public static SamInputResource of(final URL url) { return new SamInputResource(new UrlInputResource(url)); }
+
+    /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
+    public static SamInputResource of(final SeekableStream seekableStream) { return new SamInputResource(new SeekableStreamInputResource(seekableStream)); }
+
+    /** Updates the index to point at the provided resource, then returns itself. */
+    public SamInputResource index(final File file) {
+        this.index = new FileInputResource(file);
+        return this;
+    }
+
+    /** Updates the index to point at the provided resource, then returns itself. */
+    public SamInputResource index(final InputStream inputStream) {
+        this.index = new InputStreamInputResource(inputStream);
+        return this;
+    }
+
+    /** Updates the index to point at the provided resource, then returns itself. */
+    public SamInputResource index(final URL url) {
+        this.index = new UrlInputResource(url);
+        return this;
+    }
+
+    /** Updates the index to point at the provided resource, then returns itself. */
+    public SamInputResource index(final SeekableStream seekableStream) {
+        this.index = new SeekableStreamInputResource(seekableStream);
+        return this;
+    }
+
+}
+
+/**
+ * Describes an arbitrary input source, which is something that can be accessed as either a
+ * {@link htsjdk.samtools.seekablestream.SeekableStream} or {@link java.io.InputStream}.  A concrete implementation of this class exists for
+ * each of {@link InputResource.Type}.
+ */
+abstract class InputResource {
+    protected InputResource(final Type type) {this.type = type;}
+
+    enum Type {
+        FILE, URL, SEEKABLE_STREAM, INPUT_STREAM
+    }
+
+    private final Type type;
+
+    final Type type() {
+        return type;
+    }
+
+    /** Returns null if this resource cannot be represented as a {@link File}. */
+    abstract File asFile();
+
+    /** Returns null if this resource cannot be represented as a {@link URL}. */
+    abstract URL asUrl();
+
+    /** Returns null if this resource cannot be represented as a {@link htsjdk.samtools.seekablestream.SeekableStream}. */
+    abstract SeekableStream asUnbufferedSeekableStream();
+
+    /** All resource types support {@link java.io.InputStream} generation. */
+    abstract InputStream asUnbufferedInputStream();
+
+    @Override
+    public String toString() {
+        final String childToString;
+        switch (type()) {
+            case FILE:
+                childToString = asFile().toString();
+                break;
+            case INPUT_STREAM:
+                childToString = asUnbufferedInputStream().toString();
+                break;
+            case SEEKABLE_STREAM:
+                childToString = asUnbufferedSeekableStream().toString();
+                break;
+            case URL:
+                childToString = asUrl().toString();
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+        return String.format("%s:%s", type(), childToString);
+    }
+}
+
+class FileInputResource extends InputResource {
+
+    final File fileResource;
+    final Lazy<SeekableStream> lazySeekableStream = new Lazy<SeekableStream>(new Lazy.LazyInitializer<SeekableStream>() {
+        @Override
+        public SeekableStream make() {
+            try {
+                return new SeekableFileStream(fileResource);
+            } catch (final FileNotFoundException e) {
+                throw new RuntimeIOException(e);
+            }
+        }
+    });
+
+
+    FileInputResource(final File fileResource) {
+        super(Type.FILE);
+        this.fileResource = fileResource;
+    }
+
+    @Override
+    public File asFile() {
+        return fileResource;
+    }
+
+    @Override
+    public URL asUrl() {
+        return null;
+    }
+
+    @Override
+    public SeekableStream asUnbufferedSeekableStream() {
+        return lazySeekableStream.get();
+    }
+
+    @Override
+    public InputStream asUnbufferedInputStream() {
+        return asUnbufferedSeekableStream();
+    }
+}
+
+class UrlInputResource extends InputResource {
+
+    final URL urlResource;
+    final Lazy<SeekableStream> lazySeekableStream = new Lazy<SeekableStream>(new Lazy.LazyInitializer<SeekableStream>() {
+        @Override
+        public SeekableStream make() {
+            return new SeekableHTTPStream(urlResource);
+        }
+    });
+
+    UrlInputResource(final URL urlResource) {
+        super(Type.URL);
+        this.urlResource = urlResource;
+    }
+
+    @Override
+    public File asFile() {
+        return null;
+    }
+
+    @Override
+    public URL asUrl() {
+        return urlResource;
+    }
+
+    @Override
+    public SeekableStream asUnbufferedSeekableStream() {
+        return lazySeekableStream.get();
+    }
+
+    @Override
+    public InputStream asUnbufferedInputStream() {
+        return asUnbufferedSeekableStream();
+    }
+}
+
+class SeekableStreamInputResource extends InputResource {
+
+    final SeekableStream seekableStreamResource;
+
+    SeekableStreamInputResource(final SeekableStream seekableStreamResource) {
+        super(Type.SEEKABLE_STREAM);
+        this.seekableStreamResource = seekableStreamResource;
+    }
+
+    @Override
+    File asFile() {
+        return null;
+    }
+
+    @Override
+    URL asUrl() {
+        return null;
+    }
+
+    @Override
+    SeekableStream asUnbufferedSeekableStream() {
+        return seekableStreamResource;
+    }
+
+    @Override
+    InputStream asUnbufferedInputStream() {
+        return asUnbufferedSeekableStream();
+    }
+}
+
+class InputStreamInputResource extends InputResource {
+
+    final InputStream inputStreamResource;
+
+    InputStreamInputResource(final InputStream inputStreamResource) {
+        super(Type.INPUT_STREAM);
+        this.inputStreamResource = inputStreamResource;
+    }
+
+    @Override
+    File asFile() {
+        return null;
+    }
+
+    @Override
+    URL asUrl() {
+        return null;
+    }
+
+    @Override
+    SeekableStream asUnbufferedSeekableStream() {
+        return null;
+    }
+
+    @Override
+    InputStream asUnbufferedInputStream() {
+        return inputStreamResource;
+    }
+}

--- a/src/java/htsjdk/samtools/SamReader.java
+++ b/src/java/htsjdk/samtools/SamReader.java
@@ -1,0 +1,541 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.util.CloseableIterator;
+
+import java.io.Closeable;
+import java.text.MessageFormat;
+
+/**
+ * Describes functionality for objects that produce {@link SAMRecord}s and associated information.
+ *
+ * @author mccowan
+ */
+public interface SamReader extends Iterable<SAMRecord>, Closeable {
+
+    /** Describes a type of SAM file. */
+    public abstract class Type {
+        /** A string representation of this type. */
+        abstract String name();
+
+        /** The recommended file extension for SAMs of this type, without a period. */
+        abstract String fileExtension();
+
+        /** The recommended file extension for SAM indexes of this type, without a period, or null if this type is not associated with indexes. */
+        abstract String indexExtension();
+
+        static class TypeImpl extends Type {
+            final String name, fileExtension, indexExtension;
+
+            TypeImpl(final String name, final String fileExtension, final String indexExtension) {
+                this.name = name;
+                this.fileExtension = fileExtension;
+                this.indexExtension = indexExtension;
+            }
+
+            @Override
+            String name() {
+                return name;
+            }
+
+            @Override
+            String fileExtension() {
+                return fileExtension;
+            }
+
+            @Override
+            String indexExtension() {
+                return indexExtension;
+            }
+
+            @Override
+            public String toString() {
+                return String.format("TypeImpl{name='%s', fileExtension='%s', indexExtension='%s'}", name, fileExtension, indexExtension);
+            }
+        }
+
+        public static Type BAM_TYPE = new TypeImpl("BAM", "bam", "bai");
+        public static Type SAM_TYPE = new TypeImpl("SAM", "sam", null);
+    }
+
+    /**
+     * Facet for index-related operations.
+     */
+    public interface Indexing {
+        /**
+         * Retrieves the index for the given file type.  Ensure that the index is of the specified type.
+         *
+         * @return An index of the given type.
+         */
+        public BAMIndex getIndex();
+
+        /**
+         * Returns true if the supported index is browseable, meaning the bins in it can be traversed
+         * and chunk data inspected and retrieved.
+         *
+         * @return True if the index supports the BrowseableBAMIndex interface.  False otherwise.
+         */
+        public boolean hasBrowseableIndex();
+
+        /**
+         * Gets an index tagged with the BrowseableBAMIndex interface.  Throws an exception if no such
+         * index is available.
+         *
+         * @return An index with a browseable interface, if possible.
+         * @throws SAMException if no such index is available.
+         */
+        public BrowseableBAMIndex getBrowseableIndex();
+
+        /**
+         * Iterate through the given chunks in the file.
+         *
+         * @param chunks List of chunks for which to retrieve data.
+         * @return An iterator over the given chunks.
+         */
+        public SAMRecordIterator iterator(final SAMFileSpan chunks);
+
+        /**
+         * Gets a pointer spanning all reads in the BAM file.
+         *
+         * @return Unbounded pointer to the first record, in chunk format.
+         */
+        public SAMFileSpan getFilePointerSpanningReads();
+
+    }
+
+    public SAMFileHeader getFileHeader();
+
+    /**
+     * @return Answers {@code true} if this is a BAM reader.
+     */
+    public Type type();
+
+    /**
+     * @return true if ths is a BAM file, and has an index
+     */
+    public boolean hasIndex();
+
+    /**
+     * Exposes the {@link SamReader.Indexing} facet of this {@link SamReader}.
+     *
+     * @throws java.lang.UnsupportedOperationException If {@link #hasIndex()} returns false.
+     */
+    public Indexing indexing();
+
+    /**
+     * Iterate through file in order.  For a SAMFileReader constructed from an InputStream, and for any SAM file,
+     * a 2nd iteration starts where the 1st one left off.  For a BAM constructed from a SeekableStream or File, each new iteration
+     * starts at the first record.
+     * <p/>
+     * Only a single open iterator on a SAM or BAM file may be extant at any one time.  If you want to start
+     * a second iteration, the first one must be closed first.
+     */
+    public SAMRecordIterator iterator();
+
+    /**
+     * Iterate over records that match the given interval.  Only valid to call this if hasIndex() == true.
+     * <p/>
+     * Only a single open iterator on a given SAMFileReader may be extant at any one time.  If you want to start
+     * a second iteration, the first one must be closed first.  You can use a second SAMFileReader to iterate
+     * in parallel over the same underlying file.
+     * <p/>
+     * Note that indexed lookup is not perfectly efficient in terms of disk I/O.  I.e. some SAMRecords may be read
+     * and then discarded because they do not match the interval of interest.
+     * <p/>
+     * Note that an unmapped read will be returned by this call if it has a coordinate for the purpose of sorting that
+     * is in the query region.
+     *
+     * @param sequence  Reference sequence of interest.
+     * @param start     1-based, inclusive start of interval of interest. Zero implies start of the reference sequence.
+     * @param end       1-based, inclusive end of interval of interest. Zero implies end of the reference sequence.
+     * @param contained If true, each SAMRecord returned is will have its alignment completely contained in the
+     *                  interval of interest.  If false, the alignment of the returned SAMRecords need only overlap the interval of interest.
+     * @return Iterator over the SAMRecords matching the interval.
+     */
+    public SAMRecordIterator query(final String sequence, final int start, final int end, final boolean contained);
+
+    /**
+     * Iterate over records that overlap the given interval.  Only valid to call this if hasIndex() == true.
+     * <p/>
+     * Only a single open iterator on a given SAMFileReader may be extant at any one time.  If you want to start
+     * a second iteration, the first one must be closed first.
+     * <p/>
+     * Note that indexed lookup is not perfectly efficient in terms of disk I/O.  I.e. some SAMRecords may be read
+     * and then discarded because they do not match the interval of interest.
+     * <p/>
+     * Note that an unmapped read will be returned by this call if it has a coordinate for the purpose of sorting that
+     * is in the query region.
+     *
+     * @param sequence Reference sequence of interest.
+     * @param start    1-based, inclusive start of interval of interest. Zero implies start of the reference sequence.
+     * @param end      1-based, inclusive end of interval of interest. Zero implies end of the reference sequence.
+     * @return Iterator over the SAMRecords overlapping the interval.
+     */
+    public SAMRecordIterator queryOverlapping(final String sequence, final int start, final int end);
+
+    /**
+     * Iterate over records that are contained in the given interval.  Only valid to call this if hasIndex() == true.
+     * <p/>
+     * Only a single open iterator on a given SAMFileReader may be extant at any one time.  If you want to start
+     * a second iteration, the first one must be closed first.
+     * <p/>
+     * Note that indexed lookup is not perfectly efficient in terms of disk I/O.  I.e. some SAMRecords may be read
+     * and then discarded because they do not match the interval of interest.
+     * <p/>
+     * Note that an unmapped read will be returned by this call if it has a coordinate for the purpose of sorting that
+     * is in the query region.
+     *
+     * @param sequence Reference sequence of interest.
+     * @param start    1-based, inclusive start of interval of interest. Zero implies start of the reference sequence.
+     * @param end      1-based, inclusive end of interval of interest. Zero implies end of the reference sequence.
+     * @return Iterator over the SAMRecords contained in the interval.
+     */
+    public SAMRecordIterator queryContained(final String sequence, final int start, final int end);
+
+    /**
+     * Iterate over records that match one of the given intervals.  This may be more efficient than querying
+     * each interval separately, because multiple reads of the same SAMRecords is avoided.
+     * <p/>
+     * Only valid to call this if hasIndex() == true.
+     * <p/>
+     * Only a single open iterator on a given SAMFileReader may be extant at any one time.  If you want to start
+     * a second iteration, the first one must be closed first.  You can use a second SAMFileReader to iterate
+     * in parallel over the same underlying file.
+     * <p/>
+     * Note that indexed lookup is not perfectly efficient in terms of disk I/O.  I.e. some SAMRecords may be read
+     * and then discarded because they do not match an interval of interest.
+     * <p/>
+     * Note that an unmapped read will be returned by this call if it has a coordinate for the purpose of sorting that
+     * is in the query region.
+     *
+     * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
+     *                  and abutting intervals merged.  This can be done with
+     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
+     * @param contained If true, each SAMRecord returned is will have its alignment completely contained in one of the
+     *                  intervals of interest.  If false, the alignment of the returned SAMRecords need only overlap one of
+     *                  the intervals of interest.
+     * @return Iterator over the SAMRecords matching the interval.
+     */
+    public SAMRecordIterator query(final QueryInterval[] intervals, final boolean contained);
+
+    /**
+     * Iterate over records that overlap any of the given intervals.  This may be more efficient than querying
+     * each interval separately, because multiple reads of the same SAMRecords is avoided.
+     * <p/>
+     * Only valid to call this if hasIndex() == true.
+     * <p/>
+     * Only a single open iterator on a given SAMFileReader may be extant at any one time.  If you want to start
+     * a second iteration, the first one must be closed first.
+     * <p/>
+     * Note that indexed lookup is not perfectly efficient in terms of disk I/O.  I.e. some SAMRecords may be read
+     * and then discarded because they do not match the interval of interest.
+     * <p/>
+     * Note that an unmapped read will be returned by this call if it has a coordinate for the purpose of sorting that
+     * is in the query region.
+     *
+     * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
+     *                  and abutting intervals merged.  This can be done with
+     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
+     * @return Iterator over the SAMRecords overlapping any of the intervals.
+     */
+    public SAMRecordIterator queryOverlapping(final QueryInterval[] intervals);
+
+    /**
+     * Iterate over records that are contained in the given interval.  This may be more efficient than querying
+     * each interval separately, because multiple reads of the same SAMRecords is avoided.
+     * <p/>
+     * Only valid to call this if hasIndex() == true.
+     * <p/>
+     * Only a single open iterator on a given SAMFileReader may be extant at any one time.  If you want to start
+     * a second iteration, the first one must be closed first.
+     * <p/>
+     * Note that indexed lookup is not perfectly efficient in terms of disk I/O.  I.e. some SAMRecords may be read
+     * and then discarded because they do not match the interval of interest.
+     * <p/>
+     * Note that an unmapped read will be returned by this call if it has a coordinate for the purpose of sorting that
+     * is in the query region.
+     *
+     * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
+     *                  and abutting intervals merged.  This can be done with
+     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
+     * @return Iterator over the SAMRecords contained in any of the intervals.
+     */
+    public SAMRecordIterator queryContained(final QueryInterval[] intervals);
+
+
+    public SAMRecordIterator queryUnmapped();
+
+    /**
+     * Iterate over records that map to the given sequence and start at the given position.  Only valid to call this if hasIndex() == true.
+     * <p/>
+     * Only a single open iterator on a given SAMFileReader may be extant at any one time.  If you want to start
+     * a second iteration, the first one must be closed first.
+     * <p/>
+     * Note that indexed lookup is not perfectly efficient in terms of disk I/O.  I.e. some SAMRecords may be read
+     * and then discarded because they do not match the interval of interest.
+     * <p/>
+     * Note that an unmapped read will be returned by this call if it has a coordinate for the purpose of sorting that
+     * matches the arguments.
+     *
+     * @param sequence Reference sequence of interest.
+     * @param start    Alignment start of interest.
+     * @return Iterator over the SAMRecords with the given alignment start.
+     */
+    public SAMRecordIterator queryAlignmentStart(final String sequence, final int start);
+
+    /**
+     * Fetch the mate for the given read.  Only valid to call this if hasIndex() == true.
+     * This will work whether the mate has a coordinate or not, so long as the given read has correct
+     * mate information.  This method iterates over the SAM file, so there may not be an unclosed
+     * iterator on the SAM file when this method is called.
+     * <p/>
+     * Note that it is not possible to call queryMate when iterating over the SAMFileReader, because queryMate
+     * requires its own iteration, and there cannot be two simultaneous iterations on the same SAMFileReader.  The
+     * work-around is to open a second SAMFileReader on the same input file, and call queryMate on the second
+     * reader.
+     *
+     * @param rec Record for which mate is sought.  Must be a paired read.
+     * @return rec's mate, or null if it cannot be found.
+     */
+    public SAMRecord queryMate(final SAMRecord rec);
+
+
+    /**
+     * The minimal subset of functionality to implement to conform with the requirements of
+     * {@link SamReader.PrimitiveSamReaderToSamReaderAdapter}.
+     */
+    public interface PrimitiveSamReader {
+        Type type();
+
+        boolean hasIndex();
+
+        BAMIndex getIndex();
+
+        SAMFileHeader getFileHeader();
+
+        CloseableIterator<SAMRecord> getIterator();
+
+        CloseableIterator<SAMRecord> getIterator(SAMFileSpan fileSpan);
+
+        SAMFileSpan getFilePointerSpanningReads();
+
+        CloseableIterator<SAMRecord> query(QueryInterval[] intervals, boolean contained);
+
+        CloseableIterator<SAMRecord> queryAlignmentStart(String sequence, int start);
+
+        CloseableIterator<SAMRecord> queryUnmapped();
+
+        void close();
+
+        ValidationStringency getValidationStringency();
+    }
+
+    /** Decorator for a {@link SamReader.PrimitiveSamReader} that expands its functionality into a {@link SamReader}. */
+    class PrimitiveSamReaderToSamReaderAdapter implements SamReader, Indexing {
+        final PrimitiveSamReader p;
+
+        public PrimitiveSamReaderToSamReaderAdapter(final PrimitiveSamReader p) {
+            this.p = p;
+        }
+
+        PrimitiveSamReader underlyingReader() {
+            return p;
+        }
+
+        @Override
+        public SAMRecordIterator queryOverlapping(final String sequence, final int start, final int end) {
+            return query(sequence, start, end, false);
+        }
+
+        @Override
+        public SAMRecordIterator queryOverlapping(final QueryInterval[] intervals) {
+            return query(intervals, false);
+        }
+
+        @Override
+        public SAMRecordIterator queryContained(final String sequence, final int start, final int end) {
+            return query(sequence, start, end, true);
+        }
+
+        @Override
+        public SAMRecordIterator queryContained(final QueryInterval[] intervals) {
+            return query(intervals, true);
+        }
+
+        @Override
+        public SAMRecord queryMate(final SAMRecord rec) {
+            if (!rec.getReadPairedFlag()) {
+                throw new IllegalArgumentException("queryMate called for unpaired read.");
+            }
+            if (rec.getFirstOfPairFlag() == rec.getSecondOfPairFlag()) {
+                throw new IllegalArgumentException("SAMRecord must be either first and second of pair, but not both.");
+            }
+            final boolean firstOfPair = rec.getFirstOfPairFlag();
+            final CloseableIterator<SAMRecord> it;
+            if (rec.getMateReferenceIndex() == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
+                it = queryUnmapped();
+            } else {
+                it = queryAlignmentStart(rec.getMateReferenceName(), rec.getMateAlignmentStart());
+            }
+            try {
+                SAMRecord mateRec = null;
+                while (it.hasNext()) {
+                    final SAMRecord next = it.next();
+                    if (!next.getReadPairedFlag()) {
+                        if (rec.getReadName().equals(next.getReadName())) {
+                            throw new SAMFormatException("Paired and unpaired reads with same name: " + rec.getReadName());
+                        }
+                        continue;
+                    }
+                    if (firstOfPair) {
+                        if (next.getFirstOfPairFlag()) continue;
+                    } else {
+                        if (next.getSecondOfPairFlag()) continue;
+                    }
+                    if (rec.getReadName().equals(next.getReadName())) {
+                        if (mateRec != null) {
+                            throw new SAMFormatException("Multiple SAMRecord with read name " + rec.getReadName() +
+                                    " for " + (firstOfPair ? "second" : "first") + " end.");
+                        }
+                        mateRec = next;
+                    }
+                }
+                return mateRec;
+            } finally {
+                it.close();
+            }
+        }
+
+        @Override
+        public boolean hasBrowseableIndex() {
+            return hasIndex() && getIndex() instanceof BrowseableBAMIndex;
+        }
+
+        @Override
+        public BrowseableBAMIndex getBrowseableIndex() {
+            final BAMIndex index = getIndex();
+            if (!(index instanceof BrowseableBAMIndex))
+                throw new SAMException("Cannot return index: index created by BAM is not browseable.");
+            return BrowseableBAMIndex.class.cast(index);
+        }
+
+        @Override
+        public SAMRecordIterator iterator() {
+            return new AssertingIterator(p.getIterator());
+        }
+
+        @Override
+        public SAMRecordIterator iterator(final SAMFileSpan chunks) {
+            return new AssertingIterator(p.getIterator(chunks));
+        }
+
+        @Override
+        public void close() {
+            p.close();
+        }
+
+        @Override
+        public SAMFileSpan getFilePointerSpanningReads() {
+            return p.getFilePointerSpanningReads();
+        }
+
+        @Override
+        public SAMFileHeader getFileHeader() {
+            return p.getFileHeader();
+        }
+
+        @Override
+        public Type type() {
+            return p.type();
+        }
+
+        @Override
+        public boolean hasIndex() {
+            return p.hasIndex();
+        }
+
+        @Override
+        public Indexing indexing() {
+            return this;
+        }
+
+        @Override
+        public BAMIndex getIndex() {
+            return p.getIndex();
+        }
+
+        @Override
+        public SAMRecordIterator query(final QueryInterval[] intervals, final boolean contained) {
+            return AssertingIterator.of(p.query(intervals, contained));
+        }
+
+        @Override
+        public SAMRecordIterator query(final String sequence, final int start, final int end, final boolean contained) {
+            return query(new QueryInterval[]{new QueryInterval(getFileHeader().getSequenceIndex(sequence), start, end)}, contained);
+        }
+
+        @Override
+        public SAMRecordIterator queryUnmapped() {
+            return AssertingIterator.of(p.queryUnmapped());
+        }
+
+        @Override
+        public SAMRecordIterator queryAlignmentStart(final String sequence, final int start) {
+            return AssertingIterator.of(p.queryAlignmentStart(sequence, start));
+        }
+
+    }
+
+    static class AssertingIterator implements SAMRecordIterator {
+
+        static AssertingIterator of(final CloseableIterator<SAMRecord> iterator) {
+            return new AssertingIterator(iterator);
+        }
+
+        private final CloseableIterator<SAMRecord> wrappedIterator;
+        private SAMRecord previous = null;
+        private SAMRecordComparator comparator = null;
+
+        public AssertingIterator(final CloseableIterator<SAMRecord> iterator) {
+            wrappedIterator = iterator;
+        }
+
+        public SAMRecordIterator assertSorted(final SAMFileHeader.SortOrder sortOrder) {
+
+            if (sortOrder == null || sortOrder == SAMFileHeader.SortOrder.unsorted) {
+                comparator = null;
+                return this;
+            }
+
+            comparator = sortOrder.getComparatorInstance();
+            return this;
+        }
+
+        public SAMRecord next() {
+            final SAMRecord result = wrappedIterator.next();
+            if (comparator != null) {
+                if (previous != null) {
+                    if (comparator.fileOrderCompare(previous, result) > 0) {
+                        throw new IllegalStateException(MessageFormat.format(
+                                "Records {0} ({1}:{2}) should come after {3} ({4}:{5}) when sorting with {6}",
+                                previous.getReadName(),
+                                previous.getReferenceName(),
+                                previous.getAlignmentStart(),
+                                result.getReadName(),
+                                result.getReferenceName(),
+                                result.getAlignmentStart(),
+                                comparator.getClass().getName())
+                        );
+                    }
+                }
+                previous = result;
+            }
+            return result;
+        }
+
+        public void close() { wrappedIterator.close(); }
+
+        public boolean hasNext() { return wrappedIterator.hasNext(); }
+
+        public void remove() { wrappedIterator.remove(); }
+    }
+}

--- a/src/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/java/htsjdk/samtools/SamReaderFactory.java
@@ -1,0 +1,326 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.RuntimeIOException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * <p>Describes the functionality for producing {@link SamReader}, and offers a
+ * handful of static generators.</p>
+ * <pre>
+ *     SamReaderFactory.makeDefault().open(new File("/my/bam.bam");
+ * </pre>
+ * <p>Example: Configure a factory</p>
+ * <pre>
+ *      final {@link SamReaderFactory} factory =
+ *          SamReaderFactory.makeDefault()
+ *              .enable({@link Option#INCLUDE_SOURCE_IN_RECORDS}, {@link Option#VALIDATE_CRC_CHECKSUMS})
+ *              .validationStringency({@link ValidationStringency#SILENT});
+ *
+ * </pre>
+ * <p>Example: Open two bam files from different sources, using different options</p>
+ * <pre>
+ *     final {@link SamReaderFactory} factory =
+ *          SamReaderFactory.makeDefault()
+ *              .enable({@link Option#INCLUDE_SOURCE_IN_RECORDS}, {@link Option#VALIDATE_CRC_CHECKSUMS})
+ *              .validationStringency({@link ValidationStringency#SILENT});
+ *
+ *     // File-based bam
+ *     final {@link SamReader} fileReader = factory.open(new File("/my/bam.bam"));
+ *
+ *     // HTTP-hosted BAM with index from an arbitrary stream
+ *     final SeekableStream myBamIndexStream = ...
+ *     final {@link SamInputResource} resource =
+ *          {@link SamInputResource}.of(new URL("http://example.com/data.bam")).index(myBamIndexStream);
+ *     final {@link SamReader} complicatedReader = factory.open(resource);
+ * </pre>
+ *
+ * @author mccowan
+ */
+public abstract class SamReaderFactory {
+
+    abstract public SamReader open(final File file);
+
+    abstract public SamReader open(final SamInputResource resource);
+
+    abstract public ValidationStringency validationStringency();
+
+    /** Set this factory's {@link htsjdk.samtools.SAMRecordFactory} to the provided one, then returns itself. */
+    abstract public SamReaderFactory samRecordFactory(final SAMRecordFactory samRecordFactory);
+
+    /** Enables the provided {@link Option}s, then returns itself. */
+    abstract public SamReaderFactory enable(final Option... options);
+
+    /** Disables the provided {@link Option}s, then returns itself. */
+    abstract public SamReaderFactory disable(final Option... options);
+
+    /** Set this factory's {@link ValidationStringency} to the provided one, then returns itself. */
+    abstract public SamReaderFactory validationStringency(final ValidationStringency validationStringency);
+
+    private static final SamReaderFactoryImpl DEFAULT =
+            new SamReaderFactoryImpl(Option.DEFAULTS, ValidationStringency.DEFAULT_STRINGENCY, DefaultSAMRecordFactory.getInstance());
+
+    /** Creates a copy of the default {@link SamReaderFactory}. */
+    public static SamReaderFactory makeDefault() {
+        return SamReaderFactoryImpl.copyOf(DEFAULT);
+    }
+
+    /**
+     * Creates an "empty" factory with no enabled {@link Option}s, {@link ValidationStringency#DEFAULT_STRINGENCY}, and 
+     * {@link htsjdk.samtools.DefaultSAMRecordFactory}.
+     */
+    public static SamReaderFactory make() {
+        return new SamReaderFactoryImpl(EnumSet.noneOf(Option.class), ValidationStringency.DEFAULT_STRINGENCY, DefaultSAMRecordFactory.getInstance());
+    }
+
+    private static class SamReaderFactoryImpl extends SamReaderFactory {
+        private final EnumSet<Option> enabledOptions;
+        private ValidationStringency validationStringency;
+        private SAMRecordFactory samRecordFactory;
+
+        private SamReaderFactoryImpl(final EnumSet<Option> enabledOptions, final ValidationStringency validationStringency, final SAMRecordFactory samRecordFactory) {
+            this.enabledOptions = EnumSet.copyOf(enabledOptions);
+            this.samRecordFactory = samRecordFactory;
+            this.validationStringency = validationStringency;
+        }
+
+        @Override
+        public SamReader open(final File file) {
+            final SamInputResource r = SamInputResource.of(file);
+            final File indexMaybe = SamFiles.findIndex(file);
+            if (indexMaybe != null) r.index(indexMaybe);
+            return open(r);
+        }
+
+
+        @Override
+        public ValidationStringency validationStringency() {
+            return validationStringency;
+        }
+
+        @Override
+        public SamReaderFactory samRecordFactory(final SAMRecordFactory samRecordFactory) {
+            this.samRecordFactory = samRecordFactory;
+            return this;
+        }
+
+        @Override
+        public SamReaderFactory enable(final Option... options) {
+            Collections.addAll(this.enabledOptions, options);
+            return this;
+        }
+
+        @Override
+        public SamReaderFactory disable(final Option... options) {
+            for (final Option option : options) {
+                this.enabledOptions.remove(option);
+            }
+            return this;
+        }
+
+        @Override
+        public SamReaderFactory validationStringency(final ValidationStringency validationStringency) {
+            this.validationStringency = validationStringency;
+            return this;
+        }
+
+        @Override
+        public SamReader open(final SamInputResource resource) {
+            final SamReader.PrimitiveSamReader primitiveSamReader;
+            try {
+                final InputResource data = resource.data();
+                final InputResource indexMaybe = resource.indexMaybe();
+                final boolean indexDefined = indexMaybe != null;
+
+                final InputResource.Type type = data.type();
+                if (type == InputResource.Type.SEEKABLE_STREAM || type == InputResource.Type.URL) {
+                    if (SamStreams.sourceLikeBam(data.asUnbufferedSeekableStream())) {
+                        final SeekableStream bufferedIndexStream;
+                        if (indexDefined && indexMaybe.asUnbufferedSeekableStream() != null) {
+                            bufferedIndexStream = IOUtil.maybeBufferedSeekableStream(indexMaybe.asUnbufferedSeekableStream());
+                        } else {
+                            // TODO: Throw an exception here?  An index _may_ have been provided, but we're ignoring it
+                            bufferedIndexStream = null;
+                        }
+                        primitiveSamReader = new BAMFileReader(
+                                IOUtil.maybeBufferedSeekableStream(data.asUnbufferedSeekableStream()),
+                                bufferedIndexStream,
+                                false,
+                                validationStringency,
+                                this.samRecordFactory
+                        );
+                    } else {
+                        throw new SAMFormatException("Unrecognized file format: " + data.asUnbufferedSeekableStream());
+                    }
+                } else {
+                    final InputStream bufferedStream =
+                            IOUtil.maybeBufferInputStream(
+                                    data.asUnbufferedInputStream(),
+                                    Math.max(Defaults.BUFFER_SIZE, BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE)
+                            );
+                    final File sourceFile = data.asFile();
+                    final File indexFile = indexMaybe == null ? null : indexMaybe.asFile();
+                    if (SamStreams.isBAMFile(bufferedStream)) {
+                        if (sourceFile == null || !sourceFile.isFile()) {
+                            // Handle case in which file is a named pipe, e.g. /dev/stdin or created by mkfifo
+                            primitiveSamReader = new BAMFileReader(bufferedStream, indexFile, false, validationStringency, this.samRecordFactory);
+                        } else {
+                            bufferedStream.close();
+                            primitiveSamReader = new BAMFileReader(sourceFile, indexFile, false, validationStringency, this.samRecordFactory);
+                        }
+                    } else if (BlockCompressedInputStream.isValidFile(bufferedStream)) {
+                        primitiveSamReader = new SAMTextReader(new BlockCompressedInputStream(bufferedStream), validationStringency, this.samRecordFactory);
+                    } else if (SamStreams.isGzippedSAMFile(bufferedStream)) {
+                        primitiveSamReader = new SAMTextReader(new GZIPInputStream(bufferedStream), validationStringency, this.samRecordFactory);
+                    } else {
+                        if (indexDefined) {
+                            bufferedStream.close();
+                            throw new RuntimeException("Cannot use index file with textual SAM file");
+                        }
+                        primitiveSamReader = new SAMTextReader(bufferedStream, sourceFile, validationStringency, this.samRecordFactory);
+                    }
+                }
+
+                // Apply the options defined by this factory to this reader
+                final SamReader.PrimitiveSamReaderToSamReaderAdapter reader =
+                        new SamReader.PrimitiveSamReaderToSamReaderAdapter(primitiveSamReader);
+
+                for (final Option option : enabledOptions) {
+                    option.applyTo(reader);
+                }
+
+                return reader;
+            } catch (final IOException e) {
+                throw new RuntimeIOException(e);
+            }
+        }
+
+        public static SamReaderFactory copyOf(final SamReaderFactoryImpl target) {
+            return new SamReaderFactoryImpl(target.enabledOptions, target.validationStringency, target.samRecordFactory);
+        }
+    }
+
+    /** A collection of binary {@link SamReaderFactory} options. */
+    public enum Option {
+        /**
+         * The factory's {@link SamReader}s will produce populated (non-null) values when calling {@link SAMRecord#getFileSource()}.
+         * <p/>
+         * This option increases memory footprint slightly per {@link htsjdk.samtools.SAMRecord}.
+         */
+        INCLUDE_SOURCE_IN_RECORDS {
+            @Override
+            void applyTo(final BAMFileReader underlyingReader, final SamReader reader) {
+                underlyingReader.enableFileSource(reader, true);
+            }
+
+            @Override
+            void applyTo(final SAMTextReader underlyingReader, final SamReader reader) {
+                underlyingReader.enableFileSource(reader, true);
+            }
+        },
+
+        /**
+         * The factory's {@link SamReader}s' {@link SamReader#indexing()}'s calls to {@link SamReader.Indexing#getIndex()} will produce
+         * {@link BAMIndex}es that do some caching in memory instead of reading the index from the disk for each query operation.
+         *
+         * @see SamReader#indexing()
+         * @see htsjdk.samtools.SamReader.Indexing#getIndex()
+         */
+        CACHE_FILE_BASED_INDEXES {
+            @Override
+            void applyTo(final BAMFileReader underlyingReader, final SamReader reader) {
+                underlyingReader.enableIndexCaching(true);
+            }
+
+            @Override
+            void applyTo(final SAMTextReader underlyingReader, final SamReader reader) {
+                logDebugIgnoringOption(reader, this);
+            }
+        },
+
+        /**
+         * The factory's {@link SamReader}s' will not use memory mapping for accessing index files (which is used by default).  This is
+         * slower but more scalable when accessing large numbers of BAM files sequentially.
+         *
+         * @see SamReader#indexing()
+         * @see htsjdk.samtools.SamReader.Indexing#getIndex()
+         */
+        DONT_MEMORY_MAP_INDEX {
+            @Override
+            void applyTo(final BAMFileReader underlyingReader, final SamReader reader) {
+                underlyingReader.enableIndexMemoryMapping(false);
+            }
+
+            @Override
+            void applyTo(final SAMTextReader underlyingReader, final SamReader reader) {
+                logDebugIgnoringOption(reader, this);
+            }
+        },
+
+        /**
+         * Eagerly decode {@link htsjdk.samtools.SamReader}'s {@link htsjdk.samtools.SAMRecord}s, which can reduce memory footprint if many
+         * fields are being read per record, or if fields are going to be updated.
+         */
+        EAGERLY_DECODE {
+            @Override
+            void applyTo(final BAMFileReader underlyingReader, final SamReader reader) {
+                underlyingReader.setEagerDecode(true);
+            }
+
+            @Override
+            void applyTo(final SAMTextReader underlyingReader, final SamReader reader) {
+                logDebugIgnoringOption(reader, this);
+            }
+        },
+
+        /**
+         * For {@link htsjdk.samtools.SamReader}s backed by block-compressed streams, enable CRC validation of those streams.  This is an
+         * expensive operation, but serves to ensure validity of the stream.
+         */
+        VALIDATE_CRC_CHECKSUMS {
+            @Override
+            void applyTo(final BAMFileReader underlyingReader, final SamReader reader) {
+                underlyingReader.enableCrcChecking(true);
+            }
+
+            @Override
+            void applyTo(final SAMTextReader underlyingReader, final SamReader reader) {
+                logDebugIgnoringOption(reader, this);
+            }
+        };
+
+        public static EnumSet<Option> DEFAULTS = EnumSet.noneOf(Option.class);
+
+        /** Applies this option to the provided reader, if applicable. */
+        void applyTo(final SamReader.PrimitiveSamReaderToSamReaderAdapter reader) {
+            final SamReader.PrimitiveSamReader underlyingReader = reader.underlyingReader();
+            if (underlyingReader instanceof BAMFileReader) {
+                applyTo((BAMFileReader) underlyingReader, reader);
+            } else if (underlyingReader instanceof SAMTextReader) {
+                applyTo((SAMTextReader) underlyingReader, reader);
+            } else {
+                throw new IllegalArgumentException(String.format("Unrecognized reader type: %s.", underlyingReader.getClass()));
+            }
+        }
+
+        private static void logDebugIgnoringOption(final SamReader r, final Option option) {
+            LOG.debug(String.format("Ignoring %s option; does not apply to %s readers.", option, r.getClass().getSimpleName()));
+        }
+
+        private final static Log LOG = Log.getInstance(Option.class);
+
+        abstract void applyTo(final BAMFileReader underlyingReader, final SamReader reader);
+
+        abstract void applyTo(final SAMTextReader underlyingReader, final SamReader reader);
+    }
+}

--- a/src/java/htsjdk/samtools/SamStreams.java
+++ b/src/java/htsjdk/samtools/SamStreams.java
@@ -1,0 +1,82 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.BlockCompressedStreamConstants;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Utilities related to processing of {@link java.io.InputStream}s encoding SAM data
+ * 
+ * @author mccowan
+ */
+public class SamStreams {
+    private static int readBytes(final InputStream stream, final byte[] buffer, final int offset, final int length)
+            throws IOException {
+        int bytesRead = 0;
+        while (bytesRead < length) {
+            final int count = stream.read(buffer, offset + bytesRead, length - bytesRead);
+            if (count <= 0) {
+                break;
+            }
+            bytesRead += count;
+        }
+        return bytesRead;
+    }
+
+    /**
+     * @param stream stream.markSupported() must be true
+     * @return true if this looks like a BAM file.
+     */
+    public static boolean isBAMFile(final InputStream stream)
+            throws IOException {
+        if (!BlockCompressedInputStream.isValidFile(stream)) {
+            return false;
+        }
+        final int buffSize = BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE;
+        stream.mark(buffSize);
+        final byte[] buffer = new byte[buffSize];
+        readBytes(stream, buffer, 0, buffSize);
+        stream.reset();
+        final byte[] magicBuf = new byte[4];
+        final int magicLength = readBytes(new BlockCompressedInputStream(new ByteArrayInputStream(buffer)), magicBuf, 0, 4);
+        return magicLength == BAMFileConstants.BAM_MAGIC.length && Arrays.equals(BAMFileConstants.BAM_MAGIC, magicBuf);
+    }
+
+    // Its too expensive to examine the remote file to determine type.
+    // Rely on file extension.
+    public static boolean sourceLikeBam(final SeekableStream strm) {
+        String source = strm.getSource();
+        if (source == null) return true;
+        source = source.toLowerCase();
+        //Source will typically be a file path or URL
+        //If it's a URL we require one of the query parameters to be bam file
+        return source.endsWith(".bam") || source.contains(".bam?") || source.contains(".bam&") || source.contains(".bam%26");
+    }
+
+    public static boolean isGzippedSAMFile(final InputStream stream) {
+        if (!stream.markSupported()) {
+            throw new IllegalArgumentException("Cannot test a stream that doesn't support marking.");
+        }
+        stream.mark(8000);
+
+        try {
+            final GZIPInputStream gunzip = new GZIPInputStream(stream);
+            final int ch = gunzip.read();
+            return true;
+        } catch (final IOException ioe) {
+            return false;
+        } finally {
+            try {
+                stream.reset();
+            } catch (final IOException ioe) {
+                throw new IllegalStateException("Could not reset stream.");
+            }
+        }
+    }
+}

--- a/src/java/htsjdk/samtools/StreamInflatingIndexingOutputStream.java
+++ b/src/java/htsjdk/samtools/StreamInflatingIndexingOutputStream.java
@@ -67,7 +67,7 @@ class Indexer implements Runnable {
     public void run() {
         final SAMFileReader in = new SAMFileReader(this.stream);
         in.enableFileSource(true);
-        in.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        in.setValidationStringency(ValidationStringency.SILENT);
         in.enableCrcChecking(false);
         final BAMIndexer indexer = new BAMIndexer(this.index, in.getFileHeader());
         for (final SAMRecord rec : in) {

--- a/src/java/htsjdk/samtools/ValidationStringency.java
+++ b/src/java/htsjdk/samtools/ValidationStringency.java
@@ -1,0 +1,21 @@
+package htsjdk.samtools;
+
+/**
+ * How strict to be when reading a SAM or BAM, beyond bare minimum validation.
+ */
+public enum ValidationStringency {
+    /**
+     * Do the right thing, throw an exception if something looks wrong.
+     */
+    STRICT,
+    /**
+     * Emit warnings but keep going if possible.
+     */
+    LENIENT,
+    /**
+     * Like LENIENT, only don't emit warning messages.
+     */
+    SILENT;
+
+    public static final ValidationStringency DEFAULT_STRINGENCY = STRICT;
+}

--- a/src/java/htsjdk/samtools/example/ExampleSamUsage.java
+++ b/src/java/htsjdk/samtools/example/ExampleSamUsage.java
@@ -23,23 +23,75 @@
  */
 package htsjdk.samtools.example;
 
-import htsjdk.samtools.SAMFileReader;
+import htsjdk.samtools.DefaultSAMRecordFactory;
 import htsjdk.samtools.SAMFileWriter;
 import htsjdk.samtools.SAMFileWriterFactory;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SamInputResource;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.ValidationStringency;
+import htsjdk.samtools.seekablestream.SeekableStream;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 public class ExampleSamUsage {
+    public static SeekableStream myIndexSeekableStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    /** Example usages of {@link htsjdk.samtools.SamReaderFactory} */
+    public void openSamExamples() throws MalformedURLException {
+        /**
+         * Simplest case
+         */
+        final SamReader reader = SamReaderFactory.makeDefault().open(new File("/my.bam"));
+
+        /**
+         * With different reader options
+         */
+        final SamReader readerFromConfiguredFactory =
+                SamReaderFactory.make()
+                        .enable(SamReaderFactory.Option.DONT_MEMORY_MAP_INDEX)
+                        .validationStringency(ValidationStringency.SILENT)
+                        .samRecordFactory(DefaultSAMRecordFactory.getInstance())
+                        .open(new File("/my.bam"));
+
+        /**
+         * With a more complicated source 
+         */
+        final SamReader complicatedReader =
+                SamReaderFactory.makeDefault()
+                        .open(
+                                SamInputResource.of(new URL("http://broadinstitute.org/my.bam")).index(myIndexSeekableStream())
+                        );
+
+        /**
+         * Broken down
+         */
+        final SamReaderFactory factory =
+                SamReaderFactory.makeDefault().enable(SamReaderFactory.Option.VALIDATE_CRC_CHECKSUMS).validationStringency(ValidationStringency.LENIENT);
+
+        final SamInputResource resource = SamInputResource.of(new File("/my.bam")).index(new URL("http://broadinstitute.org/my.bam.bai"));
+
+        final SamReader myReader = factory.open(resource);
+
+        for (final SAMRecord samRecord : myReader) {
+            System.err.print(samRecord);
+        }
+
+    }
+
     /**
      * Read a SAM or BAM file, convert each read name to upper case, and write a new
      * SAM or BAM file.
      */
-    public void convertReadNamesToUpperCase(final File inputSamOrBamFile, final File outputSamOrBamFile) {
+    public void convertReadNamesToUpperCase(final File inputSamOrBamFile, final File outputSamOrBamFile) throws IOException {
 
-        // Open the input file.  Automatically detects whether input is SAM or BAM
-        // and delegates to a reader implementation for the appropriate format.
-        final SAMFileReader inputSam = new SAMFileReader(inputSamOrBamFile);
+        final SamReader reader = SamReaderFactory.makeDefault().open(inputSamOrBamFile);
 
         // makeSAMorBAMWriter() writes a file in SAM text or BAM binary format depending
         // on the file extension, which must be either .sam or .bam.
@@ -51,16 +103,16 @@ public class ExampleSamUsage {
         // can be written to the output file directly rather than being written to a temporary file
         // and sorted after all records have been sent to outputSam.
 
-        final SAMFileWriter outputSam = new SAMFileWriterFactory().makeSAMOrBAMWriter(inputSam.getFileHeader(),
+        final SAMFileWriter outputSam = new SAMFileWriterFactory().makeSAMOrBAMWriter(reader.getFileHeader(),
                 true, outputSamOrBamFile);
 
-        for (final SAMRecord samRecord : inputSam) {
+        for (final SAMRecord samRecord : reader) {
             // Convert read name to upper case.
             samRecord.setReadName(samRecord.getReadName().toUpperCase());
             outputSam.addAlignment(samRecord);
         }
 
         outputSam.close();
-        inputSam.close();
+        reader.close();
     }
 }

--- a/src/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/java/htsjdk/samtools/util/IOUtil.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.seekablestream.SeekableBufferedStream;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
+import htsjdk.samtools.seekablestream.SeekableHTTPStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import org.apache.tools.bzip2.CBZip2InputStream;
 import org.apache.tools.bzip2.CBZip2OutputStream;
@@ -37,6 +38,13 @@ import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URL;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -69,10 +77,11 @@ public class IOUtil {
     /**
      * @deprecated Use Defaults.NON_ZERO_BUFFER_SIZE instead.
      */
-    @Deprecated public static final int STANDARD_BUFFER_SIZE = Defaults.NON_ZERO_BUFFER_SIZE;
+    @Deprecated
+    public static final int STANDARD_BUFFER_SIZE = Defaults.NON_ZERO_BUFFER_SIZE;
 
-    public static final long ONE_GB   = 1024 * 1024 * 1024;
-    public static final long TWO_GBS  = 2 * ONE_GB;
+    public static final long ONE_GB = 1024 * 1024 * 1024;
+    public static final long TWO_GBS = 2 * ONE_GB;
     public static final long FIVE_GBS = 5 * ONE_GB;
 
     /** Possible extensions for VCF files and related formats. */
@@ -80,6 +89,7 @@ public class IOUtil {
 
     /**
      * Wrap the given stream in a BufferedInputStream, if it isn't already wrapper
+     *
      * @param stream stream to be wrapped
      * @return A BufferedInputStream wrapping stream, or stream itself if stream instanceof BufferedInputStream.
      */
@@ -140,14 +150,18 @@ public class IOUtil {
             throw new RuntimeIOException(e);
         }
     }
-    
+
+    public static SeekableStream maybeBufferedSeekableStream(final URL url) {
+        return maybeBufferedSeekableStream(new SeekableHTTPStream(url));
+    }
+
     /**
      * @return If Defaults.BUFFER_SIZE > 0, wrap is in BufferedInputStream, else return is itself.
      */
     public static InputStream maybeBufferInputStream(final InputStream is) {
         return maybeBufferInputStream(is, Defaults.BUFFER_SIZE);
     }
-    
+
     /**
      * @return If bufferSize > 0, wrap is in BufferedInputStream, else return is itself.
      */
@@ -177,6 +191,7 @@ public class IOUtil {
 
     /**
      * Delete a list of files, and write a warning message if one could not be deleted.
+     *
      * @param files Files to be deleted.
      */
     public static void deleteFiles(final File... files) {
@@ -213,8 +228,8 @@ public class IOUtil {
                                    final File[] tmpDirs, final long minBytesFree) throws IOException {
         File f = null;
 
-        for (int i=0; i<tmpDirs.length; ++i) {
-            if ( i == tmpDirs.length-1 || tmpDirs[i].getUsableSpace() > minBytesFree) {
+        for (int i = 0; i < tmpDirs.length; ++i) {
+            if (i == tmpDirs.length - 1 || tmpDirs[i].getUsableSpace() > minBytesFree) {
                 f = File.createTempFile(prefix, suffix, tmpDirs[i]);
                 f.deleteOnExit();
                 break;

--- a/src/java/htsjdk/samtools/util/Iterables.java
+++ b/src/java/htsjdk/samtools/util/Iterables.java
@@ -1,0 +1,24 @@
+package htsjdk.samtools.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author mccowan
+ */
+public class Iterables {
+    private Iterables() {
+        
+    }
+
+    public static <T> List<T> slurp(final Iterator<T> iterator) {
+        final List<T> ts = new ArrayList<T>();
+        while (iterator.hasNext()) ts.add(iterator.next());
+        return ts;
+    }
+
+    public static <T> List<T> slurp(final Iterable<T> iterable) {
+        return slurp(iterable.iterator());
+    }
+}

--- a/src/java/htsjdk/samtools/util/SamRecordIntervalIteratorFactory.java
+++ b/src/java/htsjdk/samtools/util/SamRecordIntervalIteratorFactory.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools.util;
 
+import htsjdk.samtools.QueryInterval;
 import htsjdk.samtools.SAMFileReader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.filter.IntervalFilter;
@@ -66,7 +67,7 @@ public class SamRecordIntervalIteratorFactory {
             final IntervalFilter intervalFilter = new IntervalFilter(uniqueIntervals, samReader.getFileHeader());
             return new StopAfterFilteringIterator(samReader.iterator(), intervalFilter, stopAfterSequence, stopAfterPosition);
         } else {
-            final SAMFileReader.QueryInterval[] queryIntervals = new SAMFileReader.QueryInterval[uniqueIntervals.size()];
+            final QueryInterval[] queryIntervals = new QueryInterval[uniqueIntervals.size()];
             for (int i = 0; i < queryIntervals.length; ++i) {
                 final Interval inputInterval = uniqueIntervals.get(i);
                 queryIntervals[i] = samReader.makeQueryInterval(inputInterval.getSequence(),

--- a/src/tests/java/htsjdk/samtools/BAMFileIndexTest.java
+++ b/src/tests/java/htsjdk/samtools/BAMFileIndexTest.java
@@ -235,15 +235,15 @@ public class BAMFileIndexTest
     public void testMultiIntervalQuery(final boolean contained) {
         final List<String> referenceNames = getReferenceNames(BAM_FILE);
 
-        final SAMFileReader.QueryInterval[] intervals = generateRandomIntervals(referenceNames.size(), 1000, new Random());
+        final QueryInterval[] intervals = generateRandomIntervals(referenceNames.size(), 1000, new Random());
         final Set<SAMRecord> multiIntervalRecords = new HashSet<SAMRecord>();
         final Set<SAMRecord> singleIntervalRecords = new HashSet<SAMRecord>();
         final SAMFileReader reader = new SAMFileReader(BAM_FILE);
-        for (final SAMFileReader.QueryInterval interval : intervals) {
+        for (final QueryInterval interval : intervals) {
             consumeAll(singleIntervalRecords, reader.query(referenceNames.get(interval.referenceIndex), interval.start, interval.end, contained));
         }
 
-        final SAMFileReader.QueryInterval[] optimizedIntervals = SAMFileReader.QueryInterval.optimizeIntervals(intervals);
+        final QueryInterval[] optimizedIntervals = QueryInterval.optimizeIntervals(intervals);
         consumeAll(multiIntervalRecords, reader.query(optimizedIntervals, contained));
         final Iterator<SAMRecord> singleIntervalRecordIterator = singleIntervalRecords.iterator();
         boolean failed = false;
@@ -332,8 +332,8 @@ public class BAMFileIndexTest
 
     private void runRandomTest(final File bamFile, final int count, final Random generator) {
         final List<String> referenceNames = getReferenceNames(bamFile);
-        final SAMFileReader.QueryInterval[] intervals = generateRandomIntervals(referenceNames.size(), count, generator);
-        for (final SAMFileReader.QueryInterval interval : intervals) {
+        final QueryInterval[] intervals = generateRandomIntervals(referenceNames.size(), count, generator);
+        for (final QueryInterval interval : intervals) {
             final String refName = referenceNames.get(interval.referenceIndex);
             final int startPos = interval.start;
             final int endPos = interval.end;
@@ -349,8 +349,8 @@ public class BAMFileIndexTest
         }
     }
 
-    private SAMFileReader.QueryInterval[] generateRandomIntervals(final int numReferences, final int count, final Random generator) {
-        final SAMFileReader.QueryInterval[] intervals = new SAMFileReader.QueryInterval[count];
+    private QueryInterval[] generateRandomIntervals(final int numReferences, final int count, final Random generator) {
+        final QueryInterval[] intervals = new QueryInterval[count];
         final int maxCoordinate = 10000000;
         for (int i = 0; i < count; i++) {
             final int referenceIndex = generator.nextInt(numReferences);
@@ -358,7 +358,7 @@ public class BAMFileIndexTest
             final int coord2 = generator.nextInt(maxCoordinate+1);
             final int startPos = Math.min(coord1, coord2);
             final int endPos = Math.max(coord1, coord2);
-            intervals[i] = new SAMFileReader.QueryInterval(referenceIndex, startPos, endPos);
+            intervals[i] = new QueryInterval(referenceIndex, startPos, endPos);
         }
 
         return intervals;

--- a/src/tests/java/htsjdk/samtools/SAMIntegerTagTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMIntegerTagTest.java
@@ -189,7 +189,7 @@ public class SAMIntegerTagTest {
     @Test
     public void testBadBamLenient() {
         final SAMFileReader reader = new SAMFileReader(new File(TEST_DATA_DIR, "variousAttributes.bam"), true);
-        reader.setValidationStringency(SAMFileReader.ValidationStringency.LENIENT);
+        reader.setValidationStringency(ValidationStringency.LENIENT);
         final SAMRecord rec = reader.iterator().next();
         final Map<String, Number> expectedTags = new HashMap<String, Number>();
         expectedTags.put("SB", -128);

--- a/src/tests/java/htsjdk/samtools/SamFileHeaderMergerTest.java
+++ b/src/tests/java/htsjdk/samtools/SamFileHeaderMergerTest.java
@@ -85,7 +85,7 @@ public class SamFileHeaderMergerTest {
             IOUtil.assertFileIsReadable(inFile);
             final SAMFileReader in = new SAMFileReader(inFile);
             // We are now checking for zero-length reads, so suppress complaint about that.
-            in.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+            in.setValidationStringency(ValidationStringency.SILENT);
             readers.add(in);
             headers.add(in.getFileHeader());
         }
@@ -162,7 +162,7 @@ public class SamFileHeaderMergerTest {
             IOUtil.assertFileIsReadable(inFile);
             final SAMFileReader in = new SAMFileReader(inFile);
             // We are now checking for zero-length reads, so suppress complaint about that.
-            in.setValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+            in.setValidationStringency(ValidationStringency.SILENT);
             readers.add(in);
             headers.add(in.getFileHeader());
         }

--- a/src/tests/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/tests/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -1,0 +1,196 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.seekablestream.SeekableHTTPStream;
+import htsjdk.samtools.util.Iterables;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.samtools.util.StopWatch;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SamReaderFactoryTest {
+    private static final File TEST_DATA_DIR = new File("testdata/htsjdk/samtools");
+
+    private static final Log LOG = Log.getInstance(SamReaderFactoryTest.class);
+
+    @Test(dataProvider = "variousFormatReaderTestCases")
+    public void variousFormatReaderTest(final String inputFile) throws IOException {
+        final File input = new File(TEST_DATA_DIR, inputFile);
+        final SamReader reader = SamReaderFactory.makeDefault().open(input);
+        for (final SAMRecord ignored : reader) {
+        }
+        reader.close();
+    }
+
+    @DataProvider(name = "variousFormatReaderTestCases")
+    public Object[][] variousFormatReaderTestCases() {
+        final Object[][] scenarios = new Object[][]{
+                {"block_compressed.sam.gz"},
+                {"uncompressed.sam"},
+                {"compressed.sam.gz"},
+                {"compressed.bam"},
+        };
+        return scenarios;
+    }
+
+    // Tests for the SAMRecordFactory usage
+    class SAMRecordFactoryTester extends DefaultSAMRecordFactory {
+        int samRecordsCreated;
+        int bamRecordsCreated;
+
+        public SAMRecord createSAMRecord(final SAMFileHeader header) {
+            ++samRecordsCreated;
+            return super.createSAMRecord(header);
+        }
+
+        public BAMRecord createBAMRecord(final SAMFileHeader header, final int referenceSequenceIndex, final int alignmentStart, final short readNameLength, final short mappingQuality, final int indexingBin, final int cigarLen, final int flags, final int readLen, final int mateReferenceSequenceIndex, final int mateAlignmentStart, final int insertSize, final byte[] variableLengthBlock) {
+            ++bamRecordsCreated;
+            return super.createBAMRecord(header, referenceSequenceIndex, alignmentStart, readNameLength, mappingQuality, indexingBin, cigarLen, flags, readLen, mateReferenceSequenceIndex, mateAlignmentStart, insertSize, variableLengthBlock);
+        }
+    }
+
+    @Test(dataProvider = "variousFormatReaderTestCases")
+    public void samRecordFactoryTest(final String inputFile) throws IOException {
+        final File input = new File(TEST_DATA_DIR, inputFile);
+
+        final SAMRecordFactoryTester recordFactory = new SAMRecordFactoryTester();
+        final SamReaderFactory readerFactory = SamReaderFactory.makeDefault().samRecordFactory(recordFactory);
+        final SamReader reader = readerFactory.open(input);
+
+        int i = 0;
+        for (final SAMRecord ignored : reader) {
+            ++i;
+        }
+        reader.close();
+
+        Assert.assertTrue(i > 0);
+        if (inputFile.endsWith(".sam") || inputFile.endsWith(".sam.gz")) Assert.assertEquals(recordFactory.samRecordsCreated, i);
+        else if (inputFile.endsWith(".bam")) Assert.assertEquals(recordFactory.bamRecordsCreated, i);
+    }
+
+
+    /**
+     * Unit tests for asserting all permutations of data and index sources read the same records and header.
+     */
+    final File localBam = new File("testdata/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    final File localBamIndex = new File("testdata/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai");
+
+    final URL bamUrl, bamIndexUrl;
+
+    {
+        try {
+            bamUrl = new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam");
+            bamIndexUrl = new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam.bai");
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @DataProvider
+    public Object[][] composeAllPermutationsOfSamInputResource() {
+        final List<SamInputResource> sources = new ArrayList<SamInputResource>();
+        for (final InputResource.Type dataType : InputResource.Type.values()) {
+            sources.add(new SamInputResource(composeInputResourceForType(dataType, false)));
+            for (final InputResource.Type indexType : InputResource.Type.values()) {
+                sources.add(new SamInputResource(
+                        composeInputResourceForType(dataType, false),
+                        composeInputResourceForType(indexType, true)
+                ));
+            }
+        }
+        final Object[][] data = new Object[sources.size()][];
+        for (final SamInputResource source : sources) {
+            data[sources.indexOf(source)] = new Object[]{source};
+        }
+
+        return data;
+    }
+
+    private InputResource composeInputResourceForType(final InputResource.Type type, final boolean forIndex) {
+        final File f = forIndex ? localBamIndex : localBam;
+        final URL url = forIndex ? bamIndexUrl : bamUrl;
+        switch (type) {
+            case FILE:
+                return new FileInputResource(f);
+            case URL:
+                return new UrlInputResource(url);
+            case SEEKABLE_STREAM:
+                return new SeekableStreamInputResource(new SeekableHTTPStream(url));
+            case INPUT_STREAM:
+                try {
+                    return new InputStreamInputResource(new FileInputStream(f));
+                } catch (final FileNotFoundException e) {
+                    throw new RuntimeIOException(e);
+                }
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    final Set<SAMFileHeader> observedHeaders = new HashSet<SAMFileHeader>();
+    final Set<List<SAMRecord>> observedRecordOrdering = new HashSet<List<SAMRecord>>();
+
+    @Test(dataProvider = "composeAllPermutationsOfSamInputResource")
+    public void exhaustInputResourcePermutation(final SamInputResource resource) throws IOException {
+        final SamReader reader = SamReaderFactory.makeDefault().open(resource);
+        LOG.info(String.format("Reading from %s ...", resource));
+        final List<SAMRecord> slurped = Iterables.slurp(reader);
+        final SAMFileHeader fileHeader = reader.getFileHeader();
+        reader.hasIndex();
+        reader.indexing().hasBrowseableIndex();
+        reader.close();
+        
+        /* Ensure all tests have read the same records in the same order or, if this is the first test, set it as the template. */
+        observedHeaders.add(fileHeader);
+        observedRecordOrdering.add(slurped);
+        Assert.assertEquals(observedHeaders.size(), 1, "read different headers than other testcases");
+        Assert.assertEquals(observedRecordOrdering.size(), 1, "read different records than other testcases");
+    }
+
+
+    final Set<List<SAMRecord>> observedRecordOrdering1 = new HashSet<List<SAMRecord>>();
+    final Set<List<SAMRecord>> observedRecordOrdering3 = new HashSet<List<SAMRecord>>();
+    final Set<List<SAMRecord>> observedRecordOrdering20 = new HashSet<List<SAMRecord>>();
+
+    @Test(dataProvider = "composeAllPermutationsOfSamInputResource")
+    public void queryInputResourcePermutation(final SamInputResource resource) throws IOException {
+        final SamReader reader = SamReaderFactory.makeDefault().open(resource);
+        LOG.info(String.format("Query from %s ...", resource));
+        if (reader.hasIndex()) {
+            final StopWatch stopWatch = new StopWatch();
+            stopWatch.start();
+            final SAMRecordIterator q1 = reader.query("chr1", 500000, 100000000, true);
+            observedRecordOrdering1.add(Iterables.slurp(q1));
+            q1.close();
+            final SAMRecordIterator q20 = reader.query("chr20", 1, 1000000, true);
+            observedRecordOrdering20.add(Iterables.slurp(q20));
+            q20.close();
+            final SAMRecordIterator q3 = reader.query("chr3", 1, 10000000, true);
+            observedRecordOrdering3.add(Iterables.slurp(q3));
+            q3.close();
+            stopWatch.stop();
+            LOG.info(String.format("Finished queries in %sms", stopWatch.getElapsedTime()));
+
+            Assert.assertEquals(observedRecordOrdering1.size(), 1, "read different records for chromosome 1");
+            Assert.assertEquals(observedRecordOrdering20.size(), 1, "read different records for chromosome 20");
+            Assert.assertEquals(observedRecordOrdering3.size(), 1, "read different records for chromosome 3");
+        } else if (resource.indexMaybe() != null) {
+            LOG.warn("Resource has an index source, but is not indexed: " + resource);
+        } else {
+            LOG.info("Skipping query operation: no index.");
+        }
+        reader.close();
+    }
+}

--- a/src/tests/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/tests/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -56,8 +56,8 @@ public class ValidateSamFileTest {
 
     @Test
     public void testValidSamFile() throws Exception {
-        final SAMFileReader.ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
-        SAMFileReader.setDefaultValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        final ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
+        SAMFileReader.setDefaultValidationStringency(ValidationStringency.SILENT);
         try {
             final SAMFileReader samReader = new SAMFileReader(new File(TEST_DATA_DIR, "valid.sam"));
             final Histogram<String> results = executeValidation(samReader, null);
@@ -361,8 +361,8 @@ public class ValidateSamFileTest {
 
     @Test
     public void testHeaderValidation() throws Exception {
-        final SAMFileReader.ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
-        SAMFileReader.setDefaultValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        final ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
+        SAMFileReader.setDefaultValidationStringency(ValidationStringency.SILENT);
         try {
             final SAMFileReader samReader = new SAMFileReader(new File(TEST_DATA_DIR, "buggyHeader.sam"));
             final Histogram<String> results = executeValidation(samReader, null);
@@ -375,8 +375,8 @@ public class ValidateSamFileTest {
 
     @Test
     public void testPlatformMissing() throws Exception {
-        final SAMFileReader.ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
-        SAMFileReader.setDefaultValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        final ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
+        SAMFileReader.setDefaultValidationStringency(ValidationStringency.SILENT);
         try {
             final SAMFileReader samReader = new SAMFileReader(new File(TEST_DATA_DIR, "missing_platform_unit.sam"));
             final Histogram<String> results = executeValidation(samReader, null);
@@ -388,8 +388,8 @@ public class ValidateSamFileTest {
 
     @Test
     public void testDuplicateRGIDs() throws Exception {
-        final SAMFileReader.ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
-        SAMFileReader.setDefaultValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        final ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
+        SAMFileReader.setDefaultValidationStringency(ValidationStringency.SILENT);
         try {
             final SAMFileReader samReader = new SAMFileReader(new File(TEST_DATA_DIR, "duplicate_rg.sam"));
             final Histogram<String> results = executeValidation(samReader, null);
@@ -401,8 +401,8 @@ public class ValidateSamFileTest {
 
     @Test
     public void testIndexFileValidation() throws Exception {
-        final SAMFileReader.ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
-        SAMFileReader.setDefaultValidationStringency(SAMFileReader.ValidationStringency.SILENT);
+        final ValidationStringency saveStringency = SAMFileReader.getDefaultValidationStringency();
+        SAMFileReader.setDefaultValidationStringency(ValidationStringency.SILENT);
         try {
             final SAMFileReader samReader = new SAMFileReader(new File(TEST_DATA_DIR, "bad_index.bam"));
             samReader.enableIndexCaching(true);


### PR DESCRIPTION
- Produces `SamReader` objects, which are similar to `SAMFileReader`.
- Deprecate `SAMFileReader`, as `SamReaderFactory` is the preferred approach to creating things that read SAMs.  `SAMFileReader` still functions as normal.
- See `SamReaderFactory`'s javadoc for examples of how to use it.
