### PR TITLE
added getAttributeAsList in CommonInfo and VariantContext

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -29,10 +29,12 @@ package htsjdk.variant.variantcontext;
 import htsjdk.variant.vcf.VCFConstants;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -239,6 +241,18 @@ public final class CommonInfo implements Serializable {
             return attributes.get(key);
         else
             return defaultValue;
+    }
+
+    /** returns the value as an empty list if the key was not found,
+        as a java.util.List if the value is a List or an Array,
+        as a Collections.singletonList if there is only one value */
+    @SuppressWarnings("unchecked")
+    public List<Object> getAttributeAsList(String key) {
+        Object o = getAttribute(key);
+        if ( o == null ) return Collections.emptyList();
+        if ( o instanceof List ) return (List<Object>)o;
+        if ( o.getClass().isArray() ) return Arrays.asList((Object[])o);
+        return Collections.singletonList(o);
     }
 
     public String getAttributeAsString(String key, String defaultValue) {

--- a/src/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -740,6 +740,10 @@ public class VariantContext implements Feature, Serializable {
     public int getAttributeAsInt(String key, int defaultValue)            { return commonInfo.getAttributeAsInt(key, defaultValue); }
     public double getAttributeAsDouble(String key, double  defaultValue)  { return commonInfo.getAttributeAsDouble(key, defaultValue); }
     public boolean getAttributeAsBoolean(String key, boolean  defaultValue)  { return commonInfo.getAttributeAsBoolean(key, defaultValue); }
+    /** returns the value as an empty list if the key was not found,
+        as a java.util.List if the value is a List or an Array,
+        as a Collections.singletonList if there is only one value */
+    public List<Object> getAttributeAsList(String key)  { return commonInfo.getAttributeAsList(key); }
 
     public CommonInfo getCommonInfo() {
         return commonInfo;


### PR DESCRIPTION
This pull-request contains a new utility function getAttributeAsList in ` src/java/htsjdk/variant/variantcontext/CommonInfo.java `  that always return the value as a java.util.List (empty list if the key is not found, List is the value if a List or an array, or as a ollections.singletonList . The method is also available in  src/java/htsjdk/variant/variantcontext/VariantContext.java  .

I use this function to safely loop over the value(s) in an INFO field.

```java
for(Object annotation : variantContext.getAttributeAsList("ANN"))
   {
  //...
   }
```