### PR TITLE
Modified SAMLineParser to only invoke SAMRecord.isValid() if...

### DIFF
--- a/src/java/htsjdk/samtools/SAMLineParser.java
+++ b/src/java/htsjdk/samtools/SAMLineParser.java
@@ -332,12 +332,17 @@ public class SAMLineParser {
             parseTag(samRecord, mFields[i]);
         }
 
-        final List<SAMValidationError> validationErrors = samRecord.isValid();
-        if (validationErrors != null) {
-            for (final SAMValidationError errorMessage : validationErrors) {
-                reportErrorParsingLine(errorMessage.getMessage());
+        // Only call samRecord.isValid() if errors would be reported since the validation
+        // is quite expensive in and of itself.
+        if (this.validationStringency != ValidationStringency.SILENT) {
+            final List<SAMValidationError> validationErrors = samRecord.isValid();
+            if (validationErrors != null) {
+                for (final SAMValidationError errorMessage : validationErrors) {
+                    reportErrorParsingLine(errorMessage.getMessage());
+                }
             }
         }
+
         return samRecord;
     }
 


### PR DESCRIPTION
…ValidationStringency is set to something other than SILENT. Speeds up the parsing of SAM (not BAM) text files when validaiton stringency is silent.