### PR TITLE
Added indel support to SamLocusIterator

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -217,12 +217,11 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
                                        final int defaultQuality) throws SAMException {
         final SAMRecord rec = new SAMRecord(this.header);
         rec.setReadName(name);
-        if (chroms.length <= contig) {
-            throw new SAMException("Contig too big [" + chroms.length + " < " + contig);
+        if (header.getSequenceDictionary().size() <= contig) {
+            throw new SAMException("Contig too big [" + header.getSequenceDictionary().size() + " < " + contig);
         }
         if (0 <= contig) {
             rec.setReferenceIndex(contig);
-            rec.setReferenceName(chroms[contig]);
             rec.setAlignmentStart(start);
         }
         if (!recordUnmapped) {

--- a/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
@@ -24,6 +24,9 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.AlignmentBlock;
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
@@ -75,12 +78,16 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
 
     /**
      * The unit of iteration.  Holds information about the locus (the SAMSequenceRecord and 1-based position
-     * on the reference), plus List of ReadAndOffset objects, one for each read that overlaps the locus
+     * on the reference), plus List of ReadAndOffset objects, one for each read that overlaps the locus;
+     * two more List_s_ of ReadAndOffset objects include reads that overlap the locus with insertions and deletions
+     * respectively
      */
     public static final class LocusInfo implements Locus {
         private final SAMSequenceRecord referenceSequence;
         private final int position;
         private final List<RecordAndOffset> recordAndOffsets = new ArrayList<RecordAndOffset>(100);
+        private List<RecordAndOffset> deletedInRecord = null;
+        private List<RecordAndOffset> insertedInRecord = null;
 
         LocusInfo(final SAMSequenceRecord referenceSequence, final int position) {
             this.referenceSequence = referenceSequence;
@@ -92,14 +99,49 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
             recordAndOffsets.add(new RecordAndOffset(read, position));
         }
 
+        /** Accumulate info for one read with a deletion */
+        public void addDeleted(final SAMRecord read, int previousPosition) {
+            if(deletedInRecord == null) {
+                deletedInRecord = new ArrayList<>();
+            }
+            deletedInRecord.add(new RecordAndOffset(read, previousPosition));
+        }
+
+        /**
+         * Accumulate info for one read with an insertion.
+         * For this locus, the reads in the insertion are included also in recordAndOffsets
+         */
+        public void addInserted(final SAMRecord read, int firstPosition) {
+            if(insertedInRecord == null) {
+                insertedInRecord = new ArrayList<>();
+            }
+            insertedInRecord.add(new RecordAndOffset(read, firstPosition));
+        }
+
         public int getSequenceIndex() { return referenceSequence.getSequenceIndex(); }
 
         /** @return 1-based reference position */
         public int getPosition() { return position; }
         public List<RecordAndOffset> getRecordAndPositions() { return Collections.unmodifiableList(recordAndOffsets); }
+        public List<RecordAndOffset> getDeletedInRecord() {
+            return (deletedInRecord == null) ? Collections.emptyList() : Collections.unmodifiableList(deletedInRecord);
+        }
+        public List<RecordAndOffset> getInsertedInRecord() {
+            return (insertedInRecord == null) ? Collections.emptyList() : Collections.unmodifiableList(insertedInRecord);
+        }
         public String getSequenceName() { return referenceSequence.getSequenceName(); }
         @Override public String toString() { return referenceSequence.getSequenceName() + ":" + position; }
         public int getSequenceLength() {return referenceSequence.getSequenceLength();}
+
+        /**
+         * @return <code>true</code> if all the RecordAndOffset lists are empty;
+         *         <code>false</code> if at least one have records
+         */
+        public boolean isEmpty() {
+            return recordAndOffsets.isEmpty() &&
+                    (deletedInRecord == null || deletedInRecord.isEmpty()) &&
+                    (insertedInRecord == null || insertedInRecord.isEmpty());
+        }
     }
 
 
@@ -154,6 +196,12 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
 
     // Set to true when we have enforced the accumulation limit for the first time
     private boolean enforcedAccumulationLimit = false;
+
+    /**
+     * If true, include indels in the LocusInfo
+     */
+    private boolean includeIndels = false;
+
 
     // When there is a target mask, these members remember the last locus for which a LocusInfo has been
     // returned, so that any uncovered locus in the target mask can be covered by a 0-coverage LocusInfo
@@ -300,8 +348,14 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
                 continue;
             }
 
-            final Locus alignmentStart = new LocusImpl(rec.getReferenceIndex(), rec.getAlignmentStart());
-
+            int start = rec.getAlignmentStart();
+            // only if we are including indels and the record does not start in the first base of the reference
+            // the stop locus to populate the queue is not the same if the record starts with an insertion
+            if(includeIndels && start != 1 && startWithInsertion(rec.getCigar())) {
+                // the start to populate is one less
+                start--;
+            }
+            final Locus alignmentStart = new LocusImpl(rec.getReferenceIndex(), start);
             // emit everything that is before the start of the current read, because we know no more
             // coverage will be accumulated for those loci.
             while (!accumulator.isEmpty() && locusComparator.compare(accumulator.get(0), alignmentStart) < 0) {
@@ -316,17 +370,22 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
             }
 
             // at this point, either the accumulator list is empty or the head should
-            // be the same position as the first base of the read
+            // be the same position as the first base of the read (or insertion if first)
             if (!accumulator.isEmpty()) {
                 if (accumulator.get(0).getSequenceIndex() != rec.getReferenceIndex() ||
-                        accumulator.get(0).position != rec.getAlignmentStart()) {
+                        accumulator.get(0).position != start) {
                     throw new IllegalStateException("accumulator should be empty or aligned with current SAMRecord");
                 }
             }
 
             // Store the loci for the read in the accumulator
-            if (!surpassedAccumulationThreshold()) accumulateSamRecord(rec);
-
+            if (!surpassedAccumulationThreshold()) {
+                accumulateSamRecord(rec);
+                // Store the indels if requested
+                if(includeIndels) {
+                    accumulateIndels(rec);
+                }
+            }
             samIterator.next();
         }
 
@@ -369,19 +428,29 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
     }
 
     /**
+     * Check if cigar start with an insertion, ignoring softclip
+     * @param cigar the cigar element
+     * @return <code>true</code> if it start with an insertion; <code>false</code> otherwise
+     */
+    private static boolean startWithInsertion(final Cigar cigar) {
+        for(final CigarElement element: cigar.getCigarElements()) {
+            switch(element.getOperator()) {
+                case I: return true;
+                case S: continue;
+                default: break;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Capture the loci covered by the given SAMRecord in the LocusInfos in the accumulator,
      * creating new LocusInfos as needed.
      */
     private void accumulateSamRecord(final SAMRecord rec) {
-        final SAMSequenceRecord ref = getReferenceSequence(rec.getReferenceIndex());
-        final int alignmentStart  = rec.getAlignmentStart();
-        final int alignmentEnd    = rec.getAlignmentEnd();
-        final int alignmentLength = alignmentEnd - alignmentStart;
 
-        // Ensure there are LocusInfos up to and including this position
-        for (int i=accumulator.size(); i<=alignmentLength; ++i) {
-            accumulator.add(new LocusInfo(ref, alignmentStart + i));
-        }
+        // get the accumulator offset
+        int accOffset = getAccumulatorOffset(rec);
 
         final int minQuality = getQualityScoreCutoff();
         final boolean dontCheckQualities = minQuality == 0;
@@ -397,13 +466,48 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
                 // 0-based offset into the read of the current base
                 final int readOffset = readStart + i - 1;
 
-                // 0-based offset from the aligned position of the first base in the read to the aligned position of the current base.
-                final int refOffset =  refStart + i - alignmentStart;
-
                 // if the quality score cutoff is met, accumulate the base info
                 if (dontCheckQualities || baseQualities[readOffset] >= minQuality) {
+                    // 0-based offset from the aligned position of the first base in the read to the aligned position of the current base.
+                    final int refOffset = refStart + i - accOffset;
                     accumulator.get(refOffset).add(rec, readOffset);
                 }
+            }
+        }
+    }
+
+    /**
+     * Requires that the accumulator for the record is previously fill with
+     * {@link #accumulateSamRecord(htsjdk.samtools.SAMRecord)}.
+     * Include in the LocusInfo the indels; the quality threshold does not affect insertions/deletions
+     */
+    private void accumulateIndels(final SAMRecord rec) {
+        // get the cigar elements
+        final List<CigarElement> cigar = rec.getCigar().getCigarElements();
+        // 0-based offset into the read of the current base
+        int readBase = 0;
+        // 0-based offset for the reference of the current base
+        // the accumulator could have the previous position because an indel is accumulating
+        int refBase = rec.getAlignmentStart() - getAccumulatorOffset(rec);
+        // iterate over the cigar element
+        for (int elementIndex = 0; elementIndex < cigar.size(); elementIndex++) {
+            final CigarElement e = cigar.get(elementIndex);
+            final CigarOperator operator = e.getOperator();
+            if (operator.equals(CigarOperator.I)) {
+                System.err.println("");
+                // insertions are included in the previous base
+                accumulator.get(refBase - 1).addInserted(rec, readBase);
+                readBase += e.getLength();
+            } else if (operator.equals(CigarOperator.D)) {
+                // accumulate for each position that spans the deletion
+                for (int i = 0; i < e.getLength(); i++) {
+                    // the offset is the one for the previous base
+                    accumulator.get(refBase + i).addDeleted(rec, readBase - 1);
+                }
+                refBase += e.getLength();
+            } else {
+                if (operator.consumesReadBases()) readBase += e.getLength();
+                if (operator.consumesReferenceBases()) refBase += e.getLength();
             }
         }
     }
@@ -456,8 +560,8 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
      */
     private void populateCompleteQueue(final Locus stopBeforeLocus) {
         // Because of gapped alignments, it is possible to create LocusInfo's with no reads associated with them.
-        // Skip over these.
-        while (!accumulator.isEmpty() && accumulator.get(0).getRecordAndPositions().isEmpty() &&
+        // Skip over these if not including indels
+        while (!accumulator.isEmpty() && accumulator.get(0).isEmpty() &&
                locusComparator.compare(accumulator.get(0), stopBeforeLocus) < 0) {
             accumulator.remove(0);
         }
@@ -492,6 +596,29 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
 
         lastReferenceSequence = sequenceIndex;
         lastPosition = locusInfo.getPosition();
+    }
+
+    /**
+     * Ensure that the queue is populated and get the accumulator offset for the current record
+     */
+    private int getAccumulatorOffset(SAMRecord rec) {
+        final SAMSequenceRecord ref = getReferenceSequence(rec.getReferenceIndex());
+        final int alignmentStart  = rec.getAlignmentStart();
+        final int alignmentEnd    = rec.getAlignmentEnd();
+        final int alignmentLength = alignmentEnd - alignmentStart;
+        // get the offset for an insertion if we are tracking them
+        final int insOffset =
+                (includeIndels && startWithInsertion(rec.getCigar())) ? 1 : 0;
+        // if there is an insertion in the first base and it is not tracked in the accumulator, add it
+        if (insOffset == 1 && accumulator.isEmpty()) {
+            accumulator.add(new LocusInfo(ref, alignmentStart - 1));
+        }
+
+        // Ensure there are LocusInfos up to and including this position
+        for (int i=accumulator.size(); i<=alignmentLength+insOffset; ++i) {
+            accumulator.add(new LocusInfo(ref, alignmentStart + i - insOffset));
+        }
+        return alignmentStart - insOffset;
     }
 
     private SAMSequenceRecord getReferenceSequence(final int referenceSequenceIndex) {
@@ -548,5 +675,14 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
      * cap is applied (the first maxReadsToAccumulatePerLocus reads are kept and all subsequent ones are dropped).
      */
     public void setMaxReadsToAccumulatePerLocus(final int maxReadsToAccumulatePerLocus) { this.maxReadsToAccumulatePerLocus = maxReadsToAccumulatePerLocus; }
+
+    public boolean isIncludeIndels() {
+        return includeIndels;
+    }
+
+    public void setIncludeIndels(final boolean includeIndels) {
+        this.includeIndels = includeIndels;
+    }
+
 }
 

--- a/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
@@ -107,6 +107,9 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
         /** @return 1-based reference position */
         public int getPosition() { return position; }
         public List<RecordAndOffset> getRecordAndPositions() { return Collections.unmodifiableList(recordAndOffsets); }
+        public String getSequenceName() { return referenceSequence.getSequenceName(); }
+        @Override public String toString() { return referenceSequence.getSequenceName() + ":" + position; }
+        public int getSequenceLength() {return referenceSequence.getSequenceLength();}
         public List<RecordAndOffset> getDeletedInRecord() {
             return (deletedInRecord == null) ? Collections.emptyList() : Collections.unmodifiableList(deletedInRecord);
         }

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -23,128 +23,327 @@
  */
 package htsjdk.samtools.util;
 
-import htsjdk.samtools.SamInputResource;
-import htsjdk.samtools.SamReader;
-import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.io.ByteArrayInputStream;
 
 /**
  * @author alecw@broadinstitute.org
  */
 public class SamLocusIteratorTest {
-    private SamReader createSamFileReader(final String samExample) {
-        final ByteArrayInputStream inputStream = new ByteArrayInputStream(samExample.getBytes());
-        return SamReaderFactory.makeDefault().open(SamInputResource.of(inputStream));
+
+    /** Coverage for tests with the same reads */
+    final static int coverage = 2;
+
+    /** the read length for the testss */
+    final static int readLength = 36;
+
+    final static SAMFileHeader header = new SAMFileHeader();
+
+    static {
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        SAMSequenceDictionary dict = new SAMSequenceDictionary();
+        dict.addSequence(new SAMSequenceRecord("chrM", 100000));
+        header.setSequenceDictionary(dict);
     }
 
-    private SamLocusIterator createSamLocusIterator(final SamReader samReader) {
-        final SamLocusIterator ret = new SamLocusIterator(samReader);
+    /** Get the record builder for the tests with the default parameters that are needed */
+    private static SAMRecordSetBuilder getRecordBuilder() {
+        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.setHeader(header);
+        builder.setReadLength(readLength);
+        return builder;
+    }
+
+    /** Create the SamLocusIterator with the builder*/
+    private SamLocusIterator createSamLocusIterator(final SAMRecordSetBuilder builder) {
+        final SamLocusIterator ret = new SamLocusIterator(builder.getSamReader());
         ret.setEmitUncoveredLoci(false);
         return ret;
     }
 
+	/**
+     * Test a simple with only matches, with both including or not indels
+     */
     @Test
     public void testBasicIterator() {
-
-        final String sqHeader = "@HD\tSO:coordinate\tVN:1.0\n@SQ\tSN:chrM\tAS:HG18\tLN:100000\n";
-        final String seq1 = "ACCTACGTTCAATATTACAGGCGAACATACTTACTA";
-        final String qual1 = "++++++++++++++++++++++++++++++++++++"; // phred 10
-        final String s1 = "3851612\t16\tchrM\t165\t255\t36M\t*\t0\t0\t" + seq1 + "\t" + qual1 + "\n";
-        final String exampleSam = sqHeader + s1 + s1;
-
-        final SamReader samReader = createSamFileReader(exampleSam);
-        final SamLocusIterator sli = createSamLocusIterator(samReader);
-
-
-        // make sure we accumulated depth of 2 for each position
-        int pos = 165;
-        for (final SamLocusIterator.LocusInfo li : sli) {
-            Assert.assertEquals(pos++, li.getPosition());
-            Assert.assertEquals(2, li.getRecordAndPositions().size());
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for(int i = 0; i < coverage; i++) {
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record"+i, 0, startPosition, true, false, "36M", null, 10);
         }
-
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[]{false, true}){
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setIncludeIndels(incIndels);
+            // make sure we accumulated depth for each position
+            int pos = startPosition;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                Assert.assertEquals(li.getPosition(), pos++);
+                Assert.assertEquals(li.getRecordAndPositions().size(), coverage);
+                // make sure that we are not accumulating indels
+                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+            }
+        }
     }
 
+	/**
+     * Test the emit uncovered loci, with both including or not indels
+     */
     @Test
     public void testEmitUncoveredLoci() {
 
-        final String sqHeader = "@HD\tSO:coordinate\tVN:1.0\n@SQ\tSN:chrM\tAS:HG18\tLN:100000\n";
-        final String seq1 = "ACCTACGTTCAATATTACAGGCGAACATACTTACTA";
-        final String qual1 = "++++++++++++++++++++++++++++++++++++"; // phred 10
-        final String s1 = "3851612\t16\tchrM\t165\t255\t36M\t*\t0\t0\t" + seq1 + "\t" + qual1 + "\n";
-        final String exampleSam = sqHeader + s1 + s1;
-
-        final SamReader samReader = createSamFileReader(exampleSam);
-        final SamLocusIterator sli = new SamLocusIterator(samReader);
-
-        // make sure we accumulated depth of 2 for each position
-        int pos = 1;
-        final int coveredStart = 165;
-        final int coveredEnd = CoordMath.getEnd(coveredStart, seq1.length());
-        for (final SamLocusIterator.LocusInfo li : sli) {
-            Assert.assertEquals(li.getPosition(), pos++);
-            final int expectedReads;
-            if (li.getPosition() >= coveredStart && li.getPosition() <= coveredEnd) {
-                expectedReads = 2;
-            } else {
-                expectedReads = 0;
-            }
-            Assert.assertEquals(li.getRecordAndPositions().size(), expectedReads);
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for(int i = 0; i < coverage; i++) {
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record"+i, 0, startPosition, true, false, "36M", null, 10);
         }
-        Assert.assertEquals(pos, 100001);
 
+        final int coveredEnd = CoordMath.getEnd(startPosition, readLength);
+
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[]{false, true}) {
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setEmitUncoveredLoci(true);
+            sli.setIncludeIndels(incIndels);
+            // make sure we accumulated depth of 2 for each position
+            int pos = 1;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                Assert.assertEquals(li.getPosition(), pos++);
+                final int expectedReads;
+                if (li.getPosition() >= startPosition && li.getPosition() <= coveredEnd) {
+                    expectedReads = coverage;
+                } else {
+                    expectedReads = 0;
+                }
+                Assert.assertEquals(li.getRecordAndPositions().size(), expectedReads);
+                // make sure that we are not accumulating indels
+                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+            }
+            Assert.assertEquals(pos, header.getSequence(0).getSequenceLength() + 1);
+        }
     }
 
+	/**
+     * Test the quality filter, with both including or not indels
+     */
     @Test
     public void testQualityFilter() {
-
-        final String sqHeader = "@HD\tSO:coordinate\tVN:1.0\n@SQ\tSN:chrM\tAS:HG18\tLN:100000\n";
-        final String seq1 = "ACCTACGTTCAATATTACAGGCGAACATACTTACTA";
-        final String qual1 = "++++++++++++++++++++++++++++++++++++"; // phred 10
-        final String qual2 = "+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*"; // phred 10,9...
-        final String s1 = "3851612\t16\tchrM\t165\t255\t36M\t*\t0\t0\t" + seq1 + "\t" + qual1 + "\n";
-        final String s2 = "3851612\t16\tchrM\t165\t255\t36M\t*\t0\t0\t" + seq1 + "\t" + qual2 + "\n";
-        final String exampleSam = sqHeader + s1 + s2;
-
-        final SamReader samReader = createSamFileReader(exampleSam);
-        final SamLocusIterator sli = createSamLocusIterator(samReader);
-        sli.setQualityScoreCutoff(10);
-
-
-        // make sure we accumulated depth 2 for even positions, 1 for odd positions
-        int pos = 165;
-        for (final SamLocusIterator.LocusInfo li : sli) {
-            Assert.assertEquals((pos % 2 == 0) ? 1 : 2, li.getRecordAndPositions().size());
-            Assert.assertEquals(pos++, li.getPosition());
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for(int i = 0; i < coverage; i++) {
+            final String qualityString;
+            // half of the reads have a different quality
+            if(i % 2 == 0) {
+                qualityString = null;
+            } else {
+                qualityString = "+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*";
+            }
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record"+i, 0, startPosition, true, false, "36M", qualityString, 10);
         }
 
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[]{false, true}) {
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setQualityScoreCutoff(10);
+            sli.setIncludeIndels(incIndels);
+            // make sure we accumulated depth coverage for even positions, coverage/2 for odd positions
+            int pos = startPosition;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                Assert.assertEquals(li.getRecordAndPositions().size(), (pos % 2 == 0) ? coverage / 2 : coverage);
+                Assert.assertEquals(li.getPosition(), pos++);
+                // make sure that we are not accumulating indels
+                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+            }
+        }
+    }
+
+	/**
+     * Test a simple deletion, with both including or not indels
+     */
+    @Test
+    public void testSimpleDeletion() {
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for(int i = 0; i < coverage; i++) {
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record"+i, 0, startPosition, true, false, "18M10D18M", null, 10);
+        }
+        final int deletionStart = 183;
+        final int deletionEnd = 192;
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[]{false, true}){
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setIncludeIndels(incIndels);
+            // make sure we accumulated depth for each position
+            int pos = startPosition;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                boolean isDeletedPosition = (pos >= deletionStart && pos <= deletionEnd);
+                if(!incIndels && isDeletedPosition) {
+                    pos = deletionEnd + 1;
+                    isDeletedPosition = false;
+                }
+                Assert.assertEquals(li.getPosition(), pos++);
+                if(isDeletedPosition) {
+                    // make sure there are no reads without indels
+                    Assert.assertEquals(li.getRecordAndPositions().size(), 0);
+                    // make sure that we are accumulating indels
+                    Assert.assertEquals(li.getDeletedInRecord().size(), coverage);
+                    Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+                } else {
+                    // make sure we are accumulating normal coverage
+                    Assert.assertEquals(li.getRecordAndPositions().size(), coverage);
+                    // make sure that we are not accumulating indels
+                    Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                    Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+                }
+            }
+        }
+    }
+
+	/**
+     * Test a simple insertion, with both including or not indels
+     */
+    @Test
+    public void testSimpleInsertion() {
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for(int i = 0; i < coverage; i++) {
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record"+i, 0, startPosition, true, false, "30M3I3M", null, 10);
+        }
+        final int insStart = 194;
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[]{false, true}){
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setIncludeIndels(incIndels);
+            // make sure we accumulated depth for each position
+            int pos = startPosition;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                Assert.assertEquals(li.getPosition(), pos++);
+                // make sure we are accumulating normal coverage
+                Assert.assertEquals(li.getRecordAndPositions().size(), coverage);
+                // make sure that we are not accumulating deletions
+                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                if(incIndels && li.getPosition() == insStart) {
+                    Assert.assertEquals(li.getInsertedInRecord().size(), coverage, "Tracking indels: "+incIndels+". At "+li.toString());
+                } else {
+                    Assert.assertEquals(li.getInsertedInRecord().size(), 0, "Tracking indels: "+incIndels+". At "+li.toString());
+                }
+            }
+        }
     }
 
     /**
-     * Try all CIGAR operands (except H and P) and confirm that loci produced by SamLocusIterator are as expected.
+     * Test an insertion at the start of the read, with both including or not indels
+     */
+    @Test
+    public void testStartWithInsertion() {
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for(int i = 0; i < coverage; i++) {
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record"+i, 0, startPosition, true, false, "3I33M", null, 10);
+        }
+
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[]{false, true}) {
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setIncludeIndels(incIndels);
+            // make sure we accumulated depth for each position
+            int pos = (incIndels) ? startPosition - 1 : startPosition;
+            boolean indelPosition = incIndels;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                Assert.assertEquals(li.getPosition(), pos);
+                // accumulation of coverage
+                Assert.assertEquals(li.getRecordAndPositions().size(), (indelPosition) ? 0 : coverage);
+                // no accumulation of deletions
+                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                // accumulation of insertion
+                Assert.assertEquals(li.getInsertedInRecord().size(), (indelPosition) ? coverage : 0);
+                // check offsets of the insertion
+                if(indelPosition) {
+                    Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 0);
+                    Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 0);
+                    indelPosition = false;
+                }
+                pos++;
+            }
+        }
+    }
+
+    /**
+     * Test an insertion at the start of a soft-clipped read, with both including or not indels
+     */
+    @Test
+    public void testStartWithSoftClipAndInsertion() {
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for(int i = 0; i < coverage; i++) {
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record"+i, 0, startPosition, true, false, "1S3I32M", null, 10);
+        }
+
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[]{false, true}) {
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setIncludeIndels(incIndels);
+            // make sure we accumulated depth for each position
+            int pos = (incIndels) ? startPosition - 1 : startPosition;
+            boolean indelPosition = incIndels;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                Assert.assertEquals(li.getPosition(), pos);
+                // accumulation of coverage
+                Assert.assertEquals(li.getRecordAndPositions().size(), (indelPosition) ? 0 : coverage);
+                // no accumulation of deletions
+                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                // accumulation of insertion
+                Assert.assertEquals(li.getInsertedInRecord().size(), (indelPosition) ? coverage : 0);
+                // check offsets of the insertion
+                if(indelPosition) {
+                    Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 1);
+                    Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 1);
+                    indelPosition = false;
+                }
+                pos++;
+            }
+        }
+    }
+
+    /**
+     * Try all CIGAR operands (except H and P) and confirm that loci produced by SamLocusIterator are as expected,
+     * with both including or not indels
      */
     @Test
     public void testSimpleGappedAlignment() {
-        final String sqHeader = "@HD\tSO:coordinate\tVN:1.0\n@SQ\tSN:chrM\tAS:HG18\tLN:100000\n";
-        final String seq1 = "ACCTACGTTCAATATTACAGGCGAACATACTTACTA";
-        final String qual1 = "++++++++++++++++++++++++++++++++++++"; // phred 10
-        final String s1 = "3851612\t16\tchrM\t165\t255\t3S3M3N3M3D3M3I18M3S\t*\t0\t0\t" + seq1 + "\t" + qual1 + "\n";
-        final String exampleSam = sqHeader + s1 + s1;
-
-        final SamReader samReader = createSamFileReader(exampleSam);
-        final SamLocusIterator sli = createSamLocusIterator(samReader);
-
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for(int i = 0; i < coverage; i++) {
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record"+i, 0, startPosition, true, false, "3S3M3N3M3D3M3I18M3S", null, 10);
+        }
 
         // make sure we accumulated depth of 2 for each position
-        final int[] expectedReferencePositions = new int[]{
+        final int[] expectedPositions = new int[]{
                 // 3S
                 165, 166, 167, // 3M
                 // 3N
                 171, 172, 173, // 3M
-                // 3D
+                174, 175, 176, // 3D
                 177, 178, 179, // 3M
                 // 3I
                 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197}; // 18M
@@ -154,36 +353,81 @@ public class SamLocusIteratorTest {
                 3, 4, 5, // 3M
                 // 3N
                 6, 7, 8, // 3M
-                // 3D
+                8, 8, 8, // 3D previous 0-based offset
                 9, 10, 11, // 3M
                 // 3I
                 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32 // 3M
         };
-        int i = 0;
-        for (final SamLocusIterator.LocusInfo li : sli) {
-            Assert.assertEquals(li.getRecordAndPositions().size(), 2);
-            Assert.assertEquals(li.getPosition(), expectedReferencePositions[i]);
-            Assert.assertEquals(li.getRecordAndPositions().get(0).getOffset(), expectedReadOffsets[i]);
-            Assert.assertEquals(li.getRecordAndPositions().get(1).getOffset(), expectedReadOffsets[i]);
-            ++i;
+
+        // to check the range of the insertion
+        final int firstDelBase = 174;
+        final int lastDelBase = 176;
+
+        final int expectedInsertionPosition = 179; // previous reference base
+        final int expectedInsertionOffset = 12; // first read base in the insertion
+
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[]{false, true}) {
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setIncludeIndels(incIndels);
+
+            int i = 0;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                // check if it is in the deletion range
+                boolean inDelRange = (expectedPositions[i] >= firstDelBase && expectedPositions[i] <= lastDelBase);
+                // if we are not including indels, the expected position index change if it is in an deletion range
+                if(!incIndels && inDelRange ) {
+                    i += 3;
+                    inDelRange = false; // set to false to do not check the range of deletions
+                }
+                // check if the LocusInfo is the expected
+                Assert.assertEquals(li.getPosition(), expectedPositions[i]);
+                // check the insertions
+                if(incIndels && li.getPosition() == expectedInsertionPosition) {
+                    // check the accumulated coverage
+                    Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
+                    // check the record offset
+                    Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), expectedInsertionOffset);
+                    Assert.assertEquals(li.getInsertedInRecord().get(1).getOffset(), expectedInsertionOffset);
+                } else {
+                    Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+                }
+                // check the range of deletions
+                if(inDelRange) {
+                    // check the coverage for insertion and normal records
+                    Assert.assertEquals(li.getDeletedInRecord().size(), coverage);
+                    Assert.assertEquals(li.getRecordAndPositions().size(), 0);
+                    // check the offset for the deletion
+                    Assert.assertEquals(li.getDeletedInRecord().get(0).getOffset(), expectedReadOffsets[i]);
+                    Assert.assertEquals(li.getDeletedInRecord().get(1).getOffset(), expectedReadOffsets[i]);
+                } else {
+                    // if it is not a deletion, perform the same test as before
+                    Assert.assertEquals(li.getRecordAndPositions().size(), coverage);
+                    // Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                    Assert.assertEquals(li.getRecordAndPositions().get(0).getOffset(), expectedReadOffsets[i]);
+                    Assert.assertEquals(li.getRecordAndPositions().get(1).getOffset(), expectedReadOffsets[i]);
+                }
+                ++i;
+            }
         }
+
+
     }
 
     /**
-     * Test two reads that overlap because one has a deletion in the middle of it.
+     * Test two reads that overlap because one has a deletion in the middle of it, without tracking indels
      */
     @Test
-    public void testOverlappingGappedAlignments() {
-        final String sqHeader = "@HD\tSO:coordinate\tVN:1.0\n@SQ\tSN:chrM\tAS:HG18\tLN:100000\n";
-        final String seq1 = "ACCTACGTTCAATATTACAGGCGAACATACTTACTA";
-        final String qual1 = "++++++++++++++++++++++++++++++++++++"; // phred 10
+    public void testOverlappingGappedAlignmentsWithoutIndels() {
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
         // Were it not for the gap, these two reads would not overlap
-        final String s1 = "3851612\t16\tchrM\t165\t255\t18M10D18M\t*\t0\t0\t" + seq1 + "\t" + qual1 + "\n";
-        final String s2 = "3851613\t16\tchrM\t206\t255\t36M\t*\t0\t0\t" + seq1 + "\t" + qual1 + "\n";
-        final String exampleSam = sqHeader + s1 + s2;
+        builder.addFrag("record1", 0, startPosition, true, false, "18M10D18M", null, 10);
+        builder.addFrag("record2", 0, 206, true, false, "36M", null, 10);
 
-        final SamReader samReader = createSamFileReader(exampleSam);
-        final SamLocusIterator sli = createSamLocusIterator(samReader);
+        final SamLocusIterator sli = createSamLocusIterator(builder);
+
         // 5 base overlap btw the two reads
         final int numBasesCovered = 36 + 36 - 5;
         final int[] expectedReferencePositions = new int[numBasesCovered];
@@ -193,26 +437,26 @@ public class SamLocusIteratorTest {
         int i;
         // First 18 bases are from the first read
         for (i = 0; i < 18; ++i) {
-            expectedReferencePositions[i] = 165 + i;
+            expectedReferencePositions[i] = startPosition + i;
             expectedDepths[i] = 1;
             expectedReadOffsets[i] = new int[]{i};
         }
         // Gap of 10, then 13 bases from the first read
         for (; i < 36 - 5; ++i) {
-            expectedReferencePositions[i] = 165 + 10 + i;
+            expectedReferencePositions[i] = startPosition + 10 + i;
             expectedDepths[i] = 1;
             expectedReadOffsets[i] = new int[]{i};
         }
         // Last 5 bases of first read overlap first 5 bases of second read
         for (; i < 36; ++i) {
-            expectedReferencePositions[i] = 165 + 10 + i;
+            expectedReferencePositions[i] = startPosition + 10 + i;
             expectedDepths[i] = 2;
             expectedReadOffsets[i] = new int[]{i, i - 31};
 
         }
         // Last 31 bases of 2nd read
         for (; i < 36 + 36 - 5; ++i) {
-            expectedReferencePositions[i] = 165 + 10 + i;
+            expectedReferencePositions[i] = startPosition + 10 + i;
             expectedDepths[i] = 1;
             expectedReadOffsets[i] = new int[]{i - 31};
         }
@@ -225,7 +469,90 @@ public class SamLocusIteratorTest {
             for (int j = 0; j < expectedReadOffsets[i].length; ++j) {
                 Assert.assertEquals(li.getRecordAndPositions().get(j).getOffset(), expectedReadOffsets[i][j]);
             }
+            // make sure that we are not accumulating indels
+            Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+            Assert.assertEquals(li.getInsertedInRecord().size(), 0);
             ++i;
         }
     }
+
+    /**
+     * Test two reads that overlap because one has a deletion in the middle of it, tracking indels
+     */
+    @Test
+    public void testOverlappingGappedAlignmentsWithIndels() {
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        // Were it not for the gap, these two reads would not overlap
+        builder.addFrag("record1", 0, startPosition, true, false, "18M10D18M", null, 10);
+        builder.addFrag("record2", 0, 206, true, false, "36M", null, 10);
+
+        final SamLocusIterator sli = createSamLocusIterator(builder);
+        sli.setIncludeIndels(true);
+
+        // 46 for the gapped alignment, and 5 base overlap btw the two reads
+        final int numBasesCovered = 46 + 36 - 5;
+        final int[] expectedReferencePositions = new int[numBasesCovered];
+        final int[] expectedDepths = new int[numBasesCovered];
+        final int[] expectedDelDepths = new int[numBasesCovered];
+        final int[][] expectedReadOffsets = new int[numBasesCovered][];
+        final int expectedDelOffset = 17; // previous 0-based offset
+
+        int i;
+        // First 18 bases are from the first read
+        for (i = 0; i < 18; ++i) {
+            expectedReferencePositions[i] = startPosition + i;
+            expectedDepths[i] = 1;
+            expectedDelDepths[i] = 0;
+            expectedReadOffsets[i] = new int[]{i};
+        }
+        // Gap of 10
+        for(; i < 18 + 10; ++i) {
+            expectedReferencePositions[i] = startPosition + i;
+            expectedDepths[i] = 0;
+            expectedDelDepths[i] = 1;
+            expectedReadOffsets[i] = new int[0];
+        }
+        // the next bases for the first read (without the 5 overlapping)
+        for(; i < 46 - 5; ++i) {
+            expectedReferencePositions[i] = startPosition + i;
+            expectedDepths[i] = 1;
+            expectedDelDepths[i] = 0;
+            expectedReadOffsets[i] = new int[]{i - 10};
+        }
+        // last 5 bases of the first read overlap first 5 bases of second read
+        for(; i < 46; ++i) {
+            expectedReferencePositions[i] = startPosition + i;
+            expectedDepths[i] = 2;
+            expectedDelDepths[i] = 0;
+            expectedReadOffsets[i] = new int[]{i - 10, i + 10 - 46 - 5 };
+        }
+        // Last 31 bases of 2nd read
+        for(; i < numBasesCovered; ++i) {
+            expectedReferencePositions[i] = startPosition + i;
+            expectedDepths[i] = 1;
+            expectedDelDepths[i] = 0;
+            expectedReadOffsets[i] = new int[]{i + 10 - 46 - 5};
+        }
+        i = 0;
+        for (final SamLocusIterator.LocusInfo li : sli) {
+            // checking the same as without indels
+            Assert.assertEquals(li.getRecordAndPositions().size(), expectedDepths[i]);
+            Assert.assertEquals(li.getPosition(), expectedReferencePositions[i]);
+            Assert.assertEquals(li.getRecordAndPositions().size(), expectedReadOffsets[i].length);
+            for (int j = 0; j < expectedReadOffsets[i].length; ++j) {
+                Assert.assertEquals(li.getRecordAndPositions().get(j).getOffset(), expectedReadOffsets[i][j]);
+            }
+            // check the deletions
+            Assert.assertEquals(li.getDeletedInRecord().size(), expectedDelDepths[i]);
+            if(expectedDelDepths[i] != 0) {
+                Assert.assertEquals(li.getDeletedInRecord().get(0).getOffset(), expectedDelOffset);
+            }
+            // checking that insertions are not accumulating
+            Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+            ++i;
+        }
+    }
+
 }

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -23,7 +23,10 @@
  */
 package htsjdk.samtools.util;
 
-import htsjdk.samtools.*;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecordSetBuilder;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -62,7 +65,7 @@ public class SamLocusIteratorTest {
         return ret;
     }
 
-	/**
+    /**
      * Test a simple with only matches, with both including or not indels
      */
     @Test
@@ -70,12 +73,12 @@ public class SamLocusIteratorTest {
         final SAMRecordSetBuilder builder = getRecordBuilder();
         // add records up to coverage for the test in that position
         final int startPosition = 165;
-        for(int i = 0; i < coverage; i++) {
+        for (int i = 0; i < coverage; i++) {
             // add a negative-strand fragment mapped on chrM with base quality of 10
-            builder.addFrag("record"+i, 0, startPosition, true, false, "36M", null, 10);
+            builder.addFrag("record" + i, 0, startPosition, true, false, "36M", null, 10);
         }
         // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[]{false, true}){
+        for (final boolean incIndels : new boolean[] {false, true}) {
             final SamLocusIterator sli = createSamLocusIterator(builder);
             sli.setIncludeIndels(incIndels);
             // make sure we accumulated depth for each position
@@ -90,7 +93,7 @@ public class SamLocusIteratorTest {
         }
     }
 
-	/**
+    /**
      * Test the emit uncovered loci, with both including or not indels
      */
     @Test
@@ -99,15 +102,15 @@ public class SamLocusIteratorTest {
         final SAMRecordSetBuilder builder = getRecordBuilder();
         // add records up to coverage for the test in that position
         final int startPosition = 165;
-        for(int i = 0; i < coverage; i++) {
+        for (int i = 0; i < coverage; i++) {
             // add a negative-strand fragment mapped on chrM with base quality of 10
-            builder.addFrag("record"+i, 0, startPosition, true, false, "36M", null, 10);
+            builder.addFrag("record" + i, 0, startPosition, true, false, "36M", null, 10);
         }
 
         final int coveredEnd = CoordMath.getEnd(startPosition, readLength);
 
         // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[]{false, true}) {
+        for (final boolean incIndels : new boolean[] {false, true}) {
             final SamLocusIterator sli = createSamLocusIterator(builder);
             sli.setEmitUncoveredLoci(true);
             sli.setIncludeIndels(incIndels);
@@ -130,7 +133,7 @@ public class SamLocusIteratorTest {
         }
     }
 
-	/**
+    /**
      * Test the quality filter, with both including or not indels
      */
     @Test
@@ -138,20 +141,20 @@ public class SamLocusIteratorTest {
         final SAMRecordSetBuilder builder = getRecordBuilder();
         // add records up to coverage for the test in that position
         final int startPosition = 165;
-        for(int i = 0; i < coverage; i++) {
+        for (int i = 0; i < coverage; i++) {
             final String qualityString;
             // half of the reads have a different quality
-            if(i % 2 == 0) {
+            if (i % 2 == 0) {
                 qualityString = null;
             } else {
                 qualityString = "+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*+*";
             }
             // add a negative-strand fragment mapped on chrM with base quality of 10
-            builder.addFrag("record"+i, 0, startPosition, true, false, "36M", qualityString, 10);
+            builder.addFrag("record" + i, 0, startPosition, true, false, "36M", qualityString, 10);
         }
 
         // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[]{false, true}) {
+        for (final boolean incIndels : new boolean[] {false, true}) {
             final SamLocusIterator sli = createSamLocusIterator(builder);
             sli.setQualityScoreCutoff(10);
             sli.setIncludeIndels(incIndels);
@@ -167,7 +170,7 @@ public class SamLocusIteratorTest {
         }
     }
 
-	/**
+    /**
      * Test a simple deletion, with both including or not indels
      */
     @Test
@@ -175,26 +178,26 @@ public class SamLocusIteratorTest {
         final SAMRecordSetBuilder builder = getRecordBuilder();
         // add records up to coverage for the test in that position
         final int startPosition = 165;
-        for(int i = 0; i < coverage; i++) {
+        for (int i = 0; i < coverage; i++) {
             // add a negative-strand fragment mapped on chrM with base quality of 10
-            builder.addFrag("record"+i, 0, startPosition, true, false, "18M10D18M", null, 10);
+            builder.addFrag("record" + i, 0, startPosition, true, false, "18M10D18M", null, 10);
         }
         final int deletionStart = 183;
         final int deletionEnd = 192;
         // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[]{false, true}){
+        for (final boolean incIndels : new boolean[] {false, true}) {
             final SamLocusIterator sli = createSamLocusIterator(builder);
             sli.setIncludeIndels(incIndels);
             // make sure we accumulated depth for each position
             int pos = startPosition;
             for (final SamLocusIterator.LocusInfo li : sli) {
                 boolean isDeletedPosition = (pos >= deletionStart && pos <= deletionEnd);
-                if(!incIndels && isDeletedPosition) {
+                if (!incIndels && isDeletedPosition) {
                     pos = deletionEnd + 1;
                     isDeletedPosition = false;
                 }
                 Assert.assertEquals(li.getPosition(), pos++);
-                if(isDeletedPosition) {
+                if (isDeletedPosition) {
                     // make sure there are no reads without indels
                     Assert.assertEquals(li.getRecordAndPositions().size(), 0);
                     // make sure that we are accumulating indels
@@ -211,7 +214,7 @@ public class SamLocusIteratorTest {
         }
     }
 
-	/**
+    /**
      * Test a simple insertion, with both including or not indels
      */
     @Test
@@ -219,13 +222,13 @@ public class SamLocusIteratorTest {
         final SAMRecordSetBuilder builder = getRecordBuilder();
         // add records up to coverage for the test in that position
         final int startPosition = 165;
-        for(int i = 0; i < coverage; i++) {
+        for (int i = 0; i < coverage; i++) {
             // add a negative-strand fragment mapped on chrM with base quality of 10
-            builder.addFrag("record"+i, 0, startPosition, true, false, "30M3I3M", null, 10);
+            builder.addFrag("record" + i, 0, startPosition, true, false, "30M3I3M", null, 10);
         }
         final int insStart = 194;
         // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[]{false, true}){
+        for (final boolean incIndels : new boolean[] {false, true}) {
             final SamLocusIterator sli = createSamLocusIterator(builder);
             sli.setIncludeIndels(incIndels);
             // make sure we accumulated depth for each position
@@ -236,10 +239,10 @@ public class SamLocusIteratorTest {
                 Assert.assertEquals(li.getRecordAndPositions().size(), coverage);
                 // make sure that we are not accumulating deletions
                 Assert.assertEquals(li.getDeletedInRecord().size(), 0);
-                if(incIndels && li.getPosition() == insStart) {
-                    Assert.assertEquals(li.getInsertedInRecord().size(), coverage, "Tracking indels: "+incIndels+". At "+li.toString());
+                if (incIndels && li.getPosition() == insStart) {
+                    Assert.assertEquals(li.getInsertedInRecord().size(), coverage, "Tracking indels: " + incIndels + ". At " + li.toString());
                 } else {
-                    Assert.assertEquals(li.getInsertedInRecord().size(), 0, "Tracking indels: "+incIndels+". At "+li.toString());
+                    Assert.assertEquals(li.getInsertedInRecord().size(), 0, "Tracking indels: " + incIndels + ". At " + li.toString());
                 }
             }
         }
@@ -253,13 +256,13 @@ public class SamLocusIteratorTest {
         final SAMRecordSetBuilder builder = getRecordBuilder();
         // add records up to coverage for the test in that position
         final int startPosition = 165;
-        for(int i = 0; i < coverage; i++) {
+        for (int i = 0; i < coverage; i++) {
             // add a negative-strand fragment mapped on chrM with base quality of 10
-            builder.addFrag("record"+i, 0, startPosition, true, false, "3I33M", null, 10);
+            builder.addFrag("record" + i, 0, startPosition, true, false, "3I33M", null, 10);
         }
 
         // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[]{false, true}) {
+        for (final boolean incIndels : new boolean[] {false, true}) {
             final SamLocusIterator sli = createSamLocusIterator(builder);
             sli.setIncludeIndels(incIndels);
             // make sure we accumulated depth for each position
@@ -274,7 +277,7 @@ public class SamLocusIteratorTest {
                 // accumulation of insertion
                 Assert.assertEquals(li.getInsertedInRecord().size(), (indelPosition) ? coverage : 0);
                 // check offsets of the insertion
-                if(indelPosition) {
+                if (indelPosition) {
                     Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 0);
                     Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 0);
                     indelPosition = false;
@@ -292,13 +295,13 @@ public class SamLocusIteratorTest {
         final SAMRecordSetBuilder builder = getRecordBuilder();
         // add records up to coverage for the test in that position
         final int startPosition = 165;
-        for(int i = 0; i < coverage; i++) {
+        for (int i = 0; i < coverage; i++) {
             // add a negative-strand fragment mapped on chrM with base quality of 10
-            builder.addFrag("record"+i, 0, startPosition, true, false, "1S3I32M", null, 10);
+            builder.addFrag("record" + i, 0, startPosition, true, false, "1S3I32M", null, 10);
         }
 
         // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[]{false, true}) {
+        for (final boolean incIndels : new boolean[] {false, true}) {
             final SamLocusIterator sli = createSamLocusIterator(builder);
             sli.setIncludeIndels(incIndels);
             // make sure we accumulated depth for each position
@@ -313,7 +316,7 @@ public class SamLocusIteratorTest {
                 // accumulation of insertion
                 Assert.assertEquals(li.getInsertedInRecord().size(), (indelPosition) ? coverage : 0);
                 // check offsets of the insertion
-                if(indelPosition) {
+                if (indelPosition) {
                     Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 1);
                     Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 1);
                     indelPosition = false;
@@ -332,9 +335,9 @@ public class SamLocusIteratorTest {
         final SAMRecordSetBuilder builder = getRecordBuilder();
         // add records up to coverage for the test in that position
         final int startPosition = 165;
-        for(int i = 0; i < coverage; i++) {
+        for (int i = 0; i < coverage; i++) {
             // add a negative-strand fragment mapped on chrM with base quality of 10
-            builder.addFrag("record"+i, 0, startPosition, true, false, "3S3M3N3M3D3M3I18M3S", null, 10);
+            builder.addFrag("record" + i, 0, startPosition, true, false, "3S3M3N3M3D3M3I18M3S", null, 10);
         }
 
         // make sure we accumulated depth of 2 for each position
@@ -367,7 +370,7 @@ public class SamLocusIteratorTest {
         final int expectedInsertionOffset = 12; // first read base in the insertion
 
         // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[]{false, true}) {
+        for (final boolean incIndels : new boolean[] {false, true}) {
             final SamLocusIterator sli = createSamLocusIterator(builder);
             sli.setIncludeIndels(incIndels);
 
@@ -376,14 +379,14 @@ public class SamLocusIteratorTest {
                 // check if it is in the deletion range
                 boolean inDelRange = (expectedPositions[i] >= firstDelBase && expectedPositions[i] <= lastDelBase);
                 // if we are not including indels, the expected position index change if it is in an deletion range
-                if(!incIndels && inDelRange ) {
+                if (!incIndels && inDelRange) {
                     i += 3;
                     inDelRange = false; // set to false to do not check the range of deletions
                 }
                 // check if the LocusInfo is the expected
                 Assert.assertEquals(li.getPosition(), expectedPositions[i]);
                 // check the insertions
-                if(incIndels && li.getPosition() == expectedInsertionPosition) {
+                if (incIndels && li.getPosition() == expectedInsertionPosition) {
                     // check the accumulated coverage
                     Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
                     // check the record offset
@@ -393,7 +396,7 @@ public class SamLocusIteratorTest {
                     Assert.assertEquals(li.getInsertedInRecord().size(), 0);
                 }
                 // check the range of deletions
-                if(inDelRange) {
+                if (inDelRange) {
                     // check the coverage for insertion and normal records
                     Assert.assertEquals(li.getDeletedInRecord().size(), coverage);
                     Assert.assertEquals(li.getRecordAndPositions().size(), 0);
@@ -508,28 +511,28 @@ public class SamLocusIteratorTest {
             expectedReadOffsets[i] = new int[]{i};
         }
         // Gap of 10
-        for(; i < 18 + 10; ++i) {
+        for (; i < 18 + 10; ++i) {
             expectedReferencePositions[i] = startPosition + i;
             expectedDepths[i] = 0;
             expectedDelDepths[i] = 1;
             expectedReadOffsets[i] = new int[0];
         }
         // the next bases for the first read (without the 5 overlapping)
-        for(; i < 46 - 5; ++i) {
+        for (; i < 46 - 5; ++i) {
             expectedReferencePositions[i] = startPosition + i;
             expectedDepths[i] = 1;
             expectedDelDepths[i] = 0;
             expectedReadOffsets[i] = new int[]{i - 10};
         }
         // last 5 bases of the first read overlap first 5 bases of second read
-        for(; i < 46; ++i) {
+        for (; i < 46; ++i) {
             expectedReferencePositions[i] = startPosition + i;
             expectedDepths[i] = 2;
             expectedDelDepths[i] = 0;
-            expectedReadOffsets[i] = new int[]{i - 10, i + 10 - 46 - 5 };
+            expectedReadOffsets[i] = new int[]{i - 10, i + 10 - 46 - 5};
         }
         // Last 31 bases of 2nd read
-        for(; i < numBasesCovered; ++i) {
+        for (; i < numBasesCovered; ++i) {
             expectedReferencePositions[i] = startPosition + i;
             expectedDepths[i] = 1;
             expectedDelDepths[i] = 0;
@@ -546,7 +549,7 @@ public class SamLocusIteratorTest {
             }
             // check the deletions
             Assert.assertEquals(li.getDeletedInRecord().size(), expectedDelDepths[i]);
-            if(expectedDelDepths[i] != 0) {
+            if (expectedDelDepths[i] != 0) {
                 Assert.assertEquals(li.getDeletedInRecord().get(0).getOffset(), expectedDelOffset);
             }
             // checking that insertions are not accumulating


### PR DESCRIPTION
Added indel tracking to `SamLocusIterator` (as discussed in issue #387) and some tests. The default behaviour is still do not keep reads spanning indels.