### PR TITLE
adding ngs-java as a dependency for maven

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ val buildVersion = "1.141"
 
 organization := "com.github.samtools"
 
+libraryDependencies += "gov.nih.nlm.ncbi" % "ngs-java" % "1.2.2"
+
 libraryDependencies += "org.apache.commons" % "commons-jexl" % "2.1.1"
 
 libraryDependencies += "commons-logging" % "commons-logging" % "1.1.1"


### PR DESCRIPTION
adding a dependency on gov.nih.nlm.ncbi:ngs-java:1.2.2 so that it's available when released to maven central

closes #391 