### PR TITLE
Fixing Java 8 compilation issues with type casting

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/java/htsjdk/variant/variantcontext/Genotype.java
@@ -356,10 +356,14 @@ public abstract class Genotype implements Comparable<Genotype> {
 
         // Notes:
         // 1. Make sure to use the appropriate separator depending on whether the genotype is phased
+        final String separator = isPhased() ? PHASED_ALLELE_SEPARATOR : UNPHASED_ALLELE_SEPARATOR;
         // 2. If ignoreRefState is true, then we want just the bases of the Alleles (ignoring the '*' indicating a ref Allele)
+        if (ignoreRefState) {
+          return ParsingUtils.join(separator, getAlleleStrings());
+        }
         // 3. So that everything is deterministic with regards to integration tests, we sort Alleles (when the genotype isn't phased, of course)
-        return ParsingUtils.join(isPhased() ? PHASED_ALLELE_SEPARATOR : UNPHASED_ALLELE_SEPARATOR,
-                ignoreRefState ? (Collection) getAlleleStrings() : (isPhased() ? getAlleles() : ParsingUtils.sortList(getAlleles())));
+        List<Allele> alleles = isPhased() ? getAlleles() : ParsingUtils.sortList(getAlleles());
+        return ParsingUtils.join(separator, alleles);
     }
 
     /**

--- a/src/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -52,19 +52,25 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
 
     /** Allows construction of a VCFFileReader that will or will not assert the presence of an index as desired. */
 	public VCFFileReader(final File file, final boolean requireIndex) {
-		this.reader = AbstractFeatureReader.getFeatureReader(
-						file.getAbsolutePath(),
-						isBCF(file) ? (FeatureCodec) new BCF2Codec() : new VCFCodec(),
-						requireIndex);
+	  // Note how we deal with type safety here, just casting to (FeatureCodec)
+	  // in the call to getFeatureReader is not enough for Java 8.
+      FeatureCodec<VariantContext, ?> codec = isBCF(file) ? new BCF2Codec() : new VCFCodec();
+      this.reader = AbstractFeatureReader.getFeatureReader(
+                      file.getAbsolutePath(),
+                      codec,
+                      requireIndex);
 	}
 
     /** Allows construction of a VCFFileReader with a specified index file. */
     public VCFFileReader(final File file, final File indexFile, final boolean requireIndex) {
-        this.reader = AbstractFeatureReader.getFeatureReader(
-                file.getAbsolutePath(),
-                indexFile.getAbsolutePath(),
-                isBCF(file) ? (FeatureCodec) new BCF2Codec() : new VCFCodec(),
-                requireIndex);
+      // Note how we deal with type safety here, just casting to (FeatureCodec)
+      // in the call to getFeatureReader is not enough for Java 8.
+      FeatureCodec<VariantContext, ?> codec = isBCF(file) ? new BCF2Codec() : new VCFCodec();
+      this.reader = AbstractFeatureReader.getFeatureReader(
+                      file.getAbsolutePath(),
+                      indexFile.getAbsolutePath(),
+                      codec,
+                      requireIndex);
     }
 
     /**


### PR DESCRIPTION
One of the conditional expressions in Genotype returned a different type in
each branch (List<String> vs. List<Allele>).
The type casting to FeatureCodec in VCFFileReader is not sufficient - a proper generic version has to be used.
