### PR TITLE
Correctly close underlying reader

### DIFF
--- a/src/java/htsjdk/tribble/TabixFeatureReader.java
+++ b/src/java/htsjdk/tribble/TabixFeatureReader.java
@@ -118,7 +118,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
     }
 
     public void close() throws IOException {
-
+        tabixReader.close();
     }
 
 


### PR DESCRIPTION
Fix a problem with an open TabixReader after calling close() on the TabixFeatureReader.
