### PR TITLE
Fixed bug in setSequenceDictionary where updated contigs not being set properly

### DIFF
--- a/src/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
@@ -28,7 +28,7 @@ package htsjdk.variant.vcf;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.tribble.TribbleException;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -59,7 +59,8 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
     }
 
 	VCFContigHeaderLine(final SAMSequenceRecord sequenceRecord, final String assembly) {
-		super(VCFHeader.CONTIG_KEY, new HashMap<String, String>() {{
+        // Using LinkedHashMap to preserve order of keys in contig line (ID, length, assembly)
+        super(VCFHeader.CONTIG_KEY, new LinkedHashMap<String, String>() {{
 			// Now inside an init block in an anon HashMap subclass
 			this.put("ID", sequenceRecord.getSequenceName());
 			this.put("length", Integer.toString(sequenceRecord.getSequenceLength()));
@@ -76,6 +77,7 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
 		final String lengthString = this.getGenericFieldValue("length");
 		if (lengthString == null) throw new TribbleException("Contig " + this.getID() + " does not have a length field.");
 		final SAMSequenceRecord record = new SAMSequenceRecord(this.getID(), Integer.valueOf(lengthString));
+        record.setAssembly(this.getGenericFieldValue("assembly"));
 		record.setSequenceIndex(this.contigIndex);
 		return record;
 	}

--- a/src/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/java/htsjdk/variant/vcf/VCFHeader.java
@@ -206,13 +206,22 @@ public class VCFHeader {
 	 * Completely replaces the contig records in this header with those in the given SAMSequenceDictionary.
 	 */
 	public void setSequenceDictionary(final SAMSequenceDictionary dictionary) {
-		this.contigMetaData.clear();
-		for (final SAMSequenceRecord record : dictionary.getSequences()) {
-			contigMetaData.add(new VCFContigHeaderLine(record, null));
-		}
+        this.contigMetaData.clear();
 
-		this.mMetaData.addAll(contigMetaData);
-	}
+        // Also need to remove contig record lines from mMetaData
+        final List<VCFHeaderLine> toRemove = new ArrayList<VCFHeaderLine>();
+        for (final VCFHeaderLine line : mMetaData) {
+            if (line instanceof VCFContigHeaderLine) {
+                toRemove.add(line);
+            }
+        }
+        mMetaData.removeAll(toRemove);
+        for (final SAMSequenceRecord record : dictionary.getSequences()) {
+            contigMetaData.add(new VCFContigHeaderLine(record, record.getAssembly()));
+        }
+
+        this.mMetaData.addAll(contigMetaData);
+    }
 
 	public VariantContextComparator getVCFRecordComparator() {
 		return new VariantContextComparator(this.getContigLines());


### PR DESCRIPTION
When using setSamSequenceDictionary, there were some problems:
1) The new updated VCFContigHeaderLines were being added to contigMetaData, but the overall mMetaData was not being cleared of the old contig header lines and then all being readded.
2) The assembly (i.e. "b37") was not being added properly to the contig header line and when written, it was written in the wrong order.
