### PR TITLE
Fix nullpointer in SAMFileSpan.merge

### DIFF
--- a/src/java/htsjdk/samtools/SAMFileSpan.java
+++ b/src/java/htsjdk/samtools/SAMFileSpan.java
@@ -284,9 +284,9 @@ class BAMFileSpan implements SAMFileSpan, Serializable {
     public static BAMFileSpan merge(final BAMFileSpan[] spans) {
         final ArrayList<Chunk> inputChunks = new ArrayList<Chunk>();
         for (final BAMFileSpan span : spans) {
-        	if(span != null){
-        		inputChunks.addAll(span.chunks);
-        	}
+            if (span != null) {
+                inputChunks.addAll(span.chunks);
+            }
         }
         return new BAMFileSpan(Chunk.optimizeChunkList(inputChunks, 0));
     }


### PR DESCRIPTION
When index caching is enabled there is sometimes a NullPointer Exception in SAMFileSpan.merge

The reason is that the BAMFileSpan array passed as a parameter can contain null elements. 

You can see creation of that array in:

BAMFileReader.createIndexIterator (line 729)

You can see a call to getSpanOverlapping which creates those BAMFileSpan objects.

a quick look at one of its implementations, for example:
CachingBAMFileIndex.getSpanOverlapping

shows that there are several cases where null can be returned.

This patch fixes the issue.
