### PR TITLE
Fix typo to get htsjdk version the jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -177,7 +177,7 @@
             <fileset dir="${classes}" includes="htsjdk/tribble/**/*.*"/>
             <fileset dir="${classes}" includes="htsjdk/variant/**/*.*"/>
             <manifest>
-                <attribute name="Implementation-Version" value="${hts-version}(${repository.revision})"/>
+                <attribute name="Implementation-Version" value="${htsjdk-version}(${repository.revision})"/>
                 <attribute name="Implementation-Vendor" value="Broad Institute"/>
             </manifest>
         </jar>


### PR DESCRIPTION
The Implementation-Version value in the MANIFEST file of htsjdk JAR file was using a wrong (non existent) property, and so was not even expended in the MANIFEST file.