### PR TITLE
Switched around the logic if the if-else check.

### DIFF
--- a/src/java/htsjdk/samtools/SAMUtils.java
+++ b/src/java/htsjdk/samtools/SAMUtils.java
@@ -945,14 +945,14 @@ public final class SAMUtils {
             } else {
                 if (getMateCigarString(rec) != null) {
                     ret = new ArrayList<SAMValidationError>();
-                    if (rec.getMateUnmappedFlag()) {
+                    if (!rec.getReadPairedFlag()) {
+                        // If the read is not paired, and the Mate Cigar String (MC Attribute) exists, that is a validation error
+                        ret.add(new SAMValidationError(SAMValidationError.Type.MATE_CIGAR_STRING_INVALID_PRESENCE,
+                                "Mate CIGAR String (MC Attribute) present for a read that is not paired", rec.getReadName(), recordNumber));
+                    } else { // will hit here if rec.getMateUnmappedFlag() is true
                         // If the Mate is unmapped, and the Mate Cigar String (MC Attribute) exists, that is a validation error.
                         ret.add(new SAMValidationError(SAMValidationError.Type.MATE_CIGAR_STRING_INVALID_PRESENCE,
                                 "Mate CIGAR String (MC Attribute) present for a read whose mate is unmapped", rec.getReadName(), recordNumber));
-                    } else {
-                        // If the Mate is not paired, and the Mate Cigar String (MC Attribute) exists, that is a validation error.
-                        ret.add(new SAMValidationError(SAMValidationError.Type.MATE_CIGAR_STRING_INVALID_PRESENCE,
-                                "Mate CIGAR String (MC Attribute) present for a read that is not paired", rec.getReadName(), recordNumber));
                     }
                 }
             }


### PR DESCRIPTION
In theory it should never be a problem (the BAM would have to be all sorts of f###ed up),
but in the original version the if statement could error out if the read is not paired.