### PR TITLE
Added Genotype Filters to JEXL Map

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/JEXLMap.java
+++ b/src/java/htsjdk/variant/variantcontext/JEXLMap.java
@@ -102,6 +102,8 @@ class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
                 infoMap.put("isNoCall", g.isNoCall()? "1" : "0");
                 infoMap.put("isMixed", g.isMixed()? "1" : "0");
                 infoMap.put("isAvailable", g.isAvailable()? "1" : "0");
+                infoMap.put("isPassFT", g.isFiltered()? "0" : "1");
+                infoMap.put(VCFConstants.GENOTYPE_FILTER_KEY, g.isFiltered()?  g.getFilters() : "PASS");
 
                 infoMap.put(VCFConstants.GENOTYPE_QUALITY_KEY, g.getGQ());
                 if ( g.hasDP() )


### PR DESCRIPTION
In order to use the "FT" flag in JEXL expressions, I thought it would be a good idea to add them to the JEXL map.  I needed to use this flag in GATK's GenotypeConcordance tool to set genotypes that fail genotype-level filters to no-call.

I propose the following:

- Add the meta-tag 'isPassFT' which is true when g.isFiltered() is false.  (NOTE: I believe isFiltered is already available at the variant level; I'm also open to using "isFailFT" if that's more intuitive)
- Add the VCFConstants.GENOTYPE_FILTER_KEY (FT) to the JEXL map.  If the FT key is not present or is "PASS" (and therefore not present in g.getFilters()), manually set this entry to PASS.