### PR TITLE
Case of symbolic allele ID string now being preserved as per VCFv4.1 sec...

### DIFF
--- a/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -319,7 +319,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
             builder.id(parts[2]);
 
         final String ref = getCachedString(parts[3].toUpperCase());
-        final String alts = getCachedString(parts[4].toUpperCase());
+        final String alts = getCachedString(parts[4]);
         builder.log10PError(parseQual(parts[5]));
 
         final List<String> filters = parseFilters(getCachedString(parts[6]));

--- a/src/tests/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
@@ -93,6 +93,7 @@ public class VariantContextTestProvider {
         if ( ENABLE_SYMBOLIC_ALLELE_TESTS ) {
             testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "diagnosis_targets_testfile.vcf"));
             testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "VQSR.mixedTest.recal"));
+            testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "breakpoint.vcf"));
         }
     }
 

--- a/src/tests/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
+++ b/src/tests/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
@@ -1,0 +1,24 @@
+package htsjdk.variant.vcf;
+
+import java.io.File;
+
+import htsjdk.variant.VariantBaseTest;
+import htsjdk.variant.variantcontext.VariantContext;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+
+public class AbstractVCFCodecTest extends VariantBaseTest {
+	@Test
+	public void shouldPreserveSymbolicAlleleCase() {
+		VCFFileReader reader = new VCFFileReader(new File(VariantBaseTest.variantTestDataRoot + "breakpoint.vcf"), false);
+		VariantContext variant = reader.iterator().next();
+		reader.close();
+		
+		// VCF v4.1 s1.4.5
+		// Tools processing VCF files are not required to preserve case in the allele String, except for IDs, which are case sensitive.
+		Assert.assertTrue(variant.getAlternateAllele(0).getDisplayString().contains("chr12"));
+	}
+}

--- a/testdata/htsjdk/variant/breakpoint.vcf
+++ b/testdata/htsjdk/variant/breakpoint.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.1
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##contig=<ID=chr12,length=133851895>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr12	203475	.	T	t[chr12:203540[	36	.	SVTYPE=BND
+chr12	203475	.	T	T[chr12:203540[	36	.	SVTYPE=BND


### PR DESCRIPTION
Fix for incorrect conversion to uppercase of breakpoint alt alleles containing contig or id string name
