### PR TITLE
API VariantContextUtils.initializeMatchExps fixed to use interfaces

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -241,7 +241,17 @@ public class VariantContextUtils {
         return VariantContextUtils.initializeMatchExps(map);
     }
 
-    public static List<JexlVCMatchExp> initializeMatchExps(ArrayList<String> names, ArrayList<String> exps) {
+    /**
+     * Method for creating JexlVCMatchExp from input walker arguments names and exps.  These two lists contain
+     * the name associated with each JEXL expression. initializeMatchExps will parse each expression and return
+     * a list of JexlVCMatchExp, in order, that correspond to the names and exps.  These are suitable input to
+     * match() below.
+     *
+     * @param names names
+     * @param exps  expressions
+     * @return list of matches
+     */
+    public static List<JexlVCMatchExp> initializeMatchExps(List<String> names, List<String> exps) {
         String[] nameArray = new String[names.size()];
         String[] expArray = new String[exps.size()];
         return initializeMatchExps(names.toArray(nameArray), exps.toArray(expArray));


### PR DESCRIPTION
This is a fix for the API. The method signature should use interfaces not concrete classes to allow more flexibility in client code. This is a backwards compatible change - callers are unaffected and it's a static method so no one can override it.