### PR TITLE
Moving ReaderImplementation to SamReader

### DIFF
--- a/src/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/java/htsjdk/samtools/BAMFileReader.java
@@ -43,7 +43,7 @@ import java.util.NoSuchElementException;
 /**
  * Class for reading and querying BAM files.
  */
-class BAMFileReader extends SAMFileReader.ReaderImplementation {
+class BAMFileReader extends SamReader.ReaderImplementation {
     // True if reading from a File rather than an InputStream
     private boolean mIsSeekable = false;
 

--- a/src/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/java/htsjdk/samtools/CRAMFileReader.java
@@ -38,7 +38,7 @@ import java.io.InputStream;
  *
  * @author vadim
  */
-public class CRAMFileReader extends SAMFileReader.ReaderImplementation {
+public class CRAMFileReader extends SamReader.ReaderImplementation {
     private File file;
     private final ReferenceSource referenceSource;
     private InputStream is;

--- a/src/java/htsjdk/samtools/SAMFileReader.java
+++ b/src/java/htsjdk/samtools/SAMFileReader.java
@@ -110,24 +110,6 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
         }
     }
 
-    /**
-     * Internal interface for SAM/BAM file reader implementations.
-     * Implemented as an abstract class to enforce better access control.
-     */
-    public static abstract class ReaderImplementation implements PrimitiveSamReader {
-        abstract void enableFileSource(final SamReader reader, final boolean enabled);
-
-        abstract void enableIndexCaching(final boolean enabled);
-
-        abstract void enableIndexMemoryMapping(final boolean enabled);
-
-        abstract void enableCrcChecking(final boolean enabled);
-
-        abstract void setSAMRecordFactory(final SAMRecordFactory factory);
-
-        abstract void setValidationStringency(final ValidationStringency validationStringency);
-    }
-
 
     /**
      * Prepare to read a SAM or BAM file.  Indexed lookup not allowed because reading from InputStream.
@@ -477,8 +459,7 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
      * is in the query region.
      *
      * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
-     *                  and abutting intervals merged.  This can be done with
-     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
+     *                  and abutting intervals merged.  This can be done with {@link htsjdk.samtools.QueryInterval#optimizeIntervals}
      * @param contained If true, each SAMRecord returned is will have its alignment completely contained in one of the
      *                  intervals of interest.  If false, the alignment of the returned SAMRecords need only overlap one of
      *                  the intervals of interest.
@@ -504,8 +485,7 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
      * is in the query region.
      *
      * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
-     *                  and abutting intervals merged.  This can be done with
-     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
+     *                  and abutting intervals merged.  This can be done with {@link htsjdk.samtools.QueryInterval#optimizeIntervals}
      * @return Iterator over the SAMRecords overlapping any of the intervals.
      */
     public SAMRecordIterator queryOverlapping(final QueryInterval[] intervals) {
@@ -528,8 +508,7 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
      * is in the query region.
      *
      * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
-     *                  and abutting intervals merged.  This can be done with
-     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
+     *                  and abutting intervals merged.  This can be done with {@link htsjdk.samtools.QueryInterval#optimizeIntervals}
      * @return Iterator over the SAMRecords contained in any of the intervals.
      */
     public SAMRecordIterator queryContained(final QueryInterval[] intervals) {

--- a/src/java/htsjdk/samtools/SAMTextReader.java
+++ b/src/java/htsjdk/samtools/SAMTextReader.java
@@ -34,7 +34,7 @@ import java.io.InputStream;
 /**
  * Internal class for reading SAM text files.
  */
-class SAMTextReader extends SAMFileReader.ReaderImplementation {
+class SAMTextReader extends SamReader.ReaderImplementation {
 
 
     private SAMRecordFactory samRecordFactory;

--- a/src/java/htsjdk/samtools/SamReader.java
+++ b/src/java/htsjdk/samtools/SamReader.java
@@ -214,8 +214,7 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
      * is in the query region.
      *
      * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
-     *                  and abutting intervals merged.  This can be done with
-     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
+     *                  and abutting intervals merged.  This can be done with {@link htsjdk.samtools.QueryInterval#optimizeIntervals}
      * @param contained If true, each SAMRecord returned is will have its alignment completely contained in one of the
      *                  intervals of interest.  If false, the alignment of the returned SAMRecords need only overlap one of
      *                  the intervals of interest.
@@ -239,9 +238,7 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
      * is in the query region.
      *
      * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
-     *                  and abutting intervals merged.  This can be done with
-     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
-     * @return Iterator over the SAMRecords overlapping any of the intervals.
+     *                  and abutting intervals merged.  This can be done with {@link htsjdk.samtools.QueryInterval#optimizeIntervals}
      */
     public SAMRecordIterator queryOverlapping(final QueryInterval[] intervals);
 
@@ -261,8 +258,7 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
      * is in the query region.
      *
      * @param intervals Intervals to be queried.  The intervals must be optimized, i.e. in order, with overlapping
-     *                  and abutting intervals merged.  This can be done with
-     *                  htsjdk.samtools.SAMFileReader.QueryInterval#optimizeIntervals(htsjdk.samtools.SAMFileReader.QueryInterval[])
+     *                  and abutting intervals merged.  This can be done with {@link htsjdk.samtools.QueryInterval#optimizeIntervals}
      * @return Iterator over the SAMRecords contained in any of the intervals.
      */
     public SAMRecordIterator queryContained(final QueryInterval[] intervals);
@@ -550,5 +546,23 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
         public boolean hasNext() { return wrappedIterator.hasNext(); }
 
         public void remove() { wrappedIterator.remove(); }
+    }
+
+    /**
+     * Internal interface for SAM/BAM file reader implementations.
+     * Implemented as an abstract class to enforce better access control.
+     */
+    abstract class ReaderImplementation implements PrimitiveSamReader {
+        abstract void enableFileSource(final SamReader reader, final boolean enabled);
+
+        abstract void enableIndexCaching(final boolean enabled);
+
+        abstract void enableIndexMemoryMapping(final boolean enabled);
+
+        abstract void enableCrcChecking(final boolean enabled);
+
+        abstract void setSAMRecordFactory(final SAMRecordFactory factory);
+
+        abstract void setValidationStringency(final ValidationStringency validationStringency);
     }
 }


### PR DESCRIPTION
it was in the deprecated `SAMFileReader` which is confusing especially since it depends on `PrimitiveSamReader` which is in `SamReader`

updated a few out of date documentation strings