### PR TITLE
Open up DiskBasedBAMFileIndex as a public class.

### DIFF
--- a/src/java/htsjdk/samtools/DiskBasedBAMFileIndex.java
+++ b/src/java/htsjdk/samtools/DiskBasedBAMFileIndex.java
@@ -32,17 +32,17 @@ import java.util.List;
 /**
  * A class for reading BAM file indices, hitting the disk once per query.
  */
-class DiskBasedBAMFileIndex extends AbstractBAMFileIndex
+public class DiskBasedBAMFileIndex extends AbstractBAMFileIndex
 {
-    DiskBasedBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
+    public DiskBasedBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
         super(file, dictionary);
     }
 
-    DiskBasedBAMFileIndex(final SeekableStream stream, final SAMSequenceDictionary dictionary) {
+    public DiskBasedBAMFileIndex(final SeekableStream stream, final SAMSequenceDictionary dictionary) {
         super(stream, dictionary);
     }
 
-    DiskBasedBAMFileIndex(final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
+    public DiskBasedBAMFileIndex(final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
         super(file, dictionary, useMemoryMapping);
     }
 


### PR DESCRIPTION
I was trying to make raw access to BAIs in a downstream project (see https://github.com/HadoopGenomics/Hadoop-BAM/issues/34) and found that the [AbstractBAMFileIndex](https://github.com/samtools/htsjdk/blob/master/src/java/htsjdk/samtools/AbstractBAMFileIndex.java) has no public concrete implementations. As such, I'd like to open this class up as public.