### PR TITLE
Split by char to remove some hard limits in AbstractVCFCodec

### DIFF
--- a/src/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/java/htsjdk/tribble/util/ParsingUtils.java
@@ -23,7 +23,7 @@
  */
 package htsjdk.tribble.util;
 
-import java.awt.*;
+import java.awt.Color;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -32,6 +32,7 @@ import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -164,6 +165,32 @@ public class ParsingUtils {
             ret.append(strings[i]);
         }
         return ret.toString();
+    }
+
+
+    /**
+     * Split the string into tokens separated by the given delimiter. This looks
+     * suspiciously like what String.split should do. It is here because
+     * String.split has particularly poor performance for this use case in some
+     * versions of the Java SE API because of use of java.util.regex APIs
+     * (see bug report at http://bugs.java.com/view_bug.do?bug_id=6840246 for
+     * information).
+     *
+     * @param input the string to split
+     * @param delim the character that delimits tokens
+     * @return a list of the tokens
+     */
+    public static List<String> split(String input, char delim) {
+        if (input.isEmpty()) return Arrays.asList("");
+        final ArrayList<String> output = new ArrayList<String>(1+input.length()/2);
+        int from = -1, to;
+        for (to = input.indexOf(delim);
+             to >= 0;
+             from = to, to = input.indexOf(delim, from+1)) {
+            output.add(input.substring(from+1, to));
+        }
+        output.add(input.substring(from+1));
+        return output;
     }
 
 

--- a/src/tests/java/htsjdk/tribble/util/ParsingUtilsTest.java
+++ b/src/tests/java/htsjdk/tribble/util/ParsingUtilsTest.java
@@ -6,6 +6,9 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 
 /**
@@ -66,6 +69,52 @@ public class ParsingUtilsTest {
         Assert.assertEquals(tokens[1],"b");
         Assert.assertEquals(tokens[2],"");
         Assert.assertEquals(tokens[3],"d");
+    }
+
+    /**
+     * Tests that the string "joined", when split by "delim" using ParsingUtils.split(String, char),
+     * <ol>
+     * <li>Ends up with the expected number of items</li>
+     * <li>Ends up with the expected items</li>
+     * <li>Ends up with the same items as when the split is performed using String.split</li>
+     * <li>When re-joined (using ParsingUtils.join(String, Collection&gt;String&lt;) ) results in
+     *    the original string</li>
+     * </ol>
+     *
+     * @param joined
+     * @param delim
+     * @param expectedItems
+     */
+    private void testSplitJoinRoundtrip(String joined, char delim, List<String> expectedItems) {
+        List<String> split = ParsingUtils.split(joined, delim);
+        Assert.assertEquals(split.size(), expectedItems.size());
+        Assert.assertEquals(joined.split(Character.toString(delim), -1), split.toArray());
+        Assert.assertEquals(joined, ParsingUtils.join(Character.toString(delim), split));
+    }
+
+    @Test
+    public void testSplitJoinEmptyItem() {
+        testSplitJoinRoundtrip("a\tb\t\td", '\t', Arrays.asList("a", "b", "", "d"));
+    }
+
+    @Test
+    public void testSplitJoinEmptyAtEnd() {
+        testSplitJoinRoundtrip("a\tb\t\td\t", '\t', Arrays.asList("a", "b", "", "d", ""));
+    }
+
+    @Test
+    public void testSplitJoinEmpty() {
+        testSplitJoinRoundtrip("", '\t', Arrays.asList(""));
+    }
+
+    @Test
+    public void testSplitJoinSingleItem() {
+        testSplitJoinRoundtrip("a", '\t', Arrays.asList("a"));
+    }
+
+    @Test
+    public void testSplitJoinEmptyFirst() {
+        testSplitJoinRoundtrip("\ta\tb", '\t', Arrays.asList("", "a", "b"));
     }
 
     @Test


### PR DESCRIPTION
This is an alternative to fix to #229 (in addition to those proposed under #246 and #241.

A quick check gives comparable performance of this implementation of ParsingUtils.split compared to String.split on Oracle JDK 7&8 and significantly better performance of this ParsingUtils.split compared to String.split on Oracle JDK 6.