### PR TITLE
creating a Locatable interface

### DIFF
--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -25,6 +25,8 @@ package htsjdk.samtools;
 
 
 import htsjdk.samtools.util.CoordMath;
+import htsjdk.samtools.util.Locatable;
+import htsjdk.samtools.util.SimpleInterval;
 import htsjdk.samtools.util.StringUtil;
 
 import java.lang.reflect.Array;
@@ -80,7 +82,7 @@ import java.util.List;
  * @author alecw@broadinstitute.org
  * @author mishali.naik@intel.com
  */
-public class SAMRecord implements Cloneable
+public class SAMRecord implements Cloneable, Locatable
 {
     /**
      * Alignment score for a good alignment, but where computing a Phred-score is not feasible. 
@@ -1177,6 +1179,48 @@ public class SAMRecord implements Cloneable
      */
     protected SAMBinaryTagAndValue getBinaryAttributes() {
         return mAttributes;
+    }
+
+    /**
+     * Interval covering the aligned, unclipped, bases in this read as reported by getAlignmentStart() and getAlignmentEnd()
+     * @return the aligned interval or null if getReadUnmappedFlag()
+     */
+    public SimpleInterval getLocation() {
+        if (getReadUnmappedFlag()) {
+            return null;
+        } else {
+            return new SimpleInterval(getReferenceName(), getAlignmentStart(), getAlignmentEnd());
+        }
+    }
+
+    /**
+     * @return reference name, null if this is unmapped
+     */
+    @Override
+    public String getContig() {
+        if( getReadUnmappedFlag()) {
+            return null;
+        } else {
+            return getReferenceName();
+        }
+    }
+
+    /**
+     * an alias of {@link #getAlignmentStart()
+     * @return 1-based inclusive leftmost position of the clipped sequence, or 0 if there is no position.
+     */
+    @Override
+    public int getStart() {
+        return getAlignmentStart();
+    }
+
+    /**
+     * an alias of {@link #getAlignmentEnd()}
+     * @return 1-based inclusive rightmost position of the clipped sequence, or 0 read if unmapped.
+     */
+    @Override
+    public int getEnd() {
+        return getAlignmentEnd();
     }
 
     /**

--- a/src/java/htsjdk/samtools/filter/IntervalFilter.java
+++ b/src/java/htsjdk/samtools/filter/IntervalFilter.java
@@ -79,7 +79,7 @@ public class IntervalFilter implements SamRecordFilter {
     private void advanceInterval() {
         if (intervals.hasNext()) {
             currentInterval = intervals.next();
-            currentSequenceIndex = samHeader.getSequenceIndex(currentInterval.getSequence());
+            currentSequenceIndex = samHeader.getSequenceIndex(currentInterval.getContig());
         } else {
             currentInterval = null;
         }

--- a/src/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/java/htsjdk/samtools/util/IntervalList.java
@@ -199,7 +199,7 @@ public class IntervalList implements Iterable<Interval> {
             else if (current.intersects(next) || current.abuts(next)) {
                 if (enforceSameStrands && current.isNegativeStrand() != next.isNegativeStrand()) throw new SAMException("Strands were not equal for: " + current.toString() + " and " + next.toString());
                 toBeMerged.add(next);
-                current = new Interval(current.getSequence(), current.getStart(), Math.max(current.getEnd(), next.getEnd()), current.isNegativeStrand(), null);
+                current = new Interval(current.getContig(), current.getStart(), Math.max(current.getEnd(), next.getEnd()), current.isNegativeStrand(), null);
             }
             else {
                 // Emit merged/unique interval
@@ -235,7 +235,7 @@ public class IntervalList implements Iterable<Interval> {
 
     /** Merges a sorted collection of intervals and optionally concatenates unique names or takes the first name. */
     static Interval merge(final SortedSet<Interval> intervals, final boolean concatenateNames) {
-        final String chrom = intervals.first().getSequence();
+        final String chrom = intervals.first().getContig();
         int start = intervals.first().getStart();
         int end   = intervals.last().getEnd();
         final boolean neg  = intervals.first().isNegativeStrand();
@@ -417,7 +417,7 @@ public class IntervalList implements Iterable<Interval> {
 
             // Write out the intervals
             for (final Interval interval : this) {
-                out.write(interval.getSequence());
+                out.write(interval.getContig());
                 out.write('\t');
                 out.write(format.format(interval.getStart()));
                 out.write('\t');
@@ -554,7 +554,7 @@ public class IntervalList implements Iterable<Interval> {
 
         //add all the intervals (uniqued and therefore also sorted) to a ListMap from sequenceIndex to a list of Intervals
         for(final Interval i : list.uniqued().getIntervals()){
-            map.add(list.getHeader().getSequenceIndex(i.getSequence()),i);
+            map.add(list.getHeader().getSequenceIndex(i.getContig()),i);
         }
 
         // a counter to supply newly-created intervals with a name
@@ -654,8 +654,8 @@ class IntervalCoordinateComparator implements Comparator<Interval> {
     }
 
     public int compare(final Interval lhs, final Interval rhs) {
-        final int lhsIndex = this.header.getSequenceIndex(lhs.getSequence());
-        final int rhsIndex = this.header.getSequenceIndex(rhs.getSequence());
+        final int lhsIndex = this.header.getSequenceIndex(lhs.getContig());
+        final int rhsIndex = this.header.getSequenceIndex(rhs.getContig());
         int retval = lhsIndex - rhsIndex;
 
         if (retval == 0) retval = lhs.getStart() - rhs.getStart();

--- a/src/java/htsjdk/samtools/util/IntervalListReferenceSequenceMask.java
+++ b/src/java/htsjdk/samtools/util/IntervalListReferenceSequenceMask.java
@@ -55,7 +55,7 @@ public class IntervalListReferenceSequenceMask implements ReferenceSequenceMask 
             lastPosition = 0;
         } else {
             final Interval lastInterval = uniqueIntervals.get(uniqueIntervals.size() - 1);
-            lastSequenceIndex = header.getSequenceIndex((lastInterval.getSequence()));
+            lastSequenceIndex = header.getSequenceIndex((lastInterval.getContig()));
             lastPosition = lastInterval.getEnd();
         }
         intervalIterator = new PeekableIterator<Interval>(uniqueIntervals.iterator());
@@ -91,7 +91,7 @@ public class IntervalListReferenceSequenceMask implements ReferenceSequenceMask 
             currentBitSet.clear();
             while (intervalIterator.hasNext()) {
                 final Interval interval = intervalIterator.peek();
-                final int nextSequenceIndex = header.getSequenceIndex(interval.getSequence());
+                final int nextSequenceIndex = header.getSequenceIndex(interval.getContig());
                 if (nextSequenceIndex < sequenceIndex) {
                     intervalIterator.next();
                 } else if (nextSequenceIndex == sequenceIndex) {

--- a/src/java/htsjdk/samtools/util/IntervalTreeMap.java
+++ b/src/java/htsjdk/samtools/util/IntervalTreeMap.java
@@ -72,7 +72,7 @@ public class IntervalTreeMap<T>
     }
 
     public boolean containsKey(final Interval key) {
-        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree == null) {
             return false;
         }
@@ -103,7 +103,7 @@ public class IntervalTreeMap<T>
     }
 
     public T get(final Interval key) {
-        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree == null) {
             return null;
         }
@@ -124,10 +124,10 @@ public class IntervalTreeMap<T>
     }
 
     public T put(final Interval key, final T value) {
-        IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree == null) {
             tree = new IntervalTree<T>();
-            mSequenceMap.put(key.getSequence(), tree);
+            mSequenceMap.put(key.getContig(), tree);
         }
         return tree.put(key.getStart(), key.getEnd(), value);
     }
@@ -140,7 +140,7 @@ public class IntervalTreeMap<T>
     }
 
     public T remove(final Interval key) {
-        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree == null) {
             return null;
         }
@@ -161,14 +161,14 @@ public class IntervalTreeMap<T>
      * @return true if it contains an object overlapping the interval 
      */
     public boolean containsOverlapping(final Interval key) {
-        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         return tree!=null && tree.overlappers(key.getStart(), key.getEnd()).hasNext();
     	}
     
     
     public Collection<T> getOverlapping(final Interval key) {
         final List<T> result = new ArrayList<T>();
-        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree != null) {
             final Iterator<IntervalTree.Node<T>> iterator = tree.overlappers(key.getStart(), key.getEnd());
             while (iterator.hasNext()) {
@@ -183,7 +183,7 @@ public class IntervalTreeMap<T>
      * @return true if it contains an object is contained by 'key'
      */
     public boolean containsContained(final Interval key) {
-        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if(tree==null) return false;
             final Iterator<IntervalTree.Node<T>> iterator = tree.overlappers(key.getStart(), key.getEnd());
             while (iterator.hasNext()) {
@@ -198,7 +198,7 @@ public class IntervalTreeMap<T>
     
     public Collection<T> getContained(final Interval key) {
         final List<T> result = new ArrayList<T>();
-        final IntervalTree<T> tree = mSequenceMap.get(key.getSequence());
+        final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree != null) {
             final Iterator<IntervalTree.Node<T>> iterator = tree.overlappers(key.getStart(), key.getEnd());
             while (iterator.hasNext()) {

--- a/src/java/htsjdk/samtools/util/IntervalUtil.java
+++ b/src/java/htsjdk/samtools/util/IntervalUtil.java
@@ -35,7 +35,7 @@ public class IntervalUtil {
 
     /** Return true if the sequence/position lie in the provided interval. */
     public static boolean contains(final Interval interval, final String sequenceName, final long position) {
-        return interval.getSequence().equals(sequenceName) && (position >= interval.getStart() && position <= interval.getEnd());
+        return interval.getContig().equals(sequenceName) && (position >= interval.getStart() && position <= interval.getEnd());
     }
 
     /** Return true if the sequence/position lie in the provided interval list. */
@@ -58,13 +58,13 @@ public class IntervalUtil {
             return;
         }
         Interval prevInterval = intervals.next();
-        int prevSequenceIndex = sequenceDictionary.getSequenceIndex(prevInterval.getSequence());
+        int prevSequenceIndex = sequenceDictionary.getSequenceIndex(prevInterval.getContig());
         while (intervals.hasNext()) {
             final Interval interval = intervals.next();
             if (prevInterval.intersects(interval)) {
                 throw new SAMException("Intervals should not overlap: " + prevInterval + "; " + interval);
             }
-            final int thisSequenceIndex = sequenceDictionary.getSequenceIndex(interval.getSequence());
+            final int thisSequenceIndex = sequenceDictionary.getSequenceIndex(interval.getContig());
             if (prevSequenceIndex > thisSequenceIndex ||
                     (prevSequenceIndex == thisSequenceIndex && prevInterval.compareTo(interval) >= 0)) {
                 throw new SAMException("Intervals not in order: " + prevInterval + "; " + interval);

--- a/src/java/htsjdk/samtools/util/Locatable.java
+++ b/src/java/htsjdk/samtools/util/Locatable.java
@@ -1,0 +1,25 @@
+package htsjdk.samtools.util;
+
+/**
+ * Any class that has a single logical mapping onto the genome should implement Locatable
+ * positions should be reported as 1-based and closed at both ends
+ *
+ */
+public interface Locatable {
+
+    /**
+     * Gets the contig name for the contig this is mapped to.  May return null if there is no unique mapping.
+     * @return name of the contig this is mapped to, potentially null
+     */
+    String getContig();
+
+    /**
+     * @return 1-based start position, undefined if getContig() == null
+     */
+    int getStart();
+
+    /**
+     * @return 1-based closed-ended position, undefined if getContig() == null
+     */
+    int getEnd();
+}

--- a/src/java/htsjdk/samtools/util/OverlapDetector.java
+++ b/src/java/htsjdk/samtools/util/OverlapDetector.java
@@ -55,7 +55,7 @@ public class OverlapDetector<T> {
 
     /** Adds a mapping to the set of mappings against which to match candidates. */
     public void addLhs(T object, Interval interval) {
-        Object seqId = interval.getSequence();
+        Object seqId = interval.getContig();
 
         IntervalTree<Set<T>> tree = this.cache.get(seqId);
         if (tree == null) {
@@ -106,7 +106,7 @@ public class OverlapDetector<T> {
     public Collection<T> getOverlaps(Interval rhs)  {
         Collection<T> matches = new ArrayList<T>();
 
-        Object seqId = rhs.getSequence();
+        Object seqId = rhs.getContig();
         IntervalTree<Set<T>> tree = this.cache.get(seqId);
         int start = rhs.getStart() + this.rhsBuffer;
         int end = rhs.getEnd() - this.rhsBuffer;

--- a/src/java/htsjdk/samtools/util/SamRecordIntervalIteratorFactory.java
+++ b/src/java/htsjdk/samtools/util/SamRecordIntervalIteratorFactory.java
@@ -61,7 +61,7 @@ public class SamRecordIntervalIteratorFactory {
                 stopAfterPosition = -1;
             } else {
                 final Interval lastInterval = uniqueIntervals.get(uniqueIntervals.size() - 1);
-                stopAfterSequence = samReader.getFileHeader().getSequenceIndex(lastInterval.getSequence());
+                stopAfterSequence = samReader.getFileHeader().getSequenceIndex(lastInterval.getContig());
                 stopAfterPosition = lastInterval.getEnd();
             }
             final IntervalFilter intervalFilter = new IntervalFilter(uniqueIntervals, samReader.getFileHeader());
@@ -70,7 +70,7 @@ public class SamRecordIntervalIteratorFactory {
             final QueryInterval[] queryIntervals = new QueryInterval[uniqueIntervals.size()];
             for (int i = 0; i < queryIntervals.length; ++i) {
                 final Interval inputInterval = uniqueIntervals.get(i);
-                queryIntervals[i] = new QueryInterval(samReader.getFileHeader().getSequenceIndex(inputInterval.getSequence()),
+                queryIntervals[i] = new QueryInterval(samReader.getFileHeader().getSequenceIndex(inputInterval.getContig()),
                         inputInterval.getStart(), inputInterval.getEnd());
             }
             return samReader.queryOverlapping(queryIntervals);

--- a/src/java/htsjdk/samtools/util/SimpleInterval.java
+++ b/src/java/htsjdk/samtools/util/SimpleInterval.java
@@ -1,0 +1,82 @@
+package htsjdk.samtools.util;
+
+
+/**
+ * Minimal immutable class representing a 1-based closed ended genomic interval
+ * SimpleInterval does not allow null contig names.  It cannot represent an unmapped Locatable.
+ *
+ *@warning 0 length intervals are allowed, which are represented as end = start-1
+ */
+public class SimpleInterval implements Locatable {
+
+    private final int start;
+    private final int end;
+    private final String contig;
+
+    /**
+     * Create a new immutable 1-based interval of the form [start, end]
+     * @param contig the name of the contig, must not be null
+     * @param start  1-based inclusive start position
+     * @param end  1-based inclusive end position
+     */
+    public SimpleInterval(final String contig, final int start, final int end){
+        if(contig == null){
+            throw new IllegalArgumentException("contig cannot be null");
+        }
+        if (start <= 0 ){
+            throw new IllegalArgumentException("SimpleInterval is 1 based, so start must be >= 1, start:%d" + start);
+        }
+        if (end < start -1){
+            throw new IllegalArgumentException( String.format("end must be >= start -1 . start:%d end:%d", start, end));
+        }
+        this.contig = contig;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final SimpleInterval that = (SimpleInterval) o;
+
+        if (end != that.end) return false;
+        if (start != that.start) return false;
+        if (!contig.equals(that.contig)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = start;
+        result = 31 * result + end;
+        result = 31 * result + contig.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s:%s-%s", contig, start, end);
+    }
+
+    /**
+     * @return name of the contig this is mapped to
+     */
+    public final String getContig(){
+        return contig;
+    }
+
+    /** Gets the 1-based start position of the interval on the contig. */
+    public final int getStart(){
+        return start;
+    }
+
+    /**
+     * @return the 1-based closed-ended end position of the interval on the contig.
+     * @warning in the case of a 0-length interval getEnd() == getStart - 1 */
+    public final int getEnd(){
+        return end;
+    }
+}

--- a/src/java/htsjdk/tribble/Feature.java
+++ b/src/java/htsjdk/tribble/Feature.java
@@ -24,24 +24,18 @@
 package htsjdk.tribble;
 
 
+import htsjdk.samtools.util.Locatable;
+
 /**
- * Represents a locus on a reference sequence.   The coordinate conventions for start and end are implementation
- * dependent, no specific contact is specified here.
+ * Represents a locus on a reference sequence.   All Features are expected to return 1-based closed-ended intervals.
  */
-public interface Feature {
+public interface Feature extends Locatable {
 
     /**
      * Return the features reference sequence name, e.g chromosome or contig
+     * @deprecated use getContig() instead
      */
+    @Deprecated
     public String getChr();
 
-    /**
-     * Return the start position
-     */
-    public int getStart();
-
-    /**
-     * Return the end position
-     */
-    public int getEnd();
 }

--- a/src/java/htsjdk/tribble/SimpleFeature.java
+++ b/src/java/htsjdk/tribble/SimpleFeature.java
@@ -24,31 +24,33 @@ package htsjdk.tribble;
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/**
- * Trivial feature -- all it holds is the key information.
- *
- * @author Mark DePristo
- * @since 5/3/12
- */
-public class BasicFeature implements Feature {
-    private final String chr;
-    private final int start, stop;
+import htsjdk.samtools.util.SimpleInterval;
 
-    public BasicFeature(final String chr, final int start, final int stop) {
-        this.chr = chr;
-        this.start = start;
-        this.stop = stop;
+/**
+ * A simple concrete Feature.
+ */
+public class SimpleFeature implements Feature {
+
+    private final SimpleInterval simpleInterval;
+
+    public SimpleFeature(final String contig, final int start, final int end) {
+        simpleInterval = new SimpleInterval(contig, start, end);
     }
 
+    @Deprecated
     public String getChr() {
-        return chr;
+        return getContig();
+    }
+
+    public String getContig() {
+        return simpleInterval.getContig();
     }
 
     public int getStart() {
-        return start;
+        return simpleInterval.getStart();
     }
 
     public int getEnd() {
-        return stop;
+        return simpleInterval.getEnd();
     }
 }

--- a/src/java/htsjdk/tribble/TabixFeatureReader.java
+++ b/src/java/htsjdk/tribble/TabixFeatureReader.java
@@ -197,7 +197,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
                 readNextRecord();
             } catch (IOException e) {
                 throw new RuntimeException("Unable to read the next record, the last record was at " +
-                        ret.getChr() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
+                        ret.getContig() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
             }
             return ret;
 

--- a/src/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -315,7 +315,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
                 readNextRecord();
             } catch (IOException e) {
                 throw new RuntimeException("Unable to read the next record, the last record was at " +
-                        ret.getChr() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
+                        ret.getContig() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
             }
             return ret;
         }
@@ -390,7 +390,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
 
             // The feature chromosome might not be the query chromosome, due to alias definitions.  We assume
             // the chromosome of the first record is correct and record it here.  This is not pretty.
-            chrAlias = (currentRecord == null ? chr : currentRecord.getChr());
+            chrAlias = (currentRecord == null ? chr : currentRecord.getContig());
 
         }
 
@@ -405,7 +405,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
                 readNextRecord();
             } catch (IOException e) {
                 throw new RuntimeException("Unable to read the next record, the last record was at " +
-                        ret.getChr() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
+                        ret.getContig() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
             }
             return ret;
         }
@@ -450,7 +450,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
                         if (f == null) {
                             continue;   // Skip
                         }
-                        if ((chrAlias != null && !f.getChr().equals(chrAlias)) || f.getStart() > end) {
+                        if ((chrAlias != null && !f.getContig().equals(chrAlias)) || f.getStart() > end) {
                             if (blockIterator.hasNext()) {
                                 advanceBlock();
                                 continue;

--- a/src/java/htsjdk/tribble/bed/BEDFeature.java
+++ b/src/java/htsjdk/tribble/bed/BEDFeature.java
@@ -31,6 +31,10 @@ import java.awt.*;
 /**
  * @author jrobinso
  * @date Dec 24, 2009
+ *
+ * BED feature start and end positions must adhere to the Feature interval specifications.
+ * This is different than the 0-based representation in a BED file.  This conversion is handled by {@link BEDCodec}.
+ * Anyone writing a bed file should be aware of this difference.
  */
 public interface BEDFeature extends Feature {
     Strand getStrand();

--- a/src/java/htsjdk/tribble/bed/SimpleBEDFeature.java
+++ b/src/java/htsjdk/tribble/bed/SimpleBEDFeature.java
@@ -51,7 +51,16 @@ public class SimpleBEDFeature implements BEDFeature {
         this.chr = chr;
     }
 
+
+    @Deprecated
+    @Override
     public String getChr() {
+        return getContig();
+    }
+
+
+    @Override
+    public String getContig() {
         return chr;
     }
 

--- a/src/java/htsjdk/tribble/dbsnp/OldDbSNPCodec.java
+++ b/src/java/htsjdk/tribble/dbsnp/OldDbSNPCodec.java
@@ -35,7 +35,9 @@ import htsjdk.tribble.readers.LineIterator;
  * Example format:
  * 585 chr1 433 433 rs56289060  0  +  - - -/C  genomic  insertion unknown 0  0  unknown  between  1
  * 585 chr1 491 492 rs55998931  0  +  C C C/T  genomic  single   unknown 0 0 unknown exact 1
+ * @deprecated This is deprecated and unsupported.
  */
+@Deprecated
 public class OldDbSNPCodec extends AsciiFeatureCodec<OldDbSNPFeature> {
 
     // the number of tokens we expect to parse from a dbSNP line

--- a/src/java/htsjdk/tribble/dbsnp/OldDbSNPFeature.java
+++ b/src/java/htsjdk/tribble/dbsnp/OldDbSNPFeature.java
@@ -36,7 +36,10 @@ import htsjdk.tribble.annotation.Strand;
  * bin	chrom	chromStart	chromEnd	rsID	score	strand	refNCBI	refUCSC	observed	molType	class	valid	avHet	avHetSE	func	locType	weight
  * 585 chr1 433 433 rs56289060  0  +  - - -/C  genomic  insertion unknown 0  0  unknown  between  1
  * 585 chr1 491 492 rs55998931  0  +  C C C/T  genomic  single   unknown 0 0 unknown exact 1
+ *
+ * @deprecated This is deprecated and unsupported.
  */
+@Deprecated
 public class OldDbSNPFeature implements Feature {
 
     private String contig;                      // our contig location
@@ -82,14 +85,23 @@ public class OldDbSNPFeature implements Feature {
      * the required getting and setter methods
      */
 
+    @Deprecated
+    @Override
     public String getChr() {
         return contig;
     }
 
+    @Override
+    public String getContig() {
+        return contig;
+    }
+
+    @Override
     public int getStart() {
         return start;
     }
 
+    @Override
     public int getEnd() {
         return stop;
     }

--- a/src/java/htsjdk/tribble/example/ExampleBinaryCodec.java
+++ b/src/java/htsjdk/tribble/example/ExampleBinaryCodec.java
@@ -24,7 +24,7 @@
 package htsjdk.tribble.example;
 
 import htsjdk.tribble.AbstractFeatureReader;
-import htsjdk.tribble.BasicFeature;
+import htsjdk.tribble.SimpleFeature;
 import htsjdk.tribble.BinaryFeatureCodec;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
@@ -63,7 +63,7 @@ public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
         String contig = dis.readUTF();
         int start = dis.readInt();
         int stop = dis.readInt();
-        return new BasicFeature(contig, start, stop);
+        return new SimpleFeature(contig, start, stop);
     }
 
     @Override

--- a/src/java/htsjdk/tribble/gelitext/DiploidGenotype.java
+++ b/src/java/htsjdk/tribble/gelitext/DiploidGenotype.java
@@ -32,6 +32,7 @@ package htsjdk.tribble.gelitext;
  *
  * @author aaron
  */
+@Deprecated
 public enum DiploidGenotype {
     AA, AC, AG, AT, CC, CG, CT, GG, GT, TT;
 
@@ -53,6 +54,7 @@ public enum DiploidGenotype {
     }
 }
 
+@Deprecated
 class DiploidGenotypeException extends RuntimeException {
     DiploidGenotypeException(String s) {
         super(s);

--- a/src/java/htsjdk/tribble/gelitext/GeliTextCodec.java
+++ b/src/java/htsjdk/tribble/gelitext/GeliTextCodec.java
@@ -49,7 +49,9 @@ import java.util.Arrays;
  * likelihoods        the array of all genotype likelihoods, in ordinal ordering (array of 10 doubles, in ordinal order)
  *
  * @author aaron
+ * @deprecated This is deprecated and unsupported.
  */
+@Deprecated
 public class GeliTextCodec extends AsciiFeatureCodec<GeliTextFeature> {
     public GeliTextCodec() {
         super(GeliTextFeature.class);

--- a/src/java/htsjdk/tribble/gelitext/GeliTextFeature.java
+++ b/src/java/htsjdk/tribble/gelitext/GeliTextFeature.java
@@ -35,7 +35,9 @@ import java.util.Arrays;
  *         This is a feature for the Geli text object, which is the text version of the Geli binary genotyping format.
  *
  * @author aaron
+ * @deprecated this is deprecated and no longer supported
  */
+@Deprecated
 public class GeliTextFeature implements Feature {
 
     private final String contig;                // the contig name
@@ -82,7 +84,13 @@ public class GeliTextFeature implements Feature {
     }
 
     /** Return the features reference sequence name, e.g chromosome or contig */
+    @Deprecated
     public String getChr() {
+        return getContig();
+    }
+
+    @Override
+    public String getContig() {
         return this.contig;
     }
 
@@ -142,4 +150,5 @@ public class GeliTextFeature implements Feature {
         if (!(Math.abs(LODBestToNext - other.LODBestToNext) < Epsilon)) return false;
         return true;
     }
+
 }

--- a/src/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -295,6 +295,7 @@ public class VariantContext implements Feature { // to enable tribble integratio
         }
     }
 
+
     // ---------------------------------------------------------------------------------------------------------
     //
     // validation mode
@@ -1145,7 +1146,7 @@ public class VariantContext implements Feature { // to enable tribble integratio
 
     public void validateReferenceBases(final Allele reportedReference, final Allele observedReference) {
         if ( reportedReference != null && !reportedReference.basesMatch(observedReference) ) {
-            throw new TribbleException.InternalCodecException(String.format("the REF allele is incorrect for the record at position %s:%d, fasta says %s vs. VCF says %s", getChr(), getStart(), observedReference.getBaseString(), reportedReference.getBaseString()));
+            throw new TribbleException.InternalCodecException(String.format("the REF allele is incorrect for the record at position %s:%d, fasta says %s vs. VCF says %s", getContig(), getStart(), observedReference.getBaseString(), reportedReference.getBaseString()));
         }
     }
 
@@ -1153,7 +1154,7 @@ public class VariantContext implements Feature { // to enable tribble integratio
         if ( rsIDs != null && hasID() ) {
             for ( String id : getID().split(VCFConstants.ID_FIELD_SEPARATOR) ) {
                 if ( id.startsWith("rs") && !rsIDs.contains(id) )
-                    throw new TribbleException.InternalCodecException(String.format("the rsID %s for the record at position %s:%d is not in dbSNP", id, getChr(), getStart()));
+                    throw new TribbleException.InternalCodecException(String.format("the rsID %s for the record at position %s:%d is not in dbSNP", id, getContig(), getStart()));
             }
         }
     }
@@ -1185,13 +1186,13 @@ public class VariantContext implements Feature { // to enable tribble integratio
             observedAlleles.remove(Allele.NO_CALL);
 
         if ( reportedAlleles.size() != observedAlleles.size() )
-            throw new TribbleException.InternalCodecException(String.format("one or more of the ALT allele(s) for the record at position %s:%d are not observed at all in the sample genotypes", getChr(), getStart()));
+            throw new TribbleException.InternalCodecException(String.format("one or more of the ALT allele(s) for the record at position %s:%d are not observed at all in the sample genotypes", getContig(), getStart()));
 
         int originalSize = reportedAlleles.size();
         // take the intersection and see if things change
         observedAlleles.retainAll(reportedAlleles);
         if ( observedAlleles.size() != originalSize )
-            throw new TribbleException.InternalCodecException(String.format("one or more of the ALT allele(s) for the record at position %s:%d are not observed at all in the sample genotypes", getChr(), getStart()));
+            throw new TribbleException.InternalCodecException(String.format("one or more of the ALT allele(s) for the record at position %s:%d are not observed at all in the sample genotypes", getContig(), getStart()));
     }
 
     public void validateChromosomeCounts() {
@@ -1203,7 +1204,7 @@ public class VariantContext implements Feature { // to enable tribble integratio
             int reportedAN = Integer.valueOf(getAttribute(VCFConstants.ALLELE_NUMBER_KEY).toString());
             int observedAN = getCalledChrCount();
             if ( reportedAN != observedAN )
-                throw new TribbleException.InternalCodecException(String.format("the Allele Number (AN) tag is incorrect for the record at position %s:%d, %d vs. %d", getChr(), getStart(), reportedAN, observedAN));
+                throw new TribbleException.InternalCodecException(String.format("the Allele Number (AN) tag is incorrect for the record at position %s:%d, %d vs. %d", getContig(), getStart(), reportedAN, observedAN));
         }
 
         // AC
@@ -1223,19 +1224,19 @@ public class VariantContext implements Feature { // to enable tribble integratio
             if ( getAttribute(VCFConstants.ALLELE_COUNT_KEY) instanceof List ) {
                 final List reportedACs = (List)getAttribute(VCFConstants.ALLELE_COUNT_KEY);
                 if ( observedACs.size() != reportedACs.size() )
-                    throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag doesn't have the correct number of values for the record at position %s:%d, %d vs. %d", getChr(), getStart(), reportedACs.size(), observedACs.size()));
+                    throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag doesn't have the correct number of values for the record at position %s:%d, %d vs. %d", getContig(), getStart(), reportedACs.size(), observedACs.size()));
                 for (int i = 0; i < observedACs.size(); i++) {
                     // need to cast to int to make sure we don't have an issue below with object equals (earlier bug) - EB
                     final int reportedAC = Integer.valueOf(reportedACs.get(i).toString());
                     if ( reportedAC != observedACs.get(i) )
-                        throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag is incorrect for the record at position %s:%d, %s vs. %d", getChr(), getStart(), reportedAC, observedACs.get(i)));
+                        throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag is incorrect for the record at position %s:%d, %s vs. %d", getContig(), getStart(), reportedAC, observedACs.get(i)));
                 }
             } else {
                 if ( observedACs.size() != 1 )
-                    throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag doesn't have enough values for the record at position %s:%d", getChr(), getStart()));
+                    throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag doesn't have enough values for the record at position %s:%d", getContig(), getStart()));
                 int reportedAC = Integer.valueOf(getAttribute(VCFConstants.ALLELE_COUNT_KEY).toString());
                 if ( reportedAC != observedACs.get(0) )
-                    throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag is incorrect for the record at position %s:%d, %d vs. %d", getChr(), getStart(), reportedAC, observedACs.get(0)));
+                    throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag is incorrect for the record at position %s:%d, %d vs. %d", getContig(), getStart(), reportedAC, observedACs.get(0)));
             }
         }
     }
@@ -1267,7 +1268,7 @@ public class VariantContext implements Feature { // to enable tribble integratio
             final int end = getAttributeAsInt(VCFConstants.END_KEY, -1);
             assert end != -1;
             if ( end != getEnd() ) {
-                final String message = "Badly formed variant context at location " + getChr() + ":"
+                final String message = "Badly formed variant context at location " + getContig() + ":"
                         + getStart() + "; getEnd() was " + getEnd()
                         + " but this VariantContext contains an END key with value " + end;
                 if ( GeneralUtils.DEBUG_MODE_ENABLED && WARN_ABOUT_BAD_END ) {
@@ -1524,7 +1525,7 @@ public class VariantContext implements Feature { // to enable tribble integratio
                 final int expSize = format.getCount(this);
                 if ( obsSize != expSize ) {
                     throw new TribbleException.InvalidHeader("Discordant field size detected for field " +
-                            field + " at " + getChr() + ":" + getStart() + ".  Field had " + obsSize + " values " +
+                            field + " at " + getContig() + ":" + getStart() + ".  Field had " + obsSize + " values " +
                             "but the header says this should have " + expSize + " values based on header record " +
                             format);
                 }
@@ -1574,7 +1575,7 @@ public class VariantContext implements Feature { // to enable tribble integratio
                         final boolean b = Boolean.valueOf(string) || string.equals("1");
                         if ( b == false )
                             throw new TribbleException("VariantContext FLAG fields " + field + " cannot contain false values"
-                             + " as seen at " + getChr() + ":" + getStart());
+                                    + " as seen at " + getContig() + ":" + getStart());
                         return b;
                     case String:    return string;
                     case Integer:   return Integer.valueOf(string);
@@ -1605,14 +1606,33 @@ public class VariantContext implements Feature { // to enable tribble integratio
     // tribble integration routines -- not for public consumption
     //
     // ---------------------------------------------------------------------------------------------------------
+    @Deprecated
     public String getChr() {
+        return getContig();
+    }
+
+    @Override
+    public String getContig() {
         return contig;
     }
 
+    /**
+     * @return 1-based inclusive start position of the Variant
+     * INDEL events usually start on the first unaltered reference base before the INDEL
+     * @warning be aware that the start position of the VariantContext is defined in terms of the start position specified in the
+     * underlying vcf file, VariantContexts representing the same biological event may have different start positions depending on the
+     * specifics of the vcf file they are derived from
+     */
     public int getStart() {
         return (int)start;
     }
 
+    /**
+     * @return 1-based closed end position of the Variant
+     * If the END info field is specified that value is returned, otherwise the end is the start + reference allele length - 1.
+     * For VariantContexts with a single alternate allele, if that allele is an insertion, the end position will be on the reference base
+     * before the insertion event.  If the single alt allele is a deletion, the end will be on the final deleted reference base.
+     */
     public int getEnd() {
         return (int)stop;
     }

--- a/src/tests/java/htsjdk/samtools/util/SimpleIntervalTest.java
+++ b/src/tests/java/htsjdk/samtools/util/SimpleIntervalTest.java
@@ -1,0 +1,56 @@
+package htsjdk.samtools.util;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SimpleIntervalTest {
+    final SimpleInterval i1 = new SimpleInterval("1",1,100);
+    final SimpleInterval i2 = new SimpleInterval("1",1,100);
+    final SimpleInterval i3 = new SimpleInterval("chr1", 1, 100);
+    final SimpleInterval i4 = new SimpleInterval("chr1", 2, 100);
+    final SimpleInterval i5 = new SimpleInterval("chr1", 1, 200);
+
+    @Test
+    public void testZeroLengthInterval(){
+        SimpleInterval interval = new SimpleInterval("1",100,99);
+        Assert.assertEquals(interval.getContig(), "1");
+        Assert.assertEquals(interval.getStart(), 100);
+        Assert.assertEquals(interval.getEnd(), 99);
+    }
+
+    @DataProvider(name = "badIntervals")
+    public Object[][] badIntervals(){
+        return new Object[][]{
+                {null,1,12, "null contig"},
+                {"1", 0, 10, "start==0"},
+                {"1", -10, 10, "negative start"},
+                {"1", 10, 8, "end < start - 1"}
+        };
+    }
+
+    @Test(dataProvider = "badIntervals", expectedExceptions = IllegalArgumentException.class)
+    public void badIntervals(String contig, int start, int end, String name){
+        SimpleInterval interval = new SimpleInterval(contig, start, end);
+    }
+
+    @Test
+    public void testEquality(){
+        Assert.assertTrue(i1.equals(i1));
+        Assert.assertTrue(i1.equals(i2));
+        Assert.assertTrue(i2.equals(i1));
+        Assert.assertFalse(i1.equals(i3));
+        Assert.assertFalse(i1.equals(i4));
+        Assert.assertFalse(i1.equals(i5));
+
+        //currently Interval cannot be equal to SimpleInterval, maybe we want to change this?
+        final Interval namedInterval = new Interval("1",1,100);
+        Assert.assertFalse(namedInterval.equals(i1));
+        Assert.assertFalse(i1.equals(namedInterval));
+    }
+
+    @Test
+    public void testToString(){
+        Assert.assertEquals(i1.toString(), "1:1-100");
+    }
+}

--- a/src/tests/java/htsjdk/tribble/BinaryFeaturesTest.java
+++ b/src/tests/java/htsjdk/tribble/BinaryFeaturesTest.java
@@ -45,7 +45,7 @@ public class BinaryFeaturesTest {
             Assert.assertTrue(bit.hasNext(), "Original iterator has items, but there's no items left in binary iterator");
             final Feature bf = bit.next();
 
-            Assert.assertEquals(bf.getChr(), of.getChr(), "Chr not equal between original and binary encoding");
+            Assert.assertEquals(bf.getContig(), of.getContig(), "Chr not equal between original and binary encoding");
             Assert.assertEquals(bf.getStart(), of.getStart(), "Start not equal between original and binary encoding");
             Assert.assertEquals(bf.getEnd(), of.getEnd(), "End not equal between original and binary encoding");
         }

--- a/src/tests/java/htsjdk/tribble/dbsnp/OldDbSNPCodecTest.java
+++ b/src/tests/java/htsjdk/tribble/dbsnp/OldDbSNPCodecTest.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
  *         <p/>
  *         tests out the basics of a dbsnp feature
  */
+@Deprecated
 public class OldDbSNPCodecTest {
 
     public static final File testFile = new File(TestUtils.DATA_DIR + "basicDbSNP.dbsnp");

--- a/src/tests/java/htsjdk/tribble/gelitext/GeliTextTest.java
+++ b/src/tests/java/htsjdk/tribble/gelitext/GeliTextTest.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
  *         <p/>
  *         test out the geli text source codec and feature
  */
+@Deprecated
 public class GeliTextTest {
     public static final File testFile = new File(TestUtils.DATA_DIR + "testGeliText.txt");
     public static Index index;


### PR DESCRIPTION
Renaming htsjdk.samtools.util.Interval -> NamedInterval which now extends the minimal Interval
extracting out a minimal genomic interval class from and naming that Interval
SAMRecord implements HasGenomicInterval
Feature implements HasGenomicInterval
renaming classes that are based on NamedInterval
renaming htsjdk.tribble.index.interval.Interval to FileInterval

This is motivated by the need to have a common interface to work with tribble `Feature` and `SAMRecord` for location based caching purposes. 
It's also a first step into integrating the the many interval classes that htsjdk, picard,  and GATK have and pushing functionality into a common base class.  See https://github.com/broadinstitute/hellbender/issues/100   and https://github.com/broadinstitute/hellbender/issues/159

@droazen please review 