### PR TITLE
Fix for incorrect return value in Genotype.getAnyAttribute()

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/java/htsjdk/variant/variantcontext/Genotype.java
@@ -541,9 +541,13 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
         } else if (key.equals(VCFConstants.GENOTYPE_QUALITY_KEY)) {
             return getGQ();
         } else if (key.equals(VCFConstants.GENOTYPE_ALLELE_DEPTHS)) {
-            return Arrays.asList(getAD());
+            List<Integer> intList = new ArrayList<Integer>();
+            for(int i : getAD()) intList.add(i);
+            return intList;
         } else if (key.equals(VCFConstants.GENOTYPE_PL_KEY)) {
-            return Arrays.asList(getPL());
+            List<Integer> intList = new ArrayList<Integer>();
+            for(int i : getPL()) intList.add(i);
+            return intList;
         } else if (key.equals(VCFConstants.DEPTH_KEY)) {
             return getDP();
         } else {

--- a/src/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/java/htsjdk/variant/variantcontext/Genotype.java
@@ -541,13 +541,21 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
         } else if (key.equals(VCFConstants.GENOTYPE_QUALITY_KEY)) {
             return getGQ();
         } else if (key.equals(VCFConstants.GENOTYPE_ALLELE_DEPTHS)) {
-            List<Integer> intList = new ArrayList<Integer>();
-            for(int i : getAD()) intList.add(i);
-            return intList;
+            if(hasAD()) {
+                List<Integer> intList = new ArrayList<Integer>(getAD().length);
+                for(int i : getAD()) intList.add(i);
+
+                return intList;
+            }
+            return Collections.EMPTY_LIST;
         } else if (key.equals(VCFConstants.GENOTYPE_PL_KEY)) {
-            List<Integer> intList = new ArrayList<Integer>();
-            for(int i : getPL()) intList.add(i);
-            return intList;
+            if(hasPL()) {
+                List<Integer> intList = new ArrayList<Integer>(getPL().length);
+                for(int i : getPL()) intList.add(i);
+
+                return intList;
+            }
+            return Collections.EMPTY_LIST;
         } else if (key.equals(VCFConstants.DEPTH_KEY)) {
             return getDP();
         } else {


### PR DESCRIPTION
* The Genotype.getAnyAttribute() incorrectly handles converting int[] to
  List<Integer>.  Both getAD() and getPL() return an int[], and doing
  Arrays.asList(int[]) will return a List<int[]> instead of List<Integer>.

See: https://github.com/samtools/htsjdk/issues/274