### PR TITLE
in build.xml, changed htsjdk.version.property.xml to htsjdk.version.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ intellij.testclasses
 intellij.classes
 
 /bin
-/htsjdk.version.property.xml
+/htsjdk.version.properties

--- a/build.xml
+++ b/build.xml
@@ -46,7 +46,7 @@
     </exec>
     <property name="repository.revision" value=""/>
     <property name="htsjdk-version" value="1.120"/>
-    <property name="htsjdk-version-xml" value="htsjdk.version.properties"/>
+    <property name="htsjdk-version-file" value="htsjdk.version.properties"/>
     <property name="testng.verbosity" value="2"/>
     <property name="test.debug.port" value="5005" />  <!-- override on the command line if desired -->
 
@@ -64,7 +64,7 @@
     <!-- VERSION PROPERTY --> 
     <target name="write-version-property">
         <propertyfile
-            file="${htsjdk-version-xml}"
+            file="${htsjdk-version-file}"
             comment="htsjdk version">
             <entry  key="htsjdk-version" value="${htsjdk-version}"/>
         </propertyfile>
@@ -86,7 +86,7 @@
         <delete dir="${test.output}"/>
         <delete dir="${dist}"/>
         <delete dir="javadoc"/>
-        <delete file="${htsjdk-version-xml}"/>
+        <delete file="${htsjdk-version-file}"/>
     </target>
 
     <!-- COMPILE -->


### PR DESCRIPTION
in build.xml, changed htsjdk.version.property.xml to htsjdk.version.properties.

See https://github.com/samtools/htsjdk/issues/99

```
$ ant
Buildfile: /home/lindenb/src/htsjdk/build.xml

write-version-property:
[propertyfile] Creating new property file: /home/lindenb/src/htsjdk/htsjdk.version.properties

init:
(...)

$ cat  htsjdk.version.properties
#Wed, 17 Sep 2014 20:28:57 +0200

htsjdk-version=1.120
```
