### PR TITLE
Fix VariantContextWriterBuilder.clearOptions bug.

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -125,7 +125,7 @@ public class VariantContextWriterBuilder {
     private IndexCreator idxCreator = null;
     private int bufferSize = Defaults.BUFFER_SIZE;
     private boolean createMD5 = Defaults.CREATE_MD5;
-    private EnumSet<Options> options = DEFAULT_OPTIONS.clone();
+    protected EnumSet<Options> options = DEFAULT_OPTIONS.clone();
 
     /**
      * Default constructor.  Adds <code>USE_ASYNC_IO</code> to the Options if it is present in Defaults.
@@ -364,7 +364,7 @@ public class VariantContextWriterBuilder {
      * @return this VariantContextWriterBuilder
      */
     public VariantContextWriterBuilder clearOptions() {
-        this.options = NO_OPTIONS;
+        this.options = NO_OPTIONS.clone();
         return this;
     }
 

--- a/src/tests/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -349,4 +349,14 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
                 .setOption(Options.INDEX_ON_THE_FLY)
                 .build();
     }
+
+    @Test
+    public void testClearOptions() {
+        // Verify that clearOptions doesn't have a side effect of carrying previously set options
+        // forward to subsequent builders
+        VariantContextWriterBuilder vcwb = new VariantContextWriterBuilder();
+        vcwb.clearOptions().setOption(Options.INDEX_ON_THE_FLY);
+        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder().clearOptions();
+        Assert.assertTrue(builder.options.isEmpty());
+    }
 }


### PR DESCRIPTION
Fix a bug where once you've called clearOptions followed by setOption on any VariantContextWriterBuilder, subsequent calls to clearOptions on any VariantContextWriterBuilder set the options from the previous setOption calls instead of clearing the options, due to a shared reference to a mutable set.