### PR TITLE
seq dict

### DIFF
--- a/src/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -28,10 +28,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import javax.xml.bind.annotation.XmlTransient;
+
 /**
  * Base class for the various concrete records in a SAM header, providing uniform
  * access to the attributes.
  */
+@XmlTransient /* don't consider this class for XML-serialization */
 public abstract class AbstractSAMHeaderRecord implements Serializable {
     public static final long serialVersionUID = 1L;
 

--- a/src/java/htsjdk/samtools/SAMSequenceDictionary.java
+++ b/src/java/htsjdk/samtools/SAMSequenceDictionary.java
@@ -24,6 +24,8 @@
 package htsjdk.samtools;
 
 import java.io.Serializable;
+import java.math.BigInteger;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,12 +33,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
 /**
  * Collection of SAMSequenceRecords.
  */
+@XmlRootElement(name="References")
 public class SAMSequenceDictionary implements Serializable {
     public static final long serialVersionUID = 1L;
 
+    /* xml Serialization , for `m_sequence` we use the field instead of the
+    getter because the later wraps the list into an unmodifiable List 
+    see http://tech.joshuacummings.com/2010/10/problems-with-defensive-collection.html */
+    @XmlElement(name="Reference")
     private List<SAMSequenceRecord> mSequences = new ArrayList<SAMSequenceRecord>();
     private final Map<String, SAMSequenceRecord> mSequenceMap = new HashMap<String, SAMSequenceRecord>();
 
@@ -48,6 +59,7 @@ public class SAMSequenceDictionary implements Serializable {
         setSequences(list);
     }
 
+    @XmlTransient //we use the field instead of getter/setter
     public List<SAMSequenceRecord> getSequences() {
         return Collections.unmodifiableList(mSequences);
     }
@@ -58,6 +70,7 @@ public class SAMSequenceDictionary implements Serializable {
 
     /**
      * Replaces the existing list of SAMSequenceRecords with the given list.
+     * Reset the aliases
      *
      * @param list This value is used directly, rather than being copied.
      */
@@ -105,6 +118,9 @@ public class SAMSequenceDictionary implements Serializable {
         return record.getSequenceIndex();
     }
 
+    /**
+     * @return number of SAMSequenceRecord(s) in this dictionary
+     */
     public int size() {
         return mSequences.size();
     }
@@ -119,7 +135,10 @@ public class SAMSequenceDictionary implements Serializable {
         }
         return len;
     }
-
+    
+    /**
+     * @return true is the dictionary is empty
+     */
     public boolean isEmpty() {
         return mSequences.isEmpty();
     }
@@ -129,6 +148,7 @@ public class SAMSequenceDictionary implements Serializable {
      * Non-comprehensive {@link #equals(Object)}-assertion: instead of calling {@link SAMSequenceRecord#equals(Object)} on constituent
      * {@link SAMSequenceRecord}s in this dictionary against its pair in the target dictionary, in order,  call 
      * {@link SAMSequenceRecord#isSameSequence(SAMSequenceRecord)}.
+     * Aliases are ignored.
      *
      * @throws AssertionError When the dictionaries are not the same, with some human-readable information as to why
      */
@@ -150,7 +170,8 @@ public class SAMSequenceDictionary implements Serializable {
         if (thatSequences.hasNext())
             throw new AssertionError(String.format(DICT_MISMATCH_TEMPLATE, thatSequences.next() + " is present in only one dictionary"));
     }
-    
+
+    /** returns true if the two dictionaries are the same, aliases are NOT considered */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -163,8 +184,87 @@ public class SAMSequenceDictionary implements Serializable {
         return true;
     }
 
+    /**
+     * Add an alias to a SAMSequenceRecord. This can be use to provide some
+     * alternate names fo a given contig. e.g:
+     * <code>1,chr1,chr01,01,CM000663,NC_000001.10</code> e.g:
+     * <code>MT,chrM</code>
+     * 
+     * @param originalName
+     *            existing contig name
+     * @param altName
+     *            new contig name
+     * @return the contig associated to the 'originalName/altName'
+     */
+    public SAMSequenceRecord addSequenceAlias(final String originalName,
+            final String altName) {
+        if (originalName == null) throw new IllegalArgumentException("original name cannot be null");
+        if (altName == null) throw new IllegalArgumentException("alt name cannot be null");
+        final SAMSequenceRecord originalSeqRecord = getSequence(originalName);
+        if (originalSeqRecord == null) throw new IllegalArgumentException("Sequence " + originalName + " doesn't exist in dictionary.");
+        // same name, nothing to do
+        if (originalName.equals(altName)) return originalSeqRecord;
+        final SAMSequenceRecord altSeqRecord = getSequence(altName);
+        if (altSeqRecord != null) {
+            // alias was already set to the same record
+            if (altSeqRecord.equals(originalSeqRecord)) return originalSeqRecord;
+            // alias was already set to another record
+            throw new IllegalArgumentException("Alias " + altName +
+                    " was already set to " + altSeqRecord.getSequenceName());
+        }
+        mSequenceMap.put(altName, originalSeqRecord);
+        return originalSeqRecord;
+    }
+
+    /**
+     * return a MD5 sum for ths dictionary, the checksum is re-computed each
+     * time this method is called.
+     * 
+     * <pre>
+     * md5( (seq1.md5_if_available) + ' '+(seq2.name+seq2.length) + ' '+...)
+     * </pre>
+     * 
+     * @return a MD5 checksum for this dictionary or the empty string if it is
+     *         empty
+     */
+    public String md5() {
+        if (isEmpty())
+            return "";
+        try {
+            final MessageDigest md5 = MessageDigest.getInstance("MD5");
+            md5.reset();
+            for (final SAMSequenceRecord samSequenceRecord : mSequences) {
+                if (samSequenceRecord.getSequenceIndex() > 0)
+                    md5.update((byte) ' ');
+                final String md5_tag = samSequenceRecord.getAttribute(SAMSequenceRecord.MD5_TAG);
+                if (md5_tag != null) {
+                    md5.update(md5_tag.getBytes());
+                } else {
+                    md5.update(samSequenceRecord.getSequenceName().getBytes());
+                    md5.update(String.valueOf(samSequenceRecord.getSequenceLength()).getBytes());
+                }
+            }
+            String hash = new BigInteger(1, md5.digest()).toString(16);
+            if (hash.length() != 32) {
+                final String zeros = "00000000000000000000000000000000";
+                hash = zeros.substring(0, 32 - hash.length()) + hash;
+            }
+            return hash;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public int hashCode() {
         return mSequences.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return "SAMSequenceDictionary:( sequences:"+ size()+
+                " length:"+ getReferenceLength()+" "+
+                " md5:"+md5()+")";
+    }
 }
+

--- a/src/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -23,7 +23,6 @@
  */
 package htsjdk.samtools;
 
-
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -33,11 +32,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+
 /**
  * Header information about a reference sequence.  Corresponds to @SQ header record in SAM text header.
  */
+@XmlRootElement(name="Reference")
 public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Cloneable
 {
+    public static final long serialVersionUID = 1L; // AbstractSAMHeaderRecord implements Serializable
     private String mSequenceName = null; // Value must be interned() if it's ever set/modified
     private int mSequenceIndex = -1;
     private int mSequenceLength = 0;
@@ -71,6 +76,11 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
     // These are the chars matched by \\s.
     private static char[] WHITESPACE_CHARS = {' ', '\t', '\n', '\013', '\f', '\r'}; // \013 is vertical tab
 
+    /** a (private) empty constructor is required for JAXB.XML-serialisation */
+    @SuppressWarnings("unused")
+    private SAMSequenceRecord() {
+    }
+    
     /**
      * @deprecated Use SAMSequenceRecord(final String name, final int sequenceLength) instead.
      * sequenceLength is required for the object to be considered valid.
@@ -89,10 +99,12 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
         }
         mSequenceLength = sequenceLength;
     }
-
+    
+    @XmlValue
     public String getSequenceName() { return mSequenceName; }
-    // We don't think this method should ever really be used, but we left it here
-    // in case we forget and go to implement it later!
+   
+    /* this private method is used by XML serialization */
+    @SuppressWarnings("unused")
     private void setSequenceName(final String name) {
         if (name != null) {
             mSequenceName = name.intern();
@@ -102,19 +114,26 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
         }
     }
     
+    @XmlAttribute(name="length")
     public int getSequenceLength() { return mSequenceLength; }
     public void setSequenceLength(final int value) { mSequenceLength = value; }
 
-    public String getAssembly() { return (String) getAttribute("AS"); }
-    public void setAssembly(final String value) { setAttribute("AS", value); }
+    @XmlAttribute(name="assembly")
+    public String getAssembly() { return (String) getAttribute(ASSEMBLY_TAG); }
+    public void setAssembly(final String value) { setAttribute(ASSEMBLY_TAG, value); }
 
-    public String getSpecies() { return (String) getAttribute("SP"); }
-    public void setSpecies(final String value) { setAttribute("SP", value); }
+    @XmlAttribute(name="species")
+    public String getSpecies() { return (String) getAttribute(SPECIES_TAG); }
+    public void setSpecies(final String value) { setAttribute(SPECIES_TAG, value); }
 
+    @XmlAttribute(name="md5")
+    public String getMd5() { return (String) getAttribute(MD5_TAG); }
+    public void setMd5(final String value) { setAttribute(MD5_TAG, value); }
 
     /**
      * @return Index of this record in the sequence dictionary it lives in. 
      */
+    @XmlAttribute(name="index")
     public int getSequenceIndex() { return mSequenceIndex; }
 
     // Private state used only by SAM implementation.

--- a/src/tests/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ *
+ * Date: 2015
+ * Author: Pierre Lindenbaum @yokofakun
+ *     Institut du Thorax , Nantes, France
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package htsjdk.samtools;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+
+public class SAMSequenceDictionaryTest {
+    @Test
+    public void testAliases() {
+        final SAMSequenceRecord ssr1 = new SAMSequenceRecord("1", 1);
+        final SAMSequenceRecord ssr2 = new SAMSequenceRecord("2", 1);
+
+        final SAMSequenceDictionary dict = new SAMSequenceDictionary(
+                Arrays.asList(ssr1, ssr2));
+        Assert.assertEquals(dict.size(), 2);
+        dict.addSequenceAlias("1", "chr1");
+        dict.addSequenceAlias("1", "01");
+        dict.addSequenceAlias("1", "1");
+        dict.addSequenceAlias("01", "chr01");
+        Assert.assertEquals(dict.size(), 2);
+        Assert.assertNotNull(dict.getSequence("chr1"));
+        Assert.assertNull(dict.getSequence("chr2"));
+    }
+
+    /**
+     * should be saved as XML
+     * 
+     * <pre>
+     * <?xml version="1.0" encoding="UTF-8" standalone="yes"?><References><Reference assembly="as" md5="68b329da9893e34099c7d8ad5cb9c940" index="0" length="1" species="sp">1</Reference><Reference index="1" length="1">2</Reference></References>
+     * </pre>
+     * 
+     * @throws JAXBException
+     */
+    @Test
+    public void testXmlSeralization() throws JAXBException {
+        // create dict
+        final SAMSequenceRecord ssr1 = new SAMSequenceRecord("1", 1);
+        ssr1.setMd5("68b329da9893e34099c7d8ad5cb9c940");
+        ssr1.setAssembly("as");
+        ssr1.setSpecies("sp");
+        final SAMSequenceRecord ssr2 = new SAMSequenceRecord("2", 1);
+        final StringWriter xmlWriter = new StringWriter();
+        final SAMSequenceDictionary dict1 = new SAMSequenceDictionary(
+                Arrays.asList(ssr1, ssr2));
+        // create jaxb context
+        JAXBContext jaxbContext = JAXBContext
+                .newInstance(SAMSequenceDictionary.class);
+        // save to XML
+        Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+        jaxbMarshaller.marshal(dict1, xmlWriter);
+        // reload XML
+        Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+        final SAMSequenceDictionary dict2 = (SAMSequenceDictionary) jaxbUnmarshaller
+                .unmarshal(new StringReader(xmlWriter.toString()));
+        Assert.assertEquals(dict1, dict2);
+    }
+
+}

--- a/src/tests/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractorTest.java
+++ b/src/tests/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractorTest.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.variant.utils;
 
+import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.SequenceUtil;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -54,10 +55,11 @@ public class SAMSequenceDictionaryExtractorTest {
     public void testExtractDictionary(final String dictSource, final String dictExpected) throws Exception {
         final File dictSourceFile = new File(path, dictSource);
         final File dictExpectedFile = new File(path, dictExpected);
+        final SAMSequenceDictionary dict1 = SAMSequenceDictionaryExtractor.extractDictionary(dictSourceFile);
+        final SAMSequenceDictionary dict2 = SAMSequenceDictionaryExtractor.extractDictionary(dictExpectedFile);
 
-        Assert.assertTrue(SequenceUtil.areSequenceDictionariesEqual(
-                SAMSequenceDictionaryExtractor.extractDictionary(dictSourceFile),
-                SAMSequenceDictionaryExtractor.extractDictionary(dictExpectedFile)));
-
+        Assert.assertTrue(SequenceUtil.areSequenceDictionariesEqual(dict1,
+                dict2));
+        Assert.assertTrue(dict1.md5().equals(dict2.md5()));
     }
 }


### PR DESCRIPTION
added a few functions to SAMSequenceDictionary

* md5() to get a MD5 checksum of the dictionary ( to quickly find a dictionary in a `Map<String,SAMSequenceDictionary> ` )
* toString
* countBases return the number of bases seen so far if we're at position `chrom:pos`
* fraction : same as prevous, but return the ratio with the reference length