### PR TITLE
Fixed race condition where synchronouslyClose() would be called multiple

### DIFF
--- a/htsjdk.ipr
+++ b/htsjdk.ipr
@@ -36,7 +36,9 @@
       </profile>
     </annotationProcessing>
   </component>
-  <component name="CopyrightManager" default="" />
+  <component name="CopyrightManager" default="">
+    <module2copyright />
+  </component>
   <component name="DependencyValidationManager">
     <option name="SKIP_IMPORT_STATEMENTS" value="false" />
   </component>
@@ -89,6 +91,8 @@
         <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
           <option name="REPORT_VARIABLES" value="true" />
           <option name="REPORT_PARAMETERS" value="true" />
+          <option name="REPORT_CATCH_PARAMETERS" value="true" />
+          <option name="REPORT_FOREACH_PARAMETERS" value="true" />
         </inspection_tool>
         <inspection_tool class="SqlNoDataSourceInspection" enabled="false" level="WARNING" enabled_by_default="false" />
         <inspection_tool class="UnusedDeclaration" enabled="false" level="WARNING" enabled_by_default="false">

--- a/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
+++ b/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
@@ -51,7 +51,7 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
 
         checkAndRethrow();
         try { this.queue.put(item); }
-        catch (InterruptedException ie) { throw new RuntimeException("Interrupted queueing item for writing.", ie); }
+        catch (final InterruptedException ie) { throw new RuntimeException("Interrupted queueing item for writing.", ie); }
         checkAndRethrow();
     }
 
@@ -62,14 +62,9 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
     public void close() {
         checkAndRethrow();
 
-        if (this.isClosed.get()) {
-            throw new RuntimeException("AbstractAsyncWriter already closed.");
-        }
-        else {
-            this.isClosed.set(true);
-
+        if (!this.isClosed.getAndSet(true)) {
             try { this.writer.join(); }
-            catch (InterruptedException ie) { throw new RuntimeException("Interrupted waiting on writer thread.", ie); }
+            catch (final InterruptedException ie) { throw new RuntimeException("Interrupted waiting on writer thread.", ie); }
 
             // Assert that the queue is empty
             if (!this.queue.isEmpty()) {
@@ -106,12 +101,12 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
                         final T item = queue.poll(2, TimeUnit.SECONDS);
                         if (item != null) synchronouslyWrite(item);
                     }
-                    catch (InterruptedException ie) {
+                    catch (final InterruptedException ie) {
                         /* Do Nothing */
                     }
                 }
             }
-            catch (Throwable t) {
+            catch (final Throwable t) {
                 ex.compareAndSet(null, t);
                 // In case a writer was blocking on a full queue before ex has been set, clear the queue
                 // so that the writer will no longer be blocked so that it can see the exception.


### PR DESCRIPTION
times if AbstractAsyncWriter.close() called twice simultaneously.
Allowing close() to be called multiple times as per java.io.Closeable
interface specifications.
