### PR TITLE
bug fix https://github.com/samtools/htsjdk/pull/417#issuecomment-1687…

### DIFF
--- a/src/java/htsjdk/samtools/Cigar.java
+++ b/src/java/htsjdk/samtools/Cigar.java
@@ -241,7 +241,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
     }
 
     private static boolean isInDelOperator(final CigarOperator op) {
-        return op !=null && op.isIndel();
+        return op !=null && op.isIndelOrSkippedRegion();
     }
 
     private static boolean isClippingOperator(final CigarOperator op) {


### PR DESCRIPTION
as discussed in https://github.com/samtools/htsjdk/pull/417#issuecomment-168789234

changed 'isInDelOperator'

```
        return op !=null && op.isIndel();
```

to

```
        return op !=null && op.isIndelOrSkippedRegion();
```

because the comment in the code is 

> There should be an M or P operator between any pair of IDN operators

