### PR TITLE
Removed GATK-specific constants from VCFConstants

### DIFF
--- a/src/java/htsjdk/variant/vcf/VCFConstants.java
+++ b/src/java/htsjdk/variant/vcf/VCFConstants.java
@@ -33,26 +33,21 @@ public final class VCFConstants {
     // reserved INFO/FORMAT field keys
     public static final String ANCESTRAL_ALLELE_KEY = "AA";
     public static final String ALLELE_COUNT_KEY = "AC";
-    public static final String MLE_ALLELE_COUNT_KEY = "MLEAC";
     public static final String ALLELE_FREQUENCY_KEY = "AF";
-    public static final String MLE_ALLELE_FREQUENCY_KEY = "MLEAF";
-    public static final String MLE_PER_SAMPLE_ALLELE_COUNT_KEY = "MLPSAC";
-    public static final String MLE_PER_SAMPLE_ALLELE_FRACTION_KEY = "MLPSAF";
     public static final String ALLELE_NUMBER_KEY = "AN";
     public static final String RMS_BASE_QUALITY_KEY = "BQ";
     public static final String CIGAR_KEY = "CIGAR";
     public static final String DBSNP_KEY = "DB";
     public static final String DEPTH_KEY = "DP";
-    public static final String DOWNSAMPLED_KEY = "DS";
-    public static final String EXPECTED_ALLELE_COUNT_KEY = "EC";
     public static final String END_KEY = "END";
 
     public static final String GENOTYPE_FILTER_KEY = "FT";
     public static final String GENOTYPE_KEY = "GT";
     public static final String GENOTYPE_POSTERIORS_KEY = "GP";
     public static final String GENOTYPE_QUALITY_KEY = "GQ";
-    public static final String GENOTYPE_ALLELE_DEPTHS = "AD";
+    public static final String GENOTYPE_ALLELE_DEPTHS = "AD"; //AD isn't reserved, but is specifically handled by VariantContext
     public static final String GENOTYPE_PL_KEY = "PL";   // phred-scaled genotype likelihoods
+    public static final String EXPECTED_ALLELE_COUNT_KEY = "EC";
     @Deprecated public static final String GENOTYPE_LIKELIHOODS_KEY = "GL";         // log10 scaled genotype likelihoods
 
     public static final String HAPMAP2_KEY = "H2";
@@ -93,7 +88,6 @@ public final class VCFConstants {
     public static final String ALT_HEADER_START = "##ALT";
     public static final String CONTIG_HEADER_KEY = "contig";
     public static final String CONTIG_HEADER_START = "##" + CONTIG_HEADER_KEY;
-    public static final String GATK_COMMAND_START = "##GATKCommandLine";
 
     // old indel alleles
     public static final char DELETION_ALLELE_v3 = 'D';
@@ -123,5 +117,4 @@ public final class VCFConstants {
     public static final int MAX_GENOTYPE_QUAL = 99;
 
     public static final Double VCF_ENCODING_EPSILON = 0.00005; // when we consider fields equal(), used in the Qual compare
-    public static final String REFSAMPLE_DEPTH_KEY = "REFDEPTH";
 }

--- a/src/java/htsjdk/variant/vcf/VCFStandardHeaderLines.java
+++ b/src/java/htsjdk/variant/vcf/VCFStandardHeaderLines.java
@@ -185,12 +185,10 @@ public class VCFStandardHeaderLines {
         registerStandard(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_PL_KEY, VCFHeaderLineCount.G, VCFHeaderLineType.Integer, "Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification"));
         registerStandard(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_ALLELE_DEPTHS, VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "Allelic depths for the ref and alt alleles in the order listed"));
         registerStandard(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_FILTER_KEY, 1, VCFHeaderLineType.String, "Genotype-level filter"));
+        registerStandard(new VCFFormatHeaderLine(VCFConstants.PHASE_QUALITY_KEY, 1, VCFHeaderLineType.Float, "Read-backed phasing quality"));
 
         // INFO lines
         registerStandard(new VCFInfoHeaderLine(VCFConstants.END_KEY, 1, VCFHeaderLineType.Integer, "Stop position of the interval"));
-        registerStandard(new VCFInfoHeaderLine(VCFConstants.MLE_ALLELE_COUNT_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Integer, "Maximum likelihood expectation (MLE) for the allele counts (not necessarily the same as the AC), for each ALT allele, in the same order as listed"));
-        registerStandard(new VCFInfoHeaderLine(VCFConstants.MLE_ALLELE_FREQUENCY_KEY, VCFHeaderLineCount.A, VCFHeaderLineType.Float, "Maximum likelihood expectation (MLE) for the allele frequency (not necessarily the same as the AF), for each ALT allele, in the same order as listed"));
-        registerStandard(new VCFInfoHeaderLine(VCFConstants.DOWNSAMPLED_KEY, 0, VCFHeaderLineType.Flag, "Were any of the samples downsampled?"));
         registerStandard(new VCFInfoHeaderLine(VCFConstants.DBSNP_KEY, 0, VCFHeaderLineType.Flag, "dbSNP Membership"));
         registerStandard(new VCFInfoHeaderLine(VCFConstants.DEPTH_KEY, 1, VCFHeaderLineType.Integer, "Approximate read depth; some reads may have been filtered"));
         registerStandard(new VCFInfoHeaderLine(VCFConstants.STRAND_BIAS_KEY, 1, VCFHeaderLineType.Float, "Strand Bias"));


### PR DESCRIPTION
I tried to remove everything that's not in the VCF spec, but AD is tightly coupled with VariantContext and would break too much code to remove.  Otherwise, I believe that all non-standard annotations have been removed