### PR TITLE
Changed to only interrupt the writer thread if the queue size is...

### DIFF
--- a/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
+++ b/src/java/htsjdk/samtools/util/AbstractAsyncWriter.java
@@ -64,7 +64,7 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
 
         if (!this.isClosed.getAndSet(true)) {
             try {
-            	this.writer.interrupt(); // signal to writer clean up
+                if (this.queue.isEmpty()) this.writer.interrupt(); // signal to writer clean up
             	this.writer.join();
             } catch (final InterruptedException ie) {
             	throw new RuntimeException("Interrupted waiting on writer thread.", ie);


### PR DESCRIPTION
already zero, implying that the writer will be waiting on the queue.  Resolves a nasty threading bug where on close() the writer could recieve an InterruptedException deep inside blocking I/O code and exit.  This would cause an exception to be thrown in AbstractAsyncWriter for "Queue should be empty but is size: #".