### PR TITLE
Add support for java.nio.file.Path in the reference package.

### DIFF
--- a/src/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,8 +51,12 @@ public class ReferenceSource {
     }
 
     public ReferenceSource(final File file) {
-        if (file != null)
-            rsFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(file);
+        this(file == null ? null : file.toPath());
+    }
+
+    public ReferenceSource(final Path path) {
+        if (path != null)
+            rsFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(path);
     }
 
     public ReferenceSource(final ReferenceSequenceFile rsFile) {

--- a/src/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -32,14 +32,15 @@ import htsjdk.samtools.util.BufferedLineReader;
 import htsjdk.samtools.util.IOUtil;
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Provide core sequence dictionary functionality required by all fasta file readers.
  * @author Matt Hanna
  */
 abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
-    protected final File file;
+    private final Path path;
     protected SAMSequenceDictionary sequenceDictionary;
 
     /**
@@ -47,15 +48,23 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
      * @param file Fasta file to read.  Also acts as a prefix for supporting files.
      */
     AbstractFastaSequenceFile(final File file) {
-        this.file = file;
-        final File dictionary = findSequenceDictionary(file);
+        this(file == null ? null : file.toPath());
+    }
+
+    /**
+     * Finds and loads the sequence file dictionary.
+     * @param path Fasta file to read.  Also acts as a prefix for supporting files.
+     */
+    AbstractFastaSequenceFile(final Path path) {
+        this.path = path;
+        final Path dictionary = findSequenceDictionary(path);
 
         if (dictionary != null) {
             IOUtil.assertFileIsReadable(dictionary);
 
             try {
                 final SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
-                final BufferedLineReader reader = new BufferedLineReader(new FileInputStream(dictionary));
+                final BufferedLineReader reader = new BufferedLineReader(Files.newInputStream(dictionary));
                 final SAMFileHeader header = codec.decode(reader,
                         dictionary.toString());
                 if (header.getSequenceDictionary() != null && header.getSequenceDictionary().size() > 0) {
@@ -70,31 +79,49 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     }
 
     protected static File findSequenceDictionary(final File file) {
+        if (file == null) {
+            return null;
+        }
+        Path dictionary = findSequenceDictionary(file.toPath());
+        if (dictionary == null) {
+            return null;
+        }
+        return dictionary.toFile();
+    }
+
+    protected static Path findSequenceDictionary(final Path path) {
+        if (path == null) {
+            return null;
+        }
         // Try and locate the dictionary
-        String dictionaryName = file.getAbsolutePath();
-        String dictionaryNameExt = file.getAbsolutePath();
+        Path dictionary = path.toAbsolutePath();
+        Path dictionaryExt = path.toAbsolutePath();
         boolean fileTypeSupported = false;
         for (final String extension : ReferenceSequenceFileFactory.FASTA_EXTENSIONS) {
-            if (dictionaryName.endsWith(extension)) {
-                  dictionaryNameExt = new String(dictionaryName);
-                  dictionaryNameExt += IOUtil.DICT_FILE_EXTENSION;
-                  dictionaryName = dictionaryName.substring(0, dictionaryName.lastIndexOf(extension));
-                  dictionaryName += IOUtil.DICT_FILE_EXTENSION;
-                  fileTypeSupported = true;
-                  break;
+            String filename = dictionary.getFileName().toString();
+            if (filename.endsWith(extension)) {
+                dictionaryExt = dictionary.resolveSibling(filename + IOUtil
+                    .DICT_FILE_EXTENSION);
+                String filenameNoExt = filename.substring(0, filename.lastIndexOf(extension));
+                dictionary = dictionary.resolveSibling(filenameNoExt+ IOUtil.DICT_FILE_EXTENSION);
+                fileTypeSupported = true;
+                break;
             }
         }
         if (!fileTypeSupported)
-            throw new IllegalArgumentException("File is not a supported reference file type: " + file.getAbsolutePath());
+            throw new IllegalArgumentException("File is not a supported reference file type: " + path.toAbsolutePath());
 
-        final File dictionary = new File(dictionaryName);
-        if (dictionary.exists())
+        if (Files.exists(dictionary))
             return dictionary;
         // try without removing the file extension
-        final File dictionaryExt = new File(dictionaryNameExt);
-        if (dictionaryExt.exists())
+        if (Files.exists(dictionaryExt))
             return dictionaryExt;
         else return null;
+    }
+
+    /** Returns the path to the reference file. */
+    protected Path getPath() {
+        return path;
     }
 
     /**
@@ -106,8 +133,13 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     }
 
     /** Returns the full path to the reference file. */
+    protected String getAbsolutePath() {
+        return path.toAbsolutePath().toString();
+    }
+
+    /** Returns the full path to the reference file. */
     public String toString() {
-        return this.file.getAbsolutePath();
+        return getAbsolutePath();
     }
 
     /** default implementation -- override if index is supported */
@@ -120,7 +152,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
 
     /** default implementation -- override if index is supported */
     public ReferenceSequence getSubsequenceAt( String contig, long start, long stop ) {
-        throw new UnsupportedOperationException("Index does not appear to exist for" + file.getAbsolutePath() + ".  samtools faidx can be used to create an index");
+        throw new UnsupportedOperationException("Index does not appear to exist for " + getAbsolutePath() + ".  samtools faidx can be used to create an index");
     }
 
 }

--- a/src/java/htsjdk/samtools/reference/FastaSequenceIndex.java
+++ b/src/java/htsjdk/samtools/reference/FastaSequenceIndex.java
@@ -30,6 +30,8 @@ import htsjdk.samtools.util.IOUtil;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -51,6 +53,15 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
      * @throws FileNotFoundException if the index file cannot be found.
      */
     public FastaSequenceIndex( File indexFile ) {
+        this(indexFile == null ? null : indexFile.toPath());
+    }
+
+    /**
+     * Build a sequence index from the specified file.
+     * @param indexFile File to open.
+     * @throws FileNotFoundException if the index file cannot be found.
+     */
+    public FastaSequenceIndex( Path indexFile ) {
         IOUtil.assertFileIsReadable(indexFile);
         parseIndexFile(indexFile);
     }
@@ -111,12 +122,11 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
     /**
      * Parse the contents of an index file, caching the results internally.
      * @param indexFile File to parse.
-     * @throws FileNotFoundException Thrown if file could not be opened.
+     * @throws IOException Thrown if file could not be opened.
      */
-    private void parseIndexFile(File indexFile) {
+    private void parseIndexFile(Path indexFile) {
         try {
             Scanner scanner = new Scanner(indexFile);
-
             int sequenceIndex = 0;
             while( scanner.hasNext() ) {
                 // Tokenize and validate the index line.
@@ -142,8 +152,9 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
                 add(new FastaSequenceIndexEntry(contig,location,size,basesPerLine,bytesPerLine, sequenceIndex++) );
             }
             scanner.close();
-        } catch (FileNotFoundException e) {
-            throw new SAMException("Fasta index file should be found but is not: " + indexFile, e);
+        } catch (IOException e) {
+            throw new SAMException("Fasta index file could not be opened: " + indexFile, e);
+
         }
     }
 

--- a/src/tests/java/htsjdk/samtools/reference/FastaSequenceIndexTest.java
+++ b/src/tests/java/htsjdk/samtools/reference/FastaSequenceIndexTest.java
@@ -42,13 +42,17 @@ public class FastaSequenceIndexTest {
     @DataProvider(name="homosapiens")
     public Object[][] provideHomoSapiens() throws FileNotFoundException {
         final File sequenceIndexFile = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.fasta.fai");
-        return new Object[][] { new Object[] { new FastaSequenceIndex(sequenceIndexFile) } };    
+        return new Object[][] { new Object[]
+            { new FastaSequenceIndex(sequenceIndexFile) },
+            { new FastaSequenceIndex(sequenceIndexFile.toPath()) } };
     }
 
     @DataProvider(name="specialcharacters")
     public Object[][] provideSpecialCharacters() throws FileNotFoundException {
         final File sequenceIndexFile = new File(TEST_DATA_DIR,"testing.fai");
-        return new Object[][] { new Object[] { new FastaSequenceIndex(sequenceIndexFile) } };
+        return new Object[][] { new Object[]
+            { new FastaSequenceIndex(sequenceIndexFile) },
+            { new FastaSequenceIndex(sequenceIndexFile.toPath()) } };
     }
 
     @Test(dataProvider="homosapiens")

--- a/src/tests/java/htsjdk/samtools/reference/IndexedFastaSequenceFileTest.java
+++ b/src/tests/java/htsjdk/samtools/reference/IndexedFastaSequenceFileTest.java
@@ -53,7 +53,9 @@ public class IndexedFastaSequenceFileTest{
     public Object[][] provideSequenceFile() throws FileNotFoundException {
         return new Object[][] { new Object[]
                 { new IndexedFastaSequenceFile(SEQUENCE_FILE) },
-                { new IndexedFastaSequenceFile(SEQUENCE_FILE_NODICT) }};
+                { new IndexedFastaSequenceFile(SEQUENCE_FILE_NODICT) },
+                { new IndexedFastaSequenceFile(SEQUENCE_FILE.toPath()) },
+                { new IndexedFastaSequenceFile(SEQUENCE_FILE_NODICT.toPath()) }};
     }
 
     @DataProvider(name="comparative")
@@ -62,7 +64,11 @@ public class IndexedFastaSequenceFileTest{
                 new Object[] { ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE),
                                                new IndexedFastaSequenceFile(SEQUENCE_FILE) },
                 new Object[] { ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE, true),
-                                               new IndexedFastaSequenceFile(SEQUENCE_FILE) },};
+                                               new IndexedFastaSequenceFile(SEQUENCE_FILE) },
+                new Object[] { ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE.toPath()),
+                                               new IndexedFastaSequenceFile(SEQUENCE_FILE.toPath()) },
+                new Object[] { ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE.toPath(), true),
+                                               new IndexedFastaSequenceFile(SEQUENCE_FILE.toPath()) },};
     }
 
     @Test(dataProvider="homosapiens")


### PR DESCRIPTION
This change is to make it possible to read reference sequence files (including indexes and dictionaries) from filesystems other than the local filesystem. The basic idea is to overload constructors and methods that take `java.io.File` to take `java.nio.file.Path`.

In particular, Hadoop can be supported by means of https://github.com/damiencarol/jsr203-hadoop.

Note that this requires Java 7 or above. HTSJDK currently supports Java 6, but only until October 2015, so it should be possible to use this approach after then.