### PR TITLE
adding getResourceDescription() to SamReader

### DIFF
--- a/src/java/htsjdk/samtools/SAMFileReader.java
+++ b/src/java/htsjdk/samtools/SAMFileReader.java
@@ -341,6 +341,11 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
         return mReader.type();
     }
 
+    @Override
+    public String getResourceDescription() {
+        return this.toString();
+    }
+
     /**
      * Control validation of SAMRecords as they are read from file.
      * In order to control validation stringency for SAM Header, call SAMFileReader.setDefaultValidationStringency

--- a/src/java/htsjdk/samtools/SamReader.java
+++ b/src/java/htsjdk/samtools/SamReader.java
@@ -106,9 +106,14 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
     public SAMFileHeader getFileHeader();
 
     /**
-     * @return Answers {@code true} if this is a BAM reader.
+     * @return the {@link htsjdk.samtools.SamReader.Type} of this {@link htsjdk.samtools.SamReader}
      */
     public Type type();
+
+    /**
+     * @return a human readable description of the resource backing this sam reader
+     */
+    public String getResourceDescription();
 
     /**
      * @return true if ths is a BAM file, and has an index
@@ -333,9 +338,11 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
     /** Decorator for a {@link SamReader.PrimitiveSamReader} that expands its functionality into a {@link SamReader}. */
     class PrimitiveSamReaderToSamReaderAdapter implements SamReader, Indexing {
         final PrimitiveSamReader p;
+        final SamInputResource resource;
 
-        public PrimitiveSamReaderToSamReaderAdapter(final PrimitiveSamReader p) {
+        public PrimitiveSamReaderToSamReaderAdapter(final PrimitiveSamReader p, final SamInputResource resource) {
             this.p = p;
+            this.resource = resource;
         }
 
         PrimitiveSamReader underlyingReader() {
@@ -447,6 +454,11 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
         @Override
         public Type type() {
             return p.type();
+        }
+
+        @Override
+        public String getResourceDescription() {
+            return this.resource.toString();
         }
 
         @Override

--- a/src/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/java/htsjdk/samtools/SamReaderFactory.java
@@ -276,7 +276,7 @@ public abstract class SamReaderFactory {
 
                 // Apply the options defined by this factory to this reader
                 final SamReader.PrimitiveSamReaderToSamReaderAdapter reader =
-                        new SamReader.PrimitiveSamReaderToSamReaderAdapter(primitiveSamReader);
+                        new SamReader.PrimitiveSamReaderToSamReaderAdapter(primitiveSamReader, resource);
 
                 for (final Option option : enabledOptions) {
                     option.applyTo(reader);


### PR DESCRIPTION
this is to address #161 

I also fixed a completely incorrect comment for SamReader.type()

For some reason there was a transient build failure relating to `RelativeIso8601DateTest`.  I reran the build without problem, but there seems to be some edge case where one of these tests is failing at some random time.  (I clicked rerun without recording more details thinking I could still access the old build.  I can't figure out how to get at it now though.)