### PR TITLE
removing SAMRecord.setAlignmentEnd()

### DIFF
--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -514,13 +514,6 @@ public class SAMRecord implements Cloneable
     }
 
     /**
-     * Unsupported.  This property is derived from alignment start and CIGAR. 
-     */
-    public void setAlignmentEnd(final int value) {
-        throw new UnsupportedOperationException("Not supported: setAlignmentEnd");
-    }
-
-    /**
      * @return 1-based inclusive leftmost position of the clipped mate sequence, or 0 if there is no position.
      */
     public int getMateAlignmentStart() {


### PR DESCRIPTION
It throws unsupported operation exception.
This is useless and confusing.  It it's there for backwards compatibility (which is probably even worse than removing it because programs fail at run time) it should be deprecated and then removed after whatever delay is required.  
