### PR TITLE
remove bcel from .classpath

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,7 +4,6 @@
 	<classpathentry kind="src" path="src/tests/java"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="lib/testng/testng-5.5-jdk15.jar"/>
-	<classpathentry kind="lib" path="lib/ant/bcel-5.2.jar"/>
 	<classpathentry kind="lib" path="lib/cofoja/cofoja-1.0-r139.jar"/>
 	<classpathentry kind="lib" path="lib/commons-jexl-2.1.1.jar"/>
 	<classpathentry kind="lib" path="lib/apache-ant-1.8.2-bzip2.jar"/>


### PR DESCRIPTION
bcel is no longer used in htsjdk, and no longer in the lib/ directory, so it does not need to be in .classpath
