### PR TITLE
Remove unnecessary JAVA6_HOME property

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -58,7 +58,6 @@
     <property name="test.debug.port" value="5005" />  <!-- override on the command line if desired -->
 
     <property environment="env"/>
-    <property name="java6.home" value="${env.JAVA6_HOME}"/>
 
     <condition  property="isUnix">
         <os family="unix"/>
@@ -90,10 +89,6 @@
         <path  id="metrics.classpath">
             <pathelement path="${classpath}"/>
             <pathelement location="${classes}"/>
-        </path>
-
-        <path id="java6.lib.ref">
-            <fileset dir="${java6.home}/lib" includes="*.jar"/>
         </path>
     </target>
 


### PR DESCRIPTION
The current ant build depends on a non-standard environmental variable property JAVA6_HOME

``` bash
$ ant
Buildfile: /Users/xxx/working/htsjdk/build.xml

write-version-property:
[propertyfile] Creating new property file: /Users/xxx/working/htsjdk/htsjdk.version.property.xml

init:

compile-samtools:
    [mkdir] Created dir: /Users/xxx/working/htsjdk/classes

BUILD FAILED
/Users/xxx/working/htsjdk/build.xml:119: The following error occurred while executing this line:
/Users/xxx/working/htsjdk/build.xml:264: /Users/xxx/working/htsjdk/${env.JAVA6_HOME}/lib does not exist.

Total time: 0 seconds
```

It is actually not necessary for the build.

``` bash
$ ant
Buildfile: /Users/xxx/working/htsjdk/build.xml

write-version-property:
[propertyfile] Creating new property file: /Users/xxx/working/htsjdk/htsjdk.version.property.xml

init:

compile-samtools:
    [mkdir] Created dir: /Users/xxx/working/htsjdk/classes
    [javac] /Users/xxx/working/htsjdk/build.xml:259: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 222 source files to /Users/xxx/working/htsjdk/classes
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.

compile-tribble:
    [javac] /Users/xxx/working/htsjdk/build.xml:259: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 72 source files to /Users/xxx/working/htsjdk/classes
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.

compile-variant:
    [javac] /Users/xxx/working/htsjdk/build.xml:259: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 60 source files to /Users/xxx/working/htsjdk/classes
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.

compile-src:

compile-samtools-tests:
    [mkdir] Created dir: /Users/xxx/working/htsjdk/testclasses
    [javac] /Users/xxx/working/htsjdk/build.xml:282: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 62 source files to /Users/xxx/working/htsjdk/testclasses
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.

compile-tribble-tests:
    [javac] /Users/xxx/working/htsjdk/build.xml:282: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 22 source files to /Users/xxx/working/htsjdk/testclasses
    [javac] warning: Implicitly compiled files were not subject to annotation processing.
    [javac] Use -proc:none to disable annotation processing or -implicit to specify a policy for implicit compilation.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.
    [javac] 1 warning

compile-variant-tests:
    [javac] /Users/xxx/working/htsjdk/build.xml:282: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 18 source files to /Users/xxx/working/htsjdk/testclasses
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.

compile-tests:

compile:

htsjdk-jar:
    [mkdir] Created dir: /Users/xxx/working/htsjdk/dist
      [jar] Building jar: /Users/xxx/working/htsjdk/dist/htsjdk-1.112.jar
     [copy] Copying 4 files to /Users/xxx/working/htsjdk/dist

all:

BUILD SUCCESSFUL
Total time: 8 seconds
```
