### PR TITLE
Binning index context speedup

### DIFF
--- a/src/java/htsjdk/samtools/BinningIndexContent.java
+++ b/src/java/htsjdk/samtools/BinningIndexContent.java
@@ -137,8 +137,7 @@ public class BinningIndexContent {
             return null;
         }
 
-        return Chunk.optimizeChunkList(chunkList, getLinearIndex()
-                .getMinimumOffset(startPos));
+        return Chunk.optimizeChunkList(chunkList, getLinearIndex().getMinimumOffset(startPos));
     }
     /**
      * This class is used to encapsulate the list of Bins store in the BAMIndexContent


### PR DESCRIPTION
BinningIndexContent.getChunksOverlapping showed up as a major bottleneck when profiling one of my test applications. I noticed that it iterates over a lot of Bins, to only look at a handfull of them in the end (for example 5 bins where marked as true in overlappingBins but there where over 10'000 bins to loop through).

This patch makes the function only look at the Bins that are actually interesting. I got a 40% speed improvement in my testcase.
