### PR TITLE
Change to allow callers to request the non-indexed reader(s) from the…

### DIFF
--- a/src/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
+++ b/src/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
@@ -54,7 +54,7 @@ public class ReferenceSequenceFileFactory {
      *
      * @param file the reference sequence file on disk
      */
-    public static ReferenceSequenceFile getReferenceSequenceFile(File file) {
+    public static ReferenceSequenceFile getReferenceSequenceFile(final File file) {
         return getReferenceSequenceFile(file, true);
     }
 
@@ -65,15 +65,28 @@ public class ReferenceSequenceFileFactory {
      * @param file the reference sequence file on disk
      * @param truncateNamesAtWhitespace if true, only include the first word of the sequence name
      */
-    public static ReferenceSequenceFile getReferenceSequenceFile(File file, boolean truncateNamesAtWhitespace) {
-        String name = file.getName();
-        for (String ext : FASTA_EXTENSIONS) {
+    public static ReferenceSequenceFile getReferenceSequenceFile(final File file, final boolean truncateNamesAtWhitespace) {
+        return getReferenceSequenceFile(file, truncateNamesAtWhitespace, true);
+    }
+
+    /**
+     * Attempts to determine the type of the reference file and return an instance
+     * of ReferenceSequenceFile that is appropriate to read it.
+     *
+     * @param file the reference sequence file on disk
+     * @param truncateNamesAtWhitespace if true, only include the first word of the sequence name
+     * @param preferIndexed if true attempt to return an indexed reader that supports non-linear traversal, else return the non-indexed reader
+     */
+    public static ReferenceSequenceFile getReferenceSequenceFile(final File file, final boolean truncateNamesAtWhitespace, final boolean preferIndexed) {
+        final String name = file.getName();
+        for (final String ext : FASTA_EXTENSIONS) {
             if (name.endsWith(ext)) {
                 // Using faidx requires truncateNamesAtWhitespace
-                if (truncateNamesAtWhitespace && IndexedFastaSequenceFile.canCreateIndexedFastaReader(file)) {
+                if (truncateNamesAtWhitespace && preferIndexed && IndexedFastaSequenceFile.canCreateIndexedFastaReader(file)) {
                     try {
                         return new IndexedFastaSequenceFile(file);
-                    } catch (FileNotFoundException e) {
+                    }
+                    catch (final FileNotFoundException e) {
                         throw new IllegalStateException("Should never happen, because existence of files has been checked.", e);
                     }
                 }

--- a/src/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
+++ b/src/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
@@ -46,7 +46,7 @@ public class ReferenceSequenceFileWalker implements Closeable {
     }
 
     public ReferenceSequenceFileWalker(final File file) {
-        this(ReferenceSequenceFileFactory.getReferenceSequenceFile(file));
+        this(ReferenceSequenceFileFactory.getReferenceSequenceFile(file, true, false));
     }
 
     /**

--- a/src/tests/java/htsjdk/samtools/reference/ReferenceSequenceFileFactoryTests.java
+++ b/src/tests/java/htsjdk/samtools/reference/ReferenceSequenceFileFactoryTests.java
@@ -1,0 +1,39 @@
+package htsjdk.samtools.reference;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+/**
+ * Simple tests for the reference sequence file factory
+ */
+public class ReferenceSequenceFileFactoryTests {
+    public static final File hg18 = new File("testdata/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta");
+
+    @Test public void testPositivePath() {
+        final ReferenceSequenceFile f = ReferenceSequenceFileFactory.getReferenceSequenceFile(hg18);
+        Assert.assertTrue(f instanceof AbstractFastaSequenceFile);
+    }
+
+    @Test public void testGetIndexedReader() {
+        final ReferenceSequenceFile f = ReferenceSequenceFileFactory.getReferenceSequenceFile(hg18, true, true);
+        Assert.assertTrue(f instanceof IndexedFastaSequenceFile, "Got non-indexed reader when expecting indexed reader.");
+    }
+
+    @Test public void testGetNonIndexedReader1() {
+        final ReferenceSequenceFile f = ReferenceSequenceFileFactory.getReferenceSequenceFile(hg18, false, true);
+        Assert.assertTrue(f instanceof FastaSequenceFile, "Got indexed reader when truncating at whitespace! FAI must truncate.");
+    }
+
+    @Test public void testGetNonIndexedReader2() {
+        final ReferenceSequenceFile f = ReferenceSequenceFileFactory.getReferenceSequenceFile(hg18, true, false);
+        Assert.assertTrue(f instanceof FastaSequenceFile, "Got indexed reader when requesting non-indexed reader.");
+    }
+
+    @Test public void testDefaultToIndexed() {
+        final ReferenceSequenceFile f = ReferenceSequenceFileFactory.getReferenceSequenceFile(hg18, true);
+        Assert.assertTrue(f instanceof IndexedFastaSequenceFile, "Got non-indexed reader by default.");
+    }
+
+}


### PR DESCRIPTION
… reference sequence file factory, and for the reference sequence file walker to use the non-indexed reader since it is much more efficient for a linear traversal.  See issue #269.