### PR TITLE
Bug fix: `IndexStreamBuffer` prematurely throws data-exhaustion error.

### DIFF
--- a/src/java/htsjdk/samtools/AbstractBAMFileIndex.java
+++ b/src/java/htsjdk/samtools/AbstractBAMFileIndex.java
@@ -26,7 +26,6 @@ package htsjdk.samtools;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.RuntimeIOException;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -638,9 +637,26 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
         }
     }
 
-    private static class IndexStreamBuffer extends IndexFileBuffer {
+    static class IndexStreamBuffer extends IndexFileBuffer {
         private final SeekableStream in;
         private final ByteBuffer tmpBuf;
+
+        /** Continually reads from the provided {@link SeekableStream} into the buffer until the specified number of bytes are read, or
+         * until the stream is exhausted, throwing a {@link RuntimeIOException}. */
+        private static void readFully(final SeekableStream in, final byte[] buffer, final int offset, final int length) {
+            int read = 0;
+            while (read < length) {
+                final int readThisLoop;
+                try {
+                    readThisLoop = in.read(buffer, read, length - read);
+                } catch (final IOException e) {
+                    throw new RuntimeIOException(e);
+                }
+                if (readThisLoop == -1) break;
+                read += readThisLoop;
+            }
+            if (read != length) throw new RuntimeIOException("Expected to read " + length + " bytes, but expired stream after " + read + ".");
+        }
 
         public IndexStreamBuffer(final SeekableStream s) {
             in = s;
@@ -656,8 +672,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
         
         @Override
         public void readBytes(final byte[] bytes) {
-            try { in.read(bytes); }
-            catch (final IOException e) { throw new RuntimeIOException(e); }
+            readFully(in, bytes, 0, bytes.length);
         }
         
         @Override
@@ -668,21 +683,13 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
 
         @Override
         public int readInteger() {
-           try {
-               final int r = in.read(tmpBuf.array(), 0, 4);
-               if (r != 4)
-                   throw new RuntimeIOException("Expected 4 bytes, got " + r);
-           } catch (final IOException e) { throw new RuntimeIOException(e); }
-           return tmpBuf.getInt(0);
+            readFully(in, tmpBuf.array(), 0, 4);
+            return tmpBuf.getInt(0);
         }
         
         @Override
         public long readLong() {
-            try {
-                final int r = in.read(tmpBuf.array(), 0, 8);
-                if (r != 8)
-                    throw new RuntimeIOException("Expected 8 bytes, got " + r);
-            } catch (final IOException e) { throw new RuntimeIOException(e); }
+            readFully(in, tmpBuf.array(), 0, 8);
             return tmpBuf.getLong(0);
         }
         

--- a/src/tests/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
+++ b/src/tests/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
@@ -1,0 +1,62 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class AbstractBAMFileIndexTest {
+
+    /**
+     * @see <a href="https://github.com/samtools/htsjdk/issues/73">https://github.com/samtools/htsjdk/issues/73</a>
+     */
+    @Test
+    public static void avoidDataExhaustionTest() {
+        final AbstractBAMFileIndex.IndexStreamBuffer buffer = new AbstractBAMFileIndex.IndexStreamBuffer(new SeekableStream() {
+            @Override
+            public long length() {
+                return 0;
+            }
+
+            @Override
+            public long position() throws IOException {
+                return 0;
+            }
+
+            @Override
+            public void seek(final long position) throws IOException {
+
+            }
+
+            @Override
+            public int read(final byte[] buffer, final int offset, final int length) throws IOException {
+                return 2; // This is the important line; pretend we feed 2 bytes at a time, which is fewer than any downstream calls ultimately request
+            }
+
+            @Override
+            public void close() throws IOException {
+
+            }
+
+            @Override
+            public boolean eof() throws IOException {
+                return false;
+            }
+
+            @Override
+            public String getSource() {
+                return null;
+            }
+
+            @Override
+            public int read() throws IOException {
+                return 0;
+            }
+        });
+
+        // Ensure these throw no exceptions
+        buffer.readLong();
+        buffer.readInteger();
+        buffer.readBytes(new byte[10000]);
+    }
+}


### PR DESCRIPTION
- When fewer than the requested number of bytes are read from a stream, keep reading until the stream is actually exhausted.
