### PR TITLE
removed properties and classpath which are no longer used

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -26,7 +26,6 @@
 <project name="htsjdk" basedir="." default="all">
 
     <property name="src" value="src/java"/>
-    <property name="src.scripts" value="src/scripts"/>
     <property name="src.test" value="src/tests"/>
     <property name="src.test.java" value="${src.test}/java"/>
     <property name="lib" value="lib"/>
@@ -34,7 +33,6 @@
     <property name="classes" value="classes"/>
     <property name="classes.test" value="testclasses"/>
     <property name="scripts" value="src/scripts"/>
-    <property name="reports" value="dist/test"/>
     <property name="test.output" value="dist/test"/>
 
     <property name="javac.target" value="1.6"/>
@@ -48,16 +46,9 @@
     </exec>
     <property name="repository.revision" value=""/>
     <property name="htsjdk-version" value="1.114"/>
-    <property name="sam-version" value="${htsjdk-version}"/>
-    <property name="tribble-version" value="${htsjdk-version}"/>
-    <property name="variant-version" value="${htsjdk-version}"/>
     <property name="htsjdk-version-xml" value="htsjdk.version.property.xml"/>
-    <property name="command_tmp" value=".command_tmp"/>
-    <property name="command-line-html-dir" value="${dist}/html"/>
     <property name="testng.verbosity" value="2"/>
     <property name="test.debug.port" value="5005" />  <!-- override on the command line if desired -->
-
-    <property environment="env"/>
 
     <condition  property="isUnix">
         <os family="unix"/>
@@ -86,10 +77,6 @@
                 <include name="**/*.jar"/>
             </fileset>
         </path>
-        <path  id="metrics.classpath">
-            <pathelement path="${classpath}"/>
-            <pathelement location="${classes}"/>
-        </path>
     </target>
 
     <!-- CLEAN -->
@@ -98,7 +85,6 @@
         <delete dir="${classes.test}"/>
         <delete dir="${test.output}"/>
         <delete dir="${dist}"/>
-        <delete dir="${command_tmp}"/>
         <delete dir="javadoc"/>
         <delete file="${htsjdk-version-xml}"/>
     </target>
@@ -188,9 +174,9 @@
     </target>
 
     <target name="htsjdk-jar" depends="compile-samtools, compile-tribble, compile-variant"
-            description="Builds htsjdk-${sam-version}.jar for inclusion in other projects">
+            description="Builds htsjdk-${htsjdk-version}.jar for inclusion in other projects">
         <mkdir dir="${dist}"/>
-        <jar destfile="${dist}/htsjdk-${sam-version}.jar" compress="no">
+        <jar destfile="${dist}/htsjdk-${htsjdk-version}.jar" compress="no">
             <fileset dir="${classes}" includes ="htsjdk/samtools/**/*.*"/>
             <fileset dir="${classes}" includes="htsjdk/tribble/**/*.*"/>
             <fileset dir="${classes}" includes="htsjdk/variant/**/*.*"/>
@@ -224,7 +210,6 @@
             </classpath>
             <link href="http://java.sun.com/j2se/1.5.0/docs/api/"/>
         </javadoc>
-        <mkdir dir="${command-line-html-dir}"/>
     </target>
 
     <!-- ALL -->


### PR DESCRIPTION
This removes several properties which were left over from the much-more-complicated build.xml that was used before the picard tools were split off.

Since there is only one jar combining samtools, tribble and variant packages, there is no sense in having separate versions for each (and even if separated, it would make sense for the versions to remain synchronized).

A further question would be whether there is any need to continue to separate the compilation of the three packages. If not, the build file could be substantially simplified further.
