### PR TITLE
Added support for a less-exhaustive (and less time-consuming) validat…

### DIFF
--- a/src/java/htsjdk/samtools/BamIndexValidator.java
+++ b/src/java/htsjdk/samtools/BamIndexValidator.java
@@ -25,13 +25,19 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.CloseableIterator;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
- * One crisp, informative sentence or noun phrase that explains
- * the concept modeled by the class.
- * <p/>
+ * Class to validate (at two different levels of thoroughness) the index for a BAM file.
+ *
  * This class is [<em>not</em>] thread safe [because it is immutable].
  */
 public class BamIndexValidator {
+
+    public enum IndexValidationStringency {
+        EXHAUSTIVE, LESS_EXHAUSTIVE, NONE
+    }
 
     public static int exhaustivelyTestIndex(final SamReader reader) { // throws Exception {
         // look at all chunk offsets in a linear index to make sure they are valid
@@ -40,37 +46,37 @@ public class BamIndexValidator {
 
             // content is from an existing bai file
             final CachingBAMFileIndex existingIndex = (CachingBAMFileIndex) reader.indexing().getBrowseableIndex(); // new CachingBAMFileIndex(inputBai, null);
-            final int n_ref = existingIndex.getNumberOfReferences();
+            final int numRefs = existingIndex.getNumberOfReferences();
 
             int chunkCount = 0;
             int indexCount = 0;
-            for (int i = 0; i < n_ref; i++) {
+            for (int i = 0; i < numRefs; i++) {
                 final BAMIndexContent content = existingIndex.getQueryResults(i);
                 for (final Chunk c : content.getAllChunks()) {
                     final CloseableIterator<SAMRecord> iter = ((SamReader.PrimitiveSamReaderToSamReaderAdapter) reader).iterator(new BAMFileSpan(c));
                     chunkCount++;
-                    BAMRecord b = null;
+                    SAMRecord sam = null;
                     try {
-                        b = (BAMRecord) iter.next();
+                        sam = iter.next();
                         iter.close();
                     } catch (final Exception e) {
-                        throw new SAMException("Exception in BamIndexValidator. Last good record " + b + " in chunk " + c + " chunkCount=" + chunkCount, e);
+                        throw new SAMException("Exception in BamIndexValidator. Last good record " + sam + " in chunk " + c + " chunkCount=" + chunkCount, e);
                     }
                 }
                 // also seek to every position in the linear index
                 // final BAMRecordCodec bamRecordCodec = new BAMRecordCodec(reader.getFileHeader());
                 // bamRecordCodec.setInputStream(reader.getInputStream());
 
-                LinearIndex linearIndex = content.getLinearIndex();
-                for (long l : linearIndex.getIndexEntries()) {
+                final LinearIndex linearIndex = content.getLinearIndex();
+                for (final long l : linearIndex.getIndexEntries()) {
                     try {
                         if (l != 0) {
                             final CloseableIterator<SAMRecord> iter = ((SamReader.PrimitiveSamReaderToSamReaderAdapter) reader).iterator(new BAMFileSpan(new Chunk(l, l + 1)));
-                            BAMRecord b = (BAMRecord) iter.next();   // read the first record identified by the linear index
+                            final SAMRecord sam = iter.next();   // read the first record identified by the linear index
                             indexCount++;
                             iter.close();
                         }
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         throw new SAMException("Exception in BamIndexValidator. Linear index access failure " + l + " indexCount=" + indexCount, e);
                     }
 
@@ -84,4 +90,62 @@ public class BamIndexValidator {
         return 0;
     }
 
+    /**
+     * A less time-consuming index validation that only looks at the first and last references in the index
+     * and the first and last chunks in each of those
+     *
+     * @param reader
+     * @return # of chunks examined, or 0 if there is no browseable index for the reader
+     */
+    public static int lessExhaustivelyTestIndex(final SamReader reader) {
+        // look at all chunk offsets in a linear index to make sure they are valid
+        if (reader.indexing().hasBrowseableIndex()) {
+
+            // content is from an existing bai file
+            final CachingBAMFileIndex existingIndex = (CachingBAMFileIndex) reader.indexing().getBrowseableIndex();
+            final int numRefs = existingIndex.getNumberOfReferences();
+
+            int chunkCount = 0;
+            int indexCount = 0;
+            for (int i = 0; i < numRefs; i++) {
+
+                final BAMIndexContent content = existingIndex.getQueryResults(i);
+
+                final List<Chunk> chunks = content.getAllChunks();
+                final int numChunks = chunks.size();
+                // We are looking only at the first and last chunks
+                for (final int chunkNo : Arrays.asList(0, numChunks - 1)) {
+                    chunkCount++;
+
+                    final Chunk c = chunks.get(chunkNo);
+                    final CloseableIterator<SAMRecord> iter = ((SamReader.PrimitiveSamReaderToSamReaderAdapter) reader).iterator(new BAMFileSpan(c));
+                    try {
+                        final SAMRecord sam = iter.next();
+                        iter.close();
+                    } catch (final Exception e) {
+                        throw new SAMException("Exception querying chunk " + chunkNo + " from reference index " + i, e);
+                    }
+                }
+
+                // also seek to first and last position in the linear index
+                final long linearIndexEntries[] = content.getLinearIndex().getIndexEntries();
+                for (final int binNo : Arrays.asList(0, linearIndexEntries.length - 1)) {
+                    indexCount++;
+                    final long l = linearIndexEntries[binNo];
+                    try {
+                        if (l != 0) {
+                            final CloseableIterator<SAMRecord> iter = ((SamReader.PrimitiveSamReaderToSamReaderAdapter) reader).iterator(new BAMFileSpan(new Chunk(l, l + 1)));
+                            final SAMRecord sam = iter.next();   // read the first record identified by the linear index
+                            iter.close();
+                        }
+                    } catch (final Exception e) {
+                        throw new SAMException("Exception in BamIndexValidator. Linear index access failure " + l + " indexCount=" + indexCount, e);
+                    }
+                }
+            }
+            return chunkCount;
+        }
+        // else it's not a bam file with a browseable index
+        return 0;
+    }
 }


### PR DESCRIPTION
…ion of the index, which tests only the first and last references, rather than all of them.  (First step towards addressing https://github.com/broadinstitute/picard/issues/346)