### PR TITLE
Suppress javadoc generation timestamp comments

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -197,6 +197,7 @@
                 protected="true"
                 use="true"
                 version="true"
+                additionalparam="-notimestamp"
                 failonerror="true">
             <classpath>
                 <pathelement location="${java.home}/../lib/tools.jar" />


### PR DESCRIPTION
Javadoc commits on the **gh-pages** branch (such as 738728d0376fc912a527b35b08a6accc932fad41) are illegible as all 1,300+ HTML files have differences like

```diff
 <HTML>
 <HEAD>
-<!-- Generated by javadoc (build 1.6.0_35) on Mon Jul 27 13:40:31 EDT 2015 -->
+<!-- Generated by javadoc (build 1.6.0_35) on Tue Aug 11 16:27:17 EDT 2015 -->
 <TITLE>
 API Help (HTSJDK API Documentation)
 </TITLE>
 
-<META NAME="date" CONTENT="2015-07-27">
+<META NAME="date" CONTENT="2015-08-11">
 
 <LINK REL ="stylesheet" TYPE="text/css" HREF="stylesheet.css" TITLE="Style">
```

This makes it pretty much impossible to see what actually **has** changed in these commits.  As most of the files haven't really changed, dropping the misleading `<META NAME="date" …>` would not be a loss to those looking at the web pages.