### PR TITLE
Fix 2 bugs in MetricsBase

### DIFF
--- a/src/java/htsjdk/samtools/util/FormatUtil.java
+++ b/src/java/htsjdk/samtools/util/FormatUtil.java
@@ -43,11 +43,14 @@ import java.util.Date;
  * @author Tim Fennell
  */
 public class FormatUtil {
-    private DateFormat dateFormat;
-    private NumberFormat integerFormat;
-    private NumberFormat floatFormat;
+    public static final int DECIMAL_DIGITS_TO_PRINT = 6;
+    private final DateFormat dateFormat;
+    private final NumberFormat integerFormat;
+    private final NumberFormat floatFormat;
 
-    /** Constructs a new FormatUtil and initializes various internal formatters. */
+    /** Constructs a new FormatUtil and initializes various internal formatters. 
+    * This is necessary because SimpleDateFormat and other formatters are not threadsafe.
+    */
     public FormatUtil() {
         this.dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
@@ -56,7 +59,7 @@ public class FormatUtil {
 
         this.floatFormat = NumberFormat.getNumberInstance();
         this.floatFormat.setGroupingUsed(false);
-        this.floatFormat.setMaximumFractionDigits(6);
+        this.floatFormat.setMaximumFractionDigits(DECIMAL_DIGITS_TO_PRINT);
         this.floatFormat.setRoundingMode(RoundingMode.HALF_DOWN);
         if (this.floatFormat instanceof DecimalFormat) {
             final DecimalFormat decimalFormat = (DecimalFormat)this.floatFormat;

--- a/src/tests/java/htsjdk/samtools/metrics/MetricBaseTest.java
+++ b/src/tests/java/htsjdk/samtools/metrics/MetricBaseTest.java
@@ -1,0 +1,75 @@
+package htsjdk.samtools.metrics;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class MetricBaseTest {
+
+    private static class TestMetric extends MetricBase{
+        public Object anyObject;
+
+        public TestMetric(final Object anyObject) {
+            this.anyObject = anyObject;
+        }
+    }
+
+    @Test
+    public void testHashCodeWithNull(){
+        TestMetric metric = new TestMetric(null);
+        metric.hashCode(); //test that it can get a hashcode without crashing
+    }
+
+    @DataProvider(name = "equalityTest")
+    public Object[][] equalityTestProvider(){
+        return new Object[][]{
+                {null,null, true},
+                {null, 1, false},
+                {1, null, false},
+                {1, 1, true},
+                {"Hi", "Hi", true},
+                {"Hi", "There", false},
+                {"1","1.0000000000000000001d", false},
+                {"1", 1.0000000000000000001d, true}, /* Object fields are saved using instance of which performs rounding, but loaded as a string*/
+                {1.00000000000000001d, 1.0000000002918d, true}, /* precision limit is set by {@link FormatUtil#DECIMAL_DIGITS_TO_PRINT}, if that changes this test may fail */
+                {1.0000, 1.0001, false},
+                {1.0, 1.0, true},
+                {1, 2, false}
+        };
+    }
+
+    @Test(dataProvider = "equalityTest")
+    public void testEqualsNull(Object a, Object b, boolean shouldBeEqual){
+        TestMetric metricA = new TestMetric(a);
+        TestMetric metricB = new TestMetric(b);
+        Assert.assertEquals(metricA.equals(metricB), shouldBeEqual);
+
+        //check that hashcodes are the same if they're equal
+        if(shouldBeEqual) {
+            Assert.assertEquals(metricA.hashCode(), metricB.hashCode());
+        }
+    }
+
+
+    public class A extends MetricBase {
+        public int a = 1;
+    }
+    public class B extends A{
+        public int b = 1;
+    }
+
+    @Test
+    public void testSubclassEquality(){
+        final A a = new A();
+        final B b = new B();
+        Assert.assertFalse(a.equals(b));
+        Assert.assertFalse(b.equals(a));
+    }
+
+    @Test void testSelfEquality(){
+        final A a = new A();
+        final B b = new B();
+        Assert.assertTrue(a.equals(a));
+        Assert.assertTrue(b.equals(b));
+    }
+}

--- a/src/tests/java/htsjdk/samtools/metrics/MetricsFileTest.java
+++ b/src/tests/java/htsjdk/samtools/metrics/MetricsFileTest.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -48,6 +49,8 @@ public class MetricsFileTest {
     public enum TestEnum {One, Two, Three}
 
     public static class TestMetric extends MetricBase implements Cloneable, Serializable {
+        private static final long serialVersionUID = 1l;
+
         public String    STRING_PROP;
         public Date      DATE_PROP;
         public Short     SHORT_PROP;
@@ -73,9 +76,31 @@ public class MetricsFileTest {
         }
     }
 
+    public static class FloatingPointMetric extends MetricBase{
+        public double DOUBLE_PRIMITIVE;
+        public Double DOUBLE_PROP;
+        public float  FLOAT_PRIMITIVE;
+        public Float FLOAT_PROP;
+    }
 
     @Test
-    public void testWriteMetricsFile() throws Exception {
+    public void testFloatingPointEquality() throws IOException {
+        MetricsFile<FloatingPointMetric,Integer> file = new MetricsFile<FloatingPointMetric,Integer>();
+
+        FloatingPointMetric metric = new FloatingPointMetric();
+        metric.DOUBLE_PRIMITIVE = .0000000000000000001d;
+        metric.DOUBLE_PROP = .0000000000000000001d;
+        metric.FLOAT_PRIMITIVE = .0000000000000000001f;
+        metric.FLOAT_PROP = .0000000000000000001f;
+        file.addMetric(metric);
+
+        MetricsFile<FloatingPointMetric,Integer> file2 = writeThenReadBack(file);
+        Assert.assertEquals(file, file2);
+
+    }
+
+    @Test
+    public void testWriteMetricsFile() throws IOException, ClassNotFoundException {
         MetricsFile<TestMetric,Integer> file = new MetricsFile<TestMetric,Integer>();
         TestMetric metric = new TestMetric();
         metric.STRING_PROP       = "Hello World";
@@ -154,13 +179,13 @@ public class MetricsFileTest {
     }
 
     /** Helper method to persist metrics to file and read them back again. */
-    private MetricsFile<TestMetric, Integer> writeThenReadBack(MetricsFile<TestMetric,Integer> in) throws Exception {
+    private <METRIC extends MetricBase> MetricsFile<METRIC, Integer> writeThenReadBack(MetricsFile<METRIC,Integer> in) throws IOException {
         File f = File.createTempFile("test", ".metrics");
         f.deleteOnExit();
         FileWriter out = new FileWriter(f);
         in.write(out);
 
-        MetricsFile<TestMetric,Integer> retval = new MetricsFile<TestMetric,Integer>();
+        MetricsFile<METRIC,Integer> retval = new MetricsFile<METRIC,Integer>();
         retval.read(new FileReader(f));
         return retval;
     }


### PR DESCRIPTION
I split this into 2 commits, the first should be uncontroversial, the second I want to make sure no one objects too.

Commit 1:
   Fix a bug in the implementation of `hashCode()` in `MetricsBase` it was crashing if any values were `null`.

Commit 2: 
   Fix what I consider a bug in the `equals` method of `MetricBase`
   Currently, the equality is exact equality with respect to floating point numbers.  However, when written to disk a MetricsBase has limited floating point precision, so writing something to disk and reading it back in will sometimes not equal the original file. I've altered the `equality` and `hashCode` methods to compare by using the same representation of floating point numbers as is written to disk.  This is technically backwards compatibility breaking, but I think the current behavior is erroneous.  The downside is that the equality code is complicated now.  
  The simpler and much more guaranteed way to check this would be to actually format the whole thing as an string and then compare string equality.  This would guarantee that equals and hashcode will always be in synch with the on disk representation, but will likely come at a performance cost. 

I've also deleted the `equals` specialization for `MetricsBase`s rather than having 2 complex implementations of equals.  This introduces another backwards incompatible change, since this method made no check for actual class which would allow comparing any `MetricBase` subclass to any other.  However, this equals method was broken.  It was an asymmetric equals method.  It checked the fields in one class against the same fields in the other class, but did not make any checks that those fields were all the fields in the second class.  I.e. 

```
	public class A extends MetricBase {
		public int a = 1;
	}
	public class B extends A{
		public int b = 1;
	}

	@Test
	public void testAB(){
		A a = new A();
		B b = new B();
		Assert.assertTrue(a.equals(b));  //true
		Assert.assertTrue(b.equals(a)); // illegal argument exception
	}
```

After my changes both ways will evaluate to false.  

@yfarjoun @nh13 @tfenne Let me know what you think.
