### PR TITLE
enum describing SAM FLAG (for gui/ menu / etc... )

### DIFF
--- a/src/java/htsjdk/samtools/SAMFlag.java
+++ b/src/java/htsjdk/samtools/SAMFlag.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License
+ *
+ * Author: Pierre Lindenbaum PhD @yokofakun
+ *  Institut du Thorax - Nantes - France
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * SAM flags as enum, to be used in GUI, menu, etc...
+ */
+public enum SAMFlag {
+    READ_PAIRED(                    0x1,    "Template having multiple segments in sequencing"),
+    PROPER_PAIR(                    0x2,    "Each segment properly aligned according to the aligner"),
+    READ_UNMAPPED(                  0x4,    "Segment unmapped"),
+    MATE_UNMAPPED(                  0x8,    "Next segment in the template unmapped"),
+    READ_REVERSE_STRAND(            0x10,   "SEQ being reverse complemented"),
+    MATE_REVERSE_STRAND(            0x20,   "SEQ of the next segment in the template being reverse complemented"),
+    FIRST_OF_PAIR(                  0x40,   "The first segment in the template"),
+    SECOND_OF_PAIR(                 0x80,   "The last segment in the template"),
+    NOT_PRIMARY_ALIGNMENT(          0x100,  "Secondary alignment"),
+    READ_FAILS_VENDOR_QUALITY_CHECK(0x200,  "Not passing quality controls"),
+    DUPLICATE_READ(                 0x400,  "PCR or optical duplicate"), 
+    SUPPLEMENTARY_ALIGNMENT(        0x800,  "Supplementary alignment")
+    ;
+
+    /* visible for the package, to be used by SAMRecord */
+    final int flag;
+    private final String description;
+
+    SAMFlag(int flag,String description) {
+        this.flag = flag;
+        this.description = description;
+    }
+
+    /** @return this flag as an int */
+    public int intValue() {
+        return flag;
+    }
+
+    /** @return a human label for this SAMFlag */
+    public String getLabel() {
+        return name().toLowerCase().replace('_', ' ');
+    }
+
+    /** @return a human description for this SAMFlag */
+    public String getDescription() {
+        return this.description;
+    }
+
+    /** @return the SAMFlag for the value 'flag' or null if it was not found */
+    public static SAMFlag valueOf(int flag) {
+        for (SAMFlag f : values()) {
+            if (flag == f.flag)
+                return f;
+        }
+        return null;
+    }
+
+    /** @return find SAMFlag the flag by name, or null if it was not found */
+    public static SAMFlag findByName(String flag)
+        {   
+        for (SAMFlag f : values()) {
+            if (f.name().equals(flag))
+                return f;
+        }
+        return null;
+    }
+
+    /** @returns true if the bit for is set for flag */
+    public boolean isSet(int flag) {
+        return (this.flag & flag) != 0;
+    }
+
+    /** @returns true if the bit for is not set for flag */
+    public boolean isUnset(int flag) {
+        return !isSet(flag);
+    }
+
+    /** @returns the java.util.Set of SAMFlag for 'flag' */
+    public static Set<SAMFlag> getFlags(int flag) {
+        Set<SAMFlag> set = new HashSet<SAMFlag>();
+        for (SAMFlag f : values()) {
+            if (f.isSet(flag))
+                set.add(f);
+        }
+        return set;
+    }
+}

--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 
 /**
@@ -134,24 +135,6 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * abs(insertSize) must be <= this
      */
     public static final int MAX_INSERT_SIZE = 1<<29;
-
-    /**
-     * It is not necessary in general to use the flag constants, because there are getters
-     * & setters that handles these symbolically.
-     */
-    private static final int READ_PAIRED_FLAG = 0x1;
-    private static final int PROPER_PAIR_FLAG = 0x2;
-    private static final int READ_UNMAPPED_FLAG = 0x4;
-    private static final int MATE_UNMAPPED_FLAG = 0x8;
-    private static final int READ_STRAND_FLAG = 0x10;
-    private static final int MATE_STRAND_FLAG = 0x20;
-    private static final int FIRST_OF_PAIR_FLAG = 0x40;
-    private static final int SECOND_OF_PAIR_FLAG = 0x80;
-    private static final int NOT_PRIMARY_ALIGNMENT_FLAG = 0x100;
-    private static final int READ_FAILS_VENDOR_QUALITY_CHECK_FLAG = 0x200;
-    private static final int DUPLICATE_READ_FLAG = 0x400;
-    private static final int SUPPLEMENTARY_ALIGNMENT_FLAG = 0x800;
-
 
     private String mReadName = null;
     private byte[] mReadBases = NULL_SEQUENCE;
@@ -647,7 +630,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * the read is paired in sequencing, no matter whether it is mapped in a pair.
      */
     public boolean getReadPairedFlag() {
-        return (mFlags & READ_PAIRED_FLAG) != 0;
+        return (mFlags & SAMFlag.READ_PAIRED.flag) != 0;
     }
 
     private void requireReadPaired() {
@@ -665,14 +648,14 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     private boolean getProperPairFlagUnchecked() {
-        return (mFlags & PROPER_PAIR_FLAG) != 0;
+        return (mFlags & SAMFlag.PROPER_PAIR.flag) != 0;
     }
 
     /**
      * the query sequence itself is unmapped.
      */
     public boolean getReadUnmappedFlag() {
-        return (mFlags & READ_UNMAPPED_FLAG) != 0;
+        return (mFlags & SAMFlag.READ_UNMAPPED.flag) != 0;
     }
 
     /**
@@ -684,14 +667,14 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     private boolean getMateUnmappedFlagUnchecked() {
-        return (mFlags & MATE_UNMAPPED_FLAG) != 0;
+        return (mFlags & SAMFlag.MATE_UNMAPPED.flag) != 0;
     }
 
     /**
      * strand of the query (false for forward; true for reverse strand).
      */
     public boolean getReadNegativeStrandFlag() {
-        return (mFlags & READ_STRAND_FLAG) != 0;
+        return (mFlags & SAMFlag.READ_REVERSE_STRAND.flag) != 0;
     }
 
     /**
@@ -703,7 +686,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     private boolean getMateNegativeStrandFlagUnchecked() {
-        return (mFlags & MATE_STRAND_FLAG) != 0;
+        return (mFlags & SAMFlag.MATE_REVERSE_STRAND.flag) != 0;
     }
 
     /**
@@ -715,7 +698,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     private boolean getFirstOfPairFlagUnchecked() {
-        return (mFlags & FIRST_OF_PAIR_FLAG) != 0;
+        return (mFlags & SAMFlag.FIRST_OF_PAIR.flag) != 0;
     }
 
     /**
@@ -727,49 +710,49 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     private boolean getSecondOfPairFlagUnchecked() {
-        return (mFlags & SECOND_OF_PAIR_FLAG) != 0;
+        return (mFlags & SAMFlag.SECOND_OF_PAIR.flag) != 0;
     }
 
     /**
      * the alignment is not primary (a read having split hits may have multiple primary alignment records).
      */
     public boolean getNotPrimaryAlignmentFlag() {
-        return (mFlags & NOT_PRIMARY_ALIGNMENT_FLAG) != 0;
+        return (mFlags & SAMFlag.NOT_PRIMARY_ALIGNMENT.flag) != 0;
     }
 
     /**
      * the alignment is supplementary (TODO: further explanation?).
      */
     public boolean getSupplementaryAlignmentFlag() {
-        return (mFlags & SUPPLEMENTARY_ALIGNMENT_FLAG) != 0;
+        return (mFlags & SAMFlag.SUPPLEMENTARY_ALIGNMENT.flag) != 0;
     }
 
     /**
      * the read fails platform/vendor quality checks.
      */
     public boolean getReadFailsVendorQualityCheckFlag() {
-        return (mFlags & READ_FAILS_VENDOR_QUALITY_CHECK_FLAG) != 0;
+        return (mFlags & SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK.flag) != 0;
     }
 
     /**
      * the read is either a PCR duplicate or an optical duplicate.
      */
     public boolean getDuplicateReadFlag() {
-        return (mFlags & DUPLICATE_READ_FLAG) != 0;
+        return (mFlags & SAMFlag.DUPLICATE_READ.flag) != 0;
     }
 
     /**
      * the read is paired in sequencing, no matter whether it is mapped in a pair.
      */
     public void setReadPairedFlag(final boolean flag) {
-        setFlag(flag, READ_PAIRED_FLAG);
+        setFlag(flag, SAMFlag.READ_PAIRED.flag);
     }
 
     /**
      * the read is mapped in a proper pair (depends on the protocol, normally inferred during alignment).
      */
     public void setProperPairFlag(final boolean flag) {
-        setFlag(flag, PROPER_PAIR_FLAG);
+        setFlag(flag, SAMFlag.PROPER_PAIR.flag);
     }
 
     /**
@@ -785,7 +768,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * the query sequence itself is unmapped.
      */
     public void setReadUnmappedFlag(final boolean flag) {
-        setFlag(flag, READ_UNMAPPED_FLAG);
+        setFlag(flag, SAMFlag.READ_UNMAPPED.flag);
         // Change to readUnmapped could change indexing bin
         setIndexingBin(null);
     }
@@ -794,63 +777,63 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * the mate is unmapped.
      */
     public void setMateUnmappedFlag(final boolean flag) {
-        setFlag(flag, MATE_UNMAPPED_FLAG);
+        setFlag(flag, SAMFlag.MATE_UNMAPPED.flag);
     }
 
     /**
      * strand of the query (false for forward; true for reverse strand).
      */
     public void setReadNegativeStrandFlag(final boolean flag) {
-        setFlag(flag, READ_STRAND_FLAG);
+        setFlag(flag, SAMFlag.READ_REVERSE_STRAND.flag);
     }
 
     /**
      * strand of the mate (false for forward; true for reverse strand).
      */
     public void setMateNegativeStrandFlag(final boolean flag) {
-        setFlag(flag, MATE_STRAND_FLAG);
+        setFlag(flag, SAMFlag.MATE_REVERSE_STRAND.flag);
     }
 
     /**
      * the read is the first read in a pair.
      */
     public void setFirstOfPairFlag(final boolean flag) {
-        setFlag(flag, FIRST_OF_PAIR_FLAG);
+        setFlag(flag, SAMFlag.FIRST_OF_PAIR.flag);
     }
 
     /**
      * the read is the second read in a pair.
      */
     public void setSecondOfPairFlag(final boolean flag) {
-        setFlag(flag, SECOND_OF_PAIR_FLAG);
+        setFlag(flag, SAMFlag.SECOND_OF_PAIR.flag);
     }
 
     /**
      * the alignment is not primary (a read having split hits may have multiple primary alignment records).
      */
     public void setNotPrimaryAlignmentFlag(final boolean flag) {
-        setFlag(flag, NOT_PRIMARY_ALIGNMENT_FLAG);
+        setFlag(flag, SAMFlag.NOT_PRIMARY_ALIGNMENT.flag);
     }
 
     /**
      * the alignment is supplementary (TODO: further explanation?).
      */
     public void setSupplementaryAlignmentFlag(final boolean flag) {
-        setFlag(flag, SUPPLEMENTARY_ALIGNMENT_FLAG);
+        setFlag(flag, SAMFlag.SUPPLEMENTARY_ALIGNMENT.flag);
     }
 
     /**
      * the read fails platform/vendor quality checks.
      */
     public void setReadFailsVendorQualityCheckFlag(final boolean flag) {
-        setFlag(flag, READ_FAILS_VENDOR_QUALITY_CHECK_FLAG);
+        setFlag(flag, SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK.flag);
     }
 
     /**
      * the read is either a PCR duplicate or an optical duplicate.
      */
     public void setDuplicateReadFlag(final boolean flag) {
-        setFlag(flag, DUPLICATE_READ_FLAG);
+        setFlag(flag, SAMFlag.DUPLICATE_READ.flag);
     }
 
     /**
@@ -1814,6 +1797,13 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             }
         }
         return builder.toString();
+    }
+    
+    /** 
+     * shortcut to <pre>SAMFlag.getFlags( this.getFlags() );</pre>
+     * @returns a set of SAMFlag associated to this sam record */
+    public final Set<SAMFlag> getSAMFlags() {
+        return SAMFlag.getFlags( this.getFlags() );
     }
 }
 

--- a/src/tests/java/htsjdk/samtools/SAMFlagTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFlagTest.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Author: Pierre Lindenbaum PhD @yokofakun
+ *  Institut du Thorax - Nantes - France
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SAMFlagTest {
+    @Test
+    public void testFlags() {
+        Assert.assertTrue(SAMFlag.getFlags(83).contains(SAMFlag.READ_PAIRED));
+        Assert.assertTrue(SAMFlag.getFlags(83).contains(SAMFlag.PROPER_PAIR));
+        Assert.assertTrue(SAMFlag.getFlags(83).contains(SAMFlag.READ_REVERSE_STRAND));
+        Assert.assertTrue(SAMFlag.getFlags(83).contains(SAMFlag.FIRST_OF_PAIR));
+        Assert.assertFalse(SAMFlag.getFlags(83).contains(SAMFlag.READ_UNMAPPED));
+        Assert.assertFalse(SAMFlag.getFlags(83).contains(SAMFlag.MATE_UNMAPPED));
+        Assert.assertTrue(SAMFlag.getFlags(0).isEmpty());
+        Assert.assertEquals(SAMFlag.getFlags(4095).size(),12);
+    }
+}


### PR DESCRIPTION
This pull request contains a new enum htsjdk.samtools.SAMFlag describing the available SAM flags. It can be used in a GUI, HTML form, menu... to display the available flags...

SAMFlag contains a static method returning the java.util.Set for a given integer

```java
public static Set<SAMFlag> getFlags(int flag)
```

I've added a small shortcut in src/java/htsjdk/samtools/SAMRecord.java
```java
   public final Set<SAMFlag> getSAMFlags() {
        return SAMFlag.getFlags( this.getFlags() );
    }
```

I've added a test under src/tests/java/htsjdk/samtools/SAMFlagTest.java
