### PR TITLE
Pass isRef to Allele.acceptableAlleleBases() in AbstractVCFCodec.checkAllele()

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/java/htsjdk/variant/variantcontext/Allele.java
@@ -330,12 +330,8 @@ public class Allele implements Comparable<Allele>, Serializable {
         if ( wouldBeNoCallAllele(bases) || wouldBeSymbolicAllele(bases) )
             return true;
 
-        if ( wouldBeStarAllele(bases) ) {
-            if ( isReferenceAllele )
-                return false;
-            else
-                return true;
-        }
+        if ( wouldBeStarAllele(bases) )
+            return !isReferenceAllele;
 
         for (byte base :  bases ) {
             switch (base) {

--- a/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -565,7 +565,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
                 generateException("Insertions/Deletions are not supported when reading 3.x VCF's. Please" +
                         " convert your file to VCF4 using VCFTools, available at http://vcftools.sourceforge.net/index.html", lineNo);
 
-            if (!Allele.acceptableAlleleBases(allele))
+            if (!Allele.acceptableAlleleBases(allele, isRef))
                 generateException(generateExceptionTextForBadAlleleBases(allele), lineNo);
 
             if ( isRef && allele.equals(VCFConstants.EMPTY_ALLELE) )

--- a/src/tests/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
+++ b/src/tests/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
@@ -1,8 +1,11 @@
 package htsjdk.variant.vcf;
 
 import java.io.File;
+import java.util.List;
 
+import htsjdk.tribble.TribbleException;
 import htsjdk.variant.VariantBaseTest;
+import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
 
 import org.testng.Assert;
@@ -20,5 +23,15 @@ public class AbstractVCFCodecTest extends VariantBaseTest {
 		// VCF v4.1 s1.4.5
 		// Tools processing VCF files are not required to preserve case in the allele String, except for IDs, which are case sensitive.
 		Assert.assertTrue(variant.getAlternateAllele(0).getDisplayString().contains("chr12"));
+	}
+
+	@Test
+	public void TestSpanDelParseAlleles(){
+		List<Allele> list = VCF3Codec.parseAlleles("A", Allele.SPAN_DEL_STRING, 0);
+	}
+
+	@Test(expectedExceptions = TribbleException.class)
+	public void TestSpanDelParseAllelesException(){
+		List<Allele> list1 = VCF3Codec.parseAlleles(Allele.SPAN_DEL_STRING, "A", 0);
 	}
 }


### PR DESCRIPTION
…kAllele()
If isRef is not passed, acceptableAlleleBases(final String bases)  is used instead of acceptableAlleleBases(final String bases, boolean isReferenceAllele). This version sets isReferenceAllele to true. For the case of "*",  reference allele is not acceptable and will generate an exception. 