### PR TITLE
Significant performance improvements in the DuplicateSetIterator and friends...

### DIFF
--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -32,7 +32,9 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -167,6 +169,9 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      */
     private transient SAMFileSource mFileSource;
     private SAMFileHeader mHeader = null;
+
+    /** Transient Map of attributes for use by anyone. */
+    private transient Map<Object,Object> transientAttributes;
 
     public SAMRecord(final SAMFileHeader header) {
         mHeader = header;
@@ -1932,7 +1937,39 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * shortcut to <pre>SAMFlag.getFlags( this.getFlags() );</pre>
      * @returns a set of SAMFlag associated to this sam record */
     public final Set<SAMFlag> getSAMFlags() {
-        return SAMFlag.getFlags( this.getFlags() );
+        return SAMFlag.getFlags(this.getFlags());
+    }
+
+    /**
+     * Fetches the value of a transient attribute on the SAMRecord, of null if not set.
+     *
+     * The intended use for transient attributes is to store values that are 1-to-1 with the SAMRecord,
+     * may be needed many times and are expensive to compute.  These values can be computed lazily and
+     * then stored as transient attributes to avoid frequent re-computation.
+     */
+    public final Object getTransientAttribute(final Object key) {
+        return (this.transientAttributes == null) ? null : this.transientAttributes.get(key);
+    }
+
+    /**
+     * Sets the value of a transient attribute, and returns the previous value if defined.
+     *
+     * The intended use for transient attributes is to store values that are 1-to-1 with the SAMRecord,
+     * may be needed many times and are expensive to compute.  These values can be computed lazily and
+     * then stored as transient attributes to avoid frequent re-computation.
+     */
+    public final Object setTransientAttribute(final Object key, final Object value) {
+        if (this.transientAttributes == null) this.transientAttributes = new HashMap<Object,Object>();
+        return this.transientAttributes.put(key, value);
+    }
+
+    /**
+     * Removes a transient attribute if it is stored, and returns the stored value. If there is not
+     * a stored value, will return null.
+     */
+    public final Object removeTransientAttribute(final Object key) {
+        if (this.transientAttributes != null) return this.transientAttributes.remove(key);
+        else return null;
     }
 }
 

--- a/src/tests/java/htsjdk/samtools/DuplicateSetIteratorTest.java
+++ b/src/tests/java/htsjdk/samtools/DuplicateSetIteratorTest.java
@@ -1,5 +1,6 @@
 package htsjdk.samtools;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -56,7 +57,7 @@ public class DuplicateSetIteratorTest {
         }
 
         //we expect 15 duplicate sets one for the initial two reads and one for each of the additional 14 reads.
-        assert (allSets.size() == 15);
-        assert (allSets.get("READ0").size() == 2);
+        Assert.assertEquals(allSets.size(), 15, "Wrong number of duplicate sets.");
+        Assert.assertEquals(allSets.get("READ0").size(), 2, "Should be two reads in the READ0 duplicate set, but there are not.");
     }
 }


### PR DESCRIPTION
by both making the sorting/comparing process for duplicate ordering more efficient, and also doing less of it.

The only thing in here that might be contentious is that I added the facility to SAMRecord to store arbitrary transient attributes that are not persisted but are retained either for the lifetime of the record in RAM or until a caller removes them.  This allows one-time computation of expensive derived values (e.g. unclipped mate start/end position) without adding special handling for each and every field within SAMRecord.

Left as two commits to highlight the two different changes made; happy to rebase at the end of the review.