### PR TITLE
Added the constant 0.0 to the PHRED scaled score (floating-point) result to prevent negative zero results; see issue in gatk-unstable 841

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -136,11 +136,13 @@ public final class CommonInfo {
     public double getLog10PError() { return log10PError; }
 
     /**
-     * Floating-point arithmetic allows signed zeros, +0.0 and -0.0. Adding the constant 0.0 to the
-     * result ensures that the returned value is never -0.0 since (-0.0) + 0.0 = 0.0.
-     * See issue https://github.com/broadinstitute/gsa-unstable/issues/841 for details.
+     * Floating-point arithmetic allows signed zeros such as +0.0 and -0.0.
+     * Adding the constant 0.0 to the result ensures that the returned value is never -0.0
+     * since (-0.0) + 0.0 = 0.0.
      *
-     * @return double Phred scaled quality score
+     * When this is set to '0.0', the resulting VCF would be 0 instead of -0.
+     *
+     * @return double - Phred scaled quality score
      */
     public double getPhredScaledQual() { return (getLog10PError() * -10) + 0.0; }
 

--- a/src/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -134,7 +134,15 @@ public final class CommonInfo {
      * @return the -1 * log10-based error estimate
      */
     public double getLog10PError() { return log10PError; }
-    public double getPhredScaledQual() { return getLog10PError() * -10; }
+
+    /**
+     * Floating-point arithmetic allows signed zeros, +0.0 and -0.0. Adding the constant 0.0 to the
+     * result ensures that the returned value is never -0.0 since (-0.0) + 0.0 = 0.0.
+     * See issue https://github.com/broadinstitute/gsa-unstable/issues/841 for details.
+     *
+     * @return double Phred scaled quality score
+     */
+    public double getPhredScaledQual() { return (getLog10PError() * -10) + 0.0; }
 
     public void setLog10PError(double log10PError) {
         if ( log10PError > 0 && log10PError != NO_LOG10_PERROR)


### PR DESCRIPTION
Issue #841, Prevent negative zeros -0 in output vcf files, prescribed
adding 0.0 to the PHRED scaled score result. @vdauwera, @ronlevine indicated to implement the updates in the HTSJDK repo.

<!---
@huboard:{"order":226.0,"milestone_order":226,"custom_state":"ready"}
-->
