### PR TITLE
First step in adding support for getting Reads data from APIs such as Google Genomics

### DIFF
--- a/src/java/htsjdk/samtools/CustomReaderFactory.java
+++ b/src/java/htsjdk/samtools/CustomReaderFactory.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools;
+
+import sun.reflect.Reflection;
+
+import htsjdk.samtools.util.Log;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+
+/**
+ * Factory for creating custom readers for accessing API based resources, 
+ * e.g. ga4gh.
+ * The configuration is controlled via custom_reader property (@see Defaults).
+ * This allows injection of such readers from code bases outside HTSJDK.
+ */
+public class CustomReaderFactory {
+  private final static Log LOG = Log.getInstance(CustomReaderFactory.class);
+  /**
+   * Interface to be implemented by custom factory classes that register
+   * themselves with this factory and are loaded dynamically.
+   */
+  public interface ICustomReaderFactory {
+    SamReader open(URL url);
+  }
+  
+  private static final CustomReaderFactory DEFAULT_FACTORY;
+  private static CustomReaderFactory currentFactory;
+  
+  private String urlPrefix = "";
+  private String factoryClassName = "";
+  private String jarFile = "";
+  private ICustomReaderFactory factory;
+  
+  static {
+      DEFAULT_FACTORY = new CustomReaderFactory();
+      currentFactory = DEFAULT_FACTORY;
+  }
+
+  public static void setInstance(final CustomReaderFactory factory){
+      currentFactory = factory;
+  }
+  
+  public static void resetToDefaultInstance() {
+    setInstance(DEFAULT_FACTORY);
+  }
+
+  public static CustomReaderFactory getInstance(){
+      return currentFactory;
+  }
+  
+  /**
+   * Initializes factory based on the custom_reader property specification.
+   */
+  private CustomReaderFactory() {
+    this(Defaults.CUSTOM_READER_FACTORY);
+  }
+  
+  CustomReaderFactory(String cfg) {
+    final String[] cfgComponents = cfg.split(",");
+    if (cfgComponents.length < 2) {
+      return;
+    }
+    urlPrefix = cfgComponents[0].toLowerCase();
+    factoryClassName = cfgComponents[1];
+    if (cfgComponents.length > 2) {
+      jarFile = cfgComponents[2];
+    }
+  }
+  
+  /**
+   * Lazily creates factory based on the configuration.
+   * @return null if creation fails, factory instance otherwise.
+   */
+  private synchronized ICustomReaderFactory getFactory() {
+    if (factory == null) {
+      try {
+        Class clazz = null;
+        
+        if (!jarFile.isEmpty()) {
+          LOG.info("Attempting to load factory class " + factoryClassName + 
+              " from " + jarFile);
+          final URL jarURL = new URL("file:///"+jarFile);
+          clazz = Class.forName(factoryClassName, true, 
+                    new URLClassLoader (new URL[] { jarURL }, 
+                        this.getClass().getClassLoader()));
+        } else {
+          LOG.info("Attempting to load factory class " + factoryClassName);
+          clazz = Class.forName(factoryClassName);
+        }
+        
+        factory = (ICustomReaderFactory)clazz.newInstance();
+        LOG.info("Created custom factory for " + urlPrefix + " from " + 
+            factoryClassName + " loaded from " + (jarFile.isEmpty() ? 
+                " this jar" : jarFile));
+      } catch (Exception e) {
+        LOG.error(e);
+        return null;
+      }
+    }
+    return factory;
+  }
+  
+  /**
+   * Check if the url is supposed to be handled by the custom factory and if so
+   * attempt to create reader via an instance of this custom factory.
+   * 
+   * @return null if the url is not handled by this factory, SamReader otherwise.
+   */
+  public SamReader maybeOpen(URL url) {
+    if (urlPrefix.isEmpty() || 
+        !url.toString().toLowerCase().startsWith(urlPrefix)) {
+      return null;
+    }
+    LOG.info("Attempting to open " + url + " with custom factory");
+    final ICustomReaderFactory factory = getFactory();
+    if (factory == null) {
+      return null;
+    }
+    return factory.open(url);
+  }
+}

--- a/src/java/htsjdk/samtools/Defaults.java
+++ b/src/java/htsjdk/samtools/Defaults.java
@@ -41,6 +41,13 @@ public class Defaults {
      * writing SAM files (ex. CRAM).
      */
     public static final File REFERENCE_FASTA;
+    
+    /** Custom reader factory able to handle URL based resources like ga4gh.
+     *  Expected format: <url prefix>,<fully qualified factory class name>[,<jar file name>]
+     *  E.g. https://www.googleapis.com/genomics/v1beta/reads/,com.google.genomics.ReaderFactory
+     *  OR https://www.googleapis.com/genomics/v1beta/reads/,com.google.genomics.ReaderFactory,/tmp/genomics.jar
+     */
+    public static final String CUSTOM_READER_FACTORY;
 
     static {
         CREATE_INDEX      = getBooleanProperty("create_index", false);
@@ -56,6 +63,7 @@ public class Defaults {
             NON_ZERO_BUFFER_SIZE = BUFFER_SIZE;
         }
         REFERENCE_FASTA   = getFileProperty("reference_fasta", null);
+        CUSTOM_READER_FACTORY = getStringProperty("custom_reader", "");
     }
 
     /** Gets a string system property, prefixed with "samjdk." using the default if the property does not exist.*/

--- a/src/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/java/htsjdk/samtools/SamReaderFactory.java
@@ -95,11 +95,13 @@ public abstract class SamReaderFactory {
         private final EnumSet<Option> enabledOptions;
         private ValidationStringency validationStringency;
         private SAMRecordFactory samRecordFactory;
+        private CustomReaderFactory customReaderFactory;
 
         private SamReaderFactoryImpl(final EnumSet<Option> enabledOptions, final ValidationStringency validationStringency, final SAMRecordFactory samRecordFactory) {
             this.enabledOptions = EnumSet.copyOf(enabledOptions);
             this.samRecordFactory = samRecordFactory;
             this.validationStringency = validationStringency;
+            this.customReaderFactory = CustomReaderFactory.getInstance();
         }
 
         @Override
@@ -151,6 +153,13 @@ public abstract class SamReaderFactory {
                 final boolean indexDefined = indexMaybe != null;
 
                 final InputResource.Type type = data.type();
+                if (type == InputResource.Type.URL) {
+                  SamReader reader = customReaderFactory.maybeOpen(
+                      data.asUrl());
+                  if (reader != null) {
+                    return reader;
+                  }
+                }
                 if (type == InputResource.Type.SEEKABLE_STREAM || type == InputResource.Type.URL) {
                     if (SamStreams.sourceLikeBam(data.asUnbufferedSeekableStream())) {
                         final SeekableStream bufferedIndexStream;

--- a/src/tests/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/tests/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.util.Iterables;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.StopWatch;
+
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -221,5 +222,35 @@ public class SamReaderFactoryTest {
             LOG.info("Skipping query operation: no index.");
         }
         reader.close();
+    }
+    
+    @Test
+    public void customReaderFactoryTest() throws IOException {
+        try {
+          CustomReaderFactory.setInstance(new CustomReaderFactory(
+              "https://www.googleapis.com/genomics/v1beta/reads/," +
+              "htsjdk.samtools.SamReaderFactoryTest$TestReaderFactory"));
+          final SamReader reader = SamReaderFactory.makeDefault().open(
+              SamInputResource.of(new URL(
+                  "https://www.googleapis.com/genomics/v1beta/reads/?uncompressed.sam")));
+          int i = 0;
+          for (@SuppressWarnings("unused") final SAMRecord ignored : reader) {
+              ++i;
+          }
+          reader.close();
+  
+          Assert.assertTrue(i > 0);
+        } finally {
+          CustomReaderFactory.resetToDefaultInstance();
+        }
+    }
+    
+    public static class TestReaderFactory implements CustomReaderFactory.ICustomReaderFactory {
+      @Override
+      public SamReader open(URL url) {
+        final File file = new File(TEST_DATA_DIR, url.getQuery());
+        LOG.info("Opening customr reader for " + file.toString());
+        return SamReaderFactory.makeDefault().open(file);
+      }
     }
 }


### PR DESCRIPTION
This is following preliminary discussions with @mccowan et al.
Step 1: adding ability to plug in external supplier of SamReader based on a configuration specified in the custom_reader property and using a url prefix of the SamInputResource url to trigger passing the creation request to the external factory.
Subsequent steps will add implementation of the external factory and SamReader based on Google Genomics api in https://github.com/googlegenomics/gatk-tools-java as well as changes in HTSJDK or Picard to use the new SamReader interfaces to take advantage of this capability and allow INPUT=<genomics api url> in Picard tools.
