### PR TITLE
Improve empty QNAME error message

### DIFF
--- a/src/java/htsjdk/samtools/util/StringUtil.java
+++ b/src/java/htsjdk/samtools/util/StringUtil.java
@@ -84,7 +84,7 @@ public class StringUtil {
             tokens[nTokens++] = aString;
             return nTokens;
         }
-        while ((end > 0) && (nTokens < maxTokens))
+        while ((end >= 0) && (nTokens < maxTokens))
         {
             tokens[nTokens++] = aString.substring(start, end);
             start = end + 1;
@@ -125,7 +125,7 @@ public class StringUtil {
             tokens[nTokens++] = aString;
             return nTokens;
         }
-        while ((end > 0) && (nTokens < maxTokens - 1))
+        while ((end >= 0) && (nTokens < maxTokens - 1))
         {
             tokens[nTokens++] = aString.substring(start, end);
             start = end + 1;


### PR DESCRIPTION
Currently when presented with a SAM file with a record with an empty QNAME (which is not valid by SAMv1.pdf), Picard tools report

> SAMFormatException: Error parsing text SAM file. Not enough fields

but in fact the record has plenty of fields.  With this fix, they instead report e.g.

> `$` picard SamFormatConverter I=qnames-empty.sam O=qnames-empty-picard.bam
> SAMFormatException: Error parsing text SAM file. Empty field at position 0 (zero-based)

which is more accurate.  Example SAM file:
```
@SQ	SN:chr1	LN:5000
@RG	ID:foo	SM:bar	PL:ILLUMINA
	4	*	0	0	*	*	0	0	ATGC	????	RG:Z:foo
```