### PR TITLE
Some support for VCF v4.2 files added

### DIFF
--- a/src/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
@@ -73,6 +73,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
      *
      * If the count is a fixed count, return that.  For example, a field with size of 1 in the header returns 1
      * If the count is of type A, return vc.getNAlleles - 1
+     * If the count is of type R, return vc.getNAlleles
      * If the count is of type G, return the expected number of genotypes given the number of alleles in VC and the
      *   max ploidy among all samples.  Note that if the max ploidy of the VC is 0 (there's no GT information
      *   at all, then implicitly assume diploid samples when computing G values.
@@ -86,6 +87,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
             case INTEGER:       return count;
             case UNBOUNDED:     return -1;
             case A:             return vc.getNAlleles() - 1;
+            case R:             return vc.getNAlleles();
             case G:
                 final int ploidy = vc.getMaxPloidy(2);
                 return GenotypeLikelihoods.numLikelihoods(vc.getNAlleles(), ploidy);
@@ -159,8 +161,10 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
         name = mapping.get("ID");
         count = -1;
         final String numberStr = mapping.get("Number");
-        if ( numberStr.equals(VCFConstants.PER_ALLELE_COUNT) ) {
+        if ( numberStr.equals(VCFConstants.PER_ALTERNATE_COUNT) ) {
             countType = VCFHeaderLineCount.A;
+        } else if ( numberStr.equals(VCFConstants.PER_ALLELE_COUNT) ) {
+            countType = VCFHeaderLineCount.R;
         } else if ( numberStr.equals(VCFConstants.PER_GENOTYPE_COUNT) ) {
             countType = VCFHeaderLineCount.G;
         } else if ( (version.isAtLeastAsRecentAs(VCFHeaderVersion.VCF4_0) && numberStr.equals(VCFConstants.UNBOUNDED_ENCODING_v4)) ||
@@ -218,7 +222,8 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
         map.put("ID", name);
         Object number;
         switch ( countType ) {
-            case A: number = VCFConstants.PER_ALLELE_COUNT; break;
+            case A: number = VCFConstants.PER_ALTERNATE_COUNT; break;
+            case R: number = VCFConstants.PER_ALLELE_COUNT; break;
             case G: number = VCFConstants.PER_GENOTYPE_COUNT; break;
             case UNBOUNDED: number = VCFConstants.UNBOUNDED_ENCODING_v4; break;
             case INTEGER:

--- a/src/java/htsjdk/variant/vcf/VCFConstants.java
+++ b/src/java/htsjdk/variant/vcf/VCFConstants.java
@@ -115,7 +115,8 @@ public final class VCFConstants {
     public static final String MISSING_DEPTH_v3 = "-1";
     public static final String UNBOUNDED_ENCODING_v4 = ".";
     public static final String UNBOUNDED_ENCODING_v3 = "-1";
-    public static final String PER_ALLELE_COUNT = "A";
+    public static final String PER_ALTERNATE_COUNT = "A";
+    public static final String PER_ALLELE_COUNT = "R";
     public static final String PER_GENOTYPE_COUNT = "G";
     public static final String EMPTY_ALLELE = ".";
     public static final String EMPTY_GENOTYPE = "./.";

--- a/src/java/htsjdk/variant/vcf/VCFHeaderLineCount.java
+++ b/src/java/htsjdk/variant/vcf/VCFHeaderLineCount.java
@@ -29,5 +29,5 @@ package htsjdk.variant.vcf;
  * the count encodings we use for fields in VCF header lines
  */
 public enum VCFHeaderLineCount {
-    INTEGER, A, G, UNBOUNDED;
+    INTEGER, A, R, G, UNBOUNDED;
 }


### PR DESCRIPTION
Handles "Number=R" for INFO fields in the header.
Other VCF v4.2 specific additions (Eg: Source and Version fields in INFO header lines) are not handled, but appear to be silently ignored.
Tested on output of samtools mpileup | bcftools call (1.0-17-gfaf4dd6, 1.0-55-gc661821, using htslib 1.0-11-g830ea73)

PS: At least this is sorely needed, since htslib/samtools/bcftools 1.0 produce VCF v4.2.
This is an incomplete fix, since proper v4.2 support should really be added.  However it does appear to be sufficient to get IGV to work properly with my v4.2 VCF files.
