### PR TITLE
Fix artifact names.

### DIFF
--- a/.idea/modules/htsjdk.iml
+++ b/.idea/modules/htsjdk.iml
@@ -5,11 +5,11 @@
     <output-test url="file://$MODULE_DIR$/../../target/test-classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../..">
-      <sourceFolder url="file://$MODULE_DIR$/../../src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../src/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../src/main/scala" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../target/src_managed/main" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/../../src/test/scala" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/../../src/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/../../target/src_managed/test" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/../../src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/../../target/resource_managed/main" type="java-resource" />

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,6 @@ libraryDependencies += "org.testng" % "testng" % "6.8.8"
 
 javaSource in Compile := baseDirectory.value / "src/java"
 
-excludeFilter in javaSource := "src/tests"
-
 javaSource in Test := baseDirectory.value / "src/tests"
 
 assemblySettings
@@ -43,12 +41,13 @@ publishArtifact in Test := false
 pomIncludeRepository := { _ => false }
 
 artifactName := { (sv: ScalaVersion, module: ModuleID, artifact: Artifact) =>
-  artifact.name + "-" + module.revision + "." + artifact.extension
+  val classifierStr = artifact.classifier match { case None => ""; case Some(c) => "-" + c }
+  artifact.name + "-" + module.revision + classifierStr + "." + artifact.extension
 }
 
 crossPaths := false
 
-javacOptions in (Compile) ++= Seq("-source", "1.6")
+javacOptions in Compile ++= Seq("-source", "1.6")
  
 javacOptions in (Compile, compile) ++= Seq("-target", "1.6")
 


### PR DESCRIPTION
Quick fix to avoid artifact naming collisions for javadocs/srcs etc.