### PR TITLE
setting travis to use the containerized build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+sudo: false
 jdk:
   - oraclejdk7
   - oraclejdk8


### PR DESCRIPTION
travis claims that dispatch is faster with the sudoless container builds