### PR TITLE
IntervalTreeMap added two method to test interval overlapping

### DIFF
--- a/src/java/htsjdk/samtools/util/IntervalTreeMap.java
+++ b/src/java/htsjdk/samtools/util/IntervalTreeMap.java
@@ -83,7 +83,8 @@ public class IntervalTreeMap<T>
         return mEntrySet;
     }
 
-    public boolean equals(final Object o) {
+    @SuppressWarnings("rawtypes")
+	public boolean equals(final Object o) {
         if (!(o instanceof IntervalTreeMap)) {
             return false;
         }
@@ -154,7 +155,17 @@ public class IntervalTreeMap<T>
         }
         return size;
     }
-
+    /**
+     * Test overlapping interval 
+     * @param key the interval
+     * @return true if it contains an object overlapping the interval 
+     */
+    public boolean containsOverlapping(final Interval key) {
+        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        return tree!=null && tree.overlappers(key.getStart(), key.getEnd()).hasNext();
+    	}
+    
+    
     public Collection<T> getOverlapping(final Interval key) {
         final List<T> result = new ArrayList<T>();
         final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
@@ -166,7 +177,25 @@ public class IntervalTreeMap<T>
         }
         return result;
     }
-
+    /**
+     * Test if this contains an object that is contained by 'key'
+     * @param key the interval
+     * @return true if it contains an object is contained by 'key'
+     */
+    public boolean containsContained(final Interval key) {
+        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        if(tree==null) return false;
+            final Iterator<IntervalTree.Node<T>> iterator = tree.overlappers(key.getStart(), key.getEnd());
+            while (iterator.hasNext()) {
+                final IntervalTree.Node<T> node = iterator.next();
+                if (node.getStart() >= key.getStart() && node.getEnd() <= key.getEnd()) {
+                    return true;
+                }
+            }
+        return false;
+    }
+    
+    
     public Collection<T> getContained(final Interval key) {
         final List<T> result = new ArrayList<T>();
         final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());

--- a/src/tests/java/htsjdk/samtools/util/IntervalTreeMapTest.java
+++ b/src/tests/java/htsjdk/samtools/util/IntervalTreeMapTest.java
@@ -33,11 +33,20 @@ public class IntervalTreeMapTest {
     public void testBasic() {
         IntervalTreeMap<Interval> m=new IntervalTreeMap<Interval>();
 
-        Interval chr1Interval = new Interval("chr1", 1,100);
+        Interval chr1Interval = new Interval("chr1", 10,100);
         m.put(chr1Interval, chr1Interval);
         Interval chr2Interval = new Interval("chr2", 1,200);
         m.put(chr2Interval, chr2Interval);
-
+        
+        
+        Assert.assertTrue(m.containsContained(new Interval("chr1", 9,101)));
+        Assert.assertTrue(m.containsOverlapping(new Interval("chr1", 50,150)));
+        Assert.assertFalse(m.containsOverlapping(new Interval("chr3", 1,100)));
+        Assert.assertFalse(m.containsOverlapping(new Interval("chr1", 101,150)));
+        Assert.assertFalse(m.containsContained(new Interval("chr1", 11,101)));
+        Assert.assertFalse(m.isEmpty());
+        Assert.assertTrue(m.size()==2);
+        
         final Iterator<Interval> iterator = m.keySet().iterator();
         Assert.assertEquals(iterator.next(), chr1Interval);
         Assert.assertEquals(iterator.next(), chr2Interval);


### PR DESCRIPTION
Added two methods in src/java/htsjdk/samtools/util/IntervalTreeMap.java
 to test if an item in the map  is contained by or overlap an interval. It returns a boolean: it avoids to create a (large) collection.

I also added some tests in src/tests/java/htsjdk/samtools/util/IntervalTreeMapTest.java

```
 java -cp (...) org.testng.TestNG   -testclass htsjdk.samtools.util.IntervalTreeMapTest
[Parser] Running:
  Command line suite


===============================================
Command line suite
Total tests run: 1, Failures: 0, Skips: 0
===============================================
```
