### PR TITLE
added 'checkError' in VariantContextWriter interface. Motivation: when O...

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriter.java
@@ -46,4 +46,9 @@ public class AsyncVariantContextWriter extends AbstractAsyncWriter<VariantContex
     public void writeHeader(final VCFHeader header) {
         this.underlyingWriter.writeHeader(header);
     }
+    
+    @Override
+    public boolean checkError() {
+        return false;
+    }
 }

--- a/src/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
@@ -39,6 +39,7 @@ import htsjdk.variant.vcf.VCFHeader;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.PrintStream;
 
 /**
  * this class writes VCF files
@@ -107,7 +108,16 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
             outputStream = positionalOutputStream;
         }
     }
-
+    
+    /** return true is the underlying stream is a PrintStream and 
+     * its checkError returned true. Used to stop linux pipelines 
+     */
+    @Override
+    public boolean checkError() {
+        return (getOutputStream() instanceof PrintStream) && 
+                PrintStream.class.cast(getOutputStream()).checkError();
+    }
+    
     public OutputStream getOutputStream() {
         return outputStream;
     }

--- a/src/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriter.java
@@ -58,4 +58,9 @@ public class SortingVariantContextWriter extends SortingVariantContextWriterBase
         int mostUpstreamWritableIndex = vc.getStart() - maxCachingStartDistance;
         this.mostUpstreamWritableLoc = Math.max(BEFORE_MOST_UPSTREAM_LOC, mostUpstreamWritableIndex);
     }
+    
+    @Override
+    public boolean checkError() {
+        return false;
+    }
 }

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
@@ -42,5 +42,10 @@ public interface VariantContextWriter extends Closeable {
      */
     public void close();
 
+    /**
+     * @return true if the underlying stream is a java.io.PrintStream  and its checkError returned true, used for pipelines
+     */
+    public boolean checkError();
+    
     public void add(VariantContext vc);
 }


### PR DESCRIPTION
Motivation: when a **VariantContextWriter** prints a VCF to ***stdout**, there is no way to tell if the output stream has been interrupted by another command in a linux pipeline. I've added a method __checkError()__ in __VariantContextWriter__ that returns true if the underlying stream is a PrintStream and [PrintStream.checkError()](http://docs.oracle.com/javase/7/docs/api/java/io/PrintStream.html#checkError%28%29)  returned true. 


As an example, the following program prints a large number of variants. Without checkError, the program wouldn't stop even if it is piped in 'head'.

```java
import htsjdk.variant.variantcontext.*;
import htsjdk.variant.variantcontext.writer.*;
import htsjdk.variant.vcf.*;

public class Test
	{
	public static void main(String args[]) throws Exception
		{
		VariantContextWriterBuilder vcw=new VariantContextWriterBuilder();
		vcw.setOutputVCFStream(System.out);
		vcw.setOptions(java.util.EnumSet.noneOf(Options.class));
		VariantContextWriter w = vcw.build();
		w.writeHeader(new VCFHeader());
	 
		for(int i=0;i<Integer.MAX_VALUE;++i)
			{
			if(w.checkError()) break; /** <------------------------------------ **/
			VariantContextBuilder vcb=new VariantContextBuilder();
			vcb.chr("chr"+(i%10));
			vcb.start((i%10007));
			vcb.stop((i%10007));
			vcb.alleles(java.util.Collections.singletonList(Allele.create(i%2==0?"A":"T",true)));
			w.add(vcb.make());
			}
		w.close();
		}
	}
```

compile & test:

```
javac -cp 'dist/*' -sourcepath src/java:. Test.java

$ time (java -cp '.:dist/*' Test | head)
##fileformat=VCFv4.1
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
chr0	0	.	A	.	.	.	.
chr1	1	.	T	.	.	.	.
chr2	2	.	A	.	.	.	.
chr3	3	.	T	.	.	.	.
chr4	4	.	A	.	.	.	.
chr5	5	.	T	.	.	.	.
chr6	6	.	A	.	.	.	.
chr7	7	.	T	.	.	.	.

real	0m0.126s
user	0m0.112s
sys	0m0.020s
```