### PR TITLE
javascript filters from SAM and VCF

### DIFF
--- a/src/java/htsjdk/samtools/filter/AbstractJavascriptFilter.java
+++ b/src/java/htsjdk/samtools/filter/AbstractJavascriptFilter.java
@@ -1,0 +1,159 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Pierre Lindenbaum @yokofakun Institut du Thorax - Nantes - France
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.filter;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+
+import javax.script.Bindings;
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.RuntimeScriptException;
+
+/**
+ * Javascript filter with HEADER type containing TYPE records. contains two
+ * static method to get a SAM Read filter or a VariantFilter.
+ * 
+ * warning: tools, like galaxy, using this class are not safe because a script
+ * can access the filesystem.
+ * 
+ * @author Pierre Lindenbaum PhD
+ */
+public abstract class AbstractJavascriptFilter<HEADER, TYPE> {
+    public static final String DEFAULT_HEADER_KEY = "header";
+    /** compiled user script */
+    private CompiledScript script = null;
+
+    /** javascript bindings */
+    protected Bindings bindings;
+
+    /**
+     * constructor using a java.io.File script, compiles the script, puts
+     * 'header' in the bindings
+     */
+    protected AbstractJavascriptFilter(final File scriptFile, final HEADER header) throws IOException {
+        this(new FileReader(scriptFile), header);
+    }
+
+    /**
+     * constructor using a java.lang.String script, compiles the script, puts
+     * 'header' in the bindings
+     */
+    protected AbstractJavascriptFilter(final String scriptExpression, final HEADER header) {
+        this(new StringReader(scriptExpression), header);
+    }
+
+    /**
+     * Constructor, compiles script, put header in the bindings
+     * 
+     * @param scriptReader
+     *            reader containing the script. will be closed.
+     * @param header
+     *            the header to be injected in the javascript context
+     */
+    protected AbstractJavascriptFilter(final Reader scriptReader, final HEADER header) {
+        final ScriptEngineManager manager = new ScriptEngineManager();
+        /* get javascript engine */
+        final ScriptEngine engine = manager.getEngineByName("js");
+        if (engine == null) {
+            CloserUtil.close(scriptReader);
+            throw new RuntimeScriptException("The embedded 'javascript' engine is not available in java. "
+                    + "Do you use the SUN/Oracle Java Runtime ?");
+        }
+        if (scriptReader == null) {
+            throw new RuntimeScriptException("missing ScriptReader.");
+        }
+        
+        try {
+            final Compilable compilingEngine = getCompilable(engine);
+            this.script = compilingEngine.compile(scriptReader);
+        } catch (ScriptException err) {
+            throw new RuntimeScriptException("Script error in input", err);
+        } finally {
+            CloserUtil.close(scriptReader);
+        }
+
+        /*
+         * create the javascript bindings and put the file header in that
+         * context
+         */
+        this.bindings = new SimpleBindings();
+        this.bindings.put(DEFAULT_HEADER_KEY, header);
+    }
+
+    /** return a javascript engine as a Compilable */
+    private static Compilable getCompilable(final ScriptEngine engine) {
+        if (!(engine instanceof Compilable)) {
+            throw new IllegalStateException("The current javascript engine (" + engine.getClass()
+                    + ") cannot be cast to Compilable. " + "Do you use the SUN/Oracle Java Runtime ?");
+        }
+        return Compilable.class.cast(engine);
+    }
+
+    /** returns key used for header binding */
+    public String getHeaderKey() {
+        return DEFAULT_HEADER_KEY;
+    }
+
+    /** returns key used for record binding */
+    public abstract String getRecordKey();
+
+    /**
+     * Evaluates this predicate on the given argument
+     * 
+     * @param record
+     *            the record to test. It will be inject in the javascript
+     *            context using getRecordKey()
+     * @return true (keep) if the user script returned 1 or true, else false
+     *         (reject).
+     */
+    protected boolean accept(final TYPE record) {
+        try {
+            /* insert the record into the javascript context */
+            this.bindings.put(getRecordKey(), record);
+            /* get the result */
+            final Object result = this.script.eval(this.bindings);
+            if (result == null) {
+                return false;
+            } else if (result instanceof Boolean) {
+                return Boolean.TRUE.equals(result);
+            } else if (result instanceof Number) {
+                return (((Number) result).intValue() == 1);
+            } else {
+                return false;
+            }
+        } catch (ScriptException err) {
+            throw new RuntimeException(err);
+        }
+    }
+}

--- a/src/java/htsjdk/samtools/filter/JavascriptSamRecordFilter.java
+++ b/src/java/htsjdk/samtools/filter/JavascriptSamRecordFilter.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Pierre Lindenbaum @yokofakun Institut du Thorax - Nantes - France
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.filter;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+
+/**
+ * javascript based read filter
+ * 
+ * 
+ * The script puts the following variables in the script context:
+ *
+ * - 'record' a SamRecord (
+ * https://github.com/samtools/htsjdk/blob/master/src/java/htsjdk/samtools/
+ * SAMRecord.java ) - 'header' (
+ * https://github.com/samtools/htsjdk/blob/master/src/java/htsjdk/samtools/
+ * SAMFileHeader.java )
+ * 
+ * @author Pierre Lindenbaum PhD Institut du Thorax - INSERM - Nantes - France
+ */
+public class JavascriptSamRecordFilter extends AbstractJavascriptFilter<SAMFileHeader, SAMRecord>
+        implements SamRecordFilter {
+    /**
+     * constructor using a javascript File
+     * 
+     * @param scriptFile
+     *            the javascript file to be compiled
+     * @param header
+     *            the SAMHeader
+     */
+    public JavascriptSamRecordFilter(final File scriptFile, final SAMFileHeader header) throws IOException {
+        super(scriptFile, header);
+    }
+
+    /**
+     * constructor using a javascript expression
+     * 
+     * @param scriptExpression
+     *            the javascript expression to be compiled
+     * @param header
+     *            the SAMHeader
+     */
+    public JavascriptSamRecordFilter(final String scriptExpression, final SAMFileHeader header) {
+        super(scriptExpression, header);
+    }
+
+    /**
+     * constructor using a java.io.Reader
+     * 
+     * @param scriptReader
+     *            the javascript reader to be compiled. will be closed
+     * @param header
+     *            the SAMHeader
+     */
+    public JavascriptSamRecordFilter(final Reader scriptReader, final SAMFileHeader header) {
+        super(scriptReader, header);
+    }
+
+    /** return true of both records are filteredOut (AND) */
+    @Override
+    public boolean filterOut(final SAMRecord first, final SAMRecord second) {
+        return filterOut(first) && filterOut(second);
+    }
+
+    /** read is filtered out if the javascript program returns false */
+    @Override
+    public boolean filterOut(final SAMRecord record) {
+        return !accept(record);
+    }
+
+    @Override
+    public String getRecordKey() {
+        return "record";
+    }
+}

--- a/src/java/htsjdk/samtools/util/RuntimeScriptException.java
+++ b/src/java/htsjdk/samtools/util/RuntimeScriptException.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Pierre Lindenbaum PhD @yokofakun
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.util;
+
+
+/**
+ * Thrown by classes handling script engines like the javascript-based filters for SAM/VCF
+ */
+public class RuntimeScriptException extends RuntimeException {
+    public RuntimeScriptException() {
+    }
+
+    public RuntimeScriptException(final String s) {
+        super(s);
+    }
+
+    public RuntimeScriptException(final String s, final Throwable throwable) {
+        super(s, throwable);
+    }
+
+    public RuntimeScriptException(final Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/src/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilter.java
+++ b/src/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilter.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Pierre Lindenbaum @yokofakun Institut du Thorax - Nantes - France
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.variant.variantcontext.filter;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+
+import htsjdk.samtools.filter.AbstractJavascriptFilter;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.vcf.VCFHeader;
+
+/**
+ * javascript based variant filter The script puts the following variables in
+ * the script context:
+ *
+ * - 'header' a htsjdk.variant.vcf.VCFHeader 
+ * - 'variant' a htsjdk.variant.variantcontext.VariantContext
+ * 
+ * @author Pierre Lindenbaum PhD Institut du Thorax - INSERM - Nantes - France
+ */
+public class JavascriptVariantFilter extends AbstractJavascriptFilter<VCFHeader, VariantContext>
+        implements VariantContextFilter {
+	/**
+	 * constructor using a javascript File
+	 * 
+	 * @param scriptFile
+	 *            the javascript file to be compiled
+	 * @param header
+	 *            the SAMHeader
+	 */
+	public JavascriptVariantFilter(final File scriptFile, final VCFHeader header) throws IOException {
+		super(scriptFile, header);
+	}
+
+	/**
+     * constructor using a Reader
+     * 
+     * @param scriptReader
+     *            the reader for the script to be compiled. Will be closed
+     * @param header
+     *            the SAMHeader
+     */
+    public JavascriptVariantFilter(final Reader scriptReader, final VCFHeader header) throws IOException {
+        super(scriptReader, header);
+    }
+    
+	/**
+	 * constructor using a javascript expression
+	 * 
+	 * @param scriptExpression
+	 *            the javascript expression to be compiled
+	 * @param header
+	 *            the SAMHeader
+	 */
+	public JavascriptVariantFilter(final String scriptExpression, final VCFHeader header) {
+		super(scriptExpression, header);
+	}
+
+	/**
+	 * Determines whether a VariantContext matches this filter
+	 *
+	 * @param record
+	 *            the VariantContext to evaluate
+	 * @return true if accept(record) returned true
+	 */
+	@Override
+	public boolean test(final VariantContext record) {
+		return accept(record);
+	}
+
+	@Override
+	public String getRecordKey() {
+		return "variant";
+	}
+}

--- a/src/tests/java/htsjdk/samtools/filter/JavascriptSamRecordFilterTest.java
+++ b/src/tests/java/htsjdk/samtools/filter/JavascriptSamRecordFilterTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Pierre Lindenbaum @yokofakun Institut du Thorax - Nantes - France
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.filter;
+
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.util.CloserUtil;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author Pierre Lindenbaum PhD Institut du Thorax - INSERM - Nantes - France
+ */
+
+public class JavascriptSamRecordFilterTest {
+    final File testDir = new File("./testdata/htsjdk/samtools");
+
+    @DataProvider
+    public Object[][] jsData() {
+        return new Object[][] { { "unsorted.sam", "samFilter01.js", 8 }, { "unsorted.sam", "samFilter02.js", 10 }, };
+    }
+
+    @Test(dataProvider = "jsData")
+    public void testJavascriptFilters(final String samFile, final String javascriptFile, final int expectCount) {
+        final SamReaderFactory srf = SamReaderFactory.makeDefault();
+        final SamReader samReader = srf.open(new File(testDir, samFile));
+        final JavascriptSamRecordFilter filter;
+        try {
+            filter = new JavascriptSamRecordFilter(new File(testDir, javascriptFile),
+                    samReader.getFileHeader());    
+        } catch (IOException err) {
+            Assert.fail("Cannot read script",err);
+            return;
+        }
+        final SAMRecordIterator iter = samReader.iterator();
+        int count = 0;
+        while (iter.hasNext()) {
+            if (filter.filterOut(iter.next())) {
+                continue;
+            }
+            ++count;
+        }
+        iter.close();
+        CloserUtil.close(samReader);
+        Assert.assertEquals(count, expectCount, "Expected number of reads " + expectCount + " but got " + count);
+    }
+}

--- a/src/tests/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilterTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilterTest.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 Pierre Lindenbaum @yokofakun Institut du Thorax - Nantes - France
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.variant.variantcontext.filter;
+
+import htsjdk.variant.vcf.VCFFileReader;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author Pierre Lindenbaum PhD Institut du Thorax - INSERM - Nantes - France
+ */
+
+public class JavascriptVariantFilterTest {
+    final File testDir = new File("testdata/htsjdk/variant");
+
+    @DataProvider
+    public Object[][] jsData() {
+        return new Object[][] {
+                { "ILLUMINA.wex.broad_phase2_baseline.20111114.both.exome.genotypes.1000.vcf", "variantFilter01.js",61 },
+                { "ILLUMINA.wex.broad_phase2_baseline.20111114.both.exome.genotypes.1000.vcf", "variantFilter02.js",38 }, };
+    }
+
+    @Test(dataProvider = "jsData")
+    public void testJavascriptFilters(final String vcfFile, final String javascriptFile, final int expectCount) {
+        final File vcfInput = new File(testDir, vcfFile);
+        final File jsInput = new File(testDir, javascriptFile);
+        final VCFFileReader vcfReader = new VCFFileReader(vcfInput, false);
+        final JavascriptVariantFilter filter;
+        try {
+            filter = new JavascriptVariantFilter(jsInput, vcfReader.getFileHeader());
+        } catch (IOException err) {
+            Assert.fail("cannot read script "+jsInput, err);
+            vcfReader.close();
+            return;
+        }
+        final FilteringIterator iter = new FilteringIterator(vcfReader.iterator(), filter);
+        int count = 0;
+        while (iter.hasNext()) {
+            iter.next();
+            ++count;
+        }
+        iter.close();
+        vcfReader.close();
+        Assert.assertEquals(count, expectCount, "Expected number of variants " + expectCount + " but got " + count);
+    }
+}

--- a/testdata/htsjdk/samtools/samFilter01.js
+++ b/testdata/htsjdk/samtools/samFilter01.js
@@ -1,0 +1,2 @@
+/** answer to https://www.biostars.org/p/77802/#77966 */
+(record.referenceIndex==record.mateReferenceIndex && record.referenceIndex>=0 && record.readNegativeStrandFlag!=record.mateNegativeStrandFlag &&  ((record.mateNegativeStrandFlag && record.alignmentStart < record.mateAlignmentStart ) || (record.readNegativeStrandFlag && record.mateAlignmentStart < record.alignmentStart ) ))

--- a/testdata/htsjdk/samtools/samFilter02.js
+++ b/testdata/htsjdk/samtools/samFilter02.js
@@ -1,0 +1,9 @@
+/** accept record if second base of DNA is a A */
+function accept(r)
+	{
+	/* using substring instead of charAt because http://developer.actuate.com/community/forum/index.php?/topic/25434-javascript-stringcharati-wont-return-a-character/ */
+	return r.getReadString().length()>2 &&
+		r.getReadString().substring(1,2)=="A";
+	}
+
+accept(record);

--- a/testdata/htsjdk/variant/variantFilter01.js
+++ b/testdata/htsjdk/variant/variantFilter01.js
@@ -1,0 +1,2 @@
+/** get variant having position%2==0 */
+variant.getStart()%2 == 0;

--- a/testdata/htsjdk/variant/variantFilter02.js
+++ b/testdata/htsjdk/variant/variantFilter02.js
@@ -1,0 +1,20 @@
+/** prints a VARIATION if two samples at least have a DP>100 */ 
+function myfilterFunction(thevariant)
+    {
+    var samples=header.genotypeSamples;
+    var countOkDp=0;
+
+
+    for(var i=0; i< samples.size();++i)
+        {
+        var sampleName=samples.get(i);
+        if(! variant.hasGenotype(sampleName)) continue;
+        var genotype = thevariant.genotypes.get(sampleName);
+        if( ! genotype.hasDP()) continue;
+        var dp= genotype.getDP();
+        if(dp > 100 ) countOkDp++;
+        }
+    return (countOkDp>2)
+    }
+
+myfilterFunction(variant)


### PR DESCRIPTION
from picard :  https://github.com/broadinstitute/picard/pull/335

> Could you move the filters into htsjdk?

here are the new sources:
* wrote an abstract javascript filter and two implementations for SAM and VCF
* wrote two Tests for both format as well as some javascript files used by the test.
