### PR TITLE
Added IOUtil.setDefaultCompressionLevel() to set the compression level

### DIFF
--- a/src/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -98,14 +98,14 @@ public class BlockCompressedOutputStream
     private final byte[] singleByteArray = new byte[1];
 
     /**
-     * Uses default compression level, which is 5 unless changed by setDefaultCompressionLevel
+     * Uses default compression level, which is 5 unless changed by setCompressionLevel
      */
     public BlockCompressedOutputStream(final String filename) {
         this(filename, defaultCompressionLevel);
     }
 
     /**
-     * Uses default compression level, which is 5 unless changed by setDefaultCompressionLevel
+     * Uses default compression level, which is 5 unless changed by setCompressionLevel
      */
     public BlockCompressedOutputStream(final File file) {
         this(file, defaultCompressionLevel);

--- a/src/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/java/htsjdk/samtools/util/IOUtil.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Scanner;
 import java.util.Stack;
 import java.util.regex.Pattern;
+import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -85,6 +86,23 @@ public class IOUtil {
     public static final String SAM_FILE_EXTENSION = ".sam";
 
     public static final String DICT_FILE_EXTENSION = ".dict";
+
+    private static int compressionLevel = Defaults.COMPRESSION_LEVEL;
+
+    /**
+     * Sets the GZip compression level for subsequent GZIPOutputStream object creation.
+     * @param compressionLevel 0 <= compressionLevel <= 9
+     */
+    public static void setCompressionLevel(final int compressionLevel) {
+        if (compressionLevel < Deflater.NO_COMPRESSION || compressionLevel > Deflater.BEST_COMPRESSION) {
+            throw new IllegalArgumentException("Invalid compression level: " + compressionLevel);
+        }
+        IOUtil.compressionLevel = compressionLevel;
+    }
+
+    public static int getCompressionLevel() {
+        return compressionLevel;
+    }
 
     /**
      * Wrap the given stream in a BufferedInputStream, if it isn't already wrapper
@@ -579,9 +597,9 @@ public class IOUtil {
             if (Defaults.BUFFER_SIZE > 0) {
             return new CustomGzipOutputStream(new FileOutputStream(file, append),
                                               Defaults.BUFFER_SIZE,
-                                              Defaults.COMPRESSION_LEVEL);
+                                              compressionLevel);
             } else {
-                return new CustomGzipOutputStream(new FileOutputStream(file, append), Defaults.COMPRESSION_LEVEL);
+                return new CustomGzipOutputStream(new FileOutputStream(file, append), compressionLevel);
             }
         }
         catch (IOException ioe) {


### PR DESCRIPTION
that GZIP file are opened with. Support for this already existed, but
the level was hardcoded to use Defaults.COMPRESSION_LEVEL (=5).