### PR TITLE
unsigned int is backed by a long value

### DIFF
--- a/src/java/htsjdk/samtools/BinaryTagCodec.java
+++ b/src/java/htsjdk/samtools/BinaryTagCodec.java
@@ -320,12 +320,15 @@ public class BinaryTagCodec {
                 return (char)byteBuffer.get();
             case 'I':
                 final long val = byteBuffer.getInt() & 0xffffffffL;
-                if (val <= Integer.MAX_VALUE) {
+                if ( val <= Integer.MAX_VALUE ) {
                     return (int)val;
                 }
-                SAMUtils.processValidationError(new SAMValidationError(SAMValidationError.Type.TAG_VALUE_TOO_LARGE,
-                        "Tag value " + val + " too large to store as signed integer.", null), validationStringency);
-                // convert to unsigned int stored in a long
+                // If it won't fit into a signed integer, but is within range for an unsigned 32-bit integer,
+                // return it directly as a long
+                if (! SAMUtils.isValidUnsignedIntegerAttribute(val)) {
+                    SAMUtils.processValidationError(new SAMValidationError(SAMValidationError.Type.TAG_VALUE_TOO_LARGE,
+                            "Unsigned integer is out of range for a 32-bit unsigned value: " + val, null), validationStringency);
+                }
                 return val;
             case 'i':
                 return byteBuffer.getInt();

--- a/src/java/htsjdk/samtools/CRAMFileWriter.java
+++ b/src/java/htsjdk/samtools/CRAMFileWriter.java
@@ -379,6 +379,8 @@ public class CRAMFileWriter extends SAMFileWriterImpl {
             outputStream.flush();
             if (indexer != null)
                 indexer.finish();
+        } catch (final RuntimeException re) {
+            throw re;
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/java/htsjdk/samtools/CRAMIterator.java
@@ -153,7 +153,7 @@ public class CRAMIterator implements SAMRecordIterator {
         else
             cramRecords.clear();
 
-        parser.getRecords(container, cramRecords);
+        parser.getRecords(container, cramRecords, validationStringency);
 
         if (container.sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
             refs = new byte[]{};
@@ -253,7 +253,12 @@ public class CRAMIterator implements SAMRecordIterator {
         if (!iterator.hasNext()) {
             try {
                 nextContainer();
-            } catch (final Exception e) {
+            } catch (CRAMException ce) {
+                throw ce;
+            } catch (SAMFormatException se) {
+                throw se;
+            }
+            catch (final Exception e) {
                 throw new RuntimeEOFException(e);
             }
         }

--- a/src/java/htsjdk/samtools/SAMUtils.java
+++ b/src/java/htsjdk/samtools/SAMUtils.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.CigarUtil;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.CoordMath;
@@ -1069,5 +1070,15 @@ public final class SAMUtils {
         } catch (final CloneNotSupportedException e) {
             throw new SAMException(e.getMessage(), e);
         }
+    }
+
+    /**
+     * Checks if a long attribute value is within the allowed range of a 32-bit unsigned integer.
+     *
+     * @param value a long value to check
+     * @return true if value is >= 0 and <= {@link BinaryCodec#MAX_UINT}, and false otherwise
+     */
+    public static boolean isValidUnsignedIntegerAttribute(long value) {
+        return value >= 0 && value <= BinaryCodec.MAX_UINT;
     }
 }

--- a/src/java/htsjdk/samtools/TextTagCodec.java
+++ b/src/java/htsjdk/samtools/TextTagCodec.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.DateParser;
 import htsjdk.samtools.util.Iso8601Date;
 import htsjdk.samtools.util.StringUtil;
@@ -72,8 +73,9 @@ public class TextTagCodec {
             value = getArrayType(value, false) + "," + encodeArrayValue(value);
         } else if (tagType == 'i') {
             final long longVal = ((Number) value).longValue();
-            if (longVal > Integer.MAX_VALUE || longVal < Integer.MIN_VALUE) {
-                throw new SAMFormatException("Value for tag " + tagName + " cannot be stored in an Integer: " + longVal);
+            // as the spec says: [−2^31, 2^32)
+            if (longVal < Integer.MIN_VALUE || longVal > BinaryCodec.MAX_UINT) {
+                throw new IllegalArgumentException("Value for tag " + tagName + " cannot be stored in either a signed or unsigned 32-bit integer: " + longVal);
             }
         }
         sb.append(tagType);
@@ -182,10 +184,21 @@ public class TextTagCodec {
             }
             return stringVal.charAt(0);
         } else if (type.equals("i")) {
+            final long lValue;
             try {
-                return new Integer(stringVal);
+                lValue = Long.valueOf(stringVal);
             } catch (NumberFormatException e) {
                 throw new SAMFormatException("Tag of type i should have signed decimal value");
+            }
+
+            if (lValue >= Integer.MIN_VALUE && lValue <= Integer.MAX_VALUE) {
+                return (int) lValue;
+            }
+            else if (SAMUtils.isValidUnsignedIntegerAttribute(lValue)) {
+                return lValue;
+            }
+            else {
+                throw new SAMFormatException("Integer is out of range for both a 32-bit signed and unsigned integer: " + stringVal);
             }
         } else if (type.equals("f")) {
             try {

--- a/src/java/htsjdk/samtools/cram/build/ContainerParser.java
+++ b/src/java/htsjdk/samtools/cram/build/ContainerParser.java
@@ -20,6 +20,7 @@ package htsjdk.samtools.cram.build;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.cram.encoding.reader.CramRecordReader;
 import htsjdk.samtools.cram.encoding.reader.DataReaderFactory;
 import htsjdk.samtools.cram.encoding.reader.DataReaderFactory.DataReaderWithStats;
@@ -50,14 +51,14 @@ public class ContainerParser {
     }
 
     public List<CramCompressionRecord> getRecords(final Container container,
-                                                  ArrayList<CramCompressionRecord> records) throws IllegalArgumentException,
+                                                  ArrayList<CramCompressionRecord> records, ValidationStringency validationStringency) throws IllegalArgumentException,
             IllegalAccessException {
         final long time1 = System.nanoTime();
         if (records == null)
             records = new ArrayList<CramCompressionRecord>(container.nofRecords);
 
         for (final Slice slice : container.slices)
-            records.addAll(getRecords(slice, container.header));
+            records.addAll(getRecords(slice, container.header, validationStringency));
 
         final long time2 = System.nanoTime();
 
@@ -73,7 +74,7 @@ public class ContainerParser {
     }
 
     ArrayList<CramCompressionRecord> getRecords(ArrayList<CramCompressionRecord> records,
-                                                final Slice slice, final CompressionHeader header) throws IllegalArgumentException,
+                                                final Slice slice, final CompressionHeader header, ValidationStringency validationStringency) throws IllegalArgumentException,
             IllegalAccessException {
         String seqName = SAMRecord.NO_ALIGNMENT_REFERENCE_NAME;
         switch (slice.sequenceId) {
@@ -97,7 +98,7 @@ public class ContainerParser {
         }
 
         long time;
-        final CramRecordReader reader = new CramRecordReader();
+        final CramRecordReader reader = new CramRecordReader(validationStringency);
         dataReaderFactory.buildReader(reader, new DefaultBitInputStream(
                         new ByteArrayInputStream(slice.coreBlock.getRawContent())),
                 inputMap, header, slice.sequenceId);
@@ -150,8 +151,8 @@ public class ContainerParser {
         return records;
     }
 
-    List<CramCompressionRecord> getRecords(final Slice slice, final CompressionHeader header)
+    List<CramCompressionRecord> getRecords(final Slice slice, final CompressionHeader header, ValidationStringency validationStringency)
             throws IllegalArgumentException, IllegalAccessException {
-        return getRecords(null, slice, header);
+        return getRecords(null, slice, header, validationStringency);
     }
 }

--- a/src/java/htsjdk/samtools/cram/structure/ReadTag.java
+++ b/src/java/htsjdk/samtools/cram/structure/ReadTag.java
@@ -19,9 +19,13 @@ package htsjdk.samtools.cram.structure;
 
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMFormatException;
+import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecord.SAMTagAndValue;
 import htsjdk.samtools.SAMTagUtil;
+import htsjdk.samtools.SAMUtils;
+import htsjdk.samtools.SAMValidationError;
 import htsjdk.samtools.TagValueAndUnsignedArrayFlag;
+import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.util.StringUtil;
 
 import java.nio.ByteBuffer;
@@ -50,10 +54,10 @@ public class ReadTag implements Comparable<ReadTag> {
     private short code;
     private byte index;
 
-    public ReadTag(final int id, final byte[] dataAsByteArray) {
+    public ReadTag(final int id, final byte[] dataAsByteArray, ValidationStringency validationStringency) {
         this.type = (char) (0xFF & id);
         key = new String(new char[]{(char) ((id >> 16) & 0xFF), (char) ((id >> 8) & 0xFF)});
-        value = restoreValueFromByteArray(type, dataAsByteArray);
+        value = restoreValueFromByteArray(type, dataAsByteArray, validationStringency);
         keyType3Bytes = this.key + this.type;
 
         keyType3BytesAsInt = id;
@@ -179,10 +183,10 @@ public class ReadTag implements Comparable<ReadTag> {
         return writeSingleValue((byte) type, value, false);
     }
 
-    private static Object restoreValueFromByteArray(final char type, final byte[] array) {
+    private static Object restoreValueFromByteArray(final char type, final byte[] array, ValidationStringency validationStringency) {
         final ByteBuffer buffer = ByteBuffer.wrap(array);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
-        return readSingleValue((byte) type, buffer);
+        return readSingleValue((byte) type, buffer, validationStringency);
     }
 
     // copied from net.sf.samtools.BinaryTagCodec 1.62:
@@ -216,8 +220,7 @@ public class ReadTag implements Comparable<ReadTag> {
     // copied from net.sf.samtools.BinaryTagCodec:
     static private char getIntegerType(final long val) {
         if (val > MAX_UINT) {
-            throw new IllegalArgumentException(
-                    "Integer attribute value too large to be encoded in BAM");
+            throw new IllegalArgumentException("Integer attribute value too large: "+val);
         }
         if (val > MAX_INT) {
             return 'I';
@@ -288,7 +291,7 @@ public class ReadTag implements Comparable<ReadTag> {
                 buffer.position(buffer.position() - 4);
                 break;
             case 'i':
-                buffer.putInt((Integer) value);
+                buffer.putInt(((Number) value).intValue());
                 break;
             case 's':
                 buffer.putShort(((Number) value).shortValue());
@@ -365,7 +368,7 @@ public class ReadTag implements Comparable<ReadTag> {
     }
 
     public static Object readSingleValue(final byte tagType,
-                                         final ByteBuffer byteBuffer) {
+                                         final ByteBuffer byteBuffer, ValidationStringency validationStringency) {
         switch (tagType) {
             case 'Z':
                 return readNullTerminatedString(byteBuffer);
@@ -374,10 +377,15 @@ public class ReadTag implements Comparable<ReadTag> {
             case 'I':
                 final long val = byteBuffer.getInt() & 0xffffffffL;
                 if (val <= Integer.MAX_VALUE) {
-                    return (int) val;
+                    return (int)val;
                 }
-                throw new RuntimeException(
-                        "Tag value is too large to store as signed integer.");
+                // If it won't fit into a signed integer, but is within range for an unsigned 32-bit integer,
+                // return it directly as a long
+                if (! SAMUtils.isValidUnsignedIntegerAttribute(val)) {
+                    SAMUtils.processValidationError(new SAMValidationError(SAMValidationError.Type.TAG_VALUE_TOO_LARGE,
+                            "Unsigned integer is out of range for a 32-bit unsigned value: " + val, null), validationStringency);
+                }
+                return val;
             case 'i':
                 return byteBuffer.getInt();
             case 's':

--- a/src/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/java/htsjdk/samtools/util/BinaryCodec.java
@@ -79,9 +79,9 @@ public class BinaryCodec implements Closeable {
     private static final ByteOrder LITTLE_ENDIAN = ByteOrder.LITTLE_ENDIAN;
     private static final byte NULL_BYTE[] = {0};
 
-    private static final long MAX_UBYTE = (Byte.MAX_VALUE * 2) + 1;
-    private static final long MAX_USHORT = (Short.MAX_VALUE * 2) + 1;
-    private static final long MAX_UINT = ((long)Integer.MAX_VALUE * 2) + 1;
+    public static final long MAX_UBYTE = (Byte.MAX_VALUE * 2) + 1;
+    public static final long MAX_USHORT = (Short.MAX_VALUE * 2) + 1;
+    public static final long MAX_UINT = ((long)Integer.MAX_VALUE * 2) + 1;
 
     // We never serialize more than this much at a time (except for Strings)
     private static final int MAX_BYTE_BUFFER = 8;

--- a/src/tests/java/htsjdk/samtools/CRAMEdgeCasesTest.java
+++ b/src/tests/java/htsjdk/samtools/CRAMEdgeCasesTest.java
@@ -1,17 +1,19 @@
 package htsjdk.samtools;
 
-import htsjdk.samtools.*;
 import htsjdk.samtools.cram.CRAMException;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.RuntimeEOFException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -37,25 +39,16 @@ public class CRAMEdgeCasesTest {
 
     // int test for CRAMException
     // testing for a contig found in the reads but not in the reference
-    @Test
+    @Test(expectedExceptions = CRAMException.class)
     public void testContigNotFoundInRef() throws IOException {
         boolean sawException = false;
         final File CRAMFile = new File("testdata/htsjdk/samtools/cram/CRAMException/testContigNotInRef.cram");
         final File refFile = new File("testdata/htsjdk/samtools/cram/CRAMException/testContigNotInRef.fa");
         final ReferenceSource refSource = new ReferenceSource(refFile);
         final CRAMIterator iterator = new CRAMIterator(new FileInputStream(CRAMFile), refSource);
-        try {
-            while (iterator.hasNext()) {
-                iterator.next();
-            }
+        while (iterator.hasNext()) {
+            iterator.next();
         }
-        // the iterator is wrapping our exception; ensuring that it was actually a CRAMexception
-        catch (RuntimeEOFException e) {
-            Assert.assertEquals(e.getCause().getClass(), CRAMException.class);
-            sawException = true;
-        }
-
-        if (!sawException) {Assert.fail("Expected an exception to occur, none found");}
     }
 
     @Test
@@ -67,7 +60,9 @@ public class CRAMEdgeCasesTest {
             char b1 = (char) ('A' + i / 26);
             char b2 = (char) ('A' + i % 26);
             String tag = new String(new char[]{b1, b2});
-            if ("RG".equals(tag)) continue;
+            if ("RG".equals(tag)) {
+                continue;
+            }
             record.setAttribute(tag, i);
         }
 
@@ -98,7 +93,7 @@ public class CRAMEdgeCasesTest {
         }
         cramFileWriter.close();
 
-        CRAMFileReader cramFileReader = new CRAMFileReader(new ByteArrayInputStream(baos.toByteArray()), (SeekableStream)null, source, ValidationStringency.SILENT);
+        CRAMFileReader cramFileReader = new CRAMFileReader(new ByteArrayInputStream(baos.toByteArray()), (SeekableStream) null, source, ValidationStringency.SILENT);
         final SAMRecordIterator iterator = cramFileReader.getIterator();
         Assert.assertTrue(iterator.hasNext());
 
@@ -126,7 +121,7 @@ public class CRAMEdgeCasesTest {
         cramFileWriter.addAlignment(record);
         cramFileWriter.close();
 
-        CRAMFileReader cramFileReader = new CRAMFileReader(new ByteArrayInputStream(baos.toByteArray()), (SeekableStream)null, source, ValidationStringency.SILENT);
+        CRAMFileReader cramFileReader = new CRAMFileReader(new ByteArrayInputStream(baos.toByteArray()), (SeekableStream) null, source, ValidationStringency.SILENT);
         final SAMRecordIterator iterator = cramFileReader.getIterator();
         Assert.assertTrue(iterator.hasNext());
         SAMRecord s2 = iterator.next();
@@ -152,8 +147,11 @@ public class CRAMEdgeCasesTest {
         s.setAlignmentStart(1);
         s.setReferenceName("chr1");
         s.setReadName("1");
-        if (bases == SAMRecord.NULL_SEQUENCE) s.setCigarString("10M");
-        else s.setCigarString(s.getReadLength() + "M");
+        if (bases == SAMRecord.NULL_SEQUENCE) {
+            s.setCigarString("10M");
+        } else {
+            s.setCigarString(s.getReadLength() + "M");
+        }
 
         testSingleRecord(s, ref);
     }

--- a/src/tests/java/htsjdk/samtools/SamSpecIntTest.java
+++ b/src/tests/java/htsjdk/samtools/SamSpecIntTest.java
@@ -61,7 +61,7 @@ public class SamSpecIntTest {
         CloserUtil.close(samReader);
         samWriter.close();
         bamWriter.close();
-        Assert.assertEquals(errorMessages.size(), 2);
+        Assert.assertEquals(errorMessages.size(), 0);
         bamOutput.deleteOnExit();
         samOutput.deleteOnExit();
     }
@@ -89,7 +89,7 @@ public class SamSpecIntTest {
         CloserUtil.close(bamReader);
         samWriter.close();
         bamWriter.close();
-        Assert.assertEquals(errorMessages.size(), 2);
+        Assert.assertEquals(errorMessages.size(), 0);
         bamOutput.deleteOnExit();
         samOutput.deleteOnExit();
     }

--- a/src/tests/java/htsjdk/samtools/cram/structure/ReadTagTest.java
+++ b/src/tests/java/htsjdk/samtools/cram/structure/ReadTagTest.java
@@ -25,6 +25,7 @@ package htsjdk.samtools.cram.structure;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.ValidationStringency;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -53,22 +54,34 @@ public class ReadTagTest {
         byte[] data = ReadTag.writeSingleValue((byte) 'i', intValue, false);
         ByteBuffer byteBuffer = ByteBuffer.wrap(data);
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-        Object value = ReadTag.readSingleValue((byte) 'i', byteBuffer);
+        Object value = ReadTag.readSingleValue((byte) 'i', byteBuffer, ValidationStringency.DEFAULT_STRINGENCY);
         Assert.assertEquals (((Integer) value).intValue(), intValue);
 
         String sValue = "value";
         data = ReadTag.writeSingleValue((byte) 'Z', sValue, false);
         byteBuffer = ByteBuffer.wrap(data);
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-        value = ReadTag.readSingleValue((byte) 'Z', byteBuffer);
+        value = ReadTag.readSingleValue((byte) 'Z', byteBuffer, ValidationStringency.DEFAULT_STRINGENCY);
         Assert.assertEquals(sValue, value);
 
         byte[] baValue = "value".getBytes();
         data = ReadTag.writeSingleValue((byte) 'B', baValue, false);
         byteBuffer = ByteBuffer.wrap(data);
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-        value = ReadTag.readSingleValue((byte) 'B', byteBuffer);
+        value = ReadTag.readSingleValue((byte) 'B', byteBuffer, ValidationStringency.DEFAULT_STRINGENCY);
         Assert.assertEquals((byte[]) value, baValue);
+    }
+
+    @Test
+    public void testUnsignedInt() {
+        long intValue = Integer.MAX_VALUE+1L;
+        byte[] data = ReadTag.writeSingleValue((byte) 'I', intValue, false);
+        ByteBuffer byteBuffer = ByteBuffer.wrap(data);
+        byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        Object value = ReadTag.readSingleValue((byte) 'I', byteBuffer, ValidationStringency.SILENT);
+        Assert.assertTrue(value instanceof Long);
+        long lValue = (Long)value;
+        Assert.assertEquals (lValue & 0xFFFFFFFF, intValue);
     }
 
     @Test
@@ -109,7 +122,7 @@ public class ReadTagTest {
         final byte[] data = ReadTag.writeSingleValue(tagType, originalValue, false);
         final ByteBuffer byteBuffer = ByteBuffer.wrap(data);
         byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
-        final Object readValue = ReadTag.readSingleValue(tagType, byteBuffer);
+        final Object readValue = ReadTag.readSingleValue(tagType, byteBuffer, ValidationStringency.DEFAULT_STRINGENCY);
         Assert.assertEquals(readValue, originalValue);
     }
 


### PR DESCRIPTION
replaced exception when reading unsigned int in ReadTag with a direct conversion to long