### PR TITLE
Javadoc formatting improvements for htsjdk.variant.* packages

### DIFF
--- a/src/java/htsjdk/tribble/AsciiFeatureCodec.java
+++ b/src/java/htsjdk/tribble/AsciiFeatureCodec.java
@@ -79,7 +79,7 @@ public abstract class AsciiFeatureCodec<T extends Feature> extends AbstractFeatu
         return decode(lineIterator.next());
     }
 
-    /** @see {@link AsciiFeatureCodec#decode(htsjdk.tribble.readers.LineIterator)} */
+    /** @see AsciiFeatureCodec#decode(htsjdk.tribble.readers.LineIterator) */
     public abstract T decode(String s);
 
     @Override

--- a/src/java/htsjdk/tribble/FeatureCodec.java
+++ b/src/java/htsjdk/tribble/FeatureCodec.java
@@ -68,11 +68,14 @@ public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
     public FeatureCodecHeader readHeader(final SOURCE source) throws IOException;
 
     /**
+     * <p>
      * This function returns the object the codec generates.  This is allowed to be Feature in the case where
      * conditionally different types are generated.  Be as specific as you can though.
-     * <p/>
+     * </p>
+     * <p>
      * This function is used by reflections based tools, so we can know the underlying type
-     *
+     * </p>
+     * 
      * @return the feature type this codec generates.
      */
     public Class<FEATURE_TYPE> getFeatureType();
@@ -100,12 +103,14 @@ public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
     public void close(final SOURCE source);
 
     /**
+     * <p>
      * This function returns true iff the File potentialInput can be parsed by this
      * codec.
-     * <p/>
+     * </p>
+     * <p>
      * There is an assumption that there's never a situation where two different Codecs
      * return true for the same file.  If this occurs, the recommendation would be to error out.
-     * <p/>
+     * </p>
      * Note this function must never throw an error.  All errors should be trapped
      * and false returned.
      *

--- a/src/java/htsjdk/variant/bcf2/BCF2Decoder.java
+++ b/src/java/htsjdk/variant/bcf2/BCF2Decoder.java
@@ -61,7 +61,6 @@ public final class BCF2Decoder {
      * Reads the next record from input stream and prepare this decoder to decode values from it
      *
      * @param stream
-     * @return
      */
     public void readNextBlock(final int blockSizeInBytes, final InputStream stream) {
         if ( blockSizeInBytes < 0 ) throw new TribbleException("Invalid block size " + blockSizeInBytes);
@@ -72,7 +71,6 @@ public final class BCF2Decoder {
      * Skips the next record from input stream, invalidating current block data
      *
      * @param stream
-     * @return
      */
     public void skipNextBlock(final int blockSizeInBytes, final InputStream stream) {
         try {
@@ -234,14 +232,14 @@ public final class BCF2Decoder {
      * Requires a typeDescriptor so the function knows how many elements to read,
      * and how they are encoded.
      *
-     * If size == 0 => result is null
-     * If size > 0 => result depends on the actual values in the stream
+     * If size == 0 =&gt; result is null
+     * If size &gt; 0 =&gt; result depends on the actual values in the stream
      *      -- If the first element read is MISSING, result is null (all values are missing)
      *      -- Else result = int[N] where N is the first N non-missing values decoded
      *
      * @param maybeDest if not null we'll not allocate space for the vector, but instead use
      *                  the externally allocated array of ints to store values.  If the
-     *                  size of this vector is < the actual size of the elements, we'll be
+     *                  size of this vector is &lt; the actual size of the elements, we'll be
      *                  forced to use freshly allocated arrays.  Also note that padded
      *                  int elements are still forced to do a fresh allocation as well.
      * @return see description

--- a/src/java/htsjdk/variant/bcf2/BCF2Type.java
+++ b/src/java/htsjdk/variant/bcf2/BCF2Type.java
@@ -197,7 +197,7 @@ public enum BCF2Type {
      * Read a value from in stream of this BCF2 type as an int [32 bit] collection of bits
      *
      * For intX and char values this is just the int / byte value of the underlying data represented as a 32 bit int
-     * For a char the result must be converted to a char by (char)(byte)(0x0F & value)
+     * For a char the result must be converted to a char by (char)(byte)(0x0F &amp; value)
      * For doubles it's necessary to convert subsequently this value to a double via Double.bitsToDouble()
      *
      * @param in

--- a/src/java/htsjdk/variant/bcf2/BCF2Utils.java
+++ b/src/java/htsjdk/variant/bcf2/BCF2Utils.java
@@ -133,9 +133,9 @@ public final class BCF2Utils {
     /**
      * Collapse multiple strings into a comma separated list
      *
-     * ["s1", "s2", "s3"] => ",s1,s2,s3"
+     * ["s1", "s2", "s3"] =&gt; ",s1,s2,s3"
      *
-     * @param strings size > 1 list of strings
+     * @param strings size &gt; 1 list of strings
      * @return
      */
     public static String collapseStringList(final List<String> strings) {
@@ -156,7 +156,7 @@ public final class BCF2Utils {
     /**
      * Inverse operation of collapseStringList.
      *
-     * ",s1,s2,s3" => ["s1", "s2", "s3"]
+     * ",s1,s2,s3" =&gt; ["s1", "s2", "s3"]
      *
      *
      * @param collapsed
@@ -175,8 +175,8 @@ public final class BCF2Utils {
     /**
      * Returns a good name for a shadow BCF file for vcfFile.
      *
-     * foo.vcf => foo.bcf
-     * foo.xxx => foo.xxx.bcf
+     * foo.vcf =&gt; foo.bcf
+     * foo.xxx =&gt; foo.xxx.bcf
      *
      * If the resulting BCF file cannot be written, return null.  Happens
      * when vcfFile = /dev/null for example
@@ -268,9 +268,9 @@ public final class BCF2Utils {
      * Helper function that takes an object and returns a list representation
      * of it:
      *
-     * o == null => []
-     * o is a list => o
-     * else => [o]
+     * o == null =&gt; []
+     * o is a list =&gt; o
+     * else =&gt; [o]
      *
      * @param c  the class of the object
      * @param o  the object to convert to a Java List

--- a/src/java/htsjdk/variant/utils/GeneralUtils.java
+++ b/src/java/htsjdk/variant/utils/GeneralUtils.java
@@ -79,7 +79,7 @@ public class GeneralUtils {
     }
 
     /**
-     * normalizes the log10-based array.  ASSUMES THAT ALL ARRAY ENTRIES ARE <= 0 (<= 1 IN REAL-SPACE).
+     * normalizes the log10-based array.  ASSUMES THAT ALL ARRAY ENTRIES ARE &lt;= 0 (&lt;= 1 IN REAL-SPACE).
      *
      * @param array the array to be normalized
      * @return a newly allocated array corresponding the normalized values in array
@@ -89,7 +89,7 @@ public class GeneralUtils {
     }
 
     /**
-     * normalizes the log10-based array.  ASSUMES THAT ALL ARRAY ENTRIES ARE <= 0 (<= 1 IN REAL-SPACE).
+     * normalizes the log10-based array.  ASSUMES THAT ALL ARRAY ENTRIES ARE &lt;= 0 (&lt;= 1 IN REAL-SPACE).
      *
      * @param array             the array to be normalized
      * @param takeLog10OfOutput if true, the output will be transformed back into log10 units
@@ -177,8 +177,8 @@ public class GeneralUtils {
      * Make all combinations of N size of objects
      *
      * if objects = [A, B, C]
-     * if N = 1 => [[A], [B], [C]]
-     * if N = 2 => [[A, A], [B, A], [C, A], [A, B], [B, B], [C, B], [A, C], [B, C], [C, C]]
+     * if N = 1 =&gt; [[A], [B], [C]]
+     * if N = 2 =&gt; [[A, A], [B, A], [C, A], [A, B], [B, B], [C, B], [A, C], [B, C], [C, C]]
      *
      * @param objects
      * @param n

--- a/src/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/java/htsjdk/variant/variantcontext/Allele.java
@@ -32,74 +32,86 @@ import java.util.Arrays;
 import java.util.Collection;
 
 /**
- * Immutable representation of an allele
- *
+ * Immutable representation of an allele.
+ *<p>
  * Types of alleles:
- *
- * Ref: a t C g a // C is the reference base
- *
- *    : a t G g a // C base is a G in some individuals
- *
- *    : a t - g a // C base is deleted w.r.t. the reference
- *
- *    : a t CAg a // A base is inserted w.r.t. the reference sequence
- *
- * In these cases, where are the alleles?
- *
- * SNP polymorphism of C/G  -> { C , G } -> C is the reference allele
- * 1 base deletion of C     -> { tC , t } -> C is the reference allele and we include the preceding reference base (null alleles are not allowed)
- * 1 base insertion of A    -> { C ; CA } -> C is the reference allele (because null alleles are not allowed)
- *
+ *</p>
+ *<pre>
+ Ref: a t C g a // C is the reference base
+    : a t G g a // C base is a G in some individuals
+    : a t - g a // C base is deleted w.r.t. the reference
+    : a t CAg a // A base is inserted w.r.t. the reference sequence
+ </pre>
+ *<p> In these cases, where are the alleles?</p>
+ *<ul>
+ * <li>SNP polymorphism of C/G  -&gt; { C , G } -&gt; C is the reference allele</li>
+ * <li>1 base deletion of C     -&gt; { tC , t } -&gt; C is the reference allele and we include the preceding reference base (null alleles are not allowed)</li>
+ * <li>1 base insertion of A    -&gt; { C ; CA } -&gt; C is the reference allele (because null alleles are not allowed)</li>
+ *</ul>
+ *<p>
  * Suppose I see a the following in the population:
- *
- * Ref: a t C g a // C is the reference base
- *    : a t G g a // C base is a G in some individuals
- *    : a t - g a // C base is deleted w.r.t. the reference
- *
+ *</p>
+ *<pre>
+ Ref: a t C g a // C is the reference base
+    : a t G g a // C base is a G in some individuals
+    : a t - g a // C base is deleted w.r.t. the reference
+ </pre>
+ * <p>
  * How do I represent this?  There are three segregating alleles:
- *
+ * </p>
+ *<blockquote>
  *  { C , G , - }
- *
- *  and these are represented as:
- *
+ *</blockquote>
+ *<p>and these are represented as:</p>
+ *<blockquote>
  *  { tC, tG, t }
- *
+ *</blockquote>
+ *<p>
  * Now suppose I have this more complex example:
- *
- * Ref: a t C g a // C is the reference base
- *    : a t - g a
- *    : a t - - a
- *    : a t CAg a
- *
+ </p>
+ <pre>
+ Ref: a t C g a // C is the reference base
+    : a t - g a
+    : a t - - a
+    : a t CAg a
+ </pre>
+ * <p>
  * There are actually four segregating alleles:
- *
+ * </p>
+ *<blockquote>
  *   { Cg , -g, --, and CAg } over bases 2-4
- *
- *   represented as:
- *
+ *</blockquote>
+ *<p>   represented as:</p>
+ *<blockquote>
  *   { tCg, tg, t, tCAg }
- *
+ *</blockquote>
+ *<p>
  * Critically, it should be possible to apply an allele to a reference sequence to create the
- * correct haplotype sequence:
- *
- * Allele + reference => haplotype
- *
+ * correct haplotype sequence:</p>
+ *<blockquote>
+ * Allele + reference =&gt; haplotype
+ *</blockquote>
+ *<p>
  * For convenience, we are going to create Alleles where the GenomeLoc of the allele is stored outside of the
  * Allele object itself.  So there's an idea of an A/C polymorphism independent of it's surrounding context.
  *
  * Given list of alleles it's possible to determine the "type" of the variation
- *
- *      A / C @ loc => SNP
- *      - / A => INDEL
- *
+ </p>
+ <pre>
+      A / C @ loc =&gt; SNP
+      - / A =&gt; INDEL
+ </pre>
+ * <p>
  * If you know where allele is the reference, you can determine whether the variant is an insertion or deletion.
- *
+ * </p>
+ * <p>
  * Alelle also supports is concept of a NO_CALL allele.  This Allele represents a haplotype that couldn't be
  * determined. This is usually represented by a '.' allele.
- *
+ * </p>
+ * <p>
  * Note that Alleles store all bases as bytes, in **UPPER CASE**.  So 'atc' == 'ATC' from the perspective of an
  * Allele.
-
+ * </p>
  * @author ebanks, depristo
  */
 public class Allele implements Comparable<Allele>, Serializable {
@@ -113,8 +125,8 @@ public class Allele implements Comparable<Allele>, Serializable {
 
     private byte[] bases = null;
 
-    public final static String NO_CALL_STRING = ".";
     /** A generic static NO_CALL allele for use */
+    public final static String NO_CALL_STRING = ".";
 
     // no public way to create an allele
     protected Allele(byte[] bases, boolean isRef) {
@@ -189,7 +201,7 @@ public class Allele implements Comparable<Allele>, Serializable {
      * Create a new Allele that includes bases and if tagged as the reference allele if isRef == true.  If bases
      * == '-', a Null allele is created.  If bases ==  '.', a no call Allele is created.
      *
-     * @param bases the DNA sequence of this variation, '-', of '.'
+     * @param bases the DNA sequence of this variation, '-', or '.'
      * @param isRef should we make this a reference allele?
      * @throws IllegalArgumentException if bases contains illegal characters or is otherwise malformated
      */
@@ -309,7 +321,7 @@ public class Allele implements Comparable<Allele>, Serializable {
     }
 
     /**
-     * @see Allele(byte[], boolean)
+     * @see #Allele(byte[], boolean)
      *
      * @param bases  bases representing an allele
      * @param isRef  is this the reference allele?
@@ -393,7 +405,7 @@ public class Allele implements Comparable<Allele>, Serializable {
     /**
      * Return the printed representation of this allele.
      * Same as getBaseString(), except for symbolic alleles.
-     * For symbolic alleles, the base string is empty while the display string contains <TAG>.
+     * For symbolic alleles, the base string is empty while the display string contains &lt;TAG&gt;.
      *
      * @return the allele string representation
      */

--- a/src/java/htsjdk/variant/variantcontext/FastGenotype.java
+++ b/src/java/htsjdk/variant/variantcontext/FastGenotype.java
@@ -33,41 +33,40 @@ import java.util.Map;
  *
  * A genotype has several key fields
  *
- * -- a sample name, must be a non-null string
- *
- * -- an ordered list of alleles, intrepreted as the genotype of the sample,
+ * <ul>
+ * <li> a sample name, must be a non-null string</li>
+ * <li> an ordered list of alleles, intrepreted as the genotype of the sample,
  *    each allele for each chromosome given in order.  If alleles = [a*, t]
  *    then the sample is a/t, with a (the reference from the *) the first
- *    chromosome and t on the second chromosome
+ *    chromosome and t on the second chromosome</li>
+ * <li> an <code>isPhased</code> marker indicating where the alleles are phased with respect to some global
+ *    coordinate system.  See VCF4.1 spec for a detailed discussion</li>
+ * <li> Inline, optimized <code>int</code>s and <code>int[]</code> values for:
+ * <ul>
+ *      <li> GQ: the phred-scaled genotype quality, or <code>-1</code> if it's missing</li>
+ *      <li> DP: the count of reads at this locus for this sample, or <code>-1</code> if missing</li>
+ *      <li> AD: an array of counts of reads at this locus, one for each Allele at the site,
+ *             that is, for each allele in the surrounding <code>VariantContext</code>.  <code>null</code> if missing.</li>
+ *      <li> PL: phred-scaled genotype likelihoods in standard VCF4.1 order for
+ *             all combinations of the alleles in the surrounding <code>VariantContext</code>, given
+ *             the ploidy of the sample (from the alleles vector).  <code>null</code> if missing.</li>
+ * </ul>
+ * </li>
  *
- * -- a isPhased marker indicting where the alleles are phased with respect to some global
- *    coordinate system.  See VCF4.1 spec for a detailed discussion
- *
- * -- Inline, optimized ints and int[] values for:
- *      -- GQ: the phred-scaled genotype quality, of -1 if it's missing
- *
- *      -- DP: the count of reads at this locus for this sample, of -1 if missing
- *
- *      -- AD: an array of counts of reads at this locus, one for each Allele at the site.
- *             that is, for each allele in the surrounding VariantContext.  Null if missing.
- *
- *      -- PL: phred-scaled genotype likelihoods in standard VCF4.1 order for
- *             all combinations of the alleles in the surrounding VariantContext, given
- *             the ploidy of the sample (from the alleles vector).  Null if missing.
- *
- * -- A general map from String keys to -> Object values for all other attributes in
+ * <li> A general map from String keys to -&gt; Object values for all other attributes in
  *    this genotype.  Note that this map should not contain duplicate values for the
  *    standard bindings for GQ, DP, AD, and PL.  Genotype filters can be put into
- *    this genotype, but it isn't respected by the GATK in analyses
+ *    this genotype, but it isn't respected by the GATK in analyses</li>
+ *</ul>
  *
- * The only way to build a Genotype object is with a GenotypeBuilder, which permits values
- * to be set in any order, which means that GenotypeBuilder may at some in the chain of
+ * <p>The only way to build a <code>Genotype</code> object is with a <code>GenotypeBuilder</code>, which permits values
+ * to be set in any order, which means that <code>GenotypeBuilder</code> may at some in the chain of
  * sets pass through invalid states that are not permitted in a fully formed immutable
- * Genotype.
+ * <code>Genotype</code>.</p>
  *
- * Note this is a simplified, refactored Genotype object based on the original
+ * <p>Note this is a simplified, refactored Genotype object based on the original
  * generic (and slow) implementation from the original VariantContext + Genotype
- * codebase.
+ * codebase.</p>
  *
  * @author Mark DePristo
  * @since 05/12

--- a/src/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/java/htsjdk/variant/variantcontext/Genotype.java
@@ -80,7 +80,7 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
      * Returns how many times allele appears in this genotype object?
      *
      * @param allele
-     * @return a value >= 0 indicating how many times the allele occurred in this sample's genotype
+     * @return a value &gt;= 0 indicating how many times the allele occurred in this sample's genotype
      */
     public int countAllele(final Allele allele) {
         int c = 0;
@@ -94,7 +94,7 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
     /**
      * Get the ith allele in this genotype
      *
-     * @param i the ith allele, must be < the ploidy, starting with 0
+     * @param i the ith allele, must be &lt; the ploidy, starting with 0
      * @return the allele at position i, which cannot be null
      */
     public abstract Allele getAllele(int i);
@@ -303,9 +303,9 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
     /**
      * Are all likelihoods for this sample non-informative?
      *
-     * Returns true if all PLs are 0 => 0,0,0 => true
-     * 0,0,0,0,0,0 => true
-     * 0,10,100 => false
+     * Returns true if all PLs are 0 =&gt; 0,0,0 =&gt; true
+     * 0,0,0,0,0,0 =&gt; true
+     * 0,10,100 =&gt; false
      *
      * @return true if all samples PLs are equal and == 0
      */
@@ -404,7 +404,7 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
     // ---------------------------------------------------------------------------------------------------------
 
     /**
-     * comparable genotypes -> compareTo on the sample names
+     * comparable genotypes -&gt; compareTo on the sample names
      * @param genotype
      * @return
      */
@@ -530,7 +530,7 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
     /**
      * A totally generic getter, that allows you to specific keys that correspond
      * to even inline values (GQ, for example).  Can be very expensive.  Additionally,
-     * all int[] are converted inline into List<Integer> for convenience.
+     * all <code>int[]</code> are converted inline into <code>List&lt;Integer&gt;</code> for convenience.
      *
      * @param key
      * @return

--- a/src/java/htsjdk/variant/variantcontext/GenotypeBuilder.java
+++ b/src/java/htsjdk/variant/variantcontext/GenotypeBuilder.java
@@ -342,7 +342,7 @@ public final class GenotypeBuilder {
      * which may be empty (passes) or have some value indicating the reasons
      * why it's been filtered.
      *
-     * @param filters non-null list of filters.  empty list => PASS
+     * @param filters non-null list of filters.  empty list =&gt; PASS
      * @return this builder
      */
     public GenotypeBuilder filters(final List<String> filters) {
@@ -366,7 +366,7 @@ public final class GenotypeBuilder {
     /**
      * Most efficient version of setting filters -- just set the filters string to filters
      *
-     * @param filter if filters == null or filters.equals("PASS") => genotype is PASS
+     * @param filter if filters == null or filters.equals("PASS") =&gt; genotype is PASS
      * @return
      */
     public GenotypeBuilder filter(final String filter) {

--- a/src/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
+++ b/src/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
@@ -168,9 +168,10 @@ public class GenotypeLikelihoods {
 
     /**
      * This is really dangerous and returns completely wrong results for genotypes from a multi-allelic context.
-     * Use getLog10GQ(Genotype,VariantContext) or getLog10GQ(Genotype,List<Allele>) in place of it.
+     * Use <code>getLog10GQ(Genotype,VariantContext)</code>
+     *  or <code>getLog10GQ(Genotype,List&lt;Allele&gt;)</code> in place of it.
      *
-     * If you **know** you're biallelic, use getGQLog10FromLikelihoods directly.
+     * If you <strong>know</strong> you're biallelic, use <code>getGQLog10FromLikelihoods</code> directly.
      * @param genotype - actually a genotype type (no call, hom ref, het, hom var)
      * @return an unsafe quantity that could be negative. In the bi-allelic case, the GQ resulting from best minus next best (if the type is the best).
      */
@@ -441,7 +442,7 @@ public class GenotypeLikelihoods {
     }
 
     /**
-     * get the PL indexes (AA, AB, BB) for the given allele pair; assumes allele1Index <= allele2Index.
+     * get the PL indexes (AA, AB, BB) for the given allele pair; assumes allele1Index &lt;= allele2Index.
      *
      * @param allele1Index    the index in VariantContext.getAllele() of the first allele
      * @param allele2Index    the index in VariantContext.getAllele() of the second allele

--- a/src/java/htsjdk/variant/variantcontext/GenotypesContext.java
+++ b/src/java/htsjdk/variant/variantcontext/GenotypesContext.java
@@ -335,7 +335,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
      * you will invalid the contract on this context if you add duplicate
      * samples and are running with CoFoJa enabled.
      *
-     * Second, adding genotype also updates the sample name -> index map,
+     * Second, adding genotype also updates the sample name -&gt; index map,
      * so add() followed by containsSample and related function is an efficient
      * series of operations.
      *
@@ -485,7 +485,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
     }
 
     /**
-     * Note that remove requires us to invalidate our sample -> index
+     * Note that remove requires us to invalidate our sample -&gt; index
      * cache.  The loop:
      *
      * GenotypesContext gc = ...
@@ -511,7 +511,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
     }
 
     /**
-     * See for important warning {@link this.remove(Integer)}
+     * See for important warning {@link #remove(int)}
      * @param o
      * @return
      */
@@ -559,7 +559,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
      * reasons we do not add the genotype if it's not present.  The
      * return value will be null indicating this happened.
      *
-     * Note this operation is preserves the map cache Sample -> Offset but
+     * Note this operation is preserves the map cache Sample -&gt; Offset but
      * invalidates the sorted list of samples.  Using replace within a loop
      * containing any of the SampleNameInOrder operation requires an O(n log n)
      * resorting after each replace operation.

--- a/src/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -49,68 +49,81 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Class VariantContext
- *
- * == High-level overview ==
+ * 
+ * <h3> High-level overview </h3>
  *
  * The VariantContext object is a single general class system for representing genetic variation data composed of:
- *
- * * Allele: representing single genetic haplotypes (A, T, ATC, -) (note that null alleles are used here for illustration; see the Allele class for how to represent indels)
- * * Genotype: an assignment of alleles for each chromosome of a single named sample at a particular locus
- * * VariantContext: an abstract class holding all segregating alleles at a locus as well as genotypes
- *    for multiple individuals containing alleles at that locus
- *
+ * <ul>
+ * <li>Allele: representing single genetic haplotypes (A, T, ATC, -) (note that null alleles are used here for illustration; see the Allele class for how to represent indels)</li>
+ * <li>Genotype: an assignment of alleles for each chromosome of a single named sample at a particular locus</li>
+ * <li>VariantContext: an abstract class holding all segregating alleles at a locus as well as genotypes
+ *    for multiple individuals containing alleles at that locus</li>
+ * </ul>
+ * <p>
  * The class system works by defining segregating alleles, creating a variant context representing the segregating
  * information at a locus, and potentially creating and associating genotypes with individuals in the context.
- *
- * All of the classes are highly validating -- call validate() if you modify them -- so you can rely on the
- * self-consistency of the data once you have a VariantContext in hand.  The system has a rich set of assessor
- * and manipulator routines, as well as more complex static support routines in VariantContextUtils.
- *
- * The VariantContext (and Genotype) objects are attributed (supporting addition of arbitrary key/value pairs) and
+ *</p>
+ *<p>
+ * All of the classes are highly validating -- call <code>validate()</code> if you modify them -- so you can rely on the
+ * self-consistency of the data once you have a <code>VariantContext</code> in hand.  The system has a rich set of assessor
+ * and manipulator routines, as well as more complex static support routines in <code>VariantContextUtils</code>.
+ *</p>
+ *<p>
+ * The <code>VariantContext</code> (and <code>Genotype</code>) objects are attributed (supporting addition of arbitrary key/value pairs) and
  * filtered (can represent a variation that is viewed as suspect).
- *
- * VariantContexts are dynamically typed, so whether a VariantContext is a SNP, Indel, or NoVariant depends
- * on the properties of the alleles in the context.  See the detailed documentation on the Type parameter below.
- *
+ *</p>
+ *<p>
+ *<code>VariantContext</code>s are dynamically typed, so whether a <code>VariantContext</code> is a SNP, Indel, or NoVariant depends
+ * on the properties of the alleles in the context.  See the detailed documentation on the <code>Type</code> parameter below.
+ *</p>
+ *<p>
  * It's also easy to create subcontexts based on selected genotypes.
- *
- * == Working with Variant Contexts ==
+ *</p>
+ * <h3>Working with Variant Contexts</h3>
  * By default, VariantContexts are immutable.  In order to access (in the rare circumstances where you need them)
- * setter routines, you need to create MutableVariantContexts and MutableGenotypes.
+ * setter routines, you need to create <code>MutableVariantContext</code>s and <code>MutableGenotype</code>s.
  *
- * === Some example data ===
- *
+ * <h3>Some example data </h3>
+ *<pre>
  * Allele A, Aref, T, Tref;
  * Allele del, delRef, ATC, ATCref;
- *
+ *</pre>
+ *<p>
  * A [ref] / T at 10
+ *</p>
+ *<pre> 
  * GenomeLoc snpLoc = GenomeLocParser.createGenomeLoc("chr1", 10, 10);
- *
+ *</pre>
+ *<p>
  * A / ATC [ref] from 20-23
+ *</p>
+ *<pre>
  * GenomeLoc delLoc = GenomeLocParser.createGenomeLoc("chr1", 20, 22);
- *
+ *</pre>
+ *<p>
  *  // A [ref] / ATC immediately after 20
+ *  </p>
+ *  <pre>
  * GenomeLoc insLoc = GenomeLocParser.createGenomeLoc("chr1", 20, 20);
+ *</pre>
+ * <h3> Alleles </h3>
  *
- * === Alleles ===
+ * See the documentation in the <code>Allele</code> class itself
  *
- * See the documentation in the Allele class itself
+ * <h4>What are they?</h4>
  *
- * What are they?
+ * <p>Alleles can be either reference or non-reference</p>
  *
- * Alleles can be either reference or non-reference
- *
- * Examples of alleles used here:
- *
+ * <p>Examples of alleles used here:</p>
+ *<pre>
  *   A = new Allele("A");
  *   Aref = new Allele("A", true);
  *   T = new Allele("T");
  *   ATC = new Allele("ATC");
+ *</pre>
+ * <h3> Creating variant contexts </h3>
  *
- * === Creating variant contexts ===
- *
- * ==== By hand ====
+ * <h4> By hand </h4>
  *
  * Here's an example of a A/T polymorphism with the A being reference:
  *
@@ -137,7 +150,7 @@ import java.util.Set;
  * VariantContext vc = new VariantContext("name", insLoc, Arrays.asList(delRef, ATC));
  * </pre>
  *
- * ==== Converting rods and other data structures to VCs ====
+ * <h4> Converting rods and other data structures to <code>VariantContext</code>s </h4>
  *
  * You can convert many common types into VariantContexts using the general function:
  *
@@ -145,15 +158,15 @@ import java.util.Set;
  * VariantContextAdaptors.convertToVariantContext(name, myObject)
  * </pre>
  *
- * dbSNP and VCFs, for example, can be passed in as myObject and a VariantContext corresponding to that
- * object will be returned.  A null return type indicates that the type isn't yet supported.  This is the best
+ * dbSNP and VCFs, for example, can be passed in as <code>myObject</code> and a <code>VariantContext</code> corresponding to that
+ * object will be returned.  A <code>null</code> return value indicates that the type isn't yet supported.  This is the best
  * and easiest way to create contexts using RODs.
  *
  *
- * === Working with genotypes ===
+ * <h3> Working with genotypes </h3>
  *
  * <pre>
- * List<Allele> alleles = Arrays.asList(Aref, T);
+ * List&lt;Allele&gt; alleles = Arrays.asList(Aref, T);
  * Genotype g1 = new Genotype(Arrays.asList(Aref, Aref), "g1", 10);
  * Genotype g2 = new Genotype(Arrays.asList(Aref, T), "g2", 10);
  * Genotype g3 = new Genotype(Arrays.asList(T, T), "g3", 10);
@@ -162,7 +175,7 @@ import java.util.Set;
  *
  * At this point we have 3 genotypes in our context, g1-g3.
  *
- * You can assess a good deal of information about the genotypes through the VariantContext:
+ * You can assess a good deal of information about the genotypes through the <code>VariantContext</code>:
  *
  * <pre>
  * vc.hasGenotypes()
@@ -179,15 +192,15 @@ import java.util.Set;
  * vc.getCalledChrCount(T)
  * </pre>
  *
- * === NO_CALL alleles ===
+ * <h3> NO_CALL alleles </h3>
  *
- * The system allows one to create Genotypes carrying special NO_CALL alleles that aren't present in the
+ * The system allows one to create <code>Genotype</code>s carrying special NO_CALL alleles that aren't present in the
  * set of context alleles and that represent undetermined alleles in a genotype:
- *
+ *<pre>
  * Genotype g4 = new Genotype(Arrays.asList(Allele.NO_CALL, Allele.NO_CALL), "NO_DATA_FOR_SAMPLE", 10);
+ *</pre>
  *
- *
- * === subcontexts ===
+ * <h3> subcontexts </h3>
  * It's also very easy get subcontext based only the data in a subset of the genotypes:
  *
  * <pre>
@@ -195,19 +208,21 @@ import java.util.Set;
  * VariantContext vc1 = vc.subContextFromGenotypes(Arrays.asList(g1));
  * </pre>
  *
- * <s3>
- *     Fully decoding.  Currently VariantContexts support some fields, particularly those
+ * <!-- comment by jdenvir: not sure what this tag is supposed to do:-->
+ * <!-- <s3> -->
+ *     <h3>Fully decoding.</h3>  
+ *     Currently <code>VariantContext</code>s support some fields, particularly those
  *     stored as generic attributes, to be of any type.  For example, a field AB might
  *     be naturally a floating point number, 0.51, but when it's read into a VC its
  *     not decoded into the Java presentation but left as a string "0.51".  A fully
- *     decoded VariantContext is one where all values have been converted to their
- *     corresponding Java object types, based on the types declared in a VCFHeader.
+ *     decoded <code>VariantContext</code> is one where all values have been converted to their
+ *     corresponding Java object types, based on the types declared in a <code>VCFHeader</code>.
  *
- *     The fullyDecode() takes a header object and creates a new fully decoded VariantContext
- *     where all fields are converted to their true java representation.  The VCBuilder
+ *     The <code>fullyDecode(...)</code> method takes a header object and creates a new fully decoded <code>VariantContext</code>
+ *     where all fields are converted to their true java representation.  The <code>VCBuilder</code>
  *     can be told that all fields are fully decoded, in which case no work is done when
  *     asking for a fully decoded version of the VC.
- * </s3>
+ * <!-- </s3> -->
  *
  * @author depristo
  */
@@ -234,7 +249,7 @@ public class VariantContext implements Feature, Serializable {
     /** A set of the alleles segregating in this context */
     final protected List<Allele> alleles;
 
-    /** A mapping from sampleName -> genotype objects for all genotypes associated with this context */
+    /** A mapping from sampleName -&gt; genotype objects for all genotypes associated with this context */
     protected GenotypesContext genotypes = null;
 
     /** Counts for each of the possible Genotype types in this context */
@@ -410,7 +425,7 @@ public class VariantContext implements Feature, Serializable {
      * in this VC is returned as the set of alleles in the subContext, even if
      * some of those alleles aren't in the samples
      *
-     * WARNING: BE CAREFUL WITH rederiveAllelesFromGenotypes UNLESS YOU KNOW WHAT YOU ARE DOING?
+     * WARNING: BE CAREFUL WITH rederiveAllelesFromGenotypes UNLESS YOU KNOW WHAT YOU ARE DOING
      *
      * @param sampleNames    the sample names
      * @param rederiveAllelesFromGenotypes if true, returns the alleles to just those in use by the samples, true should be default
@@ -484,59 +499,77 @@ public class VariantContext implements Feature, Serializable {
     // ---------------------------------------------------------------------------------------------------------
 
     /**
-     * see: http://www.ncbi.nlm.nih.gov/bookshelf/br.fcgi?book=handbook&part=ch5&rendertype=table&id=ch5.ch5_t3
+     * @see <a href="http://www.ncbi.nlm.nih.gov/bookshelf/br.fcgi?book=handbook&part=ch5&rendertype=table&id=ch5.ch5_t3">NCBI Handbook</a>
      *
-     * Format:
-     * dbSNP variation class
-     * Rules for assigning allele classes
-     * Sample allele definition
-     *
-     * Single Nucleotide Polymorphisms (SNPs)a
-     *   Strictly defined as single base substitutions involving A, T, C, or G.
-     *   A/T
-     *
-     * Deletion/Insertion Polymorphisms (DIPs)
-     *   Designated using the full sequence of the insertion as one allele, and either a fully
+     * <h3>Format:</h3>
+     * <ul>
+     * <li><strong>dbSNP variation class</strong></li>
+     * <li>Rules for assigning allele classes</li>
+     * <li>Sample allele definition</li>
+     * </ul>
+     * <h3>Supported Types</h3>
+     * <ul>
+     * <li><strong>Single Nucleotide Polymorphisms (SNPs)a</strong></li>
+     * <li>Strictly defined as single base substitutions involving A, T, C, or G.</li>
+     * <li>A/T</li>
+     * </ul>
+     * <br>
+     * <ul>
+     * <li><strong>Deletion/Insertion Polymorphisms (DIPs)</strong></li>
+     * <li>Designated using the full sequence of the insertion as one allele, and either a fully
      *   defined string for the variant allele or a '-' character to specify the deleted allele.
      *   This class will be assigned to a variation if the variation alleles are of different lengths or
-     *   if one of the alleles is deleted ('-').
-     *   T/-/CCTA/G
-     *
-     * No-variation
-     *   Reports may be submitted for segments of sequence that are assayed and determined to be invariant
-     *   in the sample.
-     *   (NoVariation)
-     *
-     * Mixed
-     *   Mix of other classes
-     *
+     *   if one of the alleles is deleted ('-').</li>
+     * <li>T/-/CCTA/G</li>
+     * </ul>
+     * <br>
+     * <ul>
+     * <li><strong>No-variation</strong></li>
+     * <li>Reports may be submitted for segments of sequence that are assayed and determined to be invariant
+     *   in the sample.</li>
+     * <li>(NoVariation)</li>
+     * </ul>
+     * <br>
+     * <ul>
+     * <li><strong>Mixed</strong></li>
+     * <li>Mix of other classes</li>
+     * </ul>
+     * 
      * Also supports NO_VARIATION type, used to indicate that the site isn't polymorphic in the population
      *
      *
-     * Not currently supported:
+     * <h3>Not currently supported:</h3>
      *
-     * Heterozygous sequence
-     * The term heterozygous is used to specify a region detected by certain methods that do not
+     * <ul>
+     * <li><strong>Heterozygous sequence</strong></li>
+     * <li>The term heterozygous is used to specify a region detected by certain methods that do not
      * resolve the polymorphism into a specific sequence motif. In these cases, a unique flanking
-     * sequence must be provided to define a sequence context for the variation.
-     * (heterozygous)
-     *
-     * Microsatellite or short tandem repeat (STR)
-     * Alleles are designated by providing the repeat motif and the copy number for each allele.
+     * sequence must be provided to define a sequence context for the variation.</li>
+     * <li>(heterozygous)</li>
+     * </ul>
+     * <br>
+     * <ul>
+     * <li><strong>Microsatellite or short tandem repeat (STR)</strong></li>
+     * <li>Alleles are designated by providing the repeat motif and the copy number for each allele.
      * Expansion of the allele repeat motif designated in dbSNP into full-length sequence will
      * be only an approximation of the true genomic sequence because many microsatellite markers are
-     * not fully sequenced and are resolved as size variants only.
-     * (CAC)8/9/10/11
-     *
-     * Named variant
-     * Applies to insertion/deletion polymorphisms of longer sequence features, such as retroposon
+     * not fully sequenced and are resolved as size variants only.</li>
+     * <li>(CAC)8/9/10/11</li>
+     * </ul>
+     * <br>
+     * <ul>
+     * <li><strong>Named variant</strong></li>
+     * <li>Applies to insertion/deletion polymorphisms of longer sequence features, such as retroposon
      * dimorphism for Alu or line elements. These variations frequently include a deletion '-' indicator
-     * for the absent allele.
-     * (alu) / -
-     *
-     * Multi-Nucleotide Polymorphism (MNP)
-     *   Assigned to variations that are multi-base variations of a single, common length
-     *   GGA/AGT
+     * for the absent allele.</li>
+     * <li>(alu) / -</li>
+     * </ul>
+     * <br>
+     * <ul>
+     * <li><strong>Multi-Nucleotide Polymorphism (MNP)</strong></li>
+     * <li>Assigned to variations that are multi-base variations of a single, common length</li>
+     * <li>GGA/AGT</li>
+     * </ul>
      */
     public enum Type {
         NO_VARIATION,
@@ -920,7 +953,7 @@ public class VariantContext implements Feature, Serializable {
     }
 
     /**
-     * Returns a map from sampleName -> Genotype for the genotype associated with sampleName.  Returns a map
+     * Returns a map from sampleName -&gt; Genotype for the genotype associated with sampleName.  Returns a map
      * for consistency with the multi-get function.
      *
      * @param sampleName   the sample name
@@ -932,7 +965,7 @@ public class VariantContext implements Feature, Serializable {
     }
 
     /**
-     * Returns a map from sampleName -> Genotype for each sampleName in sampleNames.  Returns a map
+     * Returns a map from sampleName -&gt; Genotype for each sampleName in sampleNames.  Returns a map
      * for consistency with the multi-get function.
      *
      * For testing convenience only
@@ -1049,7 +1082,7 @@ public class VariantContext implements Feature, Serializable {
 
     /**
      * Genotype-specific functions -- are the genotypes polymorphic w.r.t. to the alleles segregating at this
-     * site?  That is, is the number of alternate alleles among all fo the genotype > 0?
+     * site?  That is, is the number of alternate alleles among all fo the genotype &gt; 0?
      *
      * @return true if it's polymorphic
      */
@@ -1622,7 +1655,8 @@ public class VariantContext implements Feature, Serializable {
     /**
      * @return 1-based inclusive start position of the Variant
      * INDEL events usually start on the first unaltered reference base before the INDEL
-     * @warning be aware that the start position of the VariantContext is defined in terms of the start position specified in the
+     * 
+     * <strong>Warning:</strong> be aware that the start position of the VariantContext is defined in terms of the start position specified in the
      * underlying vcf file, VariantContexts representing the same biological event may have different start positions depending on the
      * specifics of the vcf file they are derived from
      */

--- a/src/java/htsjdk/variant/variantcontext/VariantContextBuilder.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContextBuilder.java
@@ -40,27 +40,27 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Builder class for VariantContext
+ * <p>Builder class for <code>VariantContext</code>.</p>
  *
- * Some basic assumptions here:
- *
- * 1 -- data isn't protectively copied.  If you provide an attribute map to
+ * <p>Some basic assumptions here:</p>
+ * <ol>
+ * <li> data isn't protectively copied.  If you provide an attribute map to
  * the build, and modify it later, the builder will see this and so will any
  * resulting variant contexts.  It's best not to modify collections provided
- * to a builder.
+ * to a builder.</li>
  *
- * 2 -- the system uses the standard builder model, allowing the simple construction idiom:
- *
- *   builder.source("a").genotypes(gc).id("x").make() => VariantContext
- *
- * 3 -- The best way to copy a VariantContext is:
- *
- *   new VariantContextBuilder(vc).make() => a copy of VC
- *
- * 4 -- validation of arguments is done at the during the final make() call, so a
- * VariantContextBuilder can exist in an inconsistent state as long as those issues
- * are resolved before the call to make() is issued.
- *
+ * <li> the system uses the standard builder model, allowing the simple construction idiom:
+ *<blockquote>
+ *   <code>builder.source("a").genotypes(gc).id("x").make()</code> =&gt; <code>VariantContext</code>
+ *</blockquote></li>
+ *<li>The best way to copy a VariantContext is:
+ *<blockquote>
+ *   <code>new VariantContextBuilder(vc).make()</code> =&gt; a copy of VC
+ *</blockquote>
+ * <li> validation of arguments is done at the during the final <code>make()</code> call, so a
+ * <code>VariantContextBuilder</code> can exist in an inconsistent state as long as those issues
+ * are resolved before the call to <code>make()</code> is issued.
+ *</ol>
  * @author depristo
  */
 public class VariantContextBuilder {
@@ -178,9 +178,9 @@ public class VariantContextBuilder {
     }
 
     /**
-     * Tells this builder to use this map of attributes alleles for the resulting VariantContext
+     * Tells this builder to use this map of attributes alleles for the resulting <code>VariantContext</code>
      *
-     * Attributes can be null -> meaning there are no attributes.  After
+     * Attributes can be <code>null</code> -&gt; meaning there are no attributes.  After
      * calling this routine the builder assumes it can modify the attributes
      * object here, if subsequent calls are made to set attribute values
      *
@@ -202,7 +202,7 @@ public class VariantContextBuilder {
     }
 
     /**
-     * Puts the key -> value mapping into this builder's attributes
+     * Puts the key -&gt; value mapping into this builder's attributes
      *
      * @param key key for the attribute
      * @param value value for the attribute (must be of a type that implements {@link Serializable} or else serialization will fail)
@@ -256,7 +256,7 @@ public class VariantContextBuilder {
     /**
      * This builder's filters are set to this value
      *
-     * filters can be null -> meaning there are no filters
+     * filters can be <code>null</code> -&gt; meaning there are no filters
      * @param filters
      */
     public VariantContextBuilder filters(final Set<String> filters) {
@@ -301,9 +301,9 @@ public class VariantContextBuilder {
     }
 
     /**
-     * Tells this builder that the resulting VariantContext should use this genotypes GenotypeContext
+     * Tells this builder that the resulting <code>VariantContext</code> should use this genotype's <code>GenotypeContext</code>.
      *
-     * Note that genotypes can be null -> meaning there are no genotypes
+     * Note that genotypes can be <code>null</code> -&gt; meaning there are no genotypes
      *
      * @param genotypes
      */
@@ -320,9 +320,9 @@ public class VariantContextBuilder {
     }
 
     /**
-     * Tells this builder that the resulting VariantContext should use a GenotypeContext containing genotypes
+     * Tells this builder that the resulting <code>VariantContext</code> should use a <code>GenotypeContext</code> containing genotypes
      *
-     * Note that genotypes can be null -> meaning there are no genotypes
+     * Note that genotypes can be <code>null</code>, meaning there are no genotypes
      *
      * @param genotypes
      */
@@ -331,7 +331,7 @@ public class VariantContextBuilder {
     }
 
     /**
-     * Tells this builder that the resulting VariantContext should use a GenotypeContext containing genotypes
+     * Tells this builder that the resulting <code>VariantContext</code> should use a <code>GenotypeContext</code> containing genotypes
      * @param genotypes
      */
     public VariantContextBuilder genotypes(final Genotype ... genotypes) {

--- a/src/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -277,7 +277,7 @@ public class VariantContextUtils {
     }
 
     /**
-     * Returns true if exp match VC.  See collection<> version for full docs.
+     * Returns true if exp match VC.  See {@link #match(VariantContext, Collection)} for full docs.
      * @param vc    variant context
      * @param exp   expression
      * @return true if there is a match
@@ -302,7 +302,7 @@ public class VariantContextUtils {
     }
 
     /**
-     * Returns true if exp match VC/g.  See collection<> version for full docs.
+     * Returns true if exp match VC/g.  See {@link #match(VariantContext, Collection)} for full docs.
      * @param vc   variant context
      * @param g    genotype
      * @param exp   expression

--- a/src/java/htsjdk/variant/variantcontext/writer/BCF2FieldEncoder.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/BCF2FieldEncoder.java
@@ -249,7 +249,7 @@ public abstract class BCF2FieldEncoder {
      * The argument should be used, not the getType() method in the superclass as an outer loop might have
      * decided a more general type (int16) to use, even through this encoder could have been done with int8.
      *
-     * If minValues > 0, then encodeValue must write in at least minValues items from value.  If value is atomic,
+     * If minValues &gt; 0, then encodeValue must write in at least minValues items from value.  If value is atomic,
      * this means that minValues - 1 MISSING values should be added to the encoder.  If minValues is a collection
      * type (int[]) then minValues - values.length should be added.  This argument is intended to handle padding
      * of values in genotype fields.

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -42,53 +42,65 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.EnumSet;
 
-/**
+/*
  * Created with IntelliJ IDEA.
  * User: thibault
  * Date: 3/7/14
  * Time: 2:07 PM
- *
- * Provides methods for creating VariantContextWriters using the Builder pattern.
- * Replaces VariantContextWriterFactory.
- *
- * The caller must choose an output file or an output stream for the VariantContextWriter to write to.
+ */
+/**
+ * @author thibault
+ * 
+ * <p>
+ * Provides methods for creating <code>VariantContextWriter</code>s using the Builder pattern.
+ * Replaces <code>VariantContextWriterFactory</code>.
+ * </p>
+ * <p>
+ * The caller must choose an output file or an output stream for the <code>VariantContextWriter</code> to write to.
  * When a file is chosen, the output stream is created implicitly based on Defaults and options passed to the builder.
- * When a stream is chosen, it is passed unchanged to the VariantContextWriter.
- *
+ * When a stream is chosen, it is passed unchanged to the <code>VariantContextWriter</code>.
+ * </p>
+ * <p>
  * Example: Create a series of files with buffering and indexing on the fly.
  * Determine the appropriate file type based on filename.
- *
- *  VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
- *      .setReferenceDictionary(refDict)
- *      .setOption(Options.INDEX_ON_THE_FLY)
- *      .setBuffer(8192);
- *
- *  VariantContextWriter sample1_writer = builder
- *      .setOutputFile("sample1.vcf")
- *      .build();
- *  VariantContextWriter sample2_writer = builder
- *      .setOutputFile("sample2.bcf")
- *      .build();
- *  VariantContextWriter sample3_writer = builder
- *      .setOutputFile("sample3.vcf.bgzf")
- *      .build();
- *
- * Example: Explicitly turn off buffering and explicitly set the file type
- *
- *  VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
- *      .setReferenceDictionary(refDict)
- *      .setOption(Options.INDEX_ON_THE_FLY)
- *      .unsetBuffering();
- *
- *  VariantContextWriter sample1_writer = builder
- *      .setOutputFile("sample1.custom_extension")
- *      .setOutputFileType(OutputType.VCF)
- *      .build();
- *  VariantContextWriter sample2_writer = builder
- *      .setOutputFile("sample2.custom_extension")
- *      .setOutputFileType(OutputType.BLOCK_COMPRESSED_VCF)
- *      .build();
+ * </p>
 
+   <pre>
+   VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+       .setReferenceDictionary(refDict)
+       .setOption(Options.INDEX_ON_THE_FLY)
+       .setBuffer(8192);
+ 
+   VariantContextWriter sample1_writer = builder
+       .setOutputFile("sample1.vcf")
+       .build();
+   VariantContextWriter sample2_writer = builder
+       .setOutputFile("sample2.bcf")
+       .build();
+   VariantContextWriter sample3_writer = builder
+       .setOutputFile("sample3.vcf.bgzf")
+       .build();
+   </pre>
+   
+   <p>
+ * Example: Explicitly turn off buffering and explicitly set the file type
+ * </p>
+ * 
+ * <pre>
+   VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+       .setReferenceDictionary(refDict)
+       .setOption(Options.INDEX_ON_THE_FLY)
+       .unsetBuffering();
+ 
+   VariantContextWriter sample1_writer = builder
+       .setOutputFile("sample1.custom_extension")
+       .setOutputFileType(OutputType.VCF)
+       .build();
+   VariantContextWriter sample2_writer = builder
+       .setOutputFile("sample2.custom_extension")
+       .setOutputFileType(OutputType.BLOCK_COMPRESSED_VCF)
+       .build();
+   </pre>
  */
 public class VariantContextWriterBuilder {
     public static final EnumSet<Options> DEFAULT_OPTIONS = EnumSet.of(Options.INDEX_ON_THE_FLY);
@@ -116,7 +128,7 @@ public class VariantContextWriterBuilder {
     private EnumSet<Options> options = DEFAULT_OPTIONS.clone();
 
     /**
-     * Default constructor.  Adds USE_ASYNC_IO to the Options if it is present in Defaults.
+     * Default constructor.  Adds <code>USE_ASYNC_IO</code> to the Options if it is present in Defaults.
      */
     public VariantContextWriterBuilder() {
         if (Defaults.USE_ASYNC_IO)
@@ -124,10 +136,10 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set the reference dictionary to be used by VariantContextWriters created by this builder
+     * Set the reference dictionary to be used by <code>VariantContextWriter</code>s created by this builder.
      *
      * @param refDict the reference dictionary
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setReferenceDictionary(final SAMSequenceDictionary refDict) {
         this.refDict = refDict;
@@ -135,11 +147,11 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set the output file for the next VariantContextWriter created by this builder
-     * Determines file type implicitly from the filename
+     * Set the output file for the next <code>VariantContextWriter</code> created by this builder.
+     * Determines file type implicitly from the filename.
      *
-     * @param outFile the file the VariantContextWriter will write to
-     * @return this VariantContextWriterBuilder
+     * @param outFile the file the <code>VariantContextWriter</code> will write to
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setOutputFile(final File outFile) {
         this.outFile = outFile;
@@ -149,11 +161,11 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set the output file for the next VariantContextWriter created by this builder
-     * Determines file type implicitly from the filename
+     * Set the output file for the next <code>VariantContextWriter</code> created by this builder.
+     * Determines file type implicitly from the filename.
      *
-     * @param outFile the file the VariantContextWriter will write to
-     * @return this VariantContextWriterBuilder
+     * @param outFile the file the <code>VariantContextWriter</code> will write to
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setOutputFile(final String outFile) {
         this.outFile = new File(outFile);
@@ -163,10 +175,10 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set the output file type for the next VariantContextWriter created by this builder
+     * Set the output file type for the next <code>VariantContextWriter</code> created by this builder.
      *
-     * @param outType the type of file the VariantContextWriter will write to
-     * @return this VariantContextWriterBuilder
+     * @param outType the type of file the <code>VariantContextWriter</code> will write to
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setOutputFileType(final OutputType outType) {
         if (!FILE_TYPES.contains(outType))
@@ -180,11 +192,11 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set the output VCF stream for the next VariantContextWriter created by this builder
-     * If buffered writing is desired, caller must provide some kind of buffered OutputStream.
+     * Set the output VCF stream for the next <code>VariantContextWriter</code> created by this builder.
+     * If buffered writing is desired, caller must provide some kind of buffered <code>OutputStream</code>.
      *
      * @param outStream the output stream to write to
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setOutputVCFStream(final OutputStream outStream) {
         this.outStream = outStream;
@@ -194,11 +206,11 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set the output BCF stream for the next VariantContextWriter created by this builder
-     * If buffered writing is desired, caller must provide some kind of buffered OutputStream.
+     * Set the output BCF stream for the next <code>VariantContextWriter</code> created by this builder.
+     * If buffered writing is desired, caller must provide some kind of buffered <code>OutputStream</code>.
      *
      * @param outStream the output stream to write to
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setOutputBCFStream(final OutputStream outStream) {
         this.outStream = outStream;
@@ -208,8 +220,8 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set the output stream (VCF, by default) for the next VariantContextWriter created by this builder
-     * If buffered writing is desired, caller must provide some kind of buffered OutputStream.
+     * Set the output stream (VCF, by default) for the next <code>VariantContextWriter</code> created by this builder.
+     * If buffered writing is desired, caller must provide some kind of buffered <code>OutputStream</code>.
      *
      * @param outStream the output stream to write to
      * @return this VariantContextWriterBuilder
@@ -219,10 +231,10 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set an IndexCreator for the next VariantContextWriter created by this builder
+     * Set an IndexCreator for the next <code>VariantContextWriter</code> created by this builder.
      *
-     * @param idxCreator the IndexCreator to use
-     * @return this VariantContextWriterBuilder
+     * @param idxCreator the <code>IndexCreator</code> to use
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setIndexCreator(final IndexCreator idxCreator) {
         this.idxCreator = idxCreator;
@@ -230,9 +242,9 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Do not pass an IndexCreator to the next VariantContextWriter created by this builder
+     * Do not pass an <code>IndexCreator</code> to the next <code>VariantContextWriter</code> created by this builder.
      *
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder clearIndexCreator() {
         this.idxCreator = null;
@@ -240,12 +252,12 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set a buffer size for the file output stream passed to the next VariantContextWriter created by this builder
-     * Set to 0 for no buffering
-     * Does not affect OutputStreams passed directly to VariantContextWriterBuilder
+     * Set a buffer size for the file output stream passed to the next <code>VariantContextWriter</code> created by this builder.
+     * Set to 0 for no buffering.
+     * Does not affect OutputStreams passed directly to <code>VariantContextWriterBuilder</code>.
      *
      * @param bufferSize the buffer size to use
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setBuffer(final int bufferSize) {
         this.bufferSize = bufferSize;
@@ -253,10 +265,10 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Do not use buffering in the next VariantContextWriter created by this builder
-     * Does not affect OutputStreams passed directly to VariantContextWriterBuilder
+     * Do not use buffering in the next <code>VariantContextWriter</code> created by this builder.
+     * Does not affect <code>OutputStream</code>s passed directly to <code>VariantContextWriterBuilder</code>.
      *
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder unsetBuffering() {
         this.bufferSize = 0;
@@ -264,10 +276,10 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Choose whether to also create an MD5 digest file for the next VariantContextWriter created by this builder
+     * Choose whether to also create an MD5 digest file for the next <code>VariantContextWriter</code> created by this builder.
      *
-     * @param createMD5 boolean, true to create an MD5 digest
-     * @return this VariantContextWriterBuilder
+     * @param createMD5 boolean, <code>true</code> to create an MD5 digest
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setCreateMD5(final boolean createMD5) {
         this.createMD5 = createMD5;
@@ -275,28 +287,28 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Create an MD5 digest file for the next VariantContextWriter created by this builder
+     * Create an MD5 digest file for the next <code>VariantContextWriter</code> created by this builder.
      *
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setCreateMD5() {
         return setCreateMD5(true);
     }
 
     /**
-     * Don't create an MD5 digest file for the next VariantContextWriter created by this builder
+     * Don't create an MD5 digest file for the next <code>VariantContextWriter</code> created by this builder.
      *
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder unsetCreateMD5() {
         return setCreateMD5(false);
     }
 
     /**
-     * Replace the set of Options for the VariantContextWriterBuilder with a new set
+     * Replace the set of <code>Options</code> for the <code>VariantContextWriterBuilder</code> with a new set.
      *
      * @param options the complete set of options to use
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setOptions(final EnumSet<Options> options) {
         this.options = options;
@@ -304,10 +316,10 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Add one option to the set of Options for the VariantContextWriterBuilder, if it's not already present
+     * Add one option to the set of <code>Options</code> for the <code>VariantContextWriterBuilder</code>, if it's not already present.
      *
      * @param option the option to set
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setOption(final Options option) {
         this.options.add(option);
@@ -315,10 +327,10 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Remove one option from the set of Options for the VariantContextWriterBuilder, if it's present
+     * Remove one option from the set of <code>Options</code> for the <code>VariantContextWriterBuilder</code>, if it's present.
      *
      * @param option the option to unset
-     * @return this VariantContextWriterBuilder
+     * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder unsetOption(final Options option) {
         this.options.remove(option);
@@ -326,7 +338,7 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Remove all options from the set of Options for the VariantContextWriterBuilder
+     * Remove all options from the set of <code>Options</code> for the <code>VariantContextWriterBuilder</code>.
      *
      * @return this VariantContextWriterBuilder
      */
@@ -336,9 +348,13 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Validate and build the VariantContextWriter
+     * Validate and build the <code>VariantContextWriter</code>.
      *
-     * @return the VariantContextWriter as specified by previous method calls
+     * @return the <code>VariantContextWriter</code> as specified by previous method calls
+     * @throws RuntimeIOException if the writer is configured to write to a file, and the corresponding path does not exist.
+     * @throws IllegalArgumentException if no output file or stream is specified.
+     * @throws IllegalArgumentException if <code>Options.INDEX_ON_THE_FLY</code> is specified and no reference dictionary is provided.
+     * @throws IllegalArgumentException if <code>Options.INDEX_ON_THE_FLY</code> is specified and a stream output is specified.
      */
     public VariantContextWriter build() {
         VariantContextWriter writer = null;

--- a/src/java/htsjdk/variant/vcf/VCFEncoder.java
+++ b/src/java/htsjdk/variant/vcf/VCFEncoder.java
@@ -208,9 +208,9 @@ public class VCFEncoder {
 	/**
 	 * Takes a double value and pretty prints it to a String for display
 	 *
-	 * Large doubles => gets %.2f style formatting
-	 * Doubles < 1 / 10 but > 1/100 </>=> get %.3f style formatting
-	 * Double < 1/100 => %.3e formatting
+	 * Large doubles =&gt; gets %.2f style formatting
+	 * Doubles &lt; 1 / 10 but &gt; 1/100 =&gt; get %.3f style formatting
+	 * Double &lt; 1/100 =&gt; %.3e formatting
 	 * @param d
 	 * @return
 	 */

--- a/src/java/htsjdk/variant/vcf/VCFFilterHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFFilterHeaderLine.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 
 /**
  * @author ebanks
+ * 
  * A class representing a key=value entry for FILTER fields in the VCF header
  */
 public class VCFFilterHeaderLine extends VCFSimpleHeaderLine  {

--- a/src/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
@@ -28,10 +28,11 @@ package htsjdk.variant.vcf;
 
 /**
  * @author ebanks
- *         <p/>
+ *         <p>
  *         Class VCFFormatHeaderLine
- *         <p/>
- *         A class representing a key=value entry for genotype FORMAT fields in the VCF header
+ *         </p>
+ *         <p>
+ *         A class representing a key=value entry for genotype FORMAT fields in the VCF header</p>
  */
 public class VCFFormatHeaderLine extends VCFCompoundHeaderLine {
 

--- a/src/java/htsjdk/variant/vcf/VCFHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFHeaderLine.java
@@ -33,10 +33,12 @@ import java.util.Map;
 
 /**
  * @author ebanks
- *         <p/>
+ *         <p>
  *         Class VCFHeaderLine
- *         <p/>
+ *         </p>
+ *         <p>
  *         A class representing a key=value entry in the VCF header
+ *         </p>
  */
 public class VCFHeaderLine implements Comparable, Serializable {
     public static final long serialVersionUID = 1L;
@@ -139,7 +141,7 @@ public class VCFHeaderLine implements Comparable, Serializable {
 
     /**
      * create a string of a mapping pair for the target VCF version
-     * @param keyValues a mapping of the key->value pairs to output
+     * @param keyValues a mapping of the key-&gt;value pairs to output
      * @return a string, correctly formatted
      */
     public static String toStringEncoding(Map<String, ? extends Object> keyValues) {

--- a/src/java/htsjdk/variant/vcf/VCFInfoHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFInfoHeaderLine.java
@@ -28,10 +28,12 @@ package htsjdk.variant.vcf;
 
 /**
  * @author ebanks
- *         <p/>
+ *         <p>
  *         Class VCFInfoHeaderLine
- *         <p/>
+ *         </p>
+ *         <p>
  *         A class representing a key=value entry for INFO fields in the VCF header
+ *         </p>
  */
 public class VCFInfoHeaderLine extends VCFCompoundHeaderLine {
     public VCFInfoHeaderLine(String name, int count, VCFHeaderLineType type, String description) {

--- a/src/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 /**
  * @author ebanks
+ * 
  * A class representing a key=value entry for simple VCF header types
  */
 public class VCFSimpleHeaderLine extends VCFHeaderLine implements VCFIDHeaderLine {

--- a/src/java/htsjdk/variant/vcf/VCFStandardHeaderLines.java
+++ b/src/java/htsjdk/variant/vcf/VCFStandardHeaderLines.java
@@ -37,10 +37,10 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Manages header lines for standard VCF INFO and FORMAT fields
+ * Manages header lines for standard VCF INFO and FORMAT fields.
  *
  * Provides simple mechanisms for registering standard lines,
- * looking them up, and adding them to headers
+ * looking them up, and adding them to headers.
  *
  * @author Mark DePristo
  * @since 6/12


### PR DESCRIPTION
These changes are to documentation only, and the vast majority are just formatting changes. These are not complete (there are still some `<code>` tags that could be included) but leave the docs for the whole package in a usable state. The Javadocs generate under my Eclipse version with no errors (though there are still warnings).