### PR TITLE
Added an option to VCFWriter to write the entire FORMAT field, even if t...

### DIFF
--- a/src/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/java/htsjdk/tribble/util/ParsingUtils.java
@@ -210,7 +210,7 @@ public class ParsingUtils {
         }
 
         if (end < 0) {
-            tokens[nTokens++] = aString;
+            tokens[nTokens++] = aString.substring(start);
             return nTokens;
         }
 

--- a/src/java/htsjdk/variant/variantcontext/writer/Options.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/Options.java
@@ -36,5 +36,6 @@ public enum Options {
     DO_NOT_WRITE_GENOTYPES,
     ALLOW_MISSING_FIELDS_IN_HEADER,
     FORCE_BCF,
-    USE_ASYNC_IO            // Turn on or off the use of asynchronous IO for writing output VCF files.
+    USE_ASYNC_IO,            // Turn on or off the use of asynchronous IO for writing output VCF files.
+    WRITE_FULL_FORMAT_FIELD  // Write the complete format field, even if trailing missing values could be trimmed?
 }

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -441,13 +441,15 @@ public class VariantContextWriterBuilder {
             return new VCFWriter(writerFile, writerStream, refDict,
                     options.contains(Options.INDEX_ON_THE_FLY),
                     options.contains(Options.DO_NOT_WRITE_GENOTYPES),
-                    options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER));
+                    options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER),
+                    options.contains(Options.WRITE_FULL_FORMAT_FIELD));
         }
         else {
             return new VCFWriter(writerFile, writerStream, refDict, idxCreator,
                     options.contains(Options.INDEX_ON_THE_FLY),
                     options.contains(Options.DO_NOT_WRITE_GENOTYPES),
-                    options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER));
+                    options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER),
+                    options.contains(Options.WRITE_FULL_FORMAT_FIELD));
         }
     }
 

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterFactory.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterFactory.java
@@ -132,7 +132,8 @@ public class VariantContextWriterFactory {
         return maybeWrapWithAsyncWriter(new VCFWriter(location, output, refDict,
                 options.contains(Options.INDEX_ON_THE_FLY),
                 options.contains(Options.DO_NOT_WRITE_GENOTYPES),
-                options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER)), options);
+                options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER),
+                options.contains(Options.WRITE_FULL_FORMAT_FIELD)), options);
     }
 
     /**
@@ -149,7 +150,8 @@ public class VariantContextWriterFactory {
         return maybeWrapWithAsyncWriter(new VCFWriter(location, output, refDict, indexCreator,
                 options.contains(Options.INDEX_ON_THE_FLY),
                 options.contains(Options.DO_NOT_WRITE_GENOTYPES),
-                options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER)), options);
+                options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER),
+                options.contains(Options.WRITE_FULL_FORMAT_FIELD)), options);
     }
 
     /**
@@ -172,7 +174,8 @@ public class VariantContextWriterFactory {
                 refDict, indexCreator,
                 options.contains(Options.INDEX_ON_THE_FLY),
                 options.contains(Options.DO_NOT_WRITE_GENOTYPES),
-                options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER)), options);
+                options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER),
+                options.contains(Options.WRITE_FULL_FORMAT_FIELD)), options);
     }
 
     /**
@@ -190,7 +193,8 @@ public class VariantContextWriterFactory {
                 refDict, indexCreator,
                 options.contains(Options.INDEX_ON_THE_FLY),
                 options.contains(Options.DO_NOT_WRITE_GENOTYPES),
-                options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER)), options);
+                options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER),
+                options.contains(Options.WRITE_FULL_FORMAT_FIELD)), options);
     }
 
     public static VariantContextWriter create(final File location,

--- a/src/java/htsjdk/variant/vcf/VCFEncoder.java
+++ b/src/java/htsjdk/variant/vcf/VCFEncoder.java
@@ -22,11 +22,11 @@ import java.util.TreeMap;
  */
 public class VCFEncoder {
 
-    /**
-     * The encoding used for VCF files: ISO-8859-1
-     */
-    public static final Charset VCF_CHARSET = Charset.forName("ISO-8859-1");
-    private static final String QUAL_FORMAT_STRING = "%.2f";
+	/**
+	 * The encoding used for VCF files: ISO-8859-1
+	 */
+	public static final Charset VCF_CHARSET = Charset.forName("ISO-8859-1");
+	private static final String QUAL_FORMAT_STRING = "%.2f";
 	private static final String QUAL_FORMAT_EXTENSION_TO_TRIM = ".00";
 
 	private final IntGenotypeFieldAccessors GENOTYPE_FIELD_ACCESSORS = new IntGenotypeFieldAccessors();
@@ -35,14 +35,17 @@ public class VCFEncoder {
 
 	private boolean allowMissingFieldsInHeader = false;
 
+	private boolean outputTrailingFormatFields = false;
+
 	/**
 	 * Prepare a VCFEncoder that will encode records appropriate to the given VCF header, optionally
 	 * allowing missing fields in the header.
 	 */
-	public VCFEncoder(final VCFHeader header, final boolean allowMissingFieldsInHeader) {
+	public VCFEncoder(final VCFHeader header, final boolean allowMissingFieldsInHeader, final boolean outputTrailingFormatFields) {
 		if (header == null) throw new NullPointerException("The VCF header must not be null.");
 		this.header = header;
 		this.allowMissingFieldsInHeader = allowMissingFieldsInHeader;
+		this.outputTrailingFormatFields = outputTrailingFormatFields;
 	}
 
 	/**
@@ -320,9 +323,11 @@ public class VCFEncoder {
 			}
 
 			// strip off trailing missing values
-			for (int i = attrs.size()-1; i >= 0; i--) {
-				if ( isMissingValue(attrs.get(i))) attrs.remove(i);
-				else break;
+			if (!outputTrailingFormatFields) {
+				for (int i = attrs.size() - 1; i >= 0; i--) {
+					if (isMissingValue(attrs.get(i))) attrs.remove(i);
+					else break;
+				}
 			}
 
 			for (int i = 0; i < attrs.size(); i++) {

--- a/src/java/htsjdk/variant/vcf/VCFRecordCodec.java
+++ b/src/java/htsjdk/variant/vcf/VCFRecordCodec.java
@@ -25,7 +25,7 @@ public class VCFRecordCodec implements SortingCollection.Codec<VariantContext> {
 	private BufferedReader inputReader = null;
 
 	public VCFRecordCodec(final VCFHeader header) {
-		this.vcfEncoder = new VCFEncoder(header, false);
+		this.vcfEncoder = new VCFEncoder(header, false, false);
 		// Explicitly set the version because it's not available in the header itself.
 		this.vcfDecoder.setVCFHeader(header, VCFHeaderVersion.VCF4_1);
 	}

--- a/src/tests/java/htsjdk/variant/vcf/VCFEncoderTest.java
+++ b/src/tests/java/htsjdk/variant/vcf/VCFEncoderTest.java
@@ -1,17 +1,28 @@
 package htsjdk.variant.vcf;
 
+import htsjdk.tribble.util.ParsingUtils;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 public class VCFEncoderTest {
 
 	@DataProvider(name = "VCFWriterDoubleFormatTestData")
 	public Object[][] makeVCFWriterDoubleFormatTestData() {
-		List<Object[]> tests = new ArrayList<Object[]>();
+		final List<Object[]> tests = new ArrayList<Object[]>();
 		tests.add(new Object[]{1.0, "1.00"});
 		tests.add(new Object[]{10.1, "10.10"});
 		tests.add(new Object[]{10.01, "10.01"});
@@ -41,5 +52,74 @@ public class VCFEncoderTest {
 	public void testVCFWriterDoubleFormatTestData(final double d, final String expected) {
 		Assert.assertEquals(VCFEncoder.formatVCFDouble(d), expected, "Failed to pretty print double in VCFWriter");
 	}
+
+    @DataProvider(name = "MissingFormatTestData")
+    public Object[][] makeMissingFormatTestData() {
+        final VCFHeader header = createSyntheticHeader(Arrays.asList("Sample1"));
+
+        final VCFEncoder dropMissing = new VCFEncoder(header, false, false);
+        final VCFEncoder keepMissing = new VCFEncoder(header, false, true);
+        final VariantContextBuilder baseVC = new VariantContextBuilder().chr("1").start(1).stop(1).noID().passFilters().log10PError(1).alleles("A", "C");
+        final GenotypeBuilder baseGT = new GenotypeBuilder("Sample1").alleles(Arrays.asList(Allele.NO_CALL, Allele.NO_CALL));
+        final Map<Allele, String> alleleMap = new HashMap<Allele, String>(3);
+        final List<String> formatKeys = Arrays.asList("GT", "AA", "BB");
+        alleleMap.put(Allele.NO_CALL, VCFConstants.EMPTY_ALLELE);
+        alleleMap.put(Allele.create("A", true), "0");
+        alleleMap.put(Allele.create("C", false), "1");
+
+        final List<Object[]> tests = new ArrayList<Object[]>();
+
+        VariantContext vc = baseVC.genotypes(baseGT.attribute("AA", "a").make()).make();
+        tests.add(new Object[]{dropMissing, vc, "./.:a", alleleMap, formatKeys});
+        tests.add(new Object[]{keepMissing, vc, "./.:a:.", alleleMap, formatKeys});
+        baseGT.noAttributes();
+
+        vc = baseVC.genotypes(baseGT.attribute("AA", "a").attribute("BB", 2).make()).make();
+        tests.add(new Object[]{dropMissing, vc, "./.:a:2", alleleMap, formatKeys});
+        tests.add(new Object[]{keepMissing, vc, "./.:a:2", alleleMap, formatKeys});
+        baseGT.noAttributes();
+
+        vc = baseVC.genotypes(baseGT.make()).make();
+        tests.add(new Object[]{dropMissing, vc, "./.", alleleMap, formatKeys});
+        tests.add(new Object[]{keepMissing, vc, "./.:.:.", alleleMap, formatKeys});
+        baseGT.noAttributes();
+
+        vc = baseVC.genotypes(baseGT.attribute("BB", 2).make()).make();
+        tests.add(new Object[]{dropMissing, vc, "./.:.:2", alleleMap, formatKeys});
+        tests.add(new Object[]{keepMissing, vc, "./.:.:2", alleleMap, formatKeys});
+        baseGT.noAttributes();
+
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "MissingFormatTestData")
+    public void testMissingFormatFields(final VCFEncoder encoder, final VariantContext vc, final String expectedLastColumn, final Map<Allele, String> alleleMap, final List<String> genotypeFormatKeys) {
+        final StringBuilder sb = new StringBuilder();
+        final String[] columns = new String[5];
+
+        encoder.addGenotypeData(vc, alleleMap, genotypeFormatKeys, sb);
+        final int nCol = ParsingUtils.split(sb.toString(), columns, VCFConstants.FIELD_SEPARATOR_CHAR);
+        Assert.assertEquals(columns[nCol-1], expectedLastColumn, "Format fields don't handle missing data in the expected way");
+    }
+
+    private Set<VCFHeaderLine> createSyntheticMetadata() {
+        final Set<VCFHeaderLine> metaData = new TreeSet<VCFHeaderLine>();
+
+        metaData.add(new VCFContigHeaderLine(Collections.singletonMap("ID", "1"), 0));
+
+        metaData.add(new VCFFormatHeaderLine("GT", 1, VCFHeaderLineType.String, "x"));
+        metaData.add(new VCFFormatHeaderLine("AA", 1, VCFHeaderLineType.String, "aa"));
+        metaData.add(new VCFFormatHeaderLine("BB", 1, VCFHeaderLineType.Integer, "bb"));
+        return metaData;
+    }
+
+    private VCFHeader createSyntheticHeader() {
+        return new VCFHeader(createSyntheticMetadata());
+    }
+
+    private VCFHeader createSyntheticHeader(final List<String> samples) {
+        return new VCFHeader(createSyntheticMetadata(), samples);
+    }
+
 
 }


### PR DESCRIPTION
...he trailing values are missing and could therefore be trimmed.  Also fixed ParsingUtils.split() to correctly handle the case where the only delimiter is the first character
