### PR TITLE
Use buffered streams in binary codec to be much faster on network drives

### DIFF
--- a/src/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/java/htsjdk/samtools/util/BinaryCodec.java
@@ -101,10 +101,10 @@ public class BinaryCodec implements Closeable {
         try {
             this.isWriting = writing;
             if (this.isWriting) {
-                this.outputStream = new FileOutputStream(file);
+                this.outputStream = IOUtil.maybeBufferOutputStream(new FileOutputStream(file));
                 this.outputFileName = file.getName();
             } else {
-                this.inputStream = new FileInputStream(file);
+                this.inputStream = IOUtil.maybeBufferInputStream(new FileInputStream(file));
                 this.inputFileName = file.getName();
             }
         } catch (FileNotFoundException e) {


### PR DESCRIPTION
When converting an unsorted SAM to a sorted BAM with index creation on a NAS i noticed that the time it took was longer than expected.
Profiling revealed that almost all the time was spent in the BinaryCodec write methods.

Using buffered streams cuts the time required for that operation in half. 
This is for my use case where the files where stored on a NAS. The speed gain on a local HD or SSD is much lower.
But as i often use code like that where the data is not stored locally, but on a network drive, this will help to speed up some operations.