### PR TITLE
Added ability to open SamReader from string, specifying either a URL or ...

### DIFF
--- a/src/java/htsjdk/samtools/SamInputResource.java
+++ b/src/java/htsjdk/samtools/SamInputResource.java
@@ -9,6 +9,7 @@ import htsjdk.samtools.util.RuntimeIOException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
@@ -65,6 +66,17 @@ public class SamInputResource {
     /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
     public static SamInputResource of(final SeekableStream seekableStream) { return new SamInputResource(new SeekableStreamInputResource(seekableStream)); }
 
+    /** Creates a {@link SamInputResource} from a string specifying *either* a url or a file path */
+    public static SamInputResource of(final String string) { 
+      try {
+        URL url = new URL(string);    // this will throw if its not a url
+        return of(url); 
+      } catch (MalformedURLException e) {
+       // ignore
+      }
+      return of(new File(string));
+    }
+    
     /** Updates the index to point at the provided resource, then returns itself. */
     public SamInputResource index(final File file) {
         this.index = new FileInputResource(file);

--- a/src/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/java/htsjdk/samtools/SamReaderFactory.java
@@ -10,6 +10,8 @@ import htsjdk.samtools.util.RuntimeIOException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.zip.GZIPInputStream;
@@ -50,7 +52,7 @@ import java.util.zip.GZIPInputStream;
 public abstract class SamReaderFactory {
 
     private static ValidationStringency defaultValidationStringency = ValidationStringency.DEFAULT_STRINGENCY;
-
+    
     abstract public SamReader open(final File file);
 
     abstract public SamReader open(final SamInputResource resource);
@@ -92,6 +94,7 @@ public abstract class SamReaderFactory {
     }
 
     private static class SamReaderFactoryImpl extends SamReaderFactory {
+        private final static Log LOG = Log.getInstance(SamReaderFactory.class);
         private final EnumSet<Option> enabledOptions;
         private ValidationStringency validationStringency;
         private SAMRecordFactory samRecordFactory;
@@ -103,7 +106,7 @@ public abstract class SamReaderFactory {
             this.validationStringency = validationStringency;
             this.customReaderFactory = CustomReaderFactory.getInstance();
         }
-
+   
         @Override
         public SamReader open(final File file) {
             final SamInputResource r = SamInputResource.of(file);

--- a/src/tests/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/tests/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -231,8 +231,8 @@ public class SamReaderFactoryTest {
               "https://www.googleapis.com/genomics/v1beta/reads/," +
               "htsjdk.samtools.SamReaderFactoryTest$TestReaderFactory"));
           final SamReader reader = SamReaderFactory.makeDefault().open(
-              SamInputResource.of(new URL(
-                  "https://www.googleapis.com/genomics/v1beta/reads/?uncompressed.sam")));
+              SamInputResource.of(
+              "https://www.googleapis.com/genomics/v1beta/reads/?uncompressed.sam"));
           int i = 0;
           for (@SuppressWarnings("unused") final SAMRecord ignored : reader) {
               ++i;
@@ -252,5 +252,17 @@ public class SamReaderFactoryTest {
         LOG.info("Opening customr reader for " + file.toString());
         return SamReaderFactory.makeDefault().open(file);
       }
+    }
+    
+    @Test
+    public void inputResourceFromStringTest() throws IOException {
+      Assert.assertEquals(SamInputResource.of("http://test.url").data().type(),
+          InputResource.Type.URL);
+      Assert.assertEquals(SamInputResource.of("https://test.url").data().type(),
+          InputResource.Type.URL);
+      Assert.assertEquals(SamInputResource.of("ftp://test.url").data().type(),
+          InputResource.Type.URL);
+      Assert.assertEquals(SamInputResource.of("/a/b/c").data().type(),
+          InputResource.Type.FILE);
     }
 }


### PR DESCRIPTION
...a file path. This will make it easier treat INPUT parameters in Picard tools uniformly regardless of whether they designate a file or URL resoures.
