### PR TITLE
Fix for Issue #229 (Unlimited PL)

### DIFF
--- a/src/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/java/htsjdk/tribble/util/ParsingUtils.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Vector;
 import java.util.WeakHashMap;
 
 /**
@@ -181,6 +182,54 @@ public class ParsingUtils {
         return split(aString, tokens, delim, false);
     }
 
+    /**
+     * Split the string into tokens given by the delimiter.  Will use a 
+     * Vector<String> to allow for dynamically resizing of the tokens array.
+     * Note that with careful pre-allocation of the tokens Vector, this should
+     * be no less efficient than the split(String, String[] char) function.
+     * Also, with this function, we do not need a split(String, Vector<String>, char, bool)
+     * function, as there is no maximum number of tokens.
+     * 
+     * @param sSrting the string to split
+     * @param tokens  a Vector<String> to hold the parsed tokens
+     * @param delim   character that delimits tokens
+     * @return the number of tkens parsed
+     */
+    public static int split(String aString, Vector<String> tokens, char delim) {
+        
+    	int nTokens = 0;
+        int start = 0;
+        int end = aString.indexOf(delim);
+        
+        // Empty out our answer, but preserve the memory allocation
+        tokens.clear();
+        
+        while(end >= 0){
+        	// Only add non-empty tokens
+        	if(start != end){
+        		tokens.add(aString.substring(start, end));
+        		start = end+1;
+        	}
+        	start = end+1;
+        	
+    		// If this condition is true, we likely ended with a token, so
+        	// manually set end = -1 to break the loop
+    		if(start >= aString.length()){
+    			end = -1;
+    		} else {
+    			end = aString.indexOf(delim, start);
+    		}
+
+        }
+        
+        // Add the final element (if non-empty)
+        if(start < aString.length()){
+        	tokens.add(aString.substring(start));
+        }
+    
+        return tokens.size();
+    }
+    
     /**
      * Split the string into tokens separated by the given delimiter.  Profiling has
      * revealed that the standard string.split() method typically takes > 1/2

--- a/src/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/java/htsjdk/tribble/util/ParsingUtils.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 import java.util.WeakHashMap;
 
 /**
@@ -195,21 +194,18 @@ public class ParsingUtils {
      * @param delim   character that delimits tokens
      * @return the number of tkens parsed
      */
-    public static int split(String aString, Vector<String> tokens, char delim) {
+    public static int split(String aString, List<String> tokens, char delim) {
         
-    	int nTokens = 0;
-        int start = 0;
+    	int start = 0;
         int end = aString.indexOf(delim);
         
         // Empty out our answer, but preserve the memory allocation
         tokens.clear();
         
         while(end >= 0){
-        	// Only add non-empty tokens
-        	if(start != end){
-        		tokens.add(aString.substring(start, end));
-        		start = end+1;
-        	}
+        	
+        	// add the string, even when empty (start == end)
+        	tokens.add(aString.substring(start, end));
         	start = end+1;
         	
     		// If this condition is true, we likely ended with a token, so
@@ -222,9 +218,12 @@ public class ParsingUtils {
 
         }
         
-        // Add the final element (if non-empty)
+        // Add the final element (if start == string.length(), then we ended
+        // with a delimiter)
         if(start < aString.length()){
         	tokens.add(aString.substring(start));
+        }else{
+        	tokens.add("");
         }
     
         return tokens.size();

--- a/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.Vector;
 import java.util.zip.GZIPInputStream;
 
 
@@ -752,13 +753,13 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
         return new LazyGenotypesContext.LazyData(genotypes, header.getSampleNamesInOrder(), header.getSampleNameToOffset());
     }
 
-    private final String[] INT_DECODE_ARRAY = new String[10000];
+    private final Vector<String> INT_DECODE_VECTOR = new Vector<String>(10000);
     private final int[] decodeInts(final String string) {
-        final int nValues = ParsingUtils.split(string, INT_DECODE_ARRAY, ',');
+        final int nValues = ParsingUtils.split(string, INT_DECODE_VECTOR, ',');
         final int[] values = new int[nValues];
         try {
             for ( int i = 0; i < nValues; i++ )
-                values[i] = Integer.valueOf(INT_DECODE_ARRAY[i]);
+                values[i] = Integer.valueOf(INT_DECODE_VECTOR.elementAt(i));
         } catch (final NumberFormatException e) {
             return null;
         }

--- a/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.Vector;
 import java.util.zip.GZIPInputStream;
 
 
@@ -753,13 +752,13 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
         return new LazyGenotypesContext.LazyData(genotypes, header.getSampleNamesInOrder(), header.getSampleNameToOffset());
     }
 
-    private final Vector<String> INT_DECODE_VECTOR = new Vector<String>(10000);
+    private final List<String> INT_DECODE_LIST = new ArrayList<String>(10000);
     private final int[] decodeInts(final String string) {
-        final int nValues = ParsingUtils.split(string, INT_DECODE_VECTOR, ',');
+        final int nValues = ParsingUtils.split(string, INT_DECODE_LIST, ',');
         final int[] values = new int[nValues];
         try {
             for ( int i = 0; i < nValues; i++ )
-                values[i] = Integer.valueOf(INT_DECODE_VECTOR.elementAt(i));
+                values[i] = Integer.valueOf(INT_DECODE_LIST.get(i));
         } catch (final NumberFormatException e) {
             return null;
         }

--- a/src/tests/java/htsjdk/tribble/util/ParsingUtilsTest.java
+++ b/src/tests/java/htsjdk/tribble/util/ParsingUtilsTest.java
@@ -6,6 +6,9 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
 
 
 /**
@@ -18,7 +21,138 @@ public class ParsingUtilsTest {
 
     static final String AVAILABLE_HTTP_URL = "https://www.google.com";
     static final String UNAVAILABLE_HTTP_URL = "http://www.unknownhostwhichshouldntexist.com";
+    
+    @Test
+    public void testVectorSplitContainers() {
+    	List<String> token_vector = new Vector<String>(10);
+    	List<String> token_arraylist = new ArrayList<String>(10);
+    	String splitStr = "a\tb\tc";
+    	int nTokens = ParsingUtils.split(splitStr, token_vector, '\t');
+    	Assert.assertEquals(nTokens, 3);
+    	Assert.assertEquals(token_vector.get(0),"a");
+        Assert.assertEquals(token_vector.get(1),"b");
+        Assert.assertEquals(token_vector.get(2),"c");
+        
+        nTokens = ParsingUtils.split(splitStr, token_arraylist, '\t');
+    	Assert.assertEquals(nTokens, 3);
+    	Assert.assertEquals(token_arraylist.get(0),"a");
+        Assert.assertEquals(token_arraylist.get(1),"b");
+        Assert.assertEquals(token_arraylist.get(2),"c");
+    }
+    
+    @Test
+    public void testVectorSplitTypical() {
+    	List<String> tokens = new ArrayList<String>(10);
+    	String splitStr = "a\tb\tc";
+    	int nTokens = ParsingUtils.split(splitStr, tokens, '\t');
+    	Assert.assertEquals(nTokens, 3);
+    	Assert.assertEquals(tokens.get(0),"a");
+        Assert.assertEquals(tokens.get(1),"b");
+        Assert.assertEquals(tokens.get(2),"c");    		
+    }
 
+    @Test
+    public void testVectorSplitExpand() {
+    	Vector<String> tokens = new Vector<String>(2);
+    	String splitStr = "a\tb\tc";
+    	
+    	// make sure the capacity is less than the # of tokens above
+    	Assert.assertTrue(tokens.capacity() < 3);
+    	
+    	int nTokens = ParsingUtils.split(splitStr, (List<String>) tokens, '\t');
+    	Assert.assertEquals(nTokens, 3);
+    	Assert.assertTrue(tokens.capacity() > 2);
+    	Assert.assertEquals(tokens.get(0),"a");
+        Assert.assertEquals(tokens.get(1),"b");
+        Assert.assertEquals(tokens.get(2),"c");
+    }
+    
+    @Test
+    public void testVectorSplitNonemptyVector() {
+    	List<String> tokens = new ArrayList<String>(10);
+        tokens.add("old_data");
+        
+        // Make sure our vector is non-empty
+        Assert.assertTrue(tokens.size() > 0);
+        Assert.assertEquals(tokens.get(0), "old_data");
+
+    	String splitStr = "a\tb\tc";
+    	
+    	int nTokens = ParsingUtils.split(splitStr, tokens, '\t');
+    	Assert.assertEquals(nTokens, 3);
+    	Assert.assertEquals(tokens.get(0),"a");
+        Assert.assertEquals(tokens.get(1),"b");
+        Assert.assertEquals(tokens.get(2),"c");
+    }
+    
+    @Test
+    public void testVectorSplitEmptyCell() {
+    	List<String> tokens = new ArrayList<String>(10);
+        String splitStr = "a\tb\t\td";
+    	int nTokens = ParsingUtils.split(splitStr, tokens, '\t');
+    	Assert.assertEquals(nTokens, 4);
+    	Assert.assertEquals(tokens.get(0),"a");
+        Assert.assertEquals(tokens.get(1),"b");
+        Assert.assertEquals(tokens.get(2),"");
+        Assert.assertEquals(tokens.get(3),"d");
+    	
+    }
+    
+    @Test
+    public void testVectorSplitEndingToken() {
+    	List<String> tokens = new ArrayList<String>(10);
+        String splitStr = "a\tb\t\td\t";
+    	int nTokens = ParsingUtils.split(splitStr, tokens, '\t');
+    	Assert.assertEquals(nTokens, 5);
+    	Assert.assertEquals(tokens.get(0),"a");
+        Assert.assertEquals(tokens.get(1),"b");
+        Assert.assertEquals(tokens.get(2),"");
+        Assert.assertEquals(tokens.get(3),"d");
+        Assert.assertEquals(tokens.get(4),"");
+    }
+    
+    @Test
+    public void testVectorSplitEmpty() {
+    	List<String> tokens = new ArrayList<String>(10);
+        String splitStr = "";
+    	int nTokens = ParsingUtils.split(splitStr, tokens, '\t');
+    	Assert.assertEquals(nTokens, 1);
+    	Assert.assertEquals(tokens.get(0),"");
+    }
+    
+    @Test
+    public void testVectorSplitOnlyToken() {
+    	List<String> tokens = new ArrayList<String>(10);
+        String splitStr = "\t";
+    	int nTokens = ParsingUtils.split(splitStr, tokens, '\t');
+    	Assert.assertEquals(nTokens, 2);
+    	Assert.assertEquals(tokens.get(0),"");
+    	Assert.assertEquals(tokens.get(1),"");
+    }
+    
+    @Test
+    public void testVectorSplitStartToken() {
+    	List<String> tokens = new ArrayList<String>(10);
+        String splitStr = "\tb\td";
+    	int nTokens = ParsingUtils.split(splitStr, tokens, '\t');
+    	Assert.assertEquals(nTokens, 3);
+    	Assert.assertEquals(tokens.get(0),"");
+    	Assert.assertEquals(tokens.get(1),"b");
+        Assert.assertEquals(tokens.get(2),"d");
+    }
+    
+    @Test
+    public void testVectorSplitStartMultiToken() {
+    	List<String> tokens = new ArrayList<String>(10);
+        String splitStr = "\t\tb\td";
+    	int nTokens = ParsingUtils.split(splitStr, tokens, '\t');
+    	Assert.assertEquals(nTokens, 4);
+    	Assert.assertEquals(tokens.get(0),"");
+    	Assert.assertEquals(tokens.get(1),"");
+    	Assert.assertEquals(tokens.get(2),"b");
+        Assert.assertEquals(tokens.get(3),"d");
+    }
+    
     @Test
     public void testSplit1() {
         String[] tokens = new String[10];


### PR DESCRIPTION
The following code should allow for the creation of arbitrarily-sized output arrays (now vectors) from the ParsingUtils.split() function, which will allow for the resolution of Issue #229 with minor modifications to the AbstractVCFCodec.

I have not yet included unit tests for the new split() functionality in ParsingUtils, but I will if it is determined that this is a good direction to go.

The specifics of what I did:
- Added a split() function in ParsingUtils that takes a vector
as output to allow for theoretically unlimited tokens in a
delimited string
- Modified the AbstractVCFCodec to utilize the above function.