### PR TITLE
remove default implementation of FeatureCodec.canDecode 

### DIFF
--- a/src/java/htsjdk/tribble/AbstractFeatureCodec.java
+++ b/src/java/htsjdk/tribble/AbstractFeatureCodec.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 
 /**
  * Simple basic class providing much of the basic functionality of codecs
+ * Every concrete subclass must implement {@link FeatureCodec#canDecode(String)} to indicate whether it can decode the file.
+ * Note that that method is the only way that the right codec for a file is identified and that <bold>only one</bold> codec
+ * is allowed to identify itself as being able to decode any given file.
  */
 public abstract class AbstractFeatureCodec<FEATURE_TYPE extends Feature, SOURCE> implements FeatureCodec<FEATURE_TYPE, SOURCE> {
     private final Class<FEATURE_TYPE> myClass;
@@ -44,10 +47,4 @@ public abstract class AbstractFeatureCodec<FEATURE_TYPE extends Feature, SOURCE>
     public Class<FEATURE_TYPE> getFeatureType() {
         return myClass;
     }
-
-    @Override
-    public boolean canDecode(final String path) {
-        return false;
-    }
-
 }

--- a/src/java/htsjdk/tribble/FeatureCodec.java
+++ b/src/java/htsjdk/tribble/FeatureCodec.java
@@ -105,7 +105,8 @@ public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
     /**
      * <p>
      * This function returns true iff the File potentialInput can be parsed by this
-     * codec.
+     * codec. Note that checking the file's extension is a perfectly acceptable implementation of this method
+     * and file contents only rarely need to be checked.
      * </p>
      * <p>
      * There is an assumption that there's never a situation where two different Codecs

--- a/src/java/htsjdk/tribble/gelitext/GeliTextCodec.java
+++ b/src/java/htsjdk/tribble/gelitext/GeliTextCodec.java
@@ -73,6 +73,11 @@ public class GeliTextCodec extends AsciiFeatureCodec<GeliTextFeature> {
     }
 
     @Override
+    public boolean canDecode(String path){
+	return path.toLowerCase().endsWith(".geli.calls") || path.toLowerCase().endsWith(".geli");
+    }
+
+    @Override
     public Object readActualHeader(LineIterator reader) {
         return null;
     }


### PR DESCRIPTION
remove default implementation of FeatureCodec.canDecode to enforce implementation in concrete classes

<!---
@huboard:{"order":198.25,"milestone_order":221,"custom_state":""}
-->
