### PR TITLE
Asynchronous IO performance enhancements

### DIFF
--- a/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
+++ b/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
@@ -63,8 +63,12 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
         checkAndRethrow();
 
         if (!this.isClosed.getAndSet(true)) {
-            try { this.writer.join(); }
-            catch (final InterruptedException ie) { throw new RuntimeException("Interrupted waiting on writer thread.", ie); }
+            try {
+            	this.writer.interrupt(); // signal to writer clean up
+            	this.writer.join();
+            } catch (final InterruptedException ie) {
+            	throw new RuntimeException("Interrupted waiting on writer thread.", ie);
+        	}
 
             // Assert that the queue is empty
             if (!this.queue.isEmpty()) {


### PR DESCRIPTION
Bug fix: Removed 2s idle thread delay when closing asynchronous SAM writer.

Asynchronous IO is currently only performed when writing records. For my use case of reading a SAM/BAM and writing a subset of records to multiple files, asynchronous parsing of the input bam on a background thread improved throughput (and CPU usage) by ~30%.

In addition to the above, basic performance profiling indicates that the performance of BlockingQueue<T> of AbstractAsyncWriter.queue can be improved by batching of records before handing over to the consumer thread (this was done in the above async reader code)

Should I incorporate an enhancement adding input parsing async capability and/or output buffering into this pull request?
