### PR TITLE
Yf geometrical downsampling

### DIFF
--- a/src/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.samtools.util.SequenceUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -66,6 +67,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
 
     private SAMProgramRecord programRecord = null;
     private SAMReadGroupRecord readGroup = null;
+    private boolean useNmFlag = false;
 
     public static final int DEFAULT_CHROMOSOME_LENGTH = 200000000;
 
@@ -156,6 +158,10 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         }
     }
 
+    public void setUseNmFlag(final boolean useNmFlag) {
+        this.useNmFlag = useNmFlag;
+    }
+
     public void setReadGroup(final SAMReadGroupRecord readGroup) {
         this.readGroup = readGroup;
         if (readGroup != null) {
@@ -225,6 +231,10 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             rec.setReadUnmappedFlag(true);
         }
         rec.setAttribute(SAMTag.RG.name(), READ_GROUP_ID);
+
+        if(useNmFlag){
+            rec.setAttribute(SAMTag.NM.name(), SequenceUtil.calculateSamNmTagFromCigar(rec));
+        }
 
         if (programRecord != null) {
             rec.setAttribute(SAMTag.PG.name(), programRecord.getProgramGroupId());
@@ -322,6 +332,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         end1.setAlignmentStart(start1);
         end1.setReadNegativeStrandFlag(false);
         end1.setCigarString(readLength + "M");
+        if(useNmFlag) end1.setAttribute(ReservedTagConstants.NM, 0);
         end1.setMappingQuality(255);
         end1.setReadPairedFlag(true);
         end1.setProperPairFlag(true);
@@ -346,6 +357,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         end2.setAlignmentStart(start2);
         end2.setReadNegativeStrandFlag(true);
         end2.setCigarString(readLength + "M");
+        if(useNmFlag) end2.setAttribute(ReservedTagConstants.NM,0);
         end2.setMappingQuality(255);
         end2.setReadPairedFlag(true);
         end2.setProperPairFlag(true);
@@ -515,13 +527,11 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             throw new RuntimeIOException("problems creating tempfile", e);
         }
 
-
         this.header.setAttribute("VN", "1.0");
         final SAMFileWriter w = new SAMFileWriterFactory().makeBAMWriter(this.header, true, tempFile);
         for (final SAMRecord r : this.getRecords()) {
             w.addAlignment(r);
         }
-
 
         w.close();
 

--- a/src/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/java/htsjdk/samtools/util/SequenceUtil.java
@@ -336,7 +336,9 @@ public class SequenceUtil {
      * than byte[].  This is because GATK needs it this way.
      * <p/>
      * TODO: Remove this method when GATK map method is changed to take refseq as byte[].
+     * TODO: UPDATE: Seems to be removed from GATK. Deprecated now to be removed in a future version.
      */
+    @Deprecated
     private static int countMismatches(final SAMRecord read, final char[] referenceBases, final int referenceOffset) {
         int mismatches = 0;
 
@@ -430,7 +432,9 @@ public class SequenceUtil {
      * than byte[].  This is because GATK needs it this way.
      * <p/>
      * TODO: Remove this method when GATK map method is changed to take refseq as byte[].
+     * TODO: UPDATE: Seems to be removed from GATK. Deprecated now to be removed in a future version.
      */
+    @Deprecated
     public static int sumQualitiesOfMismatches(final SAMRecord read, final char[] referenceBases,
                                                final int referenceOffset) {
         int qualities = 0;
@@ -524,11 +528,32 @@ public class SequenceUtil {
     }
 
     /**
+     * Attempts to calculate the for the predefined NM tag from the SAM spec using the cigar string alone.
+     * It may calculate incorrectly if ambiguous operators (Like M) are used.
+     *
+     * Needed for testing infrastructure: SAMRecordSetBuilder
+     */
+    public static int calculateSamNmTagFromCigar(final SAMRecord record) {
+        int samNm = 0;
+        for (final CigarElement el : record.getCigar().getCigarElements()) {
+            if ( el.getOperator() == CigarOperator.X ||
+                 el.getOperator() == CigarOperator.INSERTION ||
+                 el.getOperator() == CigarOperator.DELETION) {
+                samNm += el.getLength();
+            }
+        }
+        return samNm;
+    }
+
+
+    /**
      * Sadly, this is a duplicate of the method above, except that it takes char[] for referenceBases rather
      * than byte[].  This is because GATK needs it this way.
      * <p/>
      * TODO: Remove this method when GATK map method is changed to take refseq as byte[].
+     * TODO: UPDATE: Seems to be removed from GATK. Deprecated now to be removed in a future version.
      */
+    @Deprecated
     public static int calculateSamNmTag(final SAMRecord read, final char[] referenceBases,
                                         final int referenceOffset) {
         int samNm = countMismatches(read, referenceBases, referenceOffset);
@@ -578,7 +603,6 @@ public class SequenceUtil {
             bases[i] = complement(bases[i]);
         }
     }
-
 
     /** Reverses the quals in place. */
     public static void reverseQualities(final byte[] quals) {


### PR DESCRIPTION
- Moved PgIdGenerator from Picard-public to here 
- Fixed a small bug in SAMRecordSetBuilder (didn't add the NM tag which then fails validation)

Needed for a new tool in Picard (Position-based downsampling)