### PR TITLE
Set original RNAME when unmapping reads

### DIFF
--- a/src/java/htsjdk/samtools/SAMTag.java
+++ b/src/java/htsjdk/samtools/SAMTag.java
@@ -62,6 +62,7 @@ public enum SAMTag {
     OP,
     OC,
     OF,
+    OR,
     PG,
     PQ,
     PT,

--- a/src/java/htsjdk/samtools/SAMUtils.java
+++ b/src/java/htsjdk/samtools/SAMUtils.java
@@ -579,6 +579,7 @@ public final class SAMUtils {
             rec.setAttribute(SAMTag.OP.name(), rec.getAlignmentStart());
             rec.setAttribute(SAMTag.OC.name(), rec.getCigarString());
             rec.setAttribute(SAMTag.OF.name(), rec.getFlags());
+            rec.setAttribute(SAMTag.OR.name(), rec.getReferenceName());
         }
         makeReadUnmapped(rec);
     }
@@ -589,7 +590,8 @@ public final class SAMUtils {
     public static boolean hasOriginalMappingInformation(final SAMRecord rec) {
         return rec.getAttribute(SAMTag.OP.name()) != null
                 || rec.getAttribute(SAMTag.OC.name()) != null
-                || rec.getAttribute(SAMTag.OF.name()) != null;
+                || rec.getAttribute(SAMTag.OF.name()) != null
+                || rec.getAttribute(SAMTag.OR.name()) != null;
     }
 
     /**


### PR DESCRIPTION
Add OR (original RNAME) tag and use it when we call ```makeReadUnmappedWithOriginalTags```.