### PR TITLE
Make SortingVariantContextWriter public.

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriter.java
@@ -30,7 +30,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 /**
  * this class writes VCF files, allowing records to be passed in unsorted (up to a certain genomic distance away)
  */
-class SortingVariantContextWriter extends SortingVariantContextWriterBase {
+public class SortingVariantContextWriter extends SortingVariantContextWriterBase {
 
     // the maximum START distance between records that we'll cache
     private int maxCachingStartDistance;


### PR DESCRIPTION
Currently, the only way to access this functionality is through VariantContextWriterFactory.sortOnTheFly,
but VariantContextWriterFactory is deprecated.
