### PR TITLE
Avoid recursion using math.

### DIFF
--- a/src/tests/java/htsjdk/variant/variantcontext/GenotypeLikelihoodsUnitTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/GenotypeLikelihoodsUnitTest.java
@@ -108,6 +108,11 @@ public class GenotypeLikelihoodsUnitTest extends VariantBaseTest {
 
         // some special cases: ploidy = 20, #alleles = 4
         Assert.assertEquals(GenotypeLikelihoods.numLikelihoods(4, 20), 1771);
+        Assert.assertEquals(GenotypeLikelihoods.numLikelihoods(100, 4), 4421275);
+        Assert.assertEquals(GenotypeLikelihoods.numLikelihoods(4, 100), 176851);
+        Assert.assertEquals(GenotypeLikelihoods.numLikelihoods(20, 3), 1540);
+        Assert.assertEquals(GenotypeLikelihoods.numLikelihoods(3, 20), 231);
+        
     }
     
     @Test


### PR DESCRIPTION
This changes how the number of genotype likelihoods are calculated to use a direct solution rather than solve computationally by recursion. It is useful for the unifiedgenotyper when it is called at high ploidy
because the values are not cached and so are recalculated with ~100ks of function calls on each go.

Note that a future pull request could change the caching scheme to use dictionaries and further save time.
