### PR TITLE
added utilities to Cigar*

### DIFF
--- a/src/java/htsjdk/samtools/CigarElement.java
+++ b/src/java/htsjdk/samtools/CigarElement.java
@@ -67,4 +67,9 @@ public class CigarElement implements Serializable {
         result = 31 * result + (operator != null ? operator.hashCode() : 0);
         return result;
     }
+    
+    @Override
+    public String toString() {
+        return String.valueOf(this.length)+this.operator;
+    }
 }

--- a/src/java/htsjdk/samtools/CigarOperator.java
+++ b/src/java/htsjdk/samtools/CigarOperator.java
@@ -179,6 +179,31 @@ public enum CigarOperator {
         return e.character;
     }
 
+    /** Returns true if the operator is a clipped (hard or soft) operator */
+    public boolean isClipping() {
+        return this == S || this == H;
+    }
+
+    /** Returns true if the operator is a Insertion or Deletion operator */
+    public boolean isIndel() {
+        return this == I || this == D;
+    }
+
+    /** Returns true if the operator is a Skipped Region Insertion or Deletion operator */
+    public boolean isIndelOrSkippedRegion() {
+        return this == N || isIndel();
+    }
+
+    /** Returns true if the operator is a M, a X or a EQ */
+    public boolean isAlignment() {
+        return this == M || this == X || this == EQ;
+    }
+    
+    /** Returns true if the operator is a Padding operator */
+    public boolean isPadding() {
+        return this == P;
+    }
+    
     /** Returns the cigar operator as it would be seen in a SAM file. */
     @Override public String toString() {
         return this.string;

--- a/src/tests/java/htsjdk/samtools/CigarTest.java
+++ b/src/tests/java/htsjdk/samtools/CigarTest.java
@@ -27,6 +27,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -90,5 +91,28 @@ public class CigarTest {
         final List<SAMValidationError> errors = TextCigarCodec.decode(cigar).isValid(null, -1);
         Assert.assertEquals(errors.size(), 1, String.format("Got %d error, expected exactly one error.", errors.size()));
         Assert.assertEquals(errors.get(0).getType(), type);
+    }
+    
+    @Test
+    public void testMakeCigarFromOperators() {
+        final List<CigarOperator> cigarOperators = Arrays.asList(
+                CigarOperator.S,
+                CigarOperator.M,
+                CigarOperator.M,
+                CigarOperator.M,
+                CigarOperator.I,
+                CigarOperator.M,
+                CigarOperator.D,
+                CigarOperator.M
+                );
+        final Cigar cigar = Cigar.fromCigarOperators(cigarOperators);
+        Assert.assertFalse(cigar.isEmpty());
+        Assert.assertEquals(cigar.numCigarElements(), 6);
+        Assert.assertEquals(cigar.toString(),"1S3M1I1M1D1M");
+        Assert.assertFalse(cigar.containsOperator(CigarOperator.N));
+        Assert.assertTrue(cigar.containsOperator(CigarOperator.D));
+        Assert.assertTrue(cigar.isLeftClipped());
+        Assert.assertFalse(cigar.isRightClipped());
+        Assert.assertTrue(cigar.isClipped());
     }
 }


### PR DESCRIPTION
I've added a few functions to Cigar* . I'm working with split reads and I often need to know if the cigar is clipped, what is the nature if the 5' or 3' operator ,etc ...

in **CigarOperator**:
* isClipping
* isPadding
* isIndel
* isIndelOrSkippedRegion
* isAlign

in **Cigar**
* cigarElements is final and so it is never nulll
* now implements Iterable<CIgarElement>
* added static builder from a List of CigarOperator (it cannot be a constructor because a similar constructor exists)
* added 'containsOperator', isLeftClipped, isRightClipped, isClipped
* prevent IDE warnings in 'switch/case' by adding 'default'
* get first/last cigarElement

in **CigarElement**:
* added toString

in **CigarTest**:

added one test for the above functions.