### PR TITLE
Fix catastrophic bug in VCFHeader that caused newly-added header lines to be silently dropped

### DIFF
--- a/src/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/java/htsjdk/variant/vcf/VCFHeader.java
@@ -48,15 +48,11 @@ import java.util.TreeSet;
 
 
 /**
- * NOTE: This class allows duplicate entries in the metadata & stores header lines in
- * lots of places. The original author noted that this should be cleaned up at some point
- * in the future (jgentry - 5/2013)
+ * A class to represent a VCF header
  *
  * @author aaron
- *         <p/>
- *         Class VCFHeader
- *         <p/>
- *         A class representing the VCF header
+ * NOTE: This class stores header lines in lots of places. The original author noted that this should
+ * be cleaned up at some point in the future (jgentry - 5/2013)
  */
 public class VCFHeader implements Serializable {
     public static final long serialVersionUID = 1L;
@@ -110,14 +106,15 @@ public class VCFHeader implements Serializable {
     }
 
     /**
-     * create a VCF header, given a list of meta data and auxillary tags
+     * create a VCF header, given a list of meta data and auxiliary tags
      *
      * @param metaData     the meta data associated with this header
      */
     public VCFHeader(final Set<VCFHeaderLine> metaData) {
         mMetaData.addAll(metaData);
-        loadVCFVersion();
-        loadMetaDataMaps();
+        removeVCFVersionLines(mMetaData);
+        createLookupEntriesForAllHeaderLines();
+        checkForDeprecatedGenotypeLikelihoodsKey();
     }
 
     /**
@@ -171,12 +168,20 @@ public class VCFHeader implements Serializable {
 
 
     /**
-     * Sets a header line in the header metadata. This is essentially a Set.add call, which means that
-     * equals() and hashCode() are used to determine whether an additional header line is added or an
-     * existing header line is replaced.
+     * Adds a new line to the VCFHeader. If there is an existing header line of the
+     * same type with the same key, the new line is not added and the existing line
+     * is preserved.
+     *
+     * @param headerLine header line to attempt to add
      */
     public void addMetaDataLine(final VCFHeaderLine headerLine) {
-        addMetadataHeaderLine(headerLine);
+        // Try to create a lookup entry for the new line. If this succeeds (because there was
+        // no line of this type with the same key), add the line to our master list of header
+        // lines in mMetaData.
+        if ( addMetadataLineLookupEntry(headerLine) ) {
+            mMetaData.add(headerLine);
+            checkForDeprecatedGenotypeLikelihoodsKey();
+        }
     }
 
     /**
@@ -255,63 +260,67 @@ public class VCFHeader implements Serializable {
     }
 
     /**
-     * check our metadata for a VCF version tag, and throw an exception if the version is out of date
-     * or the version is not present
+     * Remove all lines with a VCF version tag from the provided set of header lines
      */
-    public void loadVCFVersion() {
+    private void removeVCFVersionLines( final Set<VCFHeaderLine> headerLines ) {
         final List<VCFHeaderLine> toRemove = new ArrayList<VCFHeaderLine>();
-        for (final VCFHeaderLine line : mMetaData)
+        for (final VCFHeaderLine line : headerLines) {
             if (VCFHeaderVersion.isFormatString(line.getKey())) {
                 toRemove.add(line);
             }
-        // remove old header lines for now,
-        mMetaData.removeAll(toRemove);
-
+        }
+        headerLines.removeAll(toRemove);
     }
 
     /**
-     * load the format/info meta data maps (these are used for quick lookup by key name)
+     * Creates lookup table entries for all header lines in mMetaData.
      */
-    private void loadMetaDataMaps() {
+    private void createLookupEntriesForAllHeaderLines() {
         for (final VCFHeaderLine line : mMetaData) {
-            addMetadataHeaderLine(line);
+            addMetadataLineLookupEntry(line);
         }
     }
 
     /**
-     * add a single header line to the appropriate map/list depending on its type.  If a header line
-     * is added that has the same key as an existing line, it will not be added.  A warning will be
-     * shown if this occurs when GeneralUtils.DEBUG_MODE_ENABLED is true, otherwise this will occur
+     * Add a single header line to the appropriate type-specific lookup table (but NOT to the master
+     * list of lines in mMetaData -- this must be done separately if desired).
+     *
+     * If a header line is present that has the same key as an existing line, it will not be added.  A warning
+     * will be shown if this occurs when GeneralUtils.DEBUG_MODE_ENABLED is true, otherwise this will occur
      * silently.
+     *
+     * @param line header line to attempt to add to its type-specific lookup table
+     * @return true if the line was added to the appropriate lookup table, false if there was an existing
+     *         line with the same key and the new line was not added
      */
-    private void addMetadataHeaderLine(final VCFHeaderLine line) {
+    private boolean addMetadataLineLookupEntry(final VCFHeaderLine line) {
         if ( line instanceof VCFInfoHeaderLine )  {
             final VCFInfoHeaderLine infoLine = (VCFInfoHeaderLine)line;
-            addMetaDataMapBinding(mInfoMetaData, infoLine.getID(), infoLine);
+            return addMetaDataLineMapLookupEntry(mInfoMetaData, infoLine.getID(), infoLine);
         } else if ( line instanceof VCFFormatHeaderLine ) {
             final VCFFormatHeaderLine formatLine = (VCFFormatHeaderLine)line;
-            addMetaDataMapBinding(mFormatMetaData, formatLine.getID(), formatLine);
-
-            if ( hasFormatLine(VCFConstants.GENOTYPE_LIKELIHOODS_KEY) && ! hasFormatLine(VCFConstants.GENOTYPE_PL_KEY) ) {
-                if ( GeneralUtils.DEBUG_MODE_ENABLED ) {
-                    System.err.println("Found " + VCFConstants.GENOTYPE_LIKELIHOODS_KEY + " format, but no "
-                            + VCFConstants.GENOTYPE_PL_KEY + " field.  We now only manage PL fields internally"
-                            + " automatically adding a corresponding PL field to your VCF header");
-                }
-                addMetadataHeaderLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_PL_KEY, VCFHeaderLineCount.G, VCFHeaderLineType.Integer, "Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification"));
-            }
+            return addMetaDataLineMapLookupEntry(mFormatMetaData, formatLine.getID(), formatLine);
         } else if ( line instanceof VCFFilterHeaderLine ) {
             final VCFFilterHeaderLine filterLine = (VCFFilterHeaderLine)line;
-            addMetaDataMapBinding(mFilterMetaData, filterLine.getID(), filterLine);
+            return addMetaDataLineMapLookupEntry(mFilterMetaData, filterLine.getID(), filterLine);
         } else if ( line instanceof VCFContigHeaderLine ) {
-            addContigMetaDataLine((VCFContigHeaderLine) line);
+            return addContigMetaDataLineLookupEntry((VCFContigHeaderLine) line);
         } else {
-            addMetaDataMapBinding(mOtherMetaData, line.getKey(), line);
+            return addMetaDataLineMapLookupEntry(mOtherMetaData, line.getKey(), line);
         }
     }
 
-    // add a VCFContigHeaderLine to contigMetaData and avoid adding duplicate contigs
-    private void addContigMetaDataLine(final VCFContigHeaderLine line) {
+    /**
+     * Add a contig header line to the lookup list for contig lines (contigMetaData). If there's
+     * already a contig line with the same ID, does not add the line.
+     *
+     * Note: does not add the contig line to the master list of header lines in mMetaData --
+     *       this must be done separately if desired.
+     *
+     * @param line contig header line to add
+     * @return true if line was added to the list of contig lines, otherwise false
+     */
+    private boolean addContigMetaDataLineLookupEntry(final VCFContigHeaderLine line) {
         for (VCFContigHeaderLine vcfContigHeaderLine : contigMetaData) {
             // if we are trying to add a contig for the same ID
             if (vcfContigHeaderLine.getID().equals(line.getID())) {
@@ -319,34 +328,55 @@ public class VCFHeader implements Serializable {
                     System.err.println("Found duplicate VCF contig header lines for " + line.getID() + "; keeping the first only" );
                 }
                 // do not add this contig if it exists
-                return;
+                return false;
             }
         }
 
         contigMetaData.add(line);
+        return true;
     }
 
     /**
-     * Add line to map at a given key.  If the key already exists, it will not be replaced.  If it does already exist and
-     * GeneralUtils.DEBUG_MODE_ENABLED is true, it will issue warnings about duplicates, otherwise it will silently leave
-     * the existing key/line pair as is.
+     * Add a header line to the provided map at a given key.  If the key already exists, it will not be replaced.
+     * If it does already exist and GeneralUtils.DEBUG_MODE_ENABLED is true, it will issue warnings about duplicates,
+     * otherwise it will silently leave the existing key/line pair as is.
+     *
+     * Note: does not add the header line to the master list of header lines in mMetaData --
+     *       this must be done separately if desired.
      *
      * @param map a map from each key to the associated VCFHeaderLine
      * @param key the key to insert this line at
      * @param line the line to insert at this key
      * @param <T> a type of vcf header line that extends VCFHeaderLine
+     * @return true if the line was added to the map, false if it was not added because there's already a line with that key
      */
-    private <T extends VCFHeaderLine> void addMetaDataMapBinding(final Map<String, T> map, final String key, final T line) {
+    private <T extends VCFHeaderLine> boolean addMetaDataLineMapLookupEntry(final Map<String, T> map, final String key, final T line) {
         if ( map.containsKey(key) ) {
             if ( GeneralUtils.DEBUG_MODE_ENABLED ) {
                 System.err.println("Found duplicate VCF header lines for " + key + "; keeping the first only" );
             }
+            return false;
         }
-        else {
-            map.put(key, line);
-        }
+
+        map.put(key, line);
+        return true;
     }
 
+    /**
+     * Check for the presence of a format line with the deprecated key {@link VCFConstants#GENOTYPE_LIKELIHOODS_KEY}.
+     * If one is present, and there isn't a format line with the key {@link VCFConstants#GENOTYPE_PL_KEY}, adds
+     * a new format line with the key {@link VCFConstants#GENOTYPE_PL_KEY}.
+     */
+    private void checkForDeprecatedGenotypeLikelihoodsKey() {
+        if ( hasFormatLine(VCFConstants.GENOTYPE_LIKELIHOODS_KEY) && ! hasFormatLine(VCFConstants.GENOTYPE_PL_KEY) ) {
+            if ( GeneralUtils.DEBUG_MODE_ENABLED ) {
+                System.err.println("Found " + VCFConstants.GENOTYPE_LIKELIHOODS_KEY + " format, but no "
+                        + VCFConstants.GENOTYPE_PL_KEY + " field.  We now only manage PL fields internally"
+                        + " automatically adding a corresponding PL field to your VCF header");
+            }
+            addMetaDataLine(new VCFFormatHeaderLine(VCFConstants.GENOTYPE_PL_KEY, VCFHeaderLineCount.G, VCFHeaderLineType.Integer, "Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification"));
+        }
+    }
 
     /**
      * get the header fields in order they're presented in the input file (which is now required to be

--- a/src/tests/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/tests/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -36,6 +36,7 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -137,6 +138,92 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         codec.setRemappedSampleName("FOOSAMPLE");
         final AsciiLineReaderIterator vcfIterator = new AsciiLineReaderIterator(new AsciiLineReader(new FileInputStream(variantTestDataRoot + "dbsnp_135.b37.1000.vcf")));
         final VCFHeader header = (VCFHeader) codec.readHeader(vcfIterator).getHeaderValue();
+    }
+
+    @DataProvider(name = "HiSeqVCFHeaderDataProvider")
+    public Object[][] getHiSeqVCFHeaderData() {
+        final File vcf = new File("testdata/htsjdk/variant/HiSeq.10000.vcf");
+        final VCFFileReader reader = new VCFFileReader(vcf, false);
+        final VCFHeader header = reader.getFileHeader();
+        reader.close();
+
+        return new Object[][] {
+                { header }
+        };
+    }
+
+    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
+    public void testVCFHeaderAddInfoLine( final VCFHeader header ) {
+        final VCFInfoHeaderLine infoLine = new VCFInfoHeaderLine("TestInfoLine", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "test info line");
+        header.addMetaDataLine(infoLine);
+
+        Assert.assertTrue(header.getInfoHeaderLines().contains(infoLine), "TestInfoLine not found in info header lines");
+        Assert.assertTrue(header.getMetaDataInInputOrder().contains(infoLine), "TestInfoLine not found in set of all header lines");
+        Assert.assertNotNull(header.getInfoHeaderLine("TestInfoLine"), "Lookup for TestInfoLine by key failed");
+
+        Assert.assertFalse(header.getFormatHeaderLines().contains(infoLine), "TestInfoLine present in format header lines");
+        Assert.assertFalse(header.getFilterLines().contains(infoLine), "TestInfoLine present in filter header lines");
+        Assert.assertFalse(header.getContigLines().contains(infoLine), "TestInfoLine present in contig header lines");
+        Assert.assertFalse(header.getOtherHeaderLines().contains(infoLine), "TestInfoLine present in other header lines");
+    }
+
+    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
+    public void testVCFHeaderAddFormatLine( final VCFHeader header ) {
+        final VCFFormatHeaderLine formatLine = new VCFFormatHeaderLine("TestFormatLine", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "test format line");
+        header.addMetaDataLine(formatLine);
+
+        Assert.assertTrue(header.getFormatHeaderLines().contains(formatLine), "TestFormatLine not found in format header lines");
+        Assert.assertTrue(header.getMetaDataInInputOrder().contains(formatLine), "TestFormatLine not found in set of all header lines");
+        Assert.assertNotNull(header.getFormatHeaderLine("TestFormatLine"), "Lookup for TestFormatLine by key failed");
+
+        Assert.assertFalse(header.getInfoHeaderLines().contains(formatLine), "TestFormatLine present in info header lines");
+        Assert.assertFalse(header.getFilterLines().contains(formatLine), "TestFormatLine present in filter header lines");
+        Assert.assertFalse(header.getContigLines().contains(formatLine), "TestFormatLine present in contig header lines");
+        Assert.assertFalse(header.getOtherHeaderLines().contains(formatLine), "TestFormatLine present in other header lines");
+    }
+
+    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
+    public void testVCFHeaderAddFilterLine( final VCFHeader header ) {
+        final VCFFilterHeaderLine filterLine = new VCFFilterHeaderLine("TestFilterLine");
+        header.addMetaDataLine(filterLine);
+
+        Assert.assertTrue(header.getFilterLines().contains(filterLine), "TestFilterLine not found in filter header lines");
+        Assert.assertTrue(header.getMetaDataInInputOrder().contains(filterLine), "TestFilterLine not found in set of all header lines");
+        Assert.assertNotNull(header.getFilterHeaderLine("TestFilterLine"), "Lookup for TestFilterLine by key failed");
+
+        Assert.assertFalse(header.getInfoHeaderLines().contains(filterLine), "TestFilterLine present in info header lines");
+        Assert.assertFalse(header.getFormatHeaderLines().contains(filterLine), "TestFilterLine present in format header lines");
+        Assert.assertFalse(header.getContigLines().contains(filterLine), "TestFilterLine present in contig header lines");
+        Assert.assertFalse(header.getOtherHeaderLines().contains(filterLine), "TestFilterLine present in other header lines");
+    }
+
+    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
+    public void testVCFHeaderAddContigLine( final VCFHeader header ) {
+        final VCFContigHeaderLine contigLine = new VCFContigHeaderLine("<ID=chr1,length=1234567890,assembly=FAKE,md5=f126cdf8a6e0c7f379d618ff66beb2da,species=\"Homo sapiens\">", VCFHeaderVersion.VCF4_0, "chr1", 0);
+        header.addMetaDataLine(contigLine);
+
+        Assert.assertTrue(header.getContigLines().contains(contigLine), "Test contig line not found in contig header lines");
+        Assert.assertTrue(header.getMetaDataInInputOrder().contains(contigLine), "Test contig line not found in set of all header lines");
+
+        Assert.assertFalse(header.getInfoHeaderLines().contains(contigLine), "Test contig line present in info header lines");
+        Assert.assertFalse(header.getFormatHeaderLines().contains(contigLine), "Test contig line present in format header lines");
+        Assert.assertFalse(header.getFilterLines().contains(contigLine), "Test contig line present in filter header lines");
+        Assert.assertFalse(header.getOtherHeaderLines().contains(contigLine), "Test contig line present in other header lines");
+    }
+
+    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
+    public void testVCFHeaderAddOtherLine( final VCFHeader header ) {
+        final VCFHeaderLine otherLine = new VCFHeaderLine("TestOtherLine", "val");
+        header.addMetaDataLine(otherLine);
+
+        Assert.assertTrue(header.getOtherHeaderLines().contains(otherLine), "TestOtherLine not found in other header lines");
+        Assert.assertTrue(header.getMetaDataInInputOrder().contains(otherLine), "TestOtherLine not found in set of all header lines");
+        Assert.assertNotNull(header.getOtherHeaderLine("TestOtherLine"), "Lookup for TestOtherLine by key failed");
+
+        Assert.assertFalse(header.getInfoHeaderLines().contains(otherLine), "TestOtherLine present in info header lines");
+        Assert.assertFalse(header.getFormatHeaderLines().contains(otherLine), "TestOtherLine present in format header lines");
+        Assert.assertFalse(header.getContigLines().contains(otherLine), "TestOtherLine present in contig header lines");
+        Assert.assertFalse(header.getFilterLines().contains(otherLine), "TestOtherLine present in filter header lines");
     }
 
     @Test


### PR DESCRIPTION
There was a nasty bug in VCFHeader that caused newly-added header lines
to only be added to type-specific lookup tables and not to the master list
of header lines. This meant that new lines got silently dropped when writing
a modified VCFHeader back out via VCFWriter.

Fixed the issue and added comprehensive unit tests for VCFHeader.addMetaDataLine().

Also attempted to improve documentation and method naming a bit in an
effort to avoid future bugs like this. Eg., there was a method "loadVCFVersion()"
that actually REMOVED the vcf version lines!