### PR TITLE
Jdk8 ternary

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -105,7 +105,7 @@
     </target>
 
     <target name="compile-variant" depends="init, compile-tribble" description="Compile variant files without cleaning">
-        <compile-src includes="htsjdk/variant/**/*.*" compiler.args="-proc:none"/>
+		<compile-src includes="htsjdk/variant/**/*.*"/>
     </target>
 
     <target name="compile-tests" depends="compile-samtools-tests, compile-tribble-tests, compile-variant-tests" description="Compile test files without cleaning"/>
@@ -119,7 +119,7 @@
     </target>
 
     <target name="compile-variant-tests" depends="init" description="Compile variant test files without cleaning">
-        <compile-tests includes="htsjdk/variant/**/*.*" compiler.args="-proc:none"/>
+        <compile-tests includes="htsjdk/variant/**/*.*"/>
     </target>
 
     <!-- TEST -->
@@ -229,7 +229,7 @@
         <attribute name="excludes" default=""/>
         <attribute name="destdir" default="${classes}"/>
         <attribute name="compile.classpath" default="classpath"/>
-        <attribute name="compiler.args" default=""/>
+        <attribute name="compiler.args" default="-proc:none"/>
         <sequential>
         <mkdir dir="${classes}"/>
             <!-- unset the sourcepath attribute in order to compile only files explicitly specified and disable javac's default searching mechanism -->
@@ -251,7 +251,7 @@
     <macrodef name="compile-tests">
         <attribute name="includes" default=""/>
         <attribute name="excludes" default=""/>
-        <attribute name="compiler.args" default=""/>
+        <attribute name="compiler.args" default="-proc:none"/>
 
         <sequential>
             <mkdir dir="${classes.test}"/>

--- a/src/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/java/htsjdk/variant/variantcontext/Genotype.java
@@ -387,7 +387,7 @@ public abstract class Genotype implements Comparable<Genotype> {
         // 2. If ignoreRefState is true, then we want just the bases of the Alleles (ignoring the '*' indicating a ref Allele)
         // 3. So that everything is deterministic with regards to integration tests, we sort Alleles (when the genotype isn't phased, of course)
         return ParsingUtils.join(isPhased() ? PHASED_ALLELE_SEPARATOR : UNPHASED_ALLELE_SEPARATOR,
-                ignoreRefState ? getAlleleStrings() : (isPhased() ? getAlleles() : ParsingUtils.sortList(getAlleles())));
+                ignoreRefState ? (Collection) getAlleleStrings() : (isPhased() ? getAlleles() : ParsingUtils.sortList(getAlleles())));
     }
 
     /**

--- a/src/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
 import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.bcf2.BCF2Codec;
@@ -53,7 +54,7 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
 	public VCFFileReader(final File file, final boolean requireIndex) {
 		this.reader = AbstractFeatureReader.getFeatureReader(
 						file.getAbsolutePath(),
-						isBCF(file) ? new BCF2Codec() : new VCFCodec(),
+						isBCF(file) ? (FeatureCodec) new BCF2Codec() : new VCFCodec(),
 						requireIndex);
 	}
 
@@ -62,7 +63,7 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
         this.reader = AbstractFeatureReader.getFeatureReader(
                 file.getAbsolutePath(),
                 indexFile.getAbsolutePath(),
-                isBCF(file) ? new BCF2Codec() : new VCFCodec(),
+                isBCF(file) ? (FeatureCodec) new BCF2Codec() : new VCFCodec(),
                 requireIndex);
     }
 


### PR DESCRIPTION
Two commits related to jdk8 compatibility.
1. cofoja (at least the version in the `lib/` directory) is not compatible with jdk8. Setting `-proc:none` as the default for all compilation (as it is currently used in compiling 'variant' classes) keeps the cofoja processor from being called. There are no cofoja annotations outside of 'variant' anyway, so this may speed up compilation anyway.
2. There was a change to the JLS with jdk8 in the way that generic LUB type inference is performed for poly expressions, which includes ternary expressions, which can lead to an error message like "error: incompatible types: inferred type does not conform to equality constraint(s)". There is some background in [a question on StackOverflow](http://stackoverflow.com/questions/22509488/generics-compilation-error-with-ternary-operator-in-java-8-but-not-in-java-7). Casting even one of the branches of the ternary expression allows compilation to proceed.

Note that these commits apply cleanly and allow all tests to pass in jdk6 and 7 still. SAMFileHeaderMergerTest fails in jdk8 even when these commits allow for compilation. That is because the test is broken (see pull request #89 )
