### PR TITLE
Explicitly implementing Closeable on classes and interfaces with close()

### DIFF
--- a/src/java/htsjdk/samtools/AbstractBAMFileIndex.java
+++ b/src/java/htsjdk/samtools/AbstractBAMFileIndex.java
@@ -26,6 +26,7 @@ package htsjdk.samtools;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.RuntimeIOException;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/src/java/htsjdk/samtools/BAMIndex.java
+++ b/src/java/htsjdk/samtools/BAMIndex.java
@@ -23,13 +23,15 @@
  */
 package htsjdk.samtools;
 
+import java.io.Closeable;
+
 /**
  * A basic interface for querying BAM indices.
  *
  * @author mhanna
  * @version 0.1
  */
-public interface BAMIndex {
+public interface BAMIndex extends Closeable {
 
     public static final String BAMIndexSuffix = ".bai";
 

--- a/src/java/htsjdk/samtools/BAMIndexWriter.java
+++ b/src/java/htsjdk/samtools/BAMIndexWriter.java
@@ -23,12 +23,14 @@
  */
 package htsjdk.samtools;
 
+import java.io.Closeable;
+
 /**
  * A basic interface for writing BAM index files
  *
  * @author mborkan
  */
-interface BAMIndexWriter {  // note - only package visibility
+interface BAMIndexWriter extends Closeable {  // note - only package visibility
 
     /**
      * Write the data for one alignments to one reference sequence

--- a/src/java/htsjdk/samtools/SAMFileWriter.java
+++ b/src/java/htsjdk/samtools/SAMFileWriter.java
@@ -23,13 +23,15 @@
  */
 package htsjdk.samtools;
 
+import java.io.Closeable;
+
 import htsjdk.samtools.util.ProgressLoggerInterface;
 
 /**
  * Interface for SAMText and BAM file writers.  Clients need not care which they write to,
  * once the object is constructed.
  */
-public interface SAMFileWriter {
+public interface SAMFileWriter extends Closeable {
 
 	void addAlignment(SAMRecord alignment);
 

--- a/src/java/htsjdk/samtools/fastq/FastqWriter.java
+++ b/src/java/htsjdk/samtools/fastq/FastqWriter.java
@@ -1,11 +1,13 @@
 package htsjdk.samtools.fastq;
 
+import java.io.Closeable;
+
 /**
  * Simple interface for a class that can write out fastq records.
  *
  * @author Tim Fennell
  */
-public interface FastqWriter {
+public interface FastqWriter extends Closeable {
     void write(final FastqRecord rec);
     void close();
 }

--- a/src/java/htsjdk/samtools/reference/ReferenceSequenceFile.java
+++ b/src/java/htsjdk/samtools/reference/ReferenceSequenceFile.java
@@ -26,6 +26,7 @@ package htsjdk.samtools.reference;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -34,7 +35,7 @@ import java.io.IOException;
  *
  * @author Tim Fennell
  */
-public interface ReferenceSequenceFile {
+public interface ReferenceSequenceFile extends Closeable {
 
     /**
      * Must return a sequence dictionary with at least the following fields completed

--- a/src/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
+++ b/src/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 
@@ -36,7 +37,7 @@ import java.io.IOException;
  *
  * @author alecw@broadinstitute.org
  */
-public class ReferenceSequenceFileWalker {
+public class ReferenceSequenceFileWalker implements Closeable {
     private final ReferenceSequenceFile referenceSequenceFile;
     private ReferenceSequence referenceSequence = null;
 

--- a/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
+++ b/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
@@ -1,5 +1,6 @@
 package htsjdk.samtools.util;
 
+import java.io.Closeable;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -12,7 +13,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @author Tim Fennell
  */
-public abstract class AbstractAsyncWriter<T> {
+public abstract class AbstractAsyncWriter<T> implements Closeable {
     private static volatile int threadsCreated = 0; // Just used for thread naming.
     public static final int DEFAULT_QUEUE_SIZE = 2000;
 

--- a/src/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/java/htsjdk/samtools/util/BinaryCodec.java
@@ -24,6 +24,7 @@
 package htsjdk.samtools.util;
 
 import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -45,7 +46,7 @@ import java.nio.ByteOrder;
  *
  * @author Dave Tefft
  */
-public class BinaryCodec {
+public class BinaryCodec implements Closeable {
 
     //Outstream to write to
     private OutputStream outputStream;

--- a/src/java/htsjdk/samtools/util/FastLineReader.java
+++ b/src/java/htsjdk/samtools/util/FastLineReader.java
@@ -25,6 +25,7 @@ package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -36,7 +37,7 @@ import java.io.InputStream;
  *
  * @author alecw@broadinstitute.org
  */
-public class FastLineReader {
+public class FastLineReader implements Closeable {
     private InputStream in;
     private byte[] fileBuffer = new byte[512000];
     // Next byte to read in fileBuffer

--- a/src/java/htsjdk/tribble/FeatureReader.java
+++ b/src/java/htsjdk/tribble/FeatureReader.java
@@ -18,6 +18,7 @@
 
 package htsjdk.tribble;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
@@ -25,7 +26,7 @@ import java.util.List;
  * the basic interface that feature sources need to match
  * @param <T> a feature type
  */
-public interface FeatureReader<T extends Feature> {
+public interface FeatureReader<T extends Feature> extends Closeable {
     
     public CloseableTribbleIterator<T> query(final String chr, final int start, final int end) throws IOException;
 

--- a/src/java/htsjdk/tribble/readers/LineReader.java
+++ b/src/java/htsjdk/tribble/readers/LineReader.java
@@ -23,12 +23,13 @@
  */
 package htsjdk.tribble.readers;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
  * Interface for line-oriented readers.
  */
-public interface LineReader {
+public interface LineReader extends Closeable {
 
     /**
      * @return The next "line" from the source. Typically a line is a set of characters

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
@@ -25,13 +25,15 @@
 
 package htsjdk.variant.variantcontext.writer;
 
+import java.io.Closeable;
+
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
 
 /**
  * this class writes VCF files
  */
-public interface VariantContextWriter {
+public interface VariantContextWriter extends Closeable {
 
     public void writeHeader(VCFHeader header);
 


### PR DESCRIPTION
A number of classes and interfaces are missing a definition of Closeable, making usage with try-with-resources and generic close implementations difficult.

There does not appear to be consistent behaviour behind when Closeable is used or not (eg: SAMFileRead does but neither SAMFileWriter nor ReferenceSequenceFile do).
