### PR TITLE
indexing tabix writer for bgzf compressed files

### DIFF
--- a/src/java/htsjdk/samtools/util/PositionalOutputStream.java
+++ b/src/java/htsjdk/samtools/util/PositionalOutputStream.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.util;
+
+import htsjdk.samtools.util.LocationAware;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * @author shenkers
+ * Wraps output stream in a manner which keeps track of the position within the
+ * file and allowing writes at arbitrary points
+ */
+public class PositionalOutputStream extends OutputStream implements LocationAware {
+
+    private final OutputStream out;
+    private long position = 0;
+
+    public PositionalOutputStream(final OutputStream out) {
+        this.out = out;
+    }
+
+    public final void write(final byte[] bytes) throws IOException {
+        write(bytes, 0, bytes.length);
+    }
+
+    public final void write(final byte[] bytes, final int startIndex, final int numBytes) throws IOException {
+        position += numBytes;
+        out.write(bytes, startIndex, numBytes);
+    }
+
+    public final void write(final int c) throws IOException {
+        position++;
+        out.write(c);
+    }
+
+    public final long getPosition() {
+        return position;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        out.close();
+    }
+}

--- a/src/java/htsjdk/tribble/index/TabixIndexingFeatureWriter.java
+++ b/src/java/htsjdk/tribble/index/TabixIndexingFeatureWriter.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.tribble.index;
+
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.LocationAware;
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.index.tabix.TabixIndexCreator;
+import htsjdk.tribble.writers.LineEncoder;
+import htsjdk.samtools.util.PositionalOutputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+/**
+ *
+ * @author shenkers
+ * @param <T> the type of the feature to be written
+ */
+public class TabixIndexingFeatureWriter<T extends Feature> {
+
+    // File to which features will be written
+    File featureFile;
+    // OutputStream for the feature file to be written
+    OutputStream featureFileOutputStream;
+    // holds a pointer to the current offset position in the file being written
+    LocationAware filePosition;
+    IndexCreator indexCreator;
+    // function to encode features as lines of text
+    LineEncoder<T> lineEncoder;
+
+    /*
+     * IndexingTabixWriter writer uses an internal Writer, based by the ByteArrayOutputStream lineBuffer,
+     * to temp. buffer the header and per-site output before flushing the per line output
+     * in one go to the super.getOutputStream.  This results in high-performance, proper encoding,
+     * and allows us to avoid flushing explicitly the output stream getOutputStream, which
+     * allows us to properly compress vcfs in gz format without breaking indexing on the fly
+     * for uncompressed streams.
+     */
+    private static final int INITIAL_BUFFER_SIZE = 1024 * 16;
+    private final ByteArrayOutputStream lineBuffer = new ByteArrayOutputStream(INITIAL_BUFFER_SIZE);
+    /* Wrapping in a {@link BufferedWriter} avoids frequent conversions with individual writes to OutputStreamWriter. */
+    private Writer writer=null;
+
+    // an indicator of how the output feature file will be compressed
+    public enum Compression {
+        BGZF, NONE
+    }
+
+    public TabixIndexingFeatureWriter(File featureFile, Compression compression, LineEncoder<T> lineEncoder, TabixIndexCreator indexCreator) throws FileNotFoundException {
+        this.featureFile = featureFile;
+        
+        switch (compression) {
+            case BGZF: {
+                BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(lineBuffer, null);
+                filePosition = bcos;
+                writer = new BufferedWriter(new OutputStreamWriter(bcos));
+                break;
+            }
+            case NONE: {
+                PositionalOutputStream pos = new PositionalOutputStream(lineBuffer);
+                filePosition = pos;
+                writer = new BufferedWriter(new OutputStreamWriter(pos));
+                break;
+            }
+        }
+
+        this.featureFileOutputStream = new BufferedOutputStream(new FileOutputStream(featureFile));
+        this.indexCreator = indexCreator;
+        this.lineEncoder = lineEncoder;
+    }
+
+    /*
+     * Write a feature line to the output stream and updates the indexCreator
+     * 
+     * Features must be added in coordinate-sorted order
+     *
+     * @param s the string to write
+     * @throws IOException
+     */
+    public void add(T feature) throws IOException {
+        indexCreator.addFeature(feature, filePosition.getPosition());
+        writer.write(lineEncoder.encode(feature));
+        writer.write("\n");
+
+        //Actually write the line buffer contents to the destination output 
+        //stream.After calling this function the line buffer is reset so the 
+        //contents of the buffer can be reused 
+        writer.flush();
+        featureFileOutputStream.write(lineBuffer.toByteArray());
+        lineBuffer.reset();
+    }
+    
+    /*
+     * Closes the feature output stream and writes the index to disk at the 
+     * conventional location
+     */
+    public Index close() throws IOException {
+        featureFileOutputStream.close();
+
+        final Index index = indexCreator.finalizeIndex(filePosition.getPosition());
+        index.writeBasedOnFeatureFile(featureFile);
+        return index;
+    }
+
+}

--- a/src/java/htsjdk/tribble/writers/LineEncoder.java
+++ b/src/java/htsjdk/tribble/writers/LineEncoder.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 sol.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.tribble.writers;
+
+import htsjdk.tribble.Feature;
+
+/**
+ *
+ * @author shenkers
+ */
+public interface LineEncoder<T extends Feature> {
+    public String encode(T feature);
+}

--- a/src/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
@@ -28,6 +28,7 @@ package htsjdk.variant.variantcontext.writer;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.LocationAware;
+import htsjdk.samtools.util.PositionalOutputStream;
 import htsjdk.tribble.index.DynamicIndexCreator;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexCreator;
@@ -179,41 +180,5 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
             final String length = String.valueOf(seq.getSequenceLength());
             indexCreator.addProperty(contig,length);
         }
-    }
-}
-
-/**
- * Wraps output stream in a manner which keeps track of the position within the file and allowing writes
- * at arbitrary points
- */
-final class PositionalOutputStream extends OutputStream implements LocationAware
-{
-    private final OutputStream out;
-    private long position = 0;
-
-    public PositionalOutputStream(final OutputStream out) {
-        this.out = out;
-    }
-
-    public final void write(final byte[] bytes) throws IOException {
-        write(bytes, 0, bytes.length);
-    }
-
-    public final void write(final byte[] bytes, final int startIndex, final int numBytes) throws IOException {
-        position += numBytes;
-        out.write(bytes, startIndex, numBytes);
-    }
-
-    public final void write(final int c)  throws IOException {
-        position++;
-        out.write(c);
-    }
-
-    public final long getPosition() { return position; }
-
-    @Override
-    public void close() throws IOException {
-        super.close();
-        out.close();
     }
 }

--- a/src/tests/java/htsjdk/tribble/index/TabixIndexingFeatureWriterNGTest.java
+++ b/src/tests/java/htsjdk/tribble/index/TabixIndexingFeatureWriterNGTest.java
@@ -1,0 +1,170 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 sol.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.tribble.index;
+
+import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.CloseableTribbleIterator;
+import htsjdk.tribble.bed.BEDCodec;
+import htsjdk.tribble.bed.BEDFeature;
+import htsjdk.tribble.index.tabix.TabixFormat;
+import htsjdk.tribble.index.tabix.TabixIndexCreator;
+import htsjdk.tribble.readers.LineIterator;
+import htsjdk.tribble.util.TabixUtils;
+import htsjdk.tribble.writers.LineEncoder;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+import static org.testng.Assert.*;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author shenkers
+ */
+public class TabixIndexingFeatureWriterNGTest {
+
+    public TabixIndexingFeatureWriterNGTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+    }
+
+    @Test
+    public void testCreateTabixIndexForBGZF() throws Exception {
+        BEDCodec codec = new BEDCodec();
+        // we'll read feature data from this file
+        String file1 = "testdata/htsjdk/tribble/test.bed";
+        // and create an indexed BGZF file at this location
+        String file2 = "testdata/htsjdk/tribble/test.tabixindex.bed.gz";
+
+        new File(file2).deleteOnExit();
+        new File(file2 + TabixUtils.STANDARD_INDEX_EXTENSION).deleteOnExit();
+
+        TabixIndexCreator tabixIndexCreator = new TabixIndexCreator(TabixFormat.BED);
+         LineEncoder<BEDFeature> encoder = new LineEncoder<BEDFeature>() {
+
+            @Override
+            public String encode(BEDFeature t) {
+                return String.format("%s\t%d\t%d", t.getChr(), t.getStart() - 1, t.getEnd());
+            }
+        };
+        
+        // setup the indexing feature writer
+        TabixIndexingFeatureWriter instance = new TabixIndexingFeatureWriter(new File(file2), TabixIndexingFeatureWriter.Compression.BGZF, encoder, tabixIndexCreator);
+
+        // read features from the feature file, pass them to the indexer
+        AbstractFeatureReader<BEDFeature, LineIterator> featureReader = AbstractFeatureReader.getFeatureReader(file1, codec, false);
+        CloseableTribbleIterator<BEDFeature> it = featureReader.iterator();
+        while (it.hasNext()) {
+            BEDFeature next = it.next();
+            instance.add(next);
+        }
+        // close the indexer, which finalizes and writes the index
+        Index index = instance.close();
+
+        // open the generated file
+        AbstractFeatureReader<BEDFeature, LineIterator> tifr = AbstractFeatureReader.getFeatureReader(file2, file2 + TabixUtils.STANDARD_INDEX_EXTENSION, codec, false);
+        // let's try querying an interval
+        CloseableTribbleIterator<BEDFeature> itt = tifr.query("chr1", 101, 201);
+
+        Set<String> overlaps = new HashSet();
+        while (itt.hasNext()) {
+            BEDFeature next = itt.next();
+            overlaps.add(String.format("%s:%d-%d", next.getChr(), next.getStart(), next.getEnd()));
+        }
+
+        Set<String> expected = new HashSet();
+        expected.add("chr1:101-101");
+        expected.add("chr1:201-201");
+        assertEquals(overlaps, expected);
+    }
+
+    @Test
+    public void testCreateTabixIndexForUncompressedFile() throws Exception {
+        BEDCodec codec = new BEDCodec();
+        // we'll read feature data from this file
+        String file1 = "testdata/htsjdk/tribble/test.bed";
+        // and create an indexed BGZF file at this location
+        String file2 = "testdata/htsjdk/tribble/test.tabixindex.uncompressed.bed";
+
+        new File(file2).deleteOnExit();
+        new File(file2 + TabixUtils.STANDARD_INDEX_EXTENSION).deleteOnExit();
+
+        TabixIndexCreator tabixIndexCreator = new TabixIndexCreator(TabixFormat.BED);
+        LineEncoder<BEDFeature> encoder = new LineEncoder<BEDFeature>() {
+
+            @Override
+            public String encode(BEDFeature t) {
+                return String.format("%s\t%d\t%d", t.getChr(), t.getStart() - 1, t.getEnd());
+            }
+        };
+
+        // setup the indexing feature writer
+        TabixIndexingFeatureWriter instance = new TabixIndexingFeatureWriter(new File(file2), TabixIndexingFeatureWriter.Compression.NONE, encoder, tabixIndexCreator);
+
+        // read features from the feature file, pass them to the indexer
+        AbstractFeatureReader<BEDFeature, LineIterator> featureReader = AbstractFeatureReader.getFeatureReader(file1, codec, false);
+        CloseableTribbleIterator<BEDFeature> it = featureReader.iterator();
+        while (it.hasNext()) {
+            BEDFeature next = it.next();
+            instance.add(next);
+        }
+        // close the indexer, which finalizes and writes the index
+        Index index = instance.close();
+
+        // open the generated file
+        AbstractFeatureReader<BEDFeature, LineIterator> tifr = AbstractFeatureReader.getFeatureReader(file2, file2 + TabixUtils.STANDARD_INDEX_EXTENSION, codec, false);
+        // let's try querying an interval
+        CloseableTribbleIterator<BEDFeature> itt = tifr.query("chr1", 101, 201);
+
+        Set<String> overlaps = new HashSet();
+        while (itt.hasNext()) {
+            BEDFeature next = itt.next();
+            overlaps.add(String.format("%s:%d-%d", next.getChr(), next.getStart(), next.getEnd()));
+        }
+
+        Set<String> expected = new HashSet();
+        expected.add("chr1:101-101");
+        expected.add("chr1:201-201");
+        assertEquals(overlaps, expected);
+    }
+
+}


### PR DESCRIPTION
It is not possible to generate a tabix indexed BGZF compressed feature file, ie

http://sourceforge.net/p/samtools/mailman/message/33486490/

I created the TabixIndexingFeatureWriter to manage this process. It currently does not do anything to enforce output file structure (ie headers). To use this class, the caller instantiates a writer, adds features to it, and the index is written to disk at the conventional location when the writer is closed. 

It doesn't seem like HTSJDK has a general interface for writing line-oriented features (something symmetric with the LineReader interface, except for writing), so I also created an interface LineEncoder, so the user can specify how different feature formats are written. 

Also, I created a toplevel class for PositionalOutputStream (which is currently an inner class of IndexingVariantContextWriter), to reduce code duplication by creating another inner class.

Finally, I created two simple tests to show that a TabixIndexingFeatureWriter can be used to generate indexes for either uncompressed or BGZF compressed BED feature files.