### PR TITLE
Require a reference for CRAM files, add javadoc and some tests.

### DIFF
--- a/src/java/htsjdk/samtools/CRAMFileWriter.java
+++ b/src/java/htsjdk/samtools/CRAMFileWriter.java
@@ -28,7 +28,6 @@ import java.util.Set;
 public class CRAMFileWriter extends SAMFileWriterImpl {
     private CRAMContainerStreamWriter cramContainerStream;
     private final SAMFileHeader samFileHeader;
-    private ReferenceSource source;
     private final String fileName;
 
     private static final Log log = Log.getInstance(CRAMFileWriter.class);
@@ -37,59 +36,71 @@ public class CRAMFileWriter extends SAMFileWriterImpl {
      * Create a CRAMFileWriter on an output stream. Requires input records to be presorted to match the
      * sort order defined by the input {@code samFileHeader}.
      *
-     * @param outputStream where to write the output.
-     * @param source reference source
-     * @param samFileHeader {@link SAMFileHeader} to be used. Sort order is determined by the sortOrder property of this arg.
+     * @param outputStream where to write the output. Can not be null.
+     * @param referenceSource reference source. Can not be null.
+     * @param samFileHeader {@link SAMFileHeader} to be used. Can not be null. Sort order is determined by the sortOrder property of this arg.
      * @param fileName used for display in error messages
+     *
+     * @throws IllegalArgumentException if the {@code outputStream}, {@code referenceSource} or {@code samFileHeader} are null
      */
     public CRAMFileWriter(
             final OutputStream outputStream,
-            final ReferenceSource source,
+            final ReferenceSource referenceSource,
             final SAMFileHeader samFileHeader,
             final String fileName)
     {
-        this(outputStream, null, source, samFileHeader, fileName); // defaults to presorted == true
+        this(outputStream, null, referenceSource, samFileHeader, fileName); // defaults to presorted == true
     }
 
     /**
-     * Create a CRAMFileWriter and index on output streams. Requires input records to be presorted to match the
+     * Create a CRAMFileWriter and optional index on output streams. Requires input records to be presorted to match the
      * sort order defined by the input {@code samFileHeader}.
      *
-     * @param outputStream where to write the output.
+     * @param outputStream where to write the output. Can not be null.
      * @param indexOS where to write the output index. Can be null if no index is required.
-     * @param source reference source
-     * @param samFileHeader {@link SAMFileHeader} to be used. Sort order is determined by the sortOrder property of this arg.
+     * @param referenceSource reference source
+     * @param samFileHeader {@link SAMFileHeader} to be used. Can not be null. Sort order is determined by the sortOrder property of this arg.
      * @param fileName used for display in error messages
+     *
+     * @throws IllegalArgumentException if the {@code outputStream}, {@code referenceSource} or {@code samFileHeader} are null
      */
     public CRAMFileWriter(
             final OutputStream outputStream,
             final OutputStream indexOS,
-            final ReferenceSource source,
+            final ReferenceSource referenceSource,
             final SAMFileHeader samFileHeader,
             final String fileName)
     {
-        this(outputStream, indexOS, true, source, samFileHeader, fileName); // defaults to presorted==true
+        this(outputStream, indexOS, true, referenceSource, samFileHeader, fileName); // defaults to presorted==true
     }
 
     /**
-     * Create a CRAMFileWriter and index on output streams.
+     * Create a CRAMFileWriter and optional index on output streams.
      *
-     * @param outputStream where to write the output.
+     * @param outputStream where to write the output. Can not be null.
      * @param indexOS where to write the output index. Can be null if no index is required.
      * @param presorted if true records written to this writer must already be sorted in the order specified by the header
-     * @param source reference source
-     * @param samFileHeader {@link SAMFileHeader} to be used. Sort order is determined by the sortOrder property of this arg.
+     * @param referenceSource reference source
+     * @param samFileHeader {@link SAMFileHeader} to be used. Can not be null. Sort order is determined by the sortOrder property of this arg.
      * @param fileName used for display in error message display
+     *
+     * @throws IllegalArgumentException if the {@code outputStream}, {@code referenceSource} or {@code samFileHeader} are null
      */
     public CRAMFileWriter(final OutputStream outputStream, final OutputStream indexOS, final boolean presorted,
-                          final ReferenceSource source, final SAMFileHeader samFileHeader, final String fileName) {
+                          final ReferenceSource referenceSource, final SAMFileHeader samFileHeader, final String fileName) {
+        if (outputStream == null) {
+            throw new IllegalArgumentException("CRAMWriter output stream can not be null.");
+        }
+        if (referenceSource == null) {
+            throw new IllegalArgumentException("A reference is required for CRAM writers");
+        }
+        if (samFileHeader == null) {
+            throw new IllegalArgumentException("A valid SAMFileHeader is required for CRAM writers");
+        }
         this.samFileHeader = samFileHeader;
         this.fileName = fileName;
-        if (this.source == null) {
-            this.source = new ReferenceSource(Defaults.REFERENCE_FASTA);
-        }
         setSortOrder(samFileHeader.getSortOrder(), presorted);
-        cramContainerStream = new CRAMContainerStreamWriter(outputStream, indexOS, source, samFileHeader, fileName);
+        cramContainerStream = new CRAMContainerStreamWriter(outputStream, indexOS, referenceSource, samFileHeader, fileName);
         setHeader(samFileHeader);
     }
 

--- a/src/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/java/htsjdk/samtools/SamReaderFactory.java
@@ -265,7 +265,9 @@ public abstract class SamReaderFactory {
                     } else if (SamStreams.isGzippedSAMFile(bufferedStream)) {
                         primitiveSamReader = new SAMTextReader(new GZIPInputStream(bufferedStream), validationStringency, this.samRecordFactory);
                     } else if (SamStreams.isCRAMFile(bufferedStream)) {
-                        if (referenceSource == null && Defaults.REFERENCE_FASTA != null) referenceSource = new ReferenceSource(Defaults.REFERENCE_FASTA);
+                        if (referenceSource == null) {
+                            referenceSource = ReferenceSource.getDefaultCRAMReferenceSource();
+                        }
                         if (sourceFile == null || !sourceFile.isFile()) {
                             primitiveSamReader = new CRAMFileReader(bufferedStream, indexFile, referenceSource, validationStringency);
                         } else {

--- a/src/java/htsjdk/samtools/cram/build/CramNormalizer.java
+++ b/src/java/htsjdk/samtools/cram/build/CramNormalizer.java
@@ -49,6 +49,9 @@ public class CramNormalizer {
     }
 
     public CramNormalizer(final SAMFileHeader header, final ReferenceSource referenceSource) {
+        if (referenceSource == null) {
+            throw new IllegalArgumentException("A reference is required.");
+        }
         this.header = header;
         this.referenceSource = referenceSource;
     }

--- a/src/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -63,6 +63,43 @@ public class ReferenceSource {
         this.rsFile = rsFile;
     }
 
+    /**
+     * Attempts to construct a default ReferenceSource for use with CRAM files when
+     * one has not been explicitly provided.
+     *
+     * @return ReferenceSource if one can be acquired. Guaranteed to no be null if none
+     * of the listed exceptions is thrown.
+     * @throws IllegalStateException if no default reference source can be acquired
+     * @throws IllegalArgumentException if the reference_fasta environment variable refers to a
+     * a file that doesn't exist
+     *<p>
+     * Construct a default reference source to use when an explicit reference has not been
+     * provided by checking for fallback sources in this order:
+     *<p><ul>
+     * <li>Defaults.REFERENCE_FASTA - the value of the system property "reference_fasta". If set,
+     * must refer to a valid reference file.</li>
+     * <li>ENA Reference Service if it is enabled</li>
+     * </ul>
+     */
+     public static ReferenceSource getDefaultCRAMReferenceSource() {
+        if (null != Defaults.REFERENCE_FASTA) {
+            if (Defaults.REFERENCE_FASTA.exists()) {
+                return new ReferenceSource(Defaults.REFERENCE_FASTA);
+            }
+            else {
+                throw new IllegalArgumentException(
+                        "The file specified by the reference_fasta property does not exist: " + Defaults.REFERENCE_FASTA.getName());
+            }
+        }
+        else if (Defaults.USE_CRAM_REF_DOWNLOAD) {
+            return new ReferenceSource();
+        }
+        else {
+            throw new IllegalStateException(
+                    "A valid CRAM reference was not supplied and one cannot be acquired via the property settings reference_fasta or use_cram_ref_download");
+        }
+    }
+
     public void clearCache() {
         cacheW.clear();
     }

--- a/src/tests/java/htsjdk/samtools/CRAMFileReaderTest.java
+++ b/src/tests/java/htsjdk/samtools/CRAMFileReaderTest.java
@@ -1,0 +1,163 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools;
+
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
+import htsjdk.samtools.seekablestream.SeekableFileStream;
+import htsjdk.samtools.util.Log;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Additional tests for CRAMFileReader are in CRAMFileIndexTest
+ */
+public class CRAMFileReaderTest {
+
+    private static final File TEST_DATA_DIR = new File("testdata/htsjdk/samtools");
+
+    @BeforeClass
+    public void initClass() {
+        Log.setGlobalLogLevel(Log.LogLevel.ERROR);
+    }
+
+    private ReferenceSource createReferenceSource() {
+        byte[] refBases = new byte[10 * 10];
+        Arrays.fill(refBases, (byte) 'A');
+        InMemoryReferenceSequenceFile rsf = new InMemoryReferenceSequenceFile();
+        rsf.add("chr1", refBases);
+        return new ReferenceSource(rsf);
+    }
+
+    // constructor 1: CRAMFileReader(final File cramFile, final InputStream inputStream)
+
+    @Test(description = "Test CRAMReader 1 reference required", expectedExceptions = IllegalStateException.class)
+    public void testCRAMReader1_ReferenceRequired() {
+        File file = new File(TEST_DATA_DIR, "cram_with_crai_index.cram");
+        InputStream bis = null;
+        // assumes that reference_fasta property is not set and the download service is not enabled
+        new CRAMFileReader(file, bis);
+    }
+
+    // constructor 2: CRAMFileReader(final File cramFile, final InputStream inputStream, final ReferenceSource referenceSource)
+
+    @Test(description = "Test CRAMReader 2 reference required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader2ReferenceRequired() {
+        File file = new File(TEST_DATA_DIR, "cram_with_crai_index.cram");
+        InputStream bis =  null;
+        new CRAMFileReader(file, bis, null);
+    }
+
+    @Test(description = "Test CRAMReader 2 input required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader2_InputRequired() {
+        File file = null;
+        InputStream bis =  null;
+        new CRAMFileReader(file, bis, createReferenceSource());
+    }
+
+    // constructor 3: CRAMFileReader(final File cramFile, final File indexFile, final ReferenceSource referenceSource)
+
+    @Test(description = "Test CRAMReader 3 reference required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader3_RequiredReference() {
+        File inputFile = new File(TEST_DATA_DIR, "cram_with_crai_index.cram");
+        File indexFile = null;
+        ReferenceSource refSource = null;
+        new CRAMFileReader(inputFile, indexFile, refSource);
+    }
+
+    @Test(description = "Test CRAMReader 3 input required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader3_InputRequirted() {
+        File inputFile = null;
+        File indexFile = null;
+        ReferenceSource refSource = null;
+        new CRAMFileReader(inputFile, indexFile, refSource);
+    }
+
+    // constructor 4: CRAMFileReader(final File cramFile, final ReferenceSource referenceSource)
+
+    @Test(description = "Test CRAMReader 4 reference required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader4_ReferenceRequired() {
+        File inputFile = new File(TEST_DATA_DIR, "cram_with_crai_index.cram");
+        ReferenceSource refSource = null;
+        new CRAMFileReader(inputFile, refSource);
+    }
+
+    @Test(description = "Test CRAMReader 4 input required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader4_InputRequired() {
+        File inputFile = null;
+        new CRAMFileReader(inputFile, createReferenceSource());
+    }
+
+    // constructor 5: CRAMFileReader(final InputStream inputStream, final SeekableStream indexInputStream,
+    //          final ReferenceSource referenceSource, final ValidationStringency validationStringency)
+    @Test(description = "Test CRAMReader 5 reference required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader5_ReferenceRequired() throws IOException {
+        InputStream bis = new ByteArrayInputStream(new byte[0]);
+        SeekableFileStream sfs = null;
+        ReferenceSource refSource = null;
+        new CRAMFileReader(bis, sfs, refSource, ValidationStringency.STRICT);
+    }
+
+    @Test(description = "Test CRAMReader 5 input required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader5_InputRequired() throws IOException {
+        InputStream bis = null;
+        SeekableFileStream sfs = null;
+        new CRAMFileReader(bis, sfs, createReferenceSource(), ValidationStringency.STRICT);
+    }
+
+    // constructor 6: CRAMFileReader(final InputStream stream, final File indexFile, final ReferenceSource referenceSource,
+    //                final ValidationStringency validationStringency)
+    @Test(description = "Test CRAMReader 6 reference required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader6_ReferenceRequired() throws IOException {
+        InputStream bis = new ByteArrayInputStream(new byte[0]);
+        File file = null;
+        ReferenceSource refSource = null;
+        new CRAMFileReader(bis, file, refSource, ValidationStringency.STRICT);
+    }
+
+    @Test(description = "Test CRAMReader 6 input required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader6_InputRequired() throws IOException {
+        InputStream bis = null;
+        File file = null;
+        ReferenceSource refSource = null;
+        new CRAMFileReader(bis, file, createReferenceSource(), ValidationStringency.STRICT);
+    }
+
+    // constructor 7: CRAMFileReader(final File cramFile, final File indexFile, final ReferenceSource referenceSource,
+    //                final ValidationStringency validationStringency)
+    @Test(description = "Test CRAMReader 7 reference required", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMReader7_ReferenceRequired() throws IOException {
+        InputStream bis = new ByteArrayInputStream(new byte[0]);
+        File file = new File(TEST_DATA_DIR, "cram_with_crai_index.cram");
+        ReferenceSource refSource = null;
+        new CRAMFileReader(file, file, refSource, ValidationStringency.STRICT);
+    }
+
+}

--- a/src/tests/java/htsjdk/samtools/CramFileWriterTest.java
+++ b/src/tests/java/htsjdk/samtools/CramFileWriterTest.java
@@ -205,6 +205,27 @@ public class CramFileWriterTest {
         Assert.assertTrue(indexStream.size() != 0);
     }
 
+    @Test(description = "Test CRAMWriter constructor reference required 1", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMWriterConstructorRequiredReference_1() {
+        final SAMFileHeader header = createSAMHeader(SAMFileHeader.SortOrder.coordinate);
+        final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        new CRAMFileWriter(outStream, null, header, null);
+    }
+
+    @Test(description = "Test CRAMWriter constructor reference required 2", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMWriterConstructorRequiredReference_2() {
+        final SAMFileHeader header = createSAMHeader(SAMFileHeader.SortOrder.coordinate);
+        final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        new CRAMFileWriter(outStream, null, null, header, null);
+    }
+
+    @Test(description = "Test CRAMWriter constructor reference required 3", expectedExceptions = IllegalArgumentException.class)
+    public void testCRAMWriterConstructorRequiredReference_3() {
+        final SAMFileHeader header = createSAMHeader(SAMFileHeader.SortOrder.coordinate);
+        final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        new CRAMFileWriter(outStream, null, true, null, header, null);
+    }
+
     @Test
     public void test_roundtrip_tlen_preserved() throws IOException {
         SamReader reader = SamReaderFactory.make().open(new File("testdata/htsjdk/samtools/cram_tlen_reads.sorted.sam"));

--- a/src/tests/java/htsjdk/samtools/SAMFileReaderTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFileReaderTest.java
@@ -142,7 +142,7 @@ public class SAMFileReaderTest {
         return scenarios;
     }
 
-    @Test(dataProvider = "cramNegativeTestCases", expectedExceptions=CRAMException.class)
+    @Test(dataProvider = "cramNegativeTestCases", expectedExceptions=IllegalStateException.class)
     public void testReferenceRequiredForCRAM(final String inputFile) {
         final File input = new File(TEST_DATA_DIR, inputFile);
         final SamReader reader = SamReaderFactory.makeDefault().open(input);


### PR DESCRIPTION
Per the discussion in https://github.com/samtools/htsjdk/issues/362, require a valid reference source for CRAMReader, CRAMWriter, CRAMIterator and CRAMNormalizer. The SAMReader factories now use a method to create a default reference source (which throws if the reference_fasta property is not set and the download services isn't enabled) if one is not supplied directly, and the CRAM* classes throw if passed a null reference source.
