### PR TITLE
Always flush outputStream, regardless of instanceof FileOutputStream

### DIFF
--- a/src/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/java/htsjdk/samtools/util/BinaryCodec.java
@@ -592,8 +592,8 @@ public class BinaryCodec implements Closeable {
             if (this.isWriting) {
                 // To the degree possible, make sure the bytes get forced to the file system,
                 // or else cause an exception to be thrown.
+                this.outputStream.flush();
                 if (this.outputStream instanceof FileOutputStream) {
-                    this.outputStream.flush();
                     FileOutputStream fos = (FileOutputStream)this.outputStream;
                     try {
                         fos.getFD().sync();


### PR DESCRIPTION
The outputStream should always be flushed. If you only flush FileOutputStreams, you'll get file truncation errors when the files are read in. I think this is probably related to wrapping the FileOutputStream in a BufferedOutputStream. Perhaps the default value changed at some point.

I was getting intermittent File truncation errors, but now I'm getting good files.
