### PR TITLE
Use RuntimeIOException instead of RuntimeException where appropriate

### DIFF
--- a/src/java/htsjdk/samtools/AbstractBAMFileIndex.java
+++ b/src/java/htsjdk/samtools/AbstractBAMFileIndex.java
@@ -83,7 +83,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
         final byte[] buffer = new byte[4];
         readBytes(buffer);
         if (!Arrays.equals(buffer, BAMFileConstants.BAM_INDEX_MAGIC)) {
-            throw new RuntimeException("Invalid file header in BAM index " + file +
+            throw new RuntimeIOException("Invalid file header in BAM index " + file +
                                        ": " + new String(buffer));
         }
         
@@ -545,7 +545,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
                 mRandomAccessFile = new RandomAccessFile(file, "r");
                 final long fileLength = mRandomAccessFile.length();
                 if (fileLength > Integer.MAX_VALUE) {
-                    throw new RuntimeException("BAM index file " + mFile + " is too large: " + fileLength);
+                    throw new RuntimeIOException("BAM index file " + mFile + " is too large: " + fileLength);
                 }
                 mFileLength = (int) fileLength;
             } catch (final IOException exc) {
@@ -558,7 +558,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
             int resultOffset = 0;
             int resultLength = bytes.length;
             if (mFilePointer + resultLength > mFileLength) {
-                throw new RuntimeException("Attempt to read past end of BAM index file (file is truncated?): " + mFile);
+                throw new RuntimeIOException("Attempt to read past end of BAM index file (file is truncated?): " + mFile);
             }
             while (resultLength > 0) {
                 loadPage(mFilePointer);

--- a/src/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/java/htsjdk/samtools/BAMFileReader.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CoordMath;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.StringLineReader;
 
 import java.io.DataInputStream;
@@ -306,7 +307,7 @@ class BAMFileReader extends SamReader.ReaderImplementation {
             try {
                 mCompressedInputStream.seek(mFirstRecordPointer);
             } catch (final IOException exc) {
-                throw new RuntimeException(exc.getMessage(), exc);
+                throw new RuntimeIOException(exc.getMessage(), exc);
             }
         }
         mCurrentIterator = new BAMFileIterator();
@@ -476,7 +477,7 @@ class BAMFileReader extends SamReader.ReaderImplementation {
             mCurrentIterator = new BAMFileIndexUnmappedIterator();
             return mCurrentIterator;
         } catch (final IOException e) {
-            throw new RuntimeException("IOException seeking to unmapped reads", e);
+            throw new RuntimeIOException("IOException seeking to unmapped reads", e);
         }
     }
 
@@ -648,7 +649,7 @@ class BAMFileReader extends SamReader.ReaderImplementation {
                     mNextRecord.eagerDecode();
                 }
             } catch (final IOException exc) {
-                throw new RuntimeException(exc.getMessage(), exc);
+                throw new RuntimeIOException(exc.getMessage(), exc);
             }
         }
 

--- a/src/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -293,7 +293,7 @@ public class SAMFileWriterFactory {
             try {
                 return makeCRAMWriter(header, new FileOutputStream(outputFile), referenceFasta);
             } catch (final FileNotFoundException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeIOException(e);
             }
         return makeSAMOrBAMWriter(header, presorted, outputFile);
     }

--- a/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
+++ b/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
@@ -47,7 +47,7 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
      * to be written out.
      */
     public void write(final T item) {
-        if (this.isClosed.get()) throw new RuntimeException("Attempt to add record to closed writer.");
+        if (this.isClosed.get()) throw new RuntimeIOException("Attempt to add record to closed writer.");
 
         checkAndRethrow();
         try { this.queue.put(item); }

--- a/src/java/htsjdk/samtools/util/BlockCompressedInputStream.java
+++ b/src/java/htsjdk/samtools/util/BlockCompressedInputStream.java
@@ -396,7 +396,7 @@ public class BlockCompressedInputStream extends InputStream implements LocationA
             try {
                 buffer = new byte[uncompressedLength];
             } catch (final NegativeArraySizeException e) {
-                throw new RuntimeException("BGZF file has invalid uncompressedLength: " + uncompressedLength, e);
+                throw new RuntimeIOException("BGZF file has invalid uncompressedLength: " + uncompressedLength, e);
             }
         }
         blockGunzipper.unzipBlock(buffer, compressedBlock, compressedLength);

--- a/src/java/htsjdk/samtools/util/BlockGunzipper.java
+++ b/src/java/htsjdk/samtools/util/BlockGunzipper.java
@@ -109,7 +109,7 @@ public class BlockGunzipper {
             }
         } catch (DataFormatException e)
         {
-            throw new RuntimeException(e);
+            throw new RuntimeIOException(e);
         }
     }
 }

--- a/src/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/java/htsjdk/samtools/util/IOUtil.java
@@ -752,7 +752,7 @@ public class IOUtil {
             }
             return canonicalPath;
         } catch (final IOException ioe) {
-            throw new RuntimeException("Error getting full canonical path for " +
+            throw new RuntimeIOException("Error getting full canonical path for " +
                     file + ": " + ioe.getMessage(), ioe);
         }
    }

--- a/src/java/htsjdk/samtools/util/SortingLongCollection.java
+++ b/src/java/htsjdk/samtools/util/SortingLongCollection.java
@@ -276,7 +276,7 @@ public class SortingLongCollection {
                 isCurrentRecord = false;
                 currentRecord = 0;
             } catch (final IOException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeIOException(e);
             }
             return ret;
         }

--- a/src/java/htsjdk/samtools/util/ftp/FTPUtils.java
+++ b/src/java/htsjdk/samtools/util/ftp/FTPUtils.java
@@ -21,6 +21,7 @@ package htsjdk.samtools.util.ftp;
 
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.seekablestream.UserPasswordInput;
+import htsjdk.samtools.util.RuntimeIOException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -94,7 +95,7 @@ public class FTPUtils {
         FTPClient ftp = new FTPClient();
         FTPReply reply = ftp.connect(host);
         if (!reply.isSuccess()) {
-            throw new RuntimeException("Could not connect to " + host);
+            throw new RuntimeIOException("Could not connect to " + host);
         }
 
         String user = "anonymous";
@@ -114,7 +115,7 @@ public class FTPUtils {
         reply = ftp.login(user, password);
         if (!reply.isSuccess()) {
         	if (userPasswordInput == null) {
-                throw new RuntimeException("Login failure for host: " + host);
+                throw new RuntimeIOException("Login failure for host: " + host);
         	}
         	else {
 	        	userPasswordInput.setHost(host);
@@ -135,14 +136,14 @@ public class FTPUtils {
 	                userInfo = user + ":" + password;
 	                userCredentials.put(host, userInfo);
 	            } else {
-	                throw new RuntimeException("Login failure for host: " + host);
+	                throw new RuntimeIOException("Login failure for host: " + host);
 	            }
         	}
         }
 
         reply = ftp.binary();
         if (!(reply.isSuccess())) {
-            throw new RuntimeException("Could not set binary mode on host: " + host);
+            throw new RuntimeIOException("Could not set binary mode on host: " + host);
         }
 
         return ftp;

--- a/src/java/htsjdk/tribble/BinaryFeatureCodec.java
+++ b/src/java/htsjdk/tribble/BinaryFeatureCodec.java
@@ -2,6 +2,7 @@ package htsjdk.tribble;
 
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.LocationAware;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.readers.PositionalBufferedStream;
 
 import java.io.IOException;
@@ -36,7 +37,7 @@ abstract public class BinaryFeatureCodec<T extends Feature> implements FeatureCo
         try {
             return source.isDone();
         } catch (final IOException e) {
-            throw new RuntimeException("Failure reading from stream.", e);
+            throw new RuntimeIOException("Failure reading from stream.", e);
         }
     }
 }

--- a/src/java/htsjdk/tribble/TabixFeatureReader.java
+++ b/src/java/htsjdk/tribble/TabixFeatureReader.java
@@ -24,6 +24,7 @@
 package htsjdk.tribble;
 
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.readers.LineReader;
 import htsjdk.tribble.readers.LineReaderUtil;
 import htsjdk.tribble.readers.PositionalBufferedStream;
@@ -196,7 +197,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
             try {
                 readNextRecord();
             } catch (IOException e) {
-                throw new RuntimeException("Unable to read the next record, the last record was at " +
+                throw new RuntimeIOException("Unable to read the next record, the last record was at " +
                         ret.getContig() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
             }
             return ret;

--- a/src/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -25,6 +25,7 @@ package htsjdk.tribble;
 
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
@@ -314,7 +315,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
             try {
                 readNextRecord();
             } catch (IOException e) {
-                throw new RuntimeException("Unable to read the next record, the last record was at " +
+                throw new RuntimeIOException("Unable to read the next record, the last record was at " +
                         ret.getContig() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
             }
             return ret;
@@ -404,7 +405,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
             try {
                 readNextRecord();
             } catch (IOException e) {
-                throw new RuntimeException("Unable to read the next record, the last record was at " +
+                throw new RuntimeIOException("Unable to read the next record, the last record was at " +
                         ret.getContig() + ":" + ret.getStart() + "-" + ret.getEnd(), e);
             }
             return ret;

--- a/src/java/htsjdk/tribble/example/CountRecords.java
+++ b/src/java/htsjdk/tribble/example/CountRecords.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.tribble.example;
 
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
@@ -112,7 +113,7 @@ public class CountRecords {
             return recordCount;
 
         } catch (IOException e) {
-            throw new RuntimeException("Something went wrong while reading feature file " + featureInput, e);
+            throw new RuntimeIOException("Something went wrong while reading feature file " + featureInput, e);
         }
     }
 
@@ -175,7 +176,7 @@ public class CountRecords {
 
             return index;
         } catch (IOException e) {
-            throw new RuntimeException("Unable to create index from file " + featureFile,e);
+            throw new RuntimeIOException("Unable to create index from file " + featureFile,e);
         }
     }
 

--- a/src/java/htsjdk/tribble/readers/AsciiLineReaderIterator.java
+++ b/src/java/htsjdk/tribble/readers/AsciiLineReaderIterator.java
@@ -3,6 +3,7 @@ package htsjdk.tribble.readers;
 import htsjdk.samtools.util.AbstractIterator;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.LocationAware;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.Tuple;
 
 import java.io.Closeable;
@@ -84,7 +85,7 @@ public class AsciiLineReaderIterator implements LocationAware, LineIterator, Clo
             try {
                 line = asciiLineReader.readLine();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new RuntimeIOException(e);
             }
             return line == null ? null : new Tuple<String, Long>(line, position);
         }

--- a/src/java/htsjdk/tribble/readers/LineIteratorImpl.java
+++ b/src/java/htsjdk/tribble/readers/LineIteratorImpl.java
@@ -2,6 +2,7 @@ package htsjdk.tribble.readers;
 
 import htsjdk.samtools.util.AbstractIterator;
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.RuntimeIOException;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -22,7 +23,7 @@ public class LineIteratorImpl extends AbstractIterator<String> implements LineIt
         try {
             return lineReader.readLine();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeIOException(e);
         }
     }
 

--- a/src/java/htsjdk/tribble/readers/LineReaderUtil.java
+++ b/src/java/htsjdk/tribble/readers/LineReaderUtil.java
@@ -2,6 +2,7 @@ package htsjdk.tribble.readers;
 
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.TribbleException;
 
 import java.io.IOException;
@@ -45,7 +46,7 @@ public class LineReaderUtil {
                         try {
                             return reader.readLine();
                         } catch (IOException e) {
-                            throw new RuntimeException(e);
+                            throw new RuntimeIOException(e);
                         }
                     }
 
@@ -76,7 +77,7 @@ public class LineReaderUtil {
                         try {
                             return reader.readLine();
                         } catch (IOException e) {
-                            throw new RuntimeException(e);
+                            throw new RuntimeIOException(e);
                         }
                     }
 

--- a/src/java/htsjdk/tribble/readers/TabixIteratorLineReader.java
+++ b/src/java/htsjdk/tribble/readers/TabixIteratorLineReader.java
@@ -23,6 +23,8 @@
  */
 package htsjdk.tribble.readers;
 
+import htsjdk.samtools.util.RuntimeIOException;
+
 import java.io.IOException;
 
 /**
@@ -42,7 +44,7 @@ public class TabixIteratorLineReader implements LineReader {
         try {
             return iterator != null ? iterator.next() : null;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeIOException(e);
         }
     }
 

--- a/src/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.IndexCreator;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.bcf2.BCF2Type;
@@ -185,7 +186,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
             BCF2Type.INT32.write(headerBytes.length, outputStream);
             outputStream.write(headerBytes);
         } catch (IOException e) {
-            throw new RuntimeException("BCF2 stream: Got IOException while trying to write BCF2 header", e);
+            throw new RuntimeIOException("BCF2 stream: Got IOException while trying to write BCF2 header", e);
         }
     }
 
@@ -205,7 +206,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
             writeBlock(infoBlock, genotypesBlock);
         }
         catch ( IOException e ) {
-            throw new RuntimeException("Error writing record to BCF2 file: " + vc.toString(), e);
+            throw new RuntimeIOException("Error writing record to BCF2 file: " + vc.toString(), e);
         }
     }
 
@@ -215,7 +216,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
             outputStream.flush();
         }
         catch ( IOException e ) {
-            throw new RuntimeException("Failed to flush BCF2 file");
+            throw new RuntimeIOException("Failed to flush BCF2 file");
         }
         super.close();
     }

--- a/src/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
@@ -28,6 +28,7 @@ package htsjdk.variant.variantcontext.writer;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.LocationAware;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.DynamicIndexCreator;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexCreator;
@@ -137,7 +138,7 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
 
 
         } catch (final IOException e) {
-            throw new RuntimeException("Unable to close index for " + getStreamName(), e);
+            throw new RuntimeIOException("Unable to close index for " + getStreamName(), e);
         }
     }
 

--- a/src/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.IndexCreator;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
@@ -135,7 +136,7 @@ class VCFWriter extends IndexingVariantContextWriter {
             writeAndResetBuffer();
 
         } catch ( IOException e ) {
-            throw new RuntimeException("Couldn't write file " + getStreamName(), e);
+            throw new RuntimeIOException("Couldn't write file " + getStreamName(), e);
         }
     }
 
@@ -187,7 +188,7 @@ class VCFWriter extends IndexingVariantContextWriter {
             writer.flush();  // necessary so that writing to an output stream will work
         }
         catch (IOException e) {
-            throw new RuntimeException("IOException writing the VCF header to " + streamNameForError, e);
+            throw new RuntimeIOException("IOException writing the VCF header to " + streamNameForError, e);
         }
 
         return header;
@@ -203,7 +204,7 @@ class VCFWriter extends IndexingVariantContextWriter {
             // TODO -- would it be useful to null out the line buffer so we don't have it around unnecessarily?
             writer.close();
         } catch (IOException e) {
-            throw new RuntimeException("Unable to close " + getStreamName(), e);
+            throw new RuntimeIOException("Unable to close " + getStreamName(), e);
         }
 
         super.close();
@@ -224,7 +225,7 @@ class VCFWriter extends IndexingVariantContextWriter {
             writeAndResetBuffer();
 
         } catch (IOException e) {
-            throw new RuntimeException("Unable to write the VCF object to " + getStreamName(), e);
+            throw new RuntimeIOException("Unable to write the VCF object to " + getStreamName(), e);
         }
     }
 }

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterFactory.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterFactory.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.index.IndexCreator;
 import htsjdk.tribble.index.tabix.TabixFormat;
@@ -275,7 +276,7 @@ public class VariantContextWriterFactory {
         try {
             return IOUtil.maybeBufferOutputStream(new FileOutputStream(location));
         } catch (final FileNotFoundException e) {
-            throw new RuntimeException(location + ": Unable to create VCF writer", e);
+            throw new RuntimeIOException(location + ": Unable to create VCF writer", e);
         }
     }
 }

--- a/src/java/htsjdk/variant/vcf/VCFRecordCodec.java
+++ b/src/java/htsjdk/variant/vcf/VCFRecordCodec.java
@@ -1,5 +1,6 @@
 package htsjdk.variant.vcf;
 
+import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.SortingCollection;
 import htsjdk.variant.variantcontext.VariantContext;
 
@@ -51,7 +52,7 @@ public class VCFRecordCodec implements SortingCollection.Codec<VariantContext> {
 			final String line;
 			return ((line = inputReader.readLine()) != null) ? this.vcfDecoder.decode(line) : null;
 		} catch (final IOException ioe) {
-			throw new RuntimeException("Could not decode/read a VCF record for a sorting collection: " + ioe.getMessage(), ioe);
+			throw new RuntimeIOException("Could not decode/read a VCF record for a sorting collection: " + ioe.getMessage(), ioe);
 		}
 	}
 


### PR DESCRIPTION
Many places in the code directly throw RuntimeException, especially under circumstances where a more specialized exception type would be informative. In particular, cases where a checked IOException is being replaced with RuntimeException now throw RuntimeIOException.

(I haven't included any of the uses in the CRAM code at this stage since it looks to be under fairly rapid development)