### PR TITLE
fixed an overflow bug in the output when indexing large bam

### DIFF
--- a/src/java/htsjdk/samtools/BAMIndexer.java
+++ b/src/java/htsjdk/samtools/BAMIndexer.java
@@ -281,7 +281,7 @@ public class BAMIndexer {
 
         BAMIndexer indexer = new BAMIndexer(output, reader.getFileHeader());
 
-        int totalRecords = 0;
+        long totalRecords = 0;
 
         // create and write the content
         for (SAMRecord rec : reader) {


### PR DESCRIPTION
this fixes a small bug in the output of the BamIndexer which presents itself on large BAMs.,

