### PR TITLE
Fixed the behavior of BCF2Utils.toList() when it's given an array

### DIFF
--- a/src/java/htsjdk/variant/bcf2/BCF2Utils.java
+++ b/src/java/htsjdk/variant/bcf2/BCF2Utils.java
@@ -36,6 +36,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -271,18 +272,21 @@ public final class BCF2Utils {
      * o is a list => o
      * else => [o]
      *
-     * @param o
+     * @param c  the class of the object
+     * @param o  the object to convert to a Java List
      * @return
      */
-    public static List<Object> toList(final Object o) {
+    public static <T> List<T> toList(final Class<T> c, final Object o) {
         if ( o == null ) return Collections.emptyList();
-        else if ( o instanceof List ) return (List<Object>)o;
+        else if ( o instanceof List ) return (List<T>)o;
         else if ( o.getClass().isArray() ) {
-            final List<Object> l = new ArrayList<Object>();
-            Collections.addAll(l, (int[])o);
-            return l;
+            final int arraySize = Array.getLength(o);
+            final List<T> list = new ArrayList<T>(arraySize);
+            for (int i=0; i<arraySize; i++)
+                list.add((T)Array.get(o, i));
+            return list;
         }
-        else return Collections.singletonList(o);
+        else return Collections.singletonList((T)o);
     }
 
     /**

--- a/src/java/htsjdk/variant/variantcontext/writer/BCF2FieldEncoder.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/BCF2FieldEncoder.java
@@ -363,7 +363,7 @@ public abstract class BCF2FieldEncoder {
                 }
             } else {
                 // handle generic case
-                final List<Double> doubles = toList(Double.class, value);
+                final List<Double> doubles = BCF2Utils.toList(Double.class, value);
                 for ( final Double d : doubles ) {
                     if ( d != null ) { // necessary because .,. => [null, null] in VC
                         encoder.encodeRawFloat(d);
@@ -446,13 +446,13 @@ public abstract class BCF2FieldEncoder {
 
         @Override
         public BCF2Type getDynamicType(final Object value) {
-            return value == null ? BCF2Type.INT8 : BCF2Utils.determineIntegerType(toList(Integer.class, value));
+            return value == null ? BCF2Type.INT8 : BCF2Utils.determineIntegerType(BCF2Utils.toList(Integer.class, value));
         }
 
         @Override
         public void encodeValue(final BCF2Encoder encoder, final Object value, final BCF2Type type, final int minValues) throws IOException {
             int count = 0;
-            for ( final Integer i : toList(Integer.class, value) ) {
+            for ( final Integer i : BCF2Utils.toList(Integer.class, value) ) {
                 if ( i != null ) { // necessary because .,. => [null, null] in VC
                     encoder.encodeRawInt(i, type);
                     count++;
@@ -460,35 +460,5 @@ public abstract class BCF2FieldEncoder {
             }
             for ( ; count < minValues; count++ ) encoder.encodeRawMissingValue(type);
         }
-    }
-
-
-    // ----------------------------------------------------------------------
-    //
-    // Helper methods
-    //
-    // ----------------------------------------------------------------------
-
-    /**
-     * Helper function that takes an object and returns a list representation
-     * of it:
-     *
-     * o == null => []
-     * o is a list => o
-     * else => [o]
-     *
-     * @param c  the class of the object
-     * @param o  the object to convert to a Java List
-     * @return
-     */
-    private final static <T> List<T> toList(final Class<T> c, final Object o) {
-        if ( o == null ) return Collections.emptyList();
-        else if ( o instanceof List ) return (List<T>)o;
-        else if ( o.getClass().isArray() ) {
-            final List<T> l = new ArrayList<T>();
-            Collections.addAll(l, (T[])o);
-            return l;
-        }
-        else return Collections.singletonList((T)o);
     }
 }

--- a/src/java/htsjdk/variant/variantcontext/writer/BCF2FieldWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/BCF2FieldWriter.java
@@ -177,8 +177,8 @@ public abstract class BCF2FieldWriter {
             // the only value that is dynamic are integers
             final List<Integer> values = new ArrayList<Integer>(vc.getNSamples());
             for ( final Genotype g : vc.getGenotypes() ) {
-                for ( final Object i : BCF2Utils.toList(g.getExtendedAttribute(getField(), null)) ) {
-                    if ( i != null ) values.add((Integer)i); // we know they are all integers
+                for ( final Integer i : BCF2Utils.toList(Integer.class, g.getExtendedAttribute(getField(), null)) ) {
+                    if ( i != null ) values.add(i);
                 }
             }
 

--- a/src/tests/java/htsjdk/variant/bcf2/BCF2UtilsUnitTest.java
+++ b/src/tests/java/htsjdk/variant/bcf2/BCF2UtilsUnitTest.java
@@ -188,6 +188,26 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
     }
 
 
+    private void assertListsAreEquivalent(final List<?> a, final List<?> b) {
+        Assert.assertEquals(a.size(), b.size());
+        for (int i=0; i<a.size(); i++)
+            Assert.assertEquals(a.get(i), b.get(i));
+    }
+
+    @DataProvider(name = "toListTestProvider")
+    public Object[][] makeToListTest() {
+        final List<Object[]> tests = new ArrayList<Object[]>();
+        tests.add(new Object[]{Object.class, null, Collections.emptyList()});
+        tests.add(new Object[]{Integer.class, 1, Arrays.asList(1)});
+        tests.add(new Object[]{Integer.class, new int[]{1, 2, 3}, Arrays.asList(1, 2, 3)});
+        tests.add(new Object[]{String.class, Arrays.asList("X", "Y"), Arrays.asList("X", "Y")});
+        return tests.toArray(new Object[][]{});
+    }
+
+    @Test(dataProvider = "toListTestProvider")
+    public void testToList(final Class<?> cls, final Object input, final List<Object> expectedOutput) {
+        assertListsAreEquivalent(BCF2Utils.toList(cls, input), expectedOutput);
+    }
 
 
 }


### PR DESCRIPTION
- Old version returned a List with a single element, which was the provided array.  This broke BCF writing, in particular when a FORMAT annotation used arrays instead of Lists
- Made toList generic, rather than returning a List&lt;Object&gt;
- Removed the redundant BCF2FieldEncoder.toList()
- Added unit tests
