### PR TITLE
Make the VCF/BCF Header tests less chatty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - openjdk7
   - openjdk6
 install: ant
-script: ant all test | grep -v "PASSED:"
+script: ant all test
 after_success:
   - echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'";
     echo "JAVA_HOME='$JAVA_HOME'";

--- a/src/tests/java/htsjdk/variant/bcf2/BCF2UtilsUnitTest.java
+++ b/src/tests/java/htsjdk/variant/bcf2/BCF2UtilsUnitTest.java
@@ -93,6 +93,21 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
         Assert.assertEquals(7,dict_size);
     }
 
+    /**
+     * Wrapper class for HeaderOrderTestProvider test cases to prevent TestNG from calling toString()
+     * on the VCFHeaders and spamming the log output.
+     */
+    private static class HeaderOrderTestCase {
+        public final VCFHeader inputHeader;
+        public final VCFHeader testHeader;
+        public final boolean expectedConsistent;
+
+        public HeaderOrderTestCase( final VCFHeader inputHeader, final VCFHeader testHeader, final boolean expectedConsistent ) {
+            this.inputHeader = inputHeader;
+            this.testHeader = testHeader;
+            this.expectedConsistent = expectedConsistent;
+        }
+    }
 
     @DataProvider(name = "HeaderOrderTestProvider")
     public Object[][] makeHeaderOrderTestProvider() {
@@ -132,7 +147,7 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
                     allLines.addAll(permutation);
                     final VCFHeader testHeader = new VCFHeader(new LinkedHashSet<VCFHeaderLine>(allLines));
                     final boolean expectedConsistent = expectedConsistent(testHeader, inputLineCounter);
-                    tests.add(new Object[]{inputHeader, testHeader, expectedConsistent});
+                    tests.add(new Object[]{new HeaderOrderTestCase(inputHeader, testHeader, expectedConsistent)});
                 }
             }
         }
@@ -153,7 +168,7 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
                 for ( final List<String> testSamplesPermutation : permutations ) {
                     final VCFHeader testHeaderWithSamples = new VCFHeader(inputHeader.getMetaDataInInputOrder(), testSamplesPermutation);
                     final boolean expectedConsistent = testSamples.equals(inSamples);
-                    tests.add(new Object[]{inputHeaderWithSamples, testHeaderWithSamples, expectedConsistent});
+                    tests.add(new Object[]{new HeaderOrderTestCase(inputHeaderWithSamples, testHeaderWithSamples, expectedConsistent)});
                 }
             }
         }
@@ -182,9 +197,9 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
     // even when the header file is slightly different
     //
     @Test(dataProvider = "HeaderOrderTestProvider")
-    public void testHeaderOrder(final VCFHeader inputHeader, final VCFHeader testHeader, final boolean expectedConsistent) {
-        final boolean actualOrderConsistency = BCF2Utils.headerLinesAreOrderedConsistently(testHeader, inputHeader);
-        Assert.assertEquals(actualOrderConsistency, expectedConsistent);
+    public void testHeaderOrder( final HeaderOrderTestCase testCase ) {
+        final boolean actualOrderConsistency = BCF2Utils.headerLinesAreOrderedConsistently(testCase.testHeader, testCase.inputHeader);
+        Assert.assertEquals(actualOrderConsistency, testCase.expectedConsistent);
     }
 
 

--- a/src/tests/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/tests/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -34,7 +34,6 @@ import htsjdk.tribble.readers.LineReaderUtil;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.variantcontext.VariantContext;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.*;
@@ -127,20 +126,17 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         final VCFHeader header = (VCFHeader) codec.readHeader(vcfIterator).getHeaderValue();
     }
 
-    @DataProvider(name = "HiSeqVCFHeaderDataProvider")
-    public Object[][] getHiSeqVCFHeaderData() {
+    private VCFHeader getHiSeqVCFHeader() {
         final File vcf = new File("testdata/htsjdk/variant/HiSeq.10000.vcf");
         final VCFFileReader reader = new VCFFileReader(vcf, false);
         final VCFHeader header = reader.getFileHeader();
         reader.close();
-
-        return new Object[][] {
-                { header }
-        };
+        return header;
     }
 
-    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
-    public void testVCFHeaderAddInfoLine( final VCFHeader header ) {
+    @Test
+    public void testVCFHeaderAddInfoLine() {
+        final VCFHeader header = getHiSeqVCFHeader();
         final VCFInfoHeaderLine infoLine = new VCFInfoHeaderLine("TestInfoLine", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "test info line");
         header.addMetaDataLine(infoLine);
 
@@ -154,8 +150,9 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertFalse(header.getOtherHeaderLines().contains(infoLine), "TestInfoLine present in other header lines");
     }
 
-    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
-    public void testVCFHeaderAddFormatLine( final VCFHeader header ) {
+    @Test
+    public void testVCFHeaderAddFormatLine() {
+        final VCFHeader header = getHiSeqVCFHeader();
         final VCFFormatHeaderLine formatLine = new VCFFormatHeaderLine("TestFormatLine", VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.String, "test format line");
         header.addMetaDataLine(formatLine);
 
@@ -169,8 +166,9 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertFalse(header.getOtherHeaderLines().contains(formatLine), "TestFormatLine present in other header lines");
     }
 
-    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
-    public void testVCFHeaderAddFilterLine( final VCFHeader header ) {
+    @Test
+    public void testVCFHeaderAddFilterLine() {
+        final VCFHeader header = getHiSeqVCFHeader();
         final VCFFilterHeaderLine filterLine = new VCFFilterHeaderLine("TestFilterLine");
         header.addMetaDataLine(filterLine);
 
@@ -184,8 +182,9 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertFalse(header.getOtherHeaderLines().contains(filterLine), "TestFilterLine present in other header lines");
     }
 
-    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
-    public void testVCFHeaderAddContigLine( final VCFHeader header ) {
+    @Test
+    public void testVCFHeaderAddContigLine() {
+        final VCFHeader header = getHiSeqVCFHeader();
         final VCFContigHeaderLine contigLine = new VCFContigHeaderLine("<ID=chr1,length=1234567890,assembly=FAKE,md5=f126cdf8a6e0c7f379d618ff66beb2da,species=\"Homo sapiens\">", VCFHeaderVersion.VCF4_0, "chr1", 0);
         header.addMetaDataLine(contigLine);
 
@@ -198,8 +197,9 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertFalse(header.getOtherHeaderLines().contains(contigLine), "Test contig line present in other header lines");
     }
 
-    @Test(dataProvider = "HiSeqVCFHeaderDataProvider")
-    public void testVCFHeaderAddOtherLine( final VCFHeader header ) {
+    @Test
+    public void testVCFHeaderAddOtherLine() {
+        final VCFHeader header = getHiSeqVCFHeader();
         final VCFHeaderLine otherLine = new VCFHeaderLine("TestOtherLine", "val");
         header.addMetaDataLine(otherLine);
 


### PR DESCRIPTION
The VCFHeader tests were dumping extremely large String representations of VCFHeaders
to the TestNG log due to the way they were using DataProviders -- this comprised
the vast majority of htsjdk test output. This refactors these tests to produce
much less output.

With this change, grepping out the "PASSED:" lines should no longer be necessary
(this approach didn't work well anyway, since it didn't correctly propagate the
TestNG exit status to travis).