### PR TITLE
Removed closing of internal output stream directly in the BCF2Writer.

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -215,10 +215,9 @@ class BCF2Writer extends IndexingVariantContextWriter {
     public void close() {
         try {
             outputStream.flush();
-            outputStream.close();
         }
         catch ( IOException e ) {
-            throw new RuntimeException("Failed to close BCF2 file");
+            throw new RuntimeException("Failed to flush BCF2 file");
         }
         super.close();
     }


### PR DESCRIPTION
BCF2Writer.close() was calling outputStream.close() and then super.close();
but in IndexingVariantContextWriter's (the super class of BCF2Writer) close() method
it also calls outputStream.close().  So we were double-closing the output stream.

This manifests itself as a problem when we try to write e.g. a compressed bcf file
because the close method tries to do a final write (which fails on the 2nd close).
