### PR TITLE
Yf add istransition

### DIFF
--- a/src/tests/java/htsjdk/tribble/util/ftp/FTPClientTest.java
+++ b/src/tests/java/htsjdk/tribble/util/ftp/FTPClientTest.java
@@ -11,9 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.UnknownHostException;
 
-
-
-
 /**
 * @author Jim Robinson
 * @since 10/3/11
@@ -30,7 +27,7 @@ public class FTPClientTest {
     public void setUp() throws IOException {
         client = new FTPClient();
         FTPReply reply = client.connect(host);
-        Assert.assertTrue(reply.isSuccess());
+        Assert.assertTrue(reply.isSuccess(), "connect");
     }
 
     @AfterMethod
@@ -48,10 +45,10 @@ public class FTPClientTest {
     public void testPasv() throws Exception {
         try {
             FTPReply reply = client.login("anonymous", "igv@broadinstitute.org");
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "login");
 
             reply = client.pasv();
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "pasv");
         } finally {
             client.closeDataStream();
         }
@@ -64,35 +61,34 @@ public class FTPClientTest {
         Assert.assertTrue(reply.isSuccess());
 
         reply = client.binary();
-        Assert.assertTrue(reply.isSuccess());
+        Assert.assertTrue(reply.isSuccess(), "binary");
 
         reply = client.size(file);
         String val = reply.getReplyString();
         int size = Integer.parseInt(val);
-        Assert.assertEquals(fileSize, size);
+        Assert.assertEquals(fileSize, size, "size");
     }
-
 
     @Test
     public void testDownload() throws Exception {
         try {
             FTPReply reply = client.login("anonymous", "igv@broadinstitute.org");
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "login");
 
             reply = client.binary();
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "binary");
 
             reply = client.pasv();
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "pasv");
 
             reply = client.retr(file);
-            Assert.assertTrue(reply.getCode() == 150);
+            Assert.assertEquals(reply.getCode(), 150, "retr");
 
             InputStream is = client.getDataStream();
             int idx = 0;
             int b;
             while ((b = is.read()) >= 0) {
-                Assert.assertEquals(expectedBytes[idx], (byte) b);
+                Assert.assertEquals(expectedBytes[idx], (byte) b,"reading from stream");
                 idx++;
             }
 
@@ -100,35 +96,33 @@ public class FTPClientTest {
             client.closeDataStream();
             FTPReply reply = client.retr(file);
             System.out.println(reply.getCode());
-            Assert.assertTrue(reply.isSuccess());
-
+            Assert.assertTrue(reply.isSuccess(), "close");
         }
     }
-
 
     @Test
     public void testRest() throws Exception {
         try {
             FTPReply reply = client.login("anonymous", "igv@broadinstitute.org");
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "login");
 
             reply = client.binary();
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "binary");
 
             reply = client.pasv();
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "pasv");
 
             final int restPosition = 5;
             client.setRestPosition(restPosition);
 
             reply = client.retr(file);
-            Assert.assertTrue(reply.getCode() == 150);
+            Assert.assertEquals(reply.getCode(), 150, "retr");
 
             InputStream is = client.getDataStream();
             int idx = restPosition;
             int b;
             while ((b = is.read()) >= 0) {
-                Assert.assertEquals(expectedBytes[idx], (byte) b);
+                Assert.assertEquals(expectedBytes[idx], (byte) b, "reading from stream");
                 idx++;
             }
 
@@ -136,8 +130,7 @@ public class FTPClientTest {
             client.closeDataStream();
             FTPReply reply = client.retr(file);
             System.out.println(reply.getCode());
-            Assert.assertTrue(reply.isSuccess());
-
+            Assert.assertTrue(reply.isSuccess(), "close");
         }
     }
 
@@ -152,22 +145,21 @@ public class FTPClientTest {
         FTPClient client = new FTPClient();
 
         FTPReply reply = client.connect(host);
-        Assert.assertTrue(reply.isSuccess());
+        Assert.assertTrue(reply.isSuccess(), "connect");
 
         reply = client.login("anonymous", "igv@broadinstitute.org");
-        Assert.assertTrue(reply.isSuccess());
+        Assert.assertTrue(reply.isSuccess(), "login");
 
         reply = client.binary();
-        Assert.assertTrue(reply.isSuccess());
+        Assert.assertTrue(reply.isSuccess(), "binary");
 
         reply = client.executeCommand("size " + file);
-        Assert.assertEquals(550, reply.getCode());
+        Assert.assertEquals(550, reply.getCode(), "size");
 
         client.disconnect();
-
     }
 
-        /**
+    /**
      * Test accessing a non-existent server
      */
     @Test
@@ -184,48 +176,40 @@ public class FTPClientTest {
             // This is expected
         }
 
-
         client.disconnect();
-
     }
-
 
     @Test
     public void testMultiplePasv() throws Exception {
 
         try {
             FTPReply reply = client.login("anonymous", "igv@broadinstitute.org");
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "login");
 
             reply = client.pasv();
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "pasv 1");
             client.closeDataStream();
 
             reply = client.pasv();
-            Assert.assertTrue(reply.isSuccess());
+            Assert.assertTrue(reply.isSuccess(), "pasv 2");
             client.closeDataStream();
-
-
         }
-
         finally {
 
         }
     }
 
-
     @Test
     public void testMultipleRest() throws Exception {
         FTPReply reply = client.login("anonymous", "igv@broadinstitute.org");
-        Assert.assertTrue(reply.isSuccess());
+        Assert.assertTrue(reply.isSuccess(), "login");
 
         reply = client.binary();
-        Assert.assertTrue(reply.isSuccess());
+        Assert.assertTrue(reply.isSuccess(), "binary");
 
         restRetr(5, 10);
         restRetr(2, 10);
         restRetr(15, 10);
-
     }
 
     private void restRetr(int restPosition, int length) throws IOException {
@@ -234,7 +218,7 @@ public class FTPClientTest {
 
             if (client.getDataStream() == null) {
                 FTPReply reply = client.pasv();
-                Assert.assertTrue(reply.isSuccess());
+                Assert.assertTrue(reply.isSuccess(), "pasv");
             }
 
             client.setRestPosition(restPosition);
@@ -247,10 +231,9 @@ public class FTPClientTest {
             byte[] buffer = new byte[length];
             is.read(buffer);
 
-
             for (int i = 0; i < length; i++) {
                 System.out.print((char) buffer[i]);
-                Assert.assertEquals(expectedBytes[i + restPosition], buffer[i]);
+                Assert.assertEquals(expectedBytes[i + restPosition], buffer[i], "reading from stream");
             }
             System.out.println();
         }
@@ -259,8 +242,6 @@ public class FTPClientTest {
             client.closeDataStream();
             FTPReply reply = client.getReply();  // <== MUST READ THE REPLY
             System.out.println(reply.getReplyString());
-
-
         }
     }
 }


### PR DESCRIPTION
- added isTransition to VariantContext, to tell if a VariantContext is a transition or a transversion. Works on bi-allelic SNPs.
- Added a java8 verion of CollectionUtils.partition which is much easier to use than the previous version (@Deprecated)