### PR TITLE
Improve handling of null SAMFileHeaders in alignment records.

### DIFF
--- a/src/java/htsjdk/samtools/BAMRecord.java
+++ b/src/java/htsjdk/samtools/BAMRecord.java
@@ -65,6 +65,11 @@ public class BAMRecord extends SAMRecord {
      */
     private boolean mBinaryDataStale;
 
+    /**
+     * Create a new BAM Record. If the reference sequence index or mate reference sequence index are any value other
+     * than NO_ALIGNMENT_REFERENCE_INDEX (-1), then the specified index values must exist in the sequence dictionary
+     * in the header argument.
+     */
     protected BAMRecord(final SAMFileHeader header,
                         final int referenceID,
                         final int coordinate,
@@ -242,7 +247,7 @@ public class BAMRecord extends SAMRecord {
             byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
             super.initializeCigar(BinaryCigarCodec.decode(byteBuffer));
             mCigarDecoded = true;
-            if (getValidationStringency() != ValidationStringency.SILENT && !this.getReadUnmappedFlag()) {
+            if (null != getHeader() && getValidationStringency() != ValidationStringency.SILENT && !this.getReadUnmappedFlag()) {
                 // Don't know line number, and don't want to force read name to be decoded.
                 SAMUtils.processValidationErrors(validateCigar(-1L), -1, getValidationStringency());
             }

--- a/src/java/htsjdk/samtools/BAMRecordCodec.java
+++ b/src/java/htsjdk/samtools/BAMRecordCodec.java
@@ -200,7 +200,11 @@ public class BAMRecordCodec implements SortingCollection.Codec<SAMRecord> {
         final BAMRecord ret = this.samRecordFactory.createBAMRecord(
                 header, referenceID, coordinate, readNameLength, mappingQuality,
                 bin, cigarLen, flags, readLen, mateReferenceID, mateCoordinate, insertSize, restOfRecord);
-        ret.setHeader(header); 
+
+        if (null != header) {
+            // don't reset a null header as this will clobber the reference and mate reference indices
+            ret.setHeader(header);
+        }
         return ret;
     }
 }

--- a/src/java/htsjdk/samtools/CRAMFileWriter.java
+++ b/src/java/htsjdk/samtools/CRAMFileWriter.java
@@ -331,6 +331,10 @@ public class CRAMFileWriter extends SAMFileWriterImpl {
         while ((cramRecord = cramRecord.next) != null);
     }
 
+    /**
+     * Write an alignment record.
+     * @param alignment must not be null and must have a valid SAMFileHeader.
+     */
     @Override
     protected void writeAlignment(final SAMRecord alignment) {
         if (shouldFlushContainer(alignment)) try {

--- a/src/java/htsjdk/samtools/DefaultSAMRecordFactory.java
+++ b/src/java/htsjdk/samtools/DefaultSAMRecordFactory.java
@@ -18,7 +18,11 @@ public class DefaultSAMRecordFactory implements SAMRecordFactory {
         return new SAMRecord(header);
     }
 
-    /** Create a new BAM Record. */
+    /**
+     * Create a new BAM Record. If the reference sequence index or mate reference sequence index are
+     * any value other than NO_ALIGNMENT_REFERENCE_INDEX, the values must be resolvable against the sequence
+     * dictionary in the header argument.
+     */
     public BAMRecord createBAMRecord (final SAMFileHeader header,
                                       final int referenceSequenceIndex,
                                       final int alignmentStart,

--- a/src/java/htsjdk/samtools/MergingSamRecordIterator.java
+++ b/src/java/htsjdk/samtools/MergingSamRecordIterator.java
@@ -124,6 +124,7 @@ public class MergingSamRecordIterator implements CloseableIterator<SAMRecord> {
         final ComparableSamRecordIterator iterator = this.pq.poll();
         final SAMRecord record = iterator.next();
         addIfNotEmpty(iterator);
+        // this will resolve the reference indices against the new, merged header
         record.setHeader(this.samHeaderMerger.getMergedHeader());
 
         // Fix the read group if needs be
@@ -141,17 +142,6 @@ public class MergingSamRecordIterator implements CloseableIterator<SAMRecord> {
             if (oldGroupId != null) {
                 final String newGroupId = this.samHeaderMerger.getProgramGroupId(iterator.getReader().getFileHeader(), oldGroupId);
                 record.setAttribute(ReservedTagConstants.PROGRAM_GROUP_ID, newGroupId);
-            }
-        }
-
-        // Fix up the sequence indexes if needs be
-        if (this.samHeaderMerger.hasMergedSequenceDictionary()) {
-            if (record.getReferenceIndex() != SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
-                record.setReferenceIndex(this.samHeaderMerger.getMergedSequenceIndex(iterator.getReader().getFileHeader(), record.getReferenceIndex()));
-            }
-
-            if (record.getReadPairedFlag() && record.getMateReferenceIndex() != SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
-                record.setMateReferenceIndex(this.samHeaderMerger.getMergedSequenceIndex(iterator.getReader().getFileHeader(), record.getMateReferenceIndex()));
             }
         }
 

--- a/src/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * Create a SAMFileWriter for writing SAM or BAM.
+ * Create a writer for writing SAM, BAM, or CRAM files.
  */
 public class SAMFileWriterFactory {
     private static boolean defaultCreateIndexWhileWriting = Defaults.CREATE_INDEX;

--- a/src/java/htsjdk/samtools/SAMRecordCoordinateComparator.java
+++ b/src/java/htsjdk/samtools/SAMRecordCoordinateComparator.java
@@ -75,10 +75,16 @@ public class SAMRecordCoordinateComparator implements SAMRecordComparator {
      * Less stringent compare method than the regular compare.  If the two records
      * are equal enough that their ordering in a sorted SAM file would be arbitrary,
      * this method returns 0.  If read is paired and unmapped, use the mate mapping to sort.
+     * Records being compared must have non-null SAMFileHeaders.
      *
      * @return negative if samRecord1 < samRecord2,  0 if equal, else positive
      */
     public int fileOrderCompare(final SAMRecord samRecord1, final SAMRecord samRecord2) {
+
+        if (null == samRecord1.getHeader() || null == samRecord2.getHeader()) {
+            throw new IllegalArgumentException("Records must have non-null SAMFileHeaders to be compared");
+        }
+
         final int refIndex1 = samRecord1.getReferenceIndex();
         final int refIndex2 = samRecord2.getReferenceIndex();
         if (refIndex1 == -1) {

--- a/src/java/htsjdk/samtools/SAMUtils.java
+++ b/src/java/htsjdk/samtools/SAMUtils.java
@@ -612,9 +612,15 @@ public final class SAMUtils {
     /**
      * Tests if the provided record is mapped entirely beyond the end of the reference (i.e., the alignment start is greater than the
      * length of the sequence to which the record is mapped).
+     * @param record must not have a null SamFileHeader
      */
     public static boolean recordMapsEntirelyBeyondEndOfReference(final SAMRecord record) {
-        return record.getHeader().getSequence(record.getReferenceIndex()).getSequenceLength() < record.getAlignmentStart();
+        if (record.getHeader() == null) {
+            throw new SAMException("A non-null SAMHeader is required to resolve the mapping position: " + record.getReadName());
+        }
+        else {
+            return record.getHeader().getSequence(record.getReferenceIndex()).getSequenceLength() < record.getAlignmentStart();
+        }
     }
 
     /**
@@ -898,14 +904,22 @@ public final class SAMUtils {
         // Don't know line number, and don't want to force read name to be decoded.
         List<SAMValidationError> ret = cigar.isValid(rec.getReadName(), recordNumber);
         if (referenceIndex != SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
-            final SAMSequenceRecord sequence = rec.getHeader().getSequence(referenceIndex);
-            final int referenceSequenceLength = sequence.getSequenceLength();
-            for (final AlignmentBlock alignmentBlock : alignmentBlocks) {
-                if (alignmentBlock.getReferenceStart() + alignmentBlock.getLength() - 1 > referenceSequenceLength) {
-                    if (ret == null) ret = new ArrayList<SAMValidationError>();
-                    ret.add(new SAMValidationError(SAMValidationError.Type.CIGAR_MAPS_OFF_REFERENCE,
-                            cigarTypeName + " M operator maps off end of reference", rec.getReadName(), recordNumber));
-                    break;
+            SAMFileHeader samHeader = rec.getHeader();
+            if (null == samHeader) {
+                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                ret.add(new SAMValidationError(SAMValidationError.Type.MISSING_HEADER,
+                        cigarTypeName + " A non-null SAMHeader is required to validate cigar elements for: ", rec.getReadName(), recordNumber));
+            }
+            else {
+                final SAMSequenceRecord sequence = samHeader.getSequence(referenceIndex);
+                final int referenceSequenceLength = sequence.getSequenceLength();
+                for (final AlignmentBlock alignmentBlock : alignmentBlocks) {
+                    if (alignmentBlock.getReferenceStart() + alignmentBlock.getLength() - 1 > referenceSequenceLength) {
+                        if (ret == null) ret = new ArrayList<SAMValidationError>();
+                        ret.add(new SAMValidationError(SAMValidationError.Type.CIGAR_MAPS_OFF_REFERENCE,
+                                cigarTypeName + " M operator maps off end of reference", rec.getReadName(), recordNumber));
+                        break;
+                    }
                 }
             }
         }

--- a/src/java/htsjdk/samtools/SamPairUtil.java
+++ b/src/java/htsjdk/samtools/SamPairUtil.java
@@ -183,8 +183,8 @@ public class SamPairUtil {
 
     /**
      * Write the mate info for two SAMRecords
-     * @param rec1 the first SAM record
-     * @param rec2 the second SAM record
+     * @param rec1 the first SAM record. Must have a non-null SAMFileHeader.
+     * @param rec2 the second SAM record. Must have a non-null SAMFileHeader.
      * @param setMateCigar true if we are to update/create the Mate CIGAR (MC) optional tag, false if we are to clear any mate cigar tag that is present.
      */
     public static void setMateInfo(final SAMRecord rec1, final SAMRecord rec2, final boolean setMateCigar) {

--- a/src/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
+++ b/src/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
@@ -62,6 +62,8 @@ public class Sam2CramRecordFactory {
     private final Version version;
     private byte[] refSNPs;
 
+    final private SAMFileHeader header;
+
     private static final Log log = Log.getInstance(Sam2CramRecordFactory.class);
 
     private final Map<String, Integer> readGroupMap = new HashMap<String, Integer>();
@@ -88,6 +90,7 @@ public class Sam2CramRecordFactory {
     public Sam2CramRecordFactory(final byte[] refBases, final SAMFileHeader samFileHeader, final Version version) {
         this.refBases = refBases;
         this.version = version;
+        this.header = samFileHeader;
 
         final List<SAMReadGroupRecord> readGroups = samFileHeader.getReadGroups();
         for (int i = 0; i < readGroups.size(); i++) {
@@ -96,7 +99,17 @@ public class Sam2CramRecordFactory {
         }
     }
 
+    /**
+     * Create a CramCompressionRecord.
+     *
+     * @param record If the input record does not have an associated SAMFileHeader, it will be updated
+     *               with the header used for the factory in order to allow reference indices to be resolved.
+     * @return CramCompressionRecord
+     */
     public CramCompressionRecord createCramRecord(final SAMRecord record) {
+        if (null == record.getHeader()) {
+            record.setHeader(header);
+        }
         final CramCompressionRecord cramRecord = new CramCompressionRecord();
         if (record.getReadPairedFlag()) {
             cramRecord.mateAlignmentStart = record.getMateAlignmentStart();

--- a/src/java/htsjdk/samtools/filter/IntervalFilter.java
+++ b/src/java/htsjdk/samtools/filter/IntervalFilter.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  * Filter SAMRecords so that only those that overlap the given list of intervals.
- * It is required that the SAMRecords are passed in coordinate order
+ * It is required that the SAMRecords are passed in coordinate order, and have non-null SAMFileHeaders.
  *
  * $Id$
  *

--- a/src/java/htsjdk/samtools/util/AbstractProgressLogger.java
+++ b/src/java/htsjdk/samtools/util/AbstractProgressLogger.java
@@ -76,7 +76,7 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
      */
     @Override
     public synchronized boolean record(final SAMRecord rec) {
-        if (rec.getReferenceIndex() == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
+        if (SAMRecord.NO_ALIGNMENT_REFERENCE_NAME.equals(rec.getReferenceName())) {
             return record(null, 0);
         }
         else {

--- a/src/tests/java/htsjdk/samtools/BAMFileWriterTest.java
+++ b/src/tests/java/htsjdk/samtools/BAMFileWriterTest.java
@@ -37,7 +37,7 @@ import java.io.File;
  */
 public class BAMFileWriterTest {
 
-    private SAMRecordSetBuilder getSAMReader(final boolean sortForMe, final SAMFileHeader.SortOrder sortOrder) {
+    private SAMRecordSetBuilder getRecordSetBuilder(final boolean sortForMe, final SAMFileHeader.SortOrder sortOrder) {
         final SAMRecordSetBuilder ret = new SAMRecordSetBuilder(sortForMe, sortOrder);
         ret.addPair("readB", 20, 200, 300);
         ret.addPair("readA", 20, 100, 150);
@@ -55,7 +55,7 @@ public class BAMFileWriterTest {
      * @param presorted           If true, samText is in the order specified by sortOrder
      */
     private void testHelper(final SAMRecordSetBuilder samRecordSetBuilder, final SAMFileHeader.SortOrder sortOrder, final boolean presorted) throws Exception {
-        SamReader samReader = samRecordSetBuilder.getSamReader();
+        final SamReader samReader = samRecordSetBuilder.getSamReader();
         final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
         bamFile.deleteOnExit();
         samReader.getFileHeader().setSortOrder(sortOrder);
@@ -68,43 +68,47 @@ public class BAMFileWriterTest {
         it.close();
         samReader.close();
 
-        if (presorted) {
-            // If SAM text input was presorted, then we can compare SAM object to BAM object
-            final SamReader bamReader = SamReaderFactory.makeDefault().open(bamFile);
-            samReader = samRecordSetBuilder.getSamReader();
-            samReader.getFileHeader().setSortOrder(bamReader.getFileHeader().getSortOrder());
-            Assert.assertEquals(bamReader.getFileHeader(), samReader.getFileHeader());
-            it = samReader.iterator();
-            final CloseableIterator<SAMRecord> bamIt = bamReader.iterator();
-            while (it.hasNext()) {
-                Assert.assertTrue(bamIt.hasNext());
-                final SAMRecord samRecord = it.next();
-                final SAMRecord bamRecord = bamIt.next();
-
-                // SAMRecords don't have this set, so stuff it in there
-                samRecord.setIndexingBin(bamRecord.getIndexingBin());
-
-                // Force reference index attributes to be populated
-                samRecord.getReferenceIndex();
-                bamRecord.getReferenceIndex();
-                samRecord.getMateReferenceIndex();
-                bamRecord.getMateReferenceIndex();
-
-                Assert.assertEquals(bamRecord, samRecord);
-            }
-            Assert.assertFalse(bamIt.hasNext());
+        if (presorted) { // If SAM text input was presorted, then we can compare SAM object to BAM object
+            verifyBAMFile(samRecordSetBuilder, bamFile);
         }
+    }
+
+    private void verifyBAMFile(final SAMRecordSetBuilder samRecordSetBuilder, final File bamFile) {
+
+        final SamReader bamReader = SamReaderFactory.makeDefault().open(bamFile);
+        final SamReader samReader = samRecordSetBuilder.getSamReader();
+        samReader.getFileHeader().setSortOrder(bamReader.getFileHeader().getSortOrder());
+        Assert.assertEquals(bamReader.getFileHeader(), samReader.getFileHeader());
+        final CloseableIterator<SAMRecord> it = samReader.iterator();
+        final CloseableIterator<SAMRecord> bamIt = bamReader.iterator();
+        while (it.hasNext()) {
+            Assert.assertTrue(bamIt.hasNext());
+            final SAMRecord samRecord = it.next();
+            final SAMRecord bamRecord = bamIt.next();
+
+            // SAMRecords don't have this set, so stuff it in there
+            samRecord.setIndexingBin(bamRecord.getIndexingBin());
+
+            // Force reference index attributes to be populated
+            samRecord.getReferenceIndex();
+            bamRecord.getReferenceIndex();
+            samRecord.getMateReferenceIndex();
+            bamRecord.getMateReferenceIndex();
+
+            Assert.assertEquals(bamRecord, samRecord);
+        }
+        Assert.assertFalse(bamIt.hasNext());
         CloserUtil.close(samReader);
     }
 
     @DataProvider(name = "test1")
     public Object[][] createTestData() {
         return new Object[][]{
-                {"coordinate sorted", getSAMReader(false, SAMFileHeader.SortOrder.unsorted), SAMFileHeader.SortOrder.coordinate, false},
-                {"query sorted", getSAMReader(false, SAMFileHeader.SortOrder.unsorted), SAMFileHeader.SortOrder.queryname, false},
-                {"unsorted", getSAMReader(false, SAMFileHeader.SortOrder.unsorted), SAMFileHeader.SortOrder.unsorted, false},
-                {"coordinate presorted", getSAMReader(true, SAMFileHeader.SortOrder.coordinate), SAMFileHeader.SortOrder.coordinate, true},
-                {"query presorted", getSAMReader(true, SAMFileHeader.SortOrder.queryname), SAMFileHeader.SortOrder.queryname, true},
+                {"coordinate sorted", getRecordSetBuilder(false, SAMFileHeader.SortOrder.unsorted), SAMFileHeader.SortOrder.coordinate, false},
+                {"query sorted", getRecordSetBuilder(false, SAMFileHeader.SortOrder.unsorted), SAMFileHeader.SortOrder.queryname, false},
+                {"unsorted", getRecordSetBuilder(false, SAMFileHeader.SortOrder.unsorted), SAMFileHeader.SortOrder.unsorted, false},
+                {"coordinate presorted", getRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate), SAMFileHeader.SortOrder.coordinate, true},
+                {"query presorted", getRecordSetBuilder(true, SAMFileHeader.SortOrder.queryname), SAMFileHeader.SortOrder.queryname, true},
         };
     }
 
@@ -114,10 +118,73 @@ public class BAMFileWriterTest {
         testHelper(samRecordSetBuilder, order, presorted);
     }
 
+    @Test(dataProvider = "test1")
+    public void testNullRecordHeaders(final String testName, final SAMRecordSetBuilder samRecordSetBuilder, final SAMFileHeader.SortOrder order, final boolean presorted) throws Exception {
+
+        // test that BAMFileWriter can write records that have a null header
+        final SAMFileHeader samHeader = samRecordSetBuilder.getHeader();
+        for (SAMRecord rec : samRecordSetBuilder.getRecords()) {
+            rec.setHeader(null);
+        }
+
+        // make sure the records can actually be written out
+        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        bamFile.deleteOnExit();
+        samHeader.setSortOrder(order);
+        final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(samHeader, presorted, bamFile);
+        for (final SAMRecord rec : samRecordSetBuilder.getRecords()) {
+            bamWriter.addAlignment(rec);
+        }
+        bamWriter.close();
+
+        if (presorted) {
+            verifyBAMFile(samRecordSetBuilder, bamFile);
+        }
+    }
+
+    @Test
+    public void testNullRecordsMismatchedHeader() throws Exception {
+
+        final SAMRecordSetBuilder samRecordSetBuilder = getRecordSetBuilder(true, SAMFileHeader.SortOrder.queryname);
+        for (final SAMRecord rec : samRecordSetBuilder.getRecords()) {
+            rec.setHeader(null);
+        }
+
+        // create a fake header to make sure the records can still be written using an invalid
+        // sequence dictionary and unresolvable references
+        final SAMFileHeader fakeHeader = new SAMFileHeader();
+        fakeHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
+        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        bamFile.deleteOnExit();
+
+        final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(fakeHeader, false, bamFile);
+        for (SAMRecord rec : samRecordSetBuilder.getRecords()) {
+            bamWriter.addAlignment(rec);
+        }
+        bamWriter.close();
+
+        final SamReader bamReader = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT).open(bamFile);
+        final SamReader samReader = samRecordSetBuilder.getSamReader();
+        samReader.getFileHeader().setSortOrder(bamReader.getFileHeader().getSortOrder());
+        final CloseableIterator<SAMRecord> it = samReader.iterator();
+        final CloseableIterator<SAMRecord> bamIt = bamReader.iterator();
+        while (it.hasNext()) {
+            Assert.assertTrue(bamIt.hasNext());
+            final SAMRecord samRecord = it.next();
+            final SAMRecord bamRecord = bamIt.next();
+
+            // test only reference names since we'll have lost reference indices due to the fake  null header
+            Assert.assertEquals(bamRecord.getReferenceName(), samRecord.getReferenceName());
+            Assert.assertEquals(bamRecord.getAlignmentStart(), samRecord.getAlignmentStart());
+        }
+        Assert.assertFalse(bamIt.hasNext());
+        CloserUtil.close(samReader);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNegativePresorted() throws Exception {
 
-        testHelper(getSAMReader(true, SAMFileHeader.SortOrder.coordinate), SAMFileHeader.SortOrder.queryname, true);
+        testHelper(getRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate), SAMFileHeader.SortOrder.queryname, true);
         Assert.fail("Exception should be thrown");
     }
 }

--- a/src/tests/java/htsjdk/samtools/CramFileWriterTest.java
+++ b/src/tests/java/htsjdk/samtools/CramFileWriterTest.java
@@ -52,6 +52,16 @@ public class CramFileWriterTest {
         doTest(createRecords(1000));
     }
 
+    @Test(description = "Tests a writing records with null SAMFileHeaders")
+    public void writeRecordsWithNullHeader() throws Exception {
+
+        final List<SAMRecord> samRecs = createRecords(50);
+        for (SAMRecord rec : samRecs) {
+            rec.setHeader(null);
+        }
+        doTest(samRecs);
+    }
+
     @Test(description = "Tests a unmapped record with sequence and quality fields")
     public void unmappedWithSequenceAndQualityField() throws Exception {
         unmappedSequenceAndQualityFieldHelper(true);
@@ -116,7 +126,7 @@ public class CramFileWriterTest {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         CRAMFileWriter writer = new CRAMFileWriter(os, source, header, null);
         for (SAMRecord record : samRecords) {
-            writer.writeAlignment(record);
+            writer.addAlignment(record);
         }
         writer.finish();
         writer.close();

--- a/src/tests/java/htsjdk/samtools/SAMFileReaderTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFileReaderTest.java
@@ -169,4 +169,12 @@ public class SAMFileReaderTest {
         }
         CloserUtil.close(reader);
     }
+
+    @Test
+    public void samRecordFactoryNullHeaderTest() {
+        final SAMRecordFactory factory = new DefaultSAMRecordFactory();
+        final SAMRecord samRec = factory.createSAMRecord(null);
+        Assert.assertTrue(samRec.getHeader() == null);
+    }
+
 }

--- a/src/tests/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -111,6 +111,35 @@ public class SAMFileWriterFactoryTest {
         Assert.assertEquals(writtensam, originalsam);
     }
 
+    @Test(description="Write SAM records with null SAMFileHeader")
+    public void samNullHeaderRoundTrip()  throws Exception  {
+        final File input = new File(TEST_DATA_DIR, "roundtrip.sam");
+
+        final SamReader reader = SamReaderFactory.makeDefault().open(input);
+        final File outputFile = File.createTempFile("nullheader-out", ".sam");
+        outputFile.delete();
+        outputFile.deleteOnExit();
+        FileOutputStream os = new FileOutputStream(outputFile);
+        final SAMFileWriterFactory factory = new SAMFileWriterFactory();
+        final SAMFileWriter writer = factory.makeSAMWriter(reader.getFileHeader(), false, os);
+        for (SAMRecord rec : reader) {
+            rec.setHeader(null);
+            writer.addAlignment(rec);
+        }
+        writer.close();
+        os.close();
+
+        InputStream is = new FileInputStream(input);
+        String originalsam = IOUtil.readFully(is);
+        is.close();
+
+        is = new FileInputStream(outputFile);
+        String writtensam = IOUtil.readFully(is);
+        is.close();
+
+        Assert.assertEquals(writtensam, originalsam);
+    }
+
     private void createSmallBam(final File outputFile) {
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         factory.setCreateIndex(true);
@@ -123,8 +152,8 @@ public class SAMFileWriterFactoryTest {
         fillSmallBam(writer);
         writer.close();
     }
-    
-    
+
+
    private void createSmallBamToOutputStream(final OutputStream outputStream,boolean binary) {
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         factory.setCreateIndex(false);

--- a/src/tests/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
@@ -27,6 +27,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -213,6 +214,20 @@ public class SAMRecordDuplicateComparatorTest {
         records.addPair("READ1", 2, 55, 55);
 
         assertEquals(Arrays.asList(-1,-1,-1), records, false);
+    }
+
+    @Test(expectedExceptions=IllegalArgumentException.class)
+    public void testNullHeaders() {
+        final SAMRecordSetBuilder records = getSAMRecordSetBuilder();
+
+        records.addPair("READ0", 1, 55, 55);
+        records.addPair("READ1", 2, 55, 55);
+        Collection<SAMRecord> recs = records.getRecords();
+        for (SAMRecord rec : recs) {
+            rec.setHeader(null);
+        }
+
+        assertEquals(Arrays.asList(-1, -1, -1), records, false);
     }
 
 }

--- a/src/tests/java/htsjdk/samtools/SAMTextWriterTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMTextWriterTest.java
@@ -44,7 +44,19 @@ public class SAMTextWriterTest {
 
     @Test
     public void testBasic() throws Exception {
+        doTest(getSAMReader(true, SAMFileHeader.SortOrder.coordinate));
+    }
+
+    @Test
+    public void testNullHeader() throws Exception {
         final SAMRecordSetBuilder recordSetBuilder = getSAMReader(true, SAMFileHeader.SortOrder.coordinate);
+        for (final SAMRecord rec : recordSetBuilder.getRecords()) {
+            rec.setHeader(null);
+        }
+        doTest(recordSetBuilder);
+    }
+
+    private void doTest(final SAMRecordSetBuilder recordSetBuilder) throws Exception{
         SamReader inputSAM = recordSetBuilder.getSamReader();
         final File samFile = File.createTempFile("tmp.", ".sam");
         samFile.deleteOnExit();

--- a/src/tests/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/tests/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -110,6 +110,25 @@ public class SamReaderFactoryTest {
         else if (inputFile.endsWith(".bam")) Assert.assertEquals(recordFactory.bamRecordsCreated, i);
     }
 
+    @Test(expectedExceptions=IllegalStateException.class)
+    public void samRecordFactoryNullHeaderBAMTest() {
+        final SAMRecordFactory recordFactory = new DefaultSAMRecordFactory();
+        recordFactory.createBAMRecord(
+                null, // null header
+                0,
+                0,
+                (short) 0,
+                (short) 0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                null);
+    }
+
 
     /**
      * Unit tests for asserting all permutations of data and index sources read the same records and header.


### PR DESCRIPTION
- This is the first pass of improving null SAMFileHeader support. There are some TODOs inline with questions.
- Once we have agreement on those, the next pass will be to find all the places that call getReferenceIndex/getReferenceName and the mate analogs internally and make sure they do something reasonable with the new sentinel values.
- The existing doc seems to already indicate that the header does not have to be set. We may want to add more detail there, but I've updated the doc for the individual methods, and will clean those up
again once we have resolution on the rest of the contract (ie null value handling, etc.)
- I chose to return a MISSING_HEADER validation error when validating records. Not sure if thats what  we want.
- The existing implementation silently allows the caller to set an invalid reference name (one that doesn't exist in the sequence dictionary), but throws if you try to set an invalid reference index. I've retained that behavior but am wondering if its deliberate/correct.
- I don't see a code path that requires any changes to BAMRecord. Likeiwse there are numerous code paths that assume non null headers that I didn't touch because the records all appear to originate from files and have valid headers (i.e., SAMFileValidator).
- The existing doc says get/setReferenceIndex() is preferred to get/setReferenceName(). Should we change that ?
