### PR TITLE
MetricBase NPE fix

### DIFF
--- a/src/java/htsjdk/samtools/metrics/MetricBase.java
+++ b/src/java/htsjdk/samtools/metrics/MetricBase.java
@@ -26,6 +26,7 @@ package htsjdk.samtools.metrics;
 
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.util.FormatUtil;
+import htsjdk.samtools.util.Objects;
 
 import java.lang.reflect.Field;
 
@@ -114,7 +115,7 @@ public class MetricBase {
     public boolean equals(MetricBase that) {
         for (Field field : this.getClass().getFields()) {
             try {
-                if (!field.get(this).equals(field.get(that))) {
+                if (!Objects.equals(field.get(this), field.get(that))) {
                     return false;
                 }
             }

--- a/src/java/htsjdk/samtools/util/Objects.java
+++ b/src/java/htsjdk/samtools/util/Objects.java
@@ -1,0 +1,12 @@
+package htsjdk.samtools.util;
+
+/**
+ * Subset of JDK7's {@link java.util.Objects} for non-JDK7 support. 
+ * 
+ * @author mccowan
+ */
+public class Objects {
+    public static boolean equals(final Object a, final Object b) {
+        return (a == b) || (a != null && a.equals(b));
+    } 
+}


### PR DESCRIPTION
Bug fix: if `this` has a field with value `null`, `equals()` throws a `NullPointerException` despite that being a valid state.
