### PR TITLE
make BAMFileSpan public

### DIFF
--- a/src/java/htsjdk/samtools/SAMFileSpan.java
+++ b/src/java/htsjdk/samtools/SAMFileSpan.java
@@ -66,7 +66,7 @@ public interface SAMFileSpan extends Cloneable {
  * @author mhanna
  * @version 0.1
  */
-class BAMFileSpan implements SAMFileSpan, Serializable {
+public class BAMFileSpan implements SAMFileSpan, Serializable {
     private static final long serialVersionUID = 1L;    
 
     /**


### PR DESCRIPTION
BAMIndex class is public and BAMIndex.getSpanOverlapping() method is public but it returns package-private BAMFileSpan.