### PR TITLE
Prevent testing from leaving extra files around

### DIFF
--- a/src/tests/java/htsjdk/samtools/BAMFileIndexTest.java
+++ b/src/tests/java/htsjdk/samtools/BAMFileIndexTest.java
@@ -294,6 +294,7 @@ public class BAMFileIndexTest
         }
         writer.close();
         final SAMFileReader bamReader = new SAMFileReader(bamFile);
+        SamFiles.findIndex(bamFile).deleteOnExit();
         Assert.assertEquals(countElements(bamReader.queryContained("chr7", 100, 100)), 1);
         Assert.assertEquals(countElements(bamReader.queryOverlapping("chr7", 100, 100)), 2);
     }

--- a/src/tests/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -43,13 +43,11 @@ public class SAMFileWriterFactoryTest {
         final File outputFile = File.createTempFile("tmp.", BamFileIoUtils.BAM_FILE_EXTENSION);
         outputFile.delete();
         outputFile.deleteOnExit();
-        String basename = outputFile.getName();
-        basename = basename.substring(0, basename.lastIndexOf("."));
-        final File indexFile = new File(outputFile.getParent(), basename + BAMIndex.BAMIndexSuffix);
+        createSmallBam(outputFile);
+        final File indexFile = SamFiles.findIndex(outputFile);
         indexFile.deleteOnExit();
         final File md5File = new File(outputFile.getParent(), outputFile.getName() + ".md5");
         md5File.deleteOnExit();
-        createSmallBam(outputFile);
         Assert.assertTrue(outputFile.length() > 0);
         Assert.assertTrue(indexFile.length() > 0);
         Assert.assertTrue(md5File.length() > 0);

--- a/src/tests/java/htsjdk/samtools/SAMIntegerTagTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMIntegerTagTest.java
@@ -154,14 +154,14 @@ public class SAMIntegerTagTest {
      * @return The same record, after having being written and read back.
      */
     private SAMRecord writeAndReadSamRecord(final String format, SAMRecord rec) throws IOException {
-        final File bamFile = File.createTempFile("test.", "." + format);
-        bamFile.deleteOnExit();
+        final File bamFile = File.createTempFile("htsjdk-writeAndReadSamRecord.", "." + format);
         final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(rec.getHeader(), false, bamFile);
         bamWriter.addAlignment(rec);
         bamWriter.close();
         final SAMFileReader reader = new SAMFileReader(bamFile);
         rec = reader.iterator().next();
         reader.close();
+        bamFile.delete();
         return rec;
     }
 

--- a/src/tests/java/htsjdk/samtools/util/BinaryCodecTest.java
+++ b/src/tests/java/htsjdk/samtools/util/BinaryCodecTest.java
@@ -45,6 +45,7 @@ import java.io.IOException;
   */
 
 public class BinaryCodecTest {
+	public final static String TEST_BASENAME = "htsjdk-BinaryCodecTest";
 
     @Test
     public void testReadAndWrite() throws IOException {
@@ -52,7 +53,8 @@ public class BinaryCodecTest {
         value[0] = 1;
         value[1] = 2;
         //Writing to file
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeBytes(value);
@@ -69,6 +71,7 @@ public class BinaryCodecTest {
         readCodec.readBytes(bytesFromBinaryFile);
         Assert.assertEquals(valuesTwo, bytesFromBinaryFile);
         readCodec.close();
+        outputFile.delete();
     }
 
     @Test
@@ -76,7 +79,8 @@ public class BinaryCodecTest {
         final String value = "Test String to Write";
 
         //Writing to file
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeString(value, true, false);
@@ -97,7 +101,8 @@ public class BinaryCodecTest {
         final int value = 42;
 
         //Writing to file
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeInt(value);
@@ -114,7 +119,8 @@ public class BinaryCodecTest {
     public void testReadAndWriteDouble() throws IOException {
         final double value = 54.4;
 
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeDouble(value);
@@ -131,7 +137,8 @@ public class BinaryCodecTest {
     public void testReadAndWriteLong() throws IOException {
         final long value = 42;
 
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeLong(value);
@@ -149,7 +156,8 @@ public class BinaryCodecTest {
     public void testReadAndWriteFloat()  throws IOException{
         final float value = 42.5F;
 
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeFloat(value);
@@ -168,7 +176,8 @@ public class BinaryCodecTest {
         boolean values[] = {true, false};
 
         for (boolean value : values) {
-            final File outputFile = File.createTempFile("temp", ".bin");
+            final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+            outputFile.deleteOnExit();
             final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
             final BinaryCodec codec = new BinaryCodec(stream);
             codec.writeBoolean(value);
@@ -187,7 +196,8 @@ public class BinaryCodecTest {
         final float fValue = 42.5F;
         final String sValue = "TestString";
 
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeFloat(fValue);
@@ -208,7 +218,8 @@ public class BinaryCodecTest {
         final long startTime = System.currentTimeMillis();
         int i = 0;
 
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         while (i<100){
@@ -242,7 +253,8 @@ public class BinaryCodecTest {
         final long startTime = System.currentTimeMillis();
         int i = 0;
 
-        final File outputFile = File.createTempFile("temp", ".bin");
+        final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
+        outputFile.deleteOnExit();
         final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
         final BinaryCodec codec = new BinaryCodec(stream);
         while (i<100){

--- a/src/tests/java/htsjdk/samtools/util/IoUtilTest.java
+++ b/src/tests/java/htsjdk/samtools/util/IoUtilTest.java
@@ -44,11 +44,11 @@ import java.util.List;
 public class IoUtilTest {
 
     private static final File SLURP_TEST_FILE = new File("testdata/htsjdk/samtools/io/slurptest.txt");
-    private static final File EMPTY_FILE = new File("testdata/htsjdk/samtools/io/empty.txt");;
+    private static final File EMPTY_FILE = new File("testdata/htsjdk/samtools/io/empty.txt");
     private static final File FIVE_SPACES_THEN_A_NEWLINE_THEN_FIVE_SPACES_FILE = new File("testdata/htsjdk/samtools/io/5newline5.txt");
     private static final List<String> SLURP_TEST_LINES = Arrays.asList("bacon   and rice   ","for breakfast  ","wont you join me");
     private static final String SLURP_TEST_LINE_SEPARATOR = "\n";
-    private static final String TEST_FILE_PREFIX = "foo";
+    private static final String TEST_FILE_PREFIX = "htsjdk-IOUtilTest";
     private static final String TEST_FILE_EXTENSIONS[] = { ".txt", ".txt.gz" };
    	private static final String TEST_STRING = "bar!";
     private File existingTempFile;
@@ -72,6 +72,7 @@ public class IoUtilTest {
         for (String ext : TEST_FILE_EXTENSIONS)
         {
             File f = File.createTempFile(TEST_FILE_PREFIX, ext);
+            f.deleteOnExit();
 
             OutputStream os = IOUtil.openFileForWriting(f);
             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(os));

--- a/src/tests/java/htsjdk/tribble/FeatureReaderTest.java
+++ b/src/tests/java/htsjdk/tribble/FeatureReaderTest.java
@@ -24,13 +24,14 @@ import java.util.List;
 
 public class FeatureReaderTest {
     private final static File asciiBedFile = new File(TestUtils.DATA_DIR + "test.bed");
-    private final static File binaryBedFile = new File(TestUtils.OUTPUT_DIR + "test.binary.bed");
+    private File binaryBedFile;
     private final static File tabixBedFile = new File(TestUtils.DATA_DIR + "test.tabix.bed.gz");
 
     @BeforeClass
     public void setup() throws IOException {
-        ExampleBinaryCodec.convertToBinaryTest(asciiBedFile, binaryBedFile, new BEDCodec());
+        binaryBedFile = File.createTempFile("htsjdk-test.featurereader", ".bed");
         binaryBedFile.deleteOnExit();
+        ExampleBinaryCodec.convertToBinaryTest(asciiBedFile, binaryBedFile, new BEDCodec());
     }
 
     @AfterClass

--- a/src/tests/java/htsjdk/tribble/TestUtils.java
+++ b/src/tests/java/htsjdk/tribble/TestUtils.java
@@ -25,5 +25,4 @@ package htsjdk.tribble;
  */
 public class TestUtils {
     public static String DATA_DIR = "testdata/htsjdk/tribble/";
-    public static String OUTPUT_DIR = DATA_DIR + "tmp/";
 }

--- a/src/tests/java/htsjdk/tribble/index/tabix/TabixIndexTest.java
+++ b/src/tests/java/htsjdk/tribble/index/tabix/TabixIndexTest.java
@@ -45,6 +45,7 @@ public class TabixIndexTest {
     public void readWriteTest(final File tabixFile) throws Exception {
         final TabixIndex index = new TabixIndex(tabixFile);
         final File indexFile = File.createTempFile("TabixIndexTest.", TabixUtils.STANDARD_INDEX_EXTENSION);
+        indexFile.deleteOnExit();
         final LittleEndianOutputStream los = new LittleEndianOutputStream(new BlockCompressedOutputStream(indexFile));
         index.write(los);
         los.close();

--- a/src/tests/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
@@ -27,6 +27,7 @@ package htsjdk.variant.variantcontext;
 
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.FeatureCodecHeader;
+import htsjdk.tribble.Tribble;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.tribble.readers.LineIteratorImpl;
 import htsjdk.tribble.readers.LineReaderUtil;
@@ -46,6 +47,7 @@ import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFHeaderLineCount;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
+
 import org.testng.Assert;
 
 import java.io.BufferedInputStream;
@@ -645,6 +647,7 @@ public class VariantContextTestProvider {
 
             final File tmpFile = File.createTempFile("testReaderWriter", tester.getExtension());
             tmpFile.deleteOnExit();
+            Tribble.indexFile(tmpFile).deleteOnExit();
 
             // write expected to disk
             final EnumSet<Options> options = EnumSet.of(Options.INDEX_ON_THE_FLY);
@@ -691,6 +694,7 @@ public class VariantContextTestProvider {
                                         final boolean recurse) throws IOException {
         final File tmpFile = File.createTempFile("testReaderWriter", tester.getExtension());
         tmpFile.deleteOnExit();
+        Tribble.indexFile(tmpFile).deleteOnExit();
 
         // write expected to disk
         final EnumSet<Options> options = EnumSet.of(Options.INDEX_ON_THE_FLY);

--- a/src/tests/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -45,14 +45,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
+	private static final String TEST_BASENAME = "htsjdk-test.VariantContextWriterBuilderUnitTest";
     private SAMSequenceDictionary dictionary;
 
-    private final File vcf = new File("test.vcf");
-    private final File vcfIdx = new File("test.vcf" + Tribble.STANDARD_INDEX_EXTENSION);
-    private final File vcfMD5 = new File("test.vcf.md5");
-    private final File bcf = new File("test.bcf");
-    private final File bcfIdx = new File("test.bcf" + Tribble.STANDARD_INDEX_EXTENSION);
-    private final File unknown = new File("test.unknown");
+    private File vcf;
+    private File vcfIdx;
+    private File vcfMD5;
+    private File bcf;
+    private File bcfIdx;
+    private File unknown;
 
     private List<File> blockCompressedVCFs;
     private List<File> blockCompressedIndices;
@@ -60,28 +61,34 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
     @BeforeSuite
     public void before() throws IOException {
         dictionary = createArtificialSequenceDictionary();
+        vcf = File.createTempFile(TEST_BASENAME, ".vcf");
         vcf.deleteOnExit();
+        vcfIdx = Tribble.indexFile(vcf);
         vcfIdx.deleteOnExit();
+        vcfMD5 = new File(vcf.getAbsolutePath() + ".md5");
         vcfMD5.deleteOnExit();
+        bcf = File.createTempFile(TEST_BASENAME, ".bcf");
         bcf.deleteOnExit();
+        bcfIdx = Tribble.indexFile(bcf);
         bcfIdx.deleteOnExit();
+        unknown = File.createTempFile(TEST_BASENAME, ".unknown");
         unknown.deleteOnExit();
 
         blockCompressedVCFs = new ArrayList<File>();
         blockCompressedIndices = new ArrayList<File>();
         for (final String extension : AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS) {
-            final File blockCompressed = new File("test.vcf" + extension);
+            final File blockCompressed = File.createTempFile(TEST_BASENAME, ".vcf" + extension);
             blockCompressed.deleteOnExit();
             blockCompressedVCFs.add(blockCompressed);
 
-            final File index = new File("test.vcf" + extension + TabixUtils.STANDARD_INDEX_EXTENSION);
+            final File index = new File(blockCompressed.getAbsolutePath() + TabixUtils.STANDARD_INDEX_EXTENSION);
             index.deleteOnExit();
             blockCompressedIndices.add(index);
         }
     }
 
     @Test
-    public void testSetOutputFile() {
+    public void testSetOutputFile() throws IOException {
         final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                 .setReferenceDictionary(dictionary);
 
@@ -94,9 +101,9 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
         Assert.assertFalse(((VCFWriter)writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile VCF File was compressed");
 
         for (final String extension : AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS) {
-            final String filename = "test.vcf" + extension;
-            final File file = new File(filename);
+            final File file = File.createTempFile(TEST_BASENAME + ".setoutput", extension);
             file.deleteOnExit();
+            final String filename = file.getAbsolutePath();
 
             writer = builder.setOutputFile(filename).build();
             Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile " + extension + " String");


### PR DESCRIPTION
The number of files left over in the temp directory after running tests has been bothering me for a while. In many cases this results from having a temporary file created as part of a test that also has a corresponding index file. The latter are not always deleted. This is fixed here.

I also did a few other things for the sake of consistency:
1. Some tribble test temp files were being written in the test data directory rather than the system temp directory. I fixed this.
2. In a few cases, the file names used for a test were very non-descriptive (things like `test32132131.bin`), so I renamed them so that they could be better identified if for some reason they were left hanging around.

I can of course squash if all of this is OK.
