### PR TITLE
moving back to travis non-containerized build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-sudo: false
+sudo: true
 jdk:
   - oraclejdk7
   - oraclejdk8


### PR DESCRIPTION
We're having constant failures since I moved us to the travis sudoless build.  Until travis fixes whatever is going on on their end I think we should revert it.  Sorry for the hassle.  Should fix #276 but we go back to having slow dispatch.  