### PR TITLE
Genotype now treats empty filter strings identically to null filter strings

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/java/htsjdk/variant/variantcontext/Genotype.java
@@ -68,7 +68,7 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
 
     protected Genotype(final String sampleName, final String filters) {
         this.sampleName = sampleName;
-        this.filters = filters;
+        this.filters = filters == null || filters.isEmpty() ? null : filters;
     }
 
     /**

--- a/src/tests/java/htsjdk/variant/variantcontext/GenotypeUnitTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/GenotypeUnitTest.java
@@ -63,6 +63,8 @@ public class GenotypeUnitTest extends VariantBaseTest {
         Assert.assertEquals(makeGB().filters("x", "y", "z").make().getFilters(), "x;y;z", "Multiple filter field values should be joined with ;");
         Assert.assertTrue(makeGB().filters("x", "y", "z").make().isFiltered(), "Multiple filter values should be filtered");
         Assert.assertEquals(makeGB().filter("x;y;z").make().getFilters(), "x;y;z", "Multiple filter field values should be joined with ;");
+        Assert.assertFalse(makeGB().filter("").make().isFiltered(), "empty filters should count as unfiltered");
+        Assert.assertEquals(makeGB().filter("").make().getFilters(), null, "empty filter string should result in null filters");
     }
 
 //    public Genotype(String sampleName, List<Allele> alleles, double negLog10PError, Set<String> filters, Map<String, ?> attributes, boolean isPhased) {


### PR DESCRIPTION
There was a potentially invalid case where a genotype could be constructed with an empty filter string.
This would result in `isFiltered()` returning `true` and `getFilters()` being empty.  There are explicit checks in gatk for `genotype.isFiltered() && genotype.getFilters().isEmpty()` so there must be cases where this has happened.  

I don't believe there is any case where this would be meaningful state to represent.