### PR TITLE
Added checks that can very early report that path is not an SRA archive and not load SRA engine and its libraries

### DIFF
--- a/src/tests/java/htsjdk/samtools/sra/SRAAccessionTest.java
+++ b/src/tests/java/htsjdk/samtools/sra/SRAAccessionTest.java
@@ -1,0 +1,33 @@
+package htsjdk.samtools.sra;
+
+import htsjdk.samtools.sra.SRAAccession;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for SRAAccession logic
+ */
+public class SRAAccessionTest {
+
+    @DataProvider(name = "isValidAccData")
+    public Object[][] getIsValidAccData() {
+        return new Object[][] {
+            { "SRR000123", true },
+            { "DRR000001", true },
+            { "SRR000000", false },
+            { "testdata/htsjdk/samtools/sra/test_archive.sra", true },
+            { "testdata/htsjdk/samtools/compressed.bam", false },
+            { "testdata/htsjdk/samtools/uncompressed.sam", false },
+        };
+    }
+
+    @Test(dataProvider = "isValidAccData")
+    public void testIsValidAcc(String accession, boolean isValid) {
+        if (!SRAAccession.isSupported()) return;
+
+        Assert.assertEquals(isValid, SRAAccession.isValid(accession));
+    }
+
+}


### PR DESCRIPTION
We implemented several checks to see if the path looks like an SRA archive and if not fail immediately and try other readers.

This PR should address issues for users working with non-SRA data sources and limited internet connections. (for instance, that one: https://github.com/broadinstitute/picard/issues/354)

The file recognition in `SamReaderFactory` will work as follows:

1. Checks if the file is a BAM file and then loads it;
2. Checks if the file is a CRAM file and then loads it;
3. Checks if the file is:
  * An existing file, then checks its header to match SRA signature. If matched - load SRA engine and pass the file to it
  * Non-existing file path, then checks if it matches to SRA accession pattern (`^[SED]RR[0-9]{6,9}$`). If matched - load SRA engine and make it check if that was a real SRA accession
4. Tries to read the file as a text SAM file

You can also pass `InputResource` of type `InputResource.Type.SRA_ACCESSION`
 to `SamReaderFactory`, then we will load SRA engine and try to read that `InputResource` as SRA (because you specified SRA type explicitly).