### PR TITLE
Improve handling of null SAMFileHeaders in alignment records.

### DIFF
--- a/src/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
+++ b/src/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
@@ -75,10 +75,16 @@ public class SAMRecordDuplicateComparator implements SAMRecordComparator {
         final String readGroupId = (String) rec.getAttribute("RG");
 
         if (readGroupId != null) {
-            final SAMReadGroupRecord rg = rec.getHeader().getReadGroup(readGroupId);
-            if (rg != null) {
-                final String libraryName = rg.getLibrary();
-                if (null != libraryName) return libraryName;
+            final SAMFileHeader samHeader = rec.getHeader();
+            if (null == samHeader) {
+               throw new SAMException("A non-null SAMHeader is required to resolve the library name: " + rec.getReadName());
+            }
+            else {
+                final SAMReadGroupRecord rg = samHeader.getReadGroup(readGroupId);
+                if (rg != null) {
+                    final String libraryName = rg.getLibrary();
+                    if (null != libraryName) return libraryName;
+                }
             }
         }
 

--- a/src/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
+++ b/src/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
@@ -89,6 +89,7 @@ public class Sam2CramRecordFactory {
         this.refBases = refBases;
         this.version = version;
 
+        // TODO: Assumes header is non-null - do we need to code defensively against null headers here ?
         final List<SAMReadGroupRecord> readGroups = samFileHeader.getReadGroups();
         for (int i = 0; i < readGroups.size(); i++) {
             final SAMReadGroupRecord readGroupRecord = readGroups.get(i);

--- a/src/tests/java/htsjdk/samtools/SAMFileReaderTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFileReaderTest.java
@@ -120,4 +120,11 @@ public class SAMFileReaderTest {
         else if (inputFile.endsWith(".bam")) Assert.assertEquals(factory.bamRecordsCreated, i);
     }
 
+    @Test
+    public void samRecordFactoryNullHeaderTest(final String inputFile) {
+        final SAMRecordFactory factory = new DefaultSAMRecordFactory();
+        final SAMRecord samRec = factory.createSAMRecord(null);
+        Assert.assertTrue(samRec.getHeader() == null);
+    }
+
 }

--- a/src/tests/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -111,6 +111,35 @@ public class SAMFileWriterFactoryTest {
         Assert.assertEquals(writtensam, originalsam);
     }
 
+    @Test(description="Write SAM records with null SAMFileHeader")
+    public void samNullHeaderRoundTrip()  throws Exception  {
+        final File input = new File(TEST_DATA_DIR, "roundtrip.sam");
+
+        final SamReader reader = SamReaderFactory.makeDefault().open(input);
+        final File outputFile = File.createTempFile("nullheader-out", ".sam");
+        outputFile.delete();
+        outputFile.deleteOnExit();
+        FileOutputStream os = new FileOutputStream(outputFile);
+        final SAMFileWriterFactory factory = new SAMFileWriterFactory();
+        final SAMFileWriter writer = factory.makeSAMWriter(reader.getFileHeader(), false, os);
+        for (SAMRecord rec : reader) {
+            rec.setHeader(null);
+            writer.addAlignment(rec);
+        }
+        writer.close();
+        os.close();
+
+        InputStream is = new FileInputStream(input);
+        String originalsam = IOUtil.readFully(is);
+        is.close();
+
+        is = new FileInputStream(outputFile);
+        String writtensam = IOUtil.readFully(is);
+        is.close();
+
+        Assert.assertEquals(writtensam, originalsam);
+    }
+
     private void createSmallBam(final File outputFile) {
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         factory.setCreateIndex(true);
@@ -123,8 +152,8 @@ public class SAMFileWriterFactoryTest {
         fillSmallBam(writer);
         writer.close();
     }
-    
-    
+
+
    private void createSmallBamToOutputStream(final OutputStream outputStream,boolean binary) {
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         factory.setCreateIndex(false);


### PR DESCRIPTION
- I'm throwing SAMExceptions for missing headers; should we instead create a new exception class for this?
- I don't see a code path that creates a BAM record with a NULL header - all code paths
create them from a serialized file with a header. The BAMRecord class itself has no direct header references.
- There are numerous code paths that assume non null headers that I didn't touch modify because
the records all appear to originate from files and have valid headers (i.e., SAMFileValidator).
- The SAMRecord doc currently says get/setReferenceIndex() is preferred to get/setReferenceName(). Should we change that ?
- There are some inlined questions marked with //TODO.
