### PR TITLE
Consistent header order

### DIFF
--- a/src/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -24,7 +24,7 @@
 package htsjdk.samtools;
 
 import java.io.Serializable;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,7 +35,7 @@ import java.util.Set;
 public abstract class AbstractSAMHeaderRecord implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    private final Map<String,String> mAttributes = new HashMap<String, String>();
+    private final Map<String,String> mAttributes = new LinkedHashMap<String, String>();
 
     public String getAttribute(final String key) {
         return mAttributes.get(key);

--- a/src/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -32,7 +32,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -250,7 +250,7 @@ public class SAMTextHeaderCodec {
      */
     private class ParsedHeaderLine {
         private HeaderRecordType mHeaderRecordType;
-        private final Map<String, String> mKeyValuePairs = new HashMap<String, String>();
+        private final Map<String, String> mKeyValuePairs = new LinkedHashMap<String, String>();
         private boolean lineValid = false;
 
         ParsedHeaderLine(final String line) {

--- a/testdata/htsjdk/samtools/roundtrip.sam
+++ b/testdata/htsjdk/samtools/roundtrip.sam
@@ -1,0 +1,16 @@
+@HD	VN:1.4	SO:unsorted
+@SQ	SN:chr1	LN:101
+@SQ	SN:chr2	LN:101
+@SQ	SN:chr3	LN:101
+@RG	ID:0	SM:Hi,Mom!
+@RG	ID:rg1	PL:ILLUMINA	SM:sm1
+A	73	chr2	1	255	10M	*	0	0	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+A	133	*	0	0	*	chr2	1	0	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+B	99	chr1	1	255	10M	=	26	35	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+B	147	chr1	26	255	10M	=	1	-35	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+C	99	chr2	1	255	10M	=	26	35	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+C	147	chr2	26	255	10M	=	1	-35	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+D	99	chr3	1	255	10M	=	25	35	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+D	147	chr3	26	255	10M	=	1	-35	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+E	99	chr1	2	255	10M	=	15	30	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1
+E	147	chr1	15	255	10M	=	2	-30	CAACAGAAGC	)'.*.+2,))	RG:Z:rg1


### PR DESCRIPTION
The HashMap implementation has changed in Java8 so the iteration order is different with respect to earlier Java versions. This results in SAM header attribute ordering changing, as they are currently being inserted into a regular HashMap. This PR swaps to using a LinkedHashMap so that the attributes are now maintained in insertion-order.
