### PR TITLE
Set TestNG verbosity back to 2, and reduce log file size by grepping out PASSED: lines.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - openjdk7
   - openjdk6
 install: ant
-script: ant all test
+script: ant all test | grep -v "PASSED:"
 after_success:
   - echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'";
     echo "JAVA_HOME='$JAVA_HOME'";

--- a/build.xml
+++ b/build.xml
@@ -43,7 +43,7 @@
     <property name="repository.revision" value=""/>
     <property name="htsjdk-version" value="1.140"/>
     <property name="htsjdk-version-file" value="htsjdk.version.properties"/>
-    <property name="testng.verbosity" value="1"/>
+    <property name="testng.verbosity" value="2"/>
     <property name="test.debug.port" value="5005" />  <!-- override on the command line if desired -->
 
     <condition  property="isUnix">


### PR DESCRIPTION
This change allows submitters to once again see which tests are failing in
their branches via travis.