### PR TITLE
Bug fix in `RelativeIso8601Date`: non-lazy times are not deserialized properly.

### DIFF
--- a/src/java/htsjdk/samtools/util/RelativeIso8601Date.java
+++ b/src/java/htsjdk/samtools/util/RelativeIso8601Date.java
@@ -22,7 +22,7 @@ public class RelativeIso8601Date extends Iso8601Date {
     public static final String LAZY_NOW_LABEL = "NOW";
     
     /** Flag that indicates this instance is lazy and has not yet been queried (and so its value should be updated at the next query). */
-    private boolean doSetTimeNextQuery;
+    private boolean doSetTimeNextQuery = false;
 
     /** Returns a "lazy now" instance. */
     public static RelativeIso8601Date generateLazyNowInstance() {
@@ -45,7 +45,7 @@ public class RelativeIso8601Date extends Iso8601Date {
 
     /** Updates the time stored by this instance if it's a "lazy now" instance and has never been stored. */
     private synchronized void conditionallyUpdateTime() {
-        if (!doSetTimeNextQuery) {
+        if (doSetTimeNextQuery) {
             super.setTime(System.currentTimeMillis());
             doSetTimeNextQuery = false;
         }

--- a/src/tests/java/htsjdk/samtools/util/RelativeIso8601DateTest.java
+++ b/src/tests/java/htsjdk/samtools/util/RelativeIso8601DateTest.java
@@ -16,24 +16,34 @@ public class RelativeIso8601DateTest {
         Assert.assertEquals(lazy.toString(), RelativeIso8601Date.LAZY_NOW_LABEL);
         Assert.assertEquals(lazy.toString(), RelativeIso8601Date.LAZY_NOW_LABEL);
         Assert.assertEquals(lazy.toString(), RelativeIso8601Date.LAZY_NOW_LABEL);
-        Assert.assertEquals((double) lazy.getTime(), (double) System.currentTimeMillis(), 2000d); // Up to 2 seconds off; iso truncates milliseconds.
+        Assert.assertEquals(lazy.getTime(), new Iso8601Date(new Date(System.currentTimeMillis())).getTime(), 1000); // 1 second resolution is ISO date
         // Assert no exception thrown; this should be valid, because toString should now return an iso-looking date.
-        new RelativeIso8601Date(lazy.toString());
+        new Iso8601Date(lazy.toString());
     }
 
     @Test
     public void testNonLazyInstance() {
+        final long time = new Iso8601Date(new Date(System.currentTimeMillis())).getTime(); // ISO strips off milliseconds
+
         // Test both constructor methods
         final List<RelativeIso8601Date> testDates = Arrays.<RelativeIso8601Date>asList(
-                new RelativeIso8601Date(new Date()),
-                new RelativeIso8601Date(new Iso8601Date(new Date()).toString())
+                new RelativeIso8601Date(new Date(time)),
+                new RelativeIso8601Date(new Iso8601Date(new Date(time)).toString())
         );
 
         for (final RelativeIso8601Date nonLazy : testDates) {
             Assert.assertFalse(nonLazy.toString().equals(RelativeIso8601Date.LAZY_NOW_LABEL));
-            Assert.assertEquals((double) nonLazy.getTime(), (double) System.currentTimeMillis(), 1d);
+            Assert.assertEquals((double) nonLazy.getTime(), (double) time);
             // Assert no exception thrown; this should be valid, because toString return an iso-looking date.
             new RelativeIso8601Date(nonLazy.toString());
         }
+    }
+
+    @Test
+    public void equalityTest() {
+        final String s = new Iso8601Date(new Date(12345)).toString();
+        final Iso8601Date iso8601Date = new Iso8601Date(s);
+        final RelativeIso8601Date relativeIso8601Date = new RelativeIso8601Date(s);
+        Assert.assertEquals(relativeIso8601Date.getTime(), iso8601Date.getTime());
     }
 }


### PR DESCRIPTION
- Tighten up unit tests, while I'm at it.
