### PR TITLE
allow lazy symlinking of bams

### DIFF
--- a/src/java/htsjdk/samtools/SamFiles.java
+++ b/src/java/htsjdk/samtools/SamFiles.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.cram.CRAIIndex;
 import htsjdk.samtools.cram.build.CramIO;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * @author mccowan
@@ -13,10 +14,39 @@ public class SamFiles {
     /**
      * Finds the index file associated with the provided SAM file.  The index file must exist and be reachable to be found.
      *
+     * If the file is a symlink and the index cannot be found, try to unsymlink the file and look for the bai in the actual file path.
+     *
      * @return The index for the provided SAM, or null if one was not found.
      */
     public static File findIndex(final File samFile) {
-        // If input is foo.bam, look for foo.bai
+        final File indexFile = lookForIndex(samFile); //try to find the index
+        if (indexFile == null) {
+            return unsymlinkAndLookForIndex(samFile);
+        } else {
+            return indexFile;
+        }
+    }
+
+    /**
+     * resolve the canonical path of samFile and attempt to find an index there.
+     * @return an index file or null if no index is found.
+     */
+    private static File unsymlinkAndLookForIndex(File samFile) {
+        try {
+            final File canonicalSamFile = samFile.getCanonicalFile();
+            final File canonicalIndexFile = lookForIndex(canonicalSamFile);
+            if ( canonicalIndexFile != null) {
+                System.err.println("The index file " + canonicalIndexFile.getPath()
+                        + " was found by resolving the canonical path of a symlink: "
+                        + samFile.getPath() + " -> " + samFile.getCanonicalPath());
+            }
+            return canonicalIndexFile;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static File lookForIndex(final File samFile) {// If input is foo.bam, look for foo.bai
         File indexFile;
         final String fileName = samFile.getName();
         if (fileName.endsWith(BamFileIoUtils.BAM_FILE_EXTENSION)) {

--- a/src/tests/java/htsjdk/samtools/SamFilesTest.java
+++ b/src/tests/java/htsjdk/samtools/SamFilesTest.java
@@ -12,6 +12,8 @@ import java.io.IOException;
  * Created by vadim on 10/08/2015.
  */
 public class SamFilesTest {
+    private static final String TEST_DATA = "testdata/htsjdk/samtools/BAMFileIndexTest/";
+    private static final File BAM_FILE = new File(TEST_DATA + "index_test.bam");
 
     @DataProvider(name = "FindIndexParams")
     public static Object[][] paramsFindIndexForSuffixes() {
@@ -56,5 +58,24 @@ public class SamFilesTest {
 
         Assert.assertNotNull(foundIndexFile);
         Assert.assertTrue(foundIndexFile.getName().endsWith(expectIndexSuffix));
+    }
+
+    @DataProvider(name = "filesAndIndicies")
+    public Object[][] getFilesAndIndicies() throws IOException {
+
+        final File REAL_INDEX_FILE = new File(BAM_FILE + ".bai"); //test regular file
+        final File SYMLINKED_BAM_WITH_SYMLINKED_INDEX = new File(TEST_DATA, "symlink_with_index.bam");
+
+        return new Object[][]{
+                {BAM_FILE, REAL_INDEX_FILE},
+                {SYMLINKED_BAM_WITH_SYMLINKED_INDEX, new File(SYMLINKED_BAM_WITH_SYMLINKED_INDEX + ".bai")},
+                {new File(TEST_DATA, "symlink_without_linked_index.bam"), REAL_INDEX_FILE.getCanonicalFile()},
+                {new File(TEST_DATA, "FileThatDoesntExist"), null}
+        };
+    }
+
+    @Test(dataProvider ="filesAndIndicies")
+    public void testIndexSymlinking(File bam, File expected_index) {
+        Assert.assertEquals(SamFiles.findIndex(bam), expected_index);
     }
 }

--- a/testdata/htsjdk/samtools/BAMFileIndexTest/symlink_with_index.bam
+++ b/testdata/htsjdk/samtools/BAMFileIndexTest/symlink_with_index.bam
@@ -1,0 +1,1 @@
+index_test.bam

--- a/testdata/htsjdk/samtools/BAMFileIndexTest/symlink_with_index.bam.bai
+++ b/testdata/htsjdk/samtools/BAMFileIndexTest/symlink_with_index.bam.bai
@@ -1,0 +1,1 @@
+index_test.bam.bai

--- a/testdata/htsjdk/samtools/BAMFileIndexTest/symlink_without_linked_index.bam
+++ b/testdata/htsjdk/samtools/BAMFileIndexTest/symlink_without_linked_index.bam
@@ -1,0 +1,1 @@
+index_test.bam


### PR DESCRIPTION
This is to enable a feature request from the GATK forums. 
https://github.com/broadinstitute/hellbender/issues/781

Allow htsjdk to find a bai file at the actual path of a symlinked bam without having to symlink the bai as well.  

So when looking for an index:
*  Look for the bai or bam.bai at the given file path
*  If not file was found, find the canonical path of the bam and then look there for the bam or bai

This is going to have a minor conflict with @vadimzalunin pull request so whichever goes in last will have to rebase on the other one.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/samtools/htsjdk/305)
<!-- Reviewable:end -->
