### PR TITLE
Adding scripts to perform and sign a Maven release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,21 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5</version>
+        <configuration>
+          <mavenExecutorId>forked-path</mavenExecutorId>
+          <useReleaseProfile>false</useReleaseProfile>
+          <arguments>-Psonatype-oss-release</arguments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.5</version>
         <configuration>

--- a/scripts/release/README
+++ b/scripts/release/README
@@ -1,0 +1,16 @@
+This document describes how to make an htsjdk release.
+
+Setup your environment
+1. Copy (or incorporate) the settings.xml file to ~/.m2/settings.xml
+2. Request the htsjdk packager private GPG key
+3. Edit the username, password, etc in ~/.m2/settings.xml
+
+Once your environment is setup, you'll be able to do a release.
+
+From the project root directory, run `./scripts/release/release.sh`.
+If you have any problems, run `./scripts/release/rollback.sh`.
+
+Once you've successfully published the release, you will need to
+"close" and "release" it following the instructions at
+https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide#SonatypeOSSMavenRepositoryUsageGuide-8.a.1.ClosingaStagingRepository
+

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mvn -P sonatype-oss-release -Dresume=false release:clean release:prepare release:perform

--- a/scripts/release/rollback.sh
+++ b/scripts/release/rollback.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+mvn -P sonatype-oss-release release:rollback

--- a/scripts/release/settings.xml
+++ b/scripts/release/settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>@SONATYPE_USERNAME@</username>
+      <password>@SONATYPE_PASSWORD@</password>
+    </server>
+    <server>
+      <id>sonatype-nexus-staging</id>
+      <username>@SONATYPE_USERNAME@</username>
+      <password>@SONATYPE_PASSWORD@</password>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>gpg</id>
+      <properties>
+        <gpg.executable>@GPG_EXECUTABLE_PATH@</gpg.executable>
+        <gpg.passphrase>@PGP_KEY_PASSPHRASE@</gpg.passphrase>
+        <gpg.keyname>@GPG_KEY_NAME</gpg.keyname>
+      </properties>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>gpg</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
Adds on to the initial Mavenization from #115. With this (and a properly configured `~/.m2/settings.xml`) an authorized user can push a release to [Sonatype](http://oss.sonatype.com) by running `./scripts/release/release.sh`.