### PR TITLE
Ignore generated file htsjdk.version.property.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ intellij.testclasses
 intellij.classes
 
 /bin
+/htsjdk.version.property.xml


### PR DESCRIPTION
This file is generated by build.xml, it doesn't want to be checked in, and we don't want to see it in "Untracked files" all the time.
