### PR TITLE
Factor out CRAM container writing code from CRAMFileWriter.

### DIFF
--- a/src/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -1,0 +1,459 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.cram.build.ContainerFactory;
+import htsjdk.samtools.cram.build.Cram2SamRecordFactory;
+import htsjdk.samtools.cram.build.CramIO;
+import htsjdk.samtools.cram.build.CramNormalizer;
+import htsjdk.samtools.cram.build.Sam2CramRecordFactory;
+import htsjdk.samtools.cram.common.CramVersions;
+import htsjdk.samtools.cram.common.Version;
+import htsjdk.samtools.cram.lossy.PreservationPolicy;
+import htsjdk.samtools.cram.lossy.QualityScorePreservation;
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.cram.ref.ReferenceTracks;
+import htsjdk.samtools.cram.structure.Container;
+import htsjdk.samtools.cram.structure.ContainerIO;
+import htsjdk.samtools.cram.structure.CramCompressionRecord;
+import htsjdk.samtools.cram.structure.Slice;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.samtools.util.StringLineReader;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Class for writing SAMRecords into a series of CRAM containers on an output stream.
+ */
+public class CRAMContainerStreamWriter {
+    private static final Version cramVersion = CramVersions.DEFAULT_CRAM_VERSION;
+
+    static int DEFAULT_RECORDS_PER_SLICE = 10000;
+    protected final int recordsPerSlice = DEFAULT_RECORDS_PER_SLICE;
+    private static final int DEFAULT_SLICES_PER_CONTAINER = 1;
+    protected final int containerSize = recordsPerSlice * DEFAULT_SLICES_PER_CONTAINER;
+    private static final int REF_SEQ_INDEX_NOT_INITIALIZED = -2;
+
+    private final SAMFileHeader samFileHeader;
+    private final String cramID;
+    private final OutputStream outputStream;
+    private ReferenceSource source;
+
+    private final List<SAMRecord> samRecords = new ArrayList<SAMRecord>();
+    private ContainerFactory containerFactory;
+    private int refSeqIndex = REF_SEQ_INDEX_NOT_INITIALIZED;
+
+    private static final Log log = Log.getInstance(CRAMContainerStreamWriter.class);
+
+    private boolean preserveReadNames = true;
+    private QualityScorePreservation preservation = null;
+    private boolean captureAllTags = true;
+    private Set<String> captureTags = new TreeSet<String>();
+    private Set<String> ignoreTags = new TreeSet<String>();
+
+    private CRAMIndexer indexer;
+    private long offset;
+
+    /**
+     * Create a CRAMContainerStreamWriter for writing SAM records into a series of CRAM
+     * containers on output stream, with an optional index.
+     *
+     * @param outputStream where to write the CRAM stream.
+     * @param indexStream where to write the output index. Can be null if no index is required.
+     * @param source reference source
+     * @param samFileHeader {@link SAMFileHeader} to be used. Sort order is determined by the sortOrder property of this arg.
+     * @param cramId used for display in error message display
+     */
+    public CRAMContainerStreamWriter(
+            final OutputStream outputStream,
+            final OutputStream indexStream,
+            final ReferenceSource source,
+            final SAMFileHeader samFileHeader,
+            final String cramId) {
+        this.outputStream = outputStream;
+        this.samFileHeader = samFileHeader;
+        this.cramID = cramId;
+        this.source = source;
+        containerFactory = new ContainerFactory(samFileHeader, recordsPerSlice);
+        if (indexStream != null) {
+            indexer = new CRAMIndexer(indexStream, samFileHeader);
+        }
+    }
+
+    /**
+     * Write an alignment record.
+     * @param alignment must not be null
+     */
+    public void writeAlignment(final SAMRecord alignment) {
+        if (shouldFlushContainer(alignment)) {
+            try {
+                flushContainer();
+            } catch (IOException e) {
+                throw new RuntimeIOException(e);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        updateReferenceContext(alignment.getReferenceIndex());
+
+        samRecords.add(alignment);
+    }
+
+    /**
+     * Write a CRAM file header and SAM header to the stream.
+
+     * @param header SAMFileHeader to write
+     */
+    public void writeHeader(final SAMFileHeader header) {
+        // TODO: header must be written exactly once per writer life cycle.
+        offset = CramIO.writeHeader(cramVersion, outputStream, header, cramID);
+    }
+
+    /**
+     * Finish writing to the stream. Flushes the record cache and optionally emits an EOF container.
+     * @param writeEOFContainer true if an EOF container should be written. Only use false if writing a CRAM file
+     *                          fragment which will later be aggregated into a complete CRAM file.
+     */
+    public void finish(final boolean writeEOFContainer) {
+        try {
+            if (!samRecords.isEmpty()) {
+                flushContainer();
+            }
+            if (writeEOFContainer) {
+                CramIO.issueEOF(cramVersion, outputStream);
+            }
+            outputStream.flush();
+            if (indexer != null) {
+                indexer.finish();
+            }
+            outputStream.close();
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        } catch (final IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean isPreserveReadNames() {
+        return preserveReadNames;
+    }
+
+    public void setPreserveReadNames(final boolean preserveReadNames) {
+        this.preserveReadNames = preserveReadNames;
+    }
+
+    public List<PreservationPolicy> getPreservationPolicies() {
+        if (preservation == null) {
+            // set up greedy policy by default:
+            preservation = new QualityScorePreservation("*8");
+        }
+        return preservation.getPreservationPolicies();
+    }
+
+    public boolean isCaptureAllTags() {
+        return captureAllTags;
+    }
+
+    public void setCaptureAllTags(final boolean captureAllTags) {
+        this.captureAllTags = captureAllTags;
+    }
+
+    public Set<String> getCaptureTags() {
+        return captureTags;
+    }
+
+    public void setCaptureTags(final Set<String> captureTags) {
+        this.captureTags = captureTags;
+    }
+
+    public Set<String> getIgnoreTags() {
+        return ignoreTags;
+    }
+
+    public void setIgnoreTags(final Set<String> ignoreTags) {
+        this.ignoreTags = ignoreTags;
+    }
+    /**
+     * Decide if the current container should be completed and flushed. The decision is based on a) number of records and b) if the
+     * reference sequence id has changed.
+     *
+     * @param nextRecord the record to be added into the current or next container
+     * @return true if the current container should be flushed and the following records should go into a new container; false otherwise.
+     */
+    private boolean shouldFlushContainer(final SAMRecord nextRecord) {
+        return samRecords.size() >= containerSize || refSeqIndex != REF_SEQ_INDEX_NOT_INITIALIZED && refSeqIndex != nextRecord.getReferenceIndex();
+    }
+
+    private static void updateTracks(final List<SAMRecord> samRecords, final ReferenceTracks tracks) {
+        for (final SAMRecord samRecord : samRecords) {
+            if (samRecord.getAlignmentStart() != SAMRecord.NO_ALIGNMENT_START) {
+                int refPos = samRecord.getAlignmentStart();
+                int readPos = 0;
+                for (final CigarElement cigarElement : samRecord.getCigar().getCigarElements()) {
+                    if (cigarElement.getOperator().consumesReferenceBases()) {
+                        for (int elementIndex = 0; elementIndex < cigarElement.getLength(); elementIndex++)
+                            tracks.addCoverage(refPos + elementIndex, 1);
+                    }
+                    switch (cigarElement.getOperator()) {
+                        case M:
+                        case X:
+                        case EQ:
+                            for (int pos = readPos; pos < cigarElement.getLength(); pos++) {
+                                final byte readBase = samRecord.getReadBases()[readPos + pos];
+                                final byte refBase = tracks.baseAt(refPos + pos);
+                                if (readBase != refBase) tracks.addMismatches(refPos + pos, 1);
+                            }
+                            break;
+
+                        default:
+                            break;
+                    }
+
+                    readPos += cigarElement.getOperator().consumesReadBases() ? cigarElement.getLength() : 0;
+                    refPos += cigarElement.getOperator().consumesReferenceBases() ? cigarElement.getLength() : 0;
+                }
+            }
+        }
+    }
+
+    /**
+     * Complete the current container and flush it to the output stream.
+     *
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     * @throws IOException
+     */
+    private void flushContainer() throws IllegalArgumentException, IllegalAccessException, IOException {
+
+        final byte[] refs;
+        String refSeqName = null;
+        if (refSeqIndex == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
+            refs = new byte[0];
+        }
+        else {
+            final SAMSequenceRecord sequence = samFileHeader.getSequence(refSeqIndex);
+            refs = source.getReferenceBases(sequence, true);
+            refSeqName = sequence.getSequenceName();
+        }
+
+        int start = SAMRecord.NO_ALIGNMENT_START;
+        int stop = SAMRecord.NO_ALIGNMENT_START;
+        for (final SAMRecord r : samRecords) {
+            if (r.getAlignmentStart() == SAMRecord.NO_ALIGNMENT_START) {
+                continue;
+            }
+
+            if (start == SAMRecord.NO_ALIGNMENT_START) {
+                start = r.getAlignmentStart();
+            }
+
+            start = Math.min(r.getAlignmentStart(), start);
+            stop = Math.max(r.getAlignmentEnd(), stop);
+        }
+
+        ReferenceTracks tracks = null;
+        if (preservation != null && preservation.areReferenceTracksRequired()) {
+            tracks = new ReferenceTracks(refSeqIndex, refSeqName, refs);
+
+            tracks.ensureRange(start, stop - start + 1);
+            updateTracks(samRecords, tracks);
+        }
+
+        final List<CramCompressionRecord> cramRecords = new ArrayList<CramCompressionRecord>(samRecords.size());
+
+        final Sam2CramRecordFactory sam2CramRecordFactory = new Sam2CramRecordFactory(refs, samFileHeader, cramVersion);
+        sam2CramRecordFactory.preserveReadNames = preserveReadNames;
+        sam2CramRecordFactory.captureAllTags = captureAllTags;
+        sam2CramRecordFactory.captureTags.addAll(captureTags);
+        sam2CramRecordFactory.ignoreTags.addAll(ignoreTags);
+        containerFactory.setPreserveReadNames(preserveReadNames);
+
+        int index = 0;
+        int prevAlStart = start;
+        for (final SAMRecord samRecord : samRecords) {
+            final CramCompressionRecord cramRecord = sam2CramRecordFactory.createCramRecord(samRecord);
+            cramRecord.index = ++index;
+            cramRecord.alignmentDelta = samRecord.getAlignmentStart() - prevAlStart;
+            cramRecord.alignmentStart = samRecord.getAlignmentStart();
+            prevAlStart = samRecord.getAlignmentStart();
+
+            cramRecords.add(cramRecord);
+
+            if (preservation != null) {
+                preservation.addQualityScores(samRecord, cramRecord, tracks);
+            }
+            else if (cramRecord.qualityScores != SAMRecord.NULL_QUALS) {
+                cramRecord.setForcePreserveQualityScores(true);
+            }
+        }
+
+        if (sam2CramRecordFactory.getBaseCount() < 3 * sam2CramRecordFactory.getFeatureCount())
+            log.warn("Abnormally high number of mismatches, possibly wrong reference.");
+
+        {
+            if (samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.coordinate) {
+                // mating:
+                final Map<String, CramCompressionRecord> primaryMateMap = new TreeMap<String, CramCompressionRecord>();
+                final Map<String, CramCompressionRecord> secondaryMateMap = new TreeMap<String, CramCompressionRecord>();
+                for (final CramCompressionRecord r : cramRecords) {
+                    if (!r.isMultiFragment()) {
+                        r.setDetached(true);
+
+                        r.setHasMateDownStream(false);
+                        r.recordsToNextFragment = -1;
+                        r.next = null;
+                        r.previous = null;
+                    } else {
+                        final String name = r.readName;
+                        final Map<String, CramCompressionRecord> mateMap = r.isSecondaryAlignment() ? secondaryMateMap : primaryMateMap;
+                        final CramCompressionRecord mate = mateMap.get(name);
+                        if (mate == null) {
+                            mateMap.put(name, r);
+                        } else {
+                            CramCompressionRecord prev = mate;
+                            while (prev.next != null) prev = prev.next;
+                            prev.recordsToNextFragment = r.index - prev.index - 1;
+                            prev.next = r;
+                            r.previous = prev;
+                            r.previous.setHasMateDownStream(true);
+                            r.setHasMateDownStream(false);
+                            r.setDetached(false);
+                            r.previous.setDetached(false);
+                        }
+                    }
+                }
+
+                // mark unpredictable reads as detached:
+                for (final CramCompressionRecord cramRecord : cramRecords) {
+                    if (cramRecord.next == null || cramRecord.previous != null) {
+                        continue;
+                    }
+                    CramCompressionRecord last = cramRecord;
+                    while (last.next != null) {
+                        last = last.next;
+                    }
+
+                    if (cramRecord.isFirstSegment() && last.isLastSegment()) {
+
+                        final int templateLength = CramNormalizer.computeInsertSize(cramRecord, last);
+
+                        if (cramRecord.templateSize == templateLength) {
+                            last = cramRecord.next;
+                            while (last.next != null) {
+                                if (last.templateSize != -templateLength)
+                                    break;
+
+                                last = last.next;
+                            }
+                            if (last.templateSize != -templateLength) {
+                                detach(cramRecord);
+                            }
+                        }
+                        else {
+                            detach(cramRecord);
+                        }
+                    }
+                    else {
+                        detach(cramRecord);
+                    }
+                }
+
+                for (final CramCompressionRecord cramRecord : primaryMateMap.values()) {
+                    if (cramRecord.next != null) {
+                        continue;
+                    }
+                    cramRecord.setDetached(true);
+
+                    cramRecord.setHasMateDownStream(false);
+                    cramRecord.recordsToNextFragment = -1;
+                    cramRecord.next = null;
+                    cramRecord.previous = null;
+                }
+
+                for (final CramCompressionRecord cramRecord : secondaryMateMap.values()) {
+                    if (cramRecord.next != null) {
+                        continue;
+                    }
+                    cramRecord.setDetached(true);
+                    cramRecord.setHasMateDownStream(false);
+                    cramRecord.recordsToNextFragment = -1;
+                    cramRecord.next = null;
+                    cramRecord.previous = null;
+                }
+            }
+            else {
+                for (final CramCompressionRecord cramRecord : cramRecords) {
+                    cramRecord.setDetached(true);
+                }
+            }
+        }
+
+
+        {
+            /**
+             * The following passage is for paranoid mode only. When java is run with asserts on it will throw an {@link AssertionError} if
+             * read bases or quality scores of a restored SAM record mismatch the original. This is effectively a runtime round trip test.
+             */
+            @SuppressWarnings("UnusedAssignment") boolean assertsEnabled = false;
+            //noinspection AssertWithSideEffects,ConstantConditions
+            assert assertsEnabled = true;
+            //noinspection ConstantConditions
+            if (assertsEnabled) {
+                final Cram2SamRecordFactory f = new Cram2SamRecordFactory(samFileHeader);
+                for (int i = 0; i < samRecords.size(); i++) {
+                    final SAMRecord restoredSamRecord = f.create(cramRecords.get(i));
+                    assert (restoredSamRecord.getAlignmentStart() == samRecords.get(i).getAlignmentStart());
+                    assert (restoredSamRecord.getReferenceName().equals(samRecords.get(i).getReferenceName()));
+                    assert (restoredSamRecord.getReadString().equals(samRecords.get(i).getReadString()));
+                    assert (restoredSamRecord.getBaseQualityString().equals(samRecords.get(i).getBaseQualityString()));
+                }
+            }
+        }
+
+        final Container container = containerFactory.buildContainer(cramRecords);
+        for (final Slice slice : container.slices) {
+            slice.setRefMD5(refs);
+        }
+        container.offset = offset;
+        offset += ContainerIO.writeContainer(cramVersion, container, outputStream);
+        if (indexer != null) {
+            for (final Slice slice : container.slices) {
+                indexer.processAlignment(slice);
+            }
+        }
+        samRecords.clear();
+    }
+
+    /**
+     * Traverse the graph and mark all segments as detached.
+     *
+     * @param cramRecord the starting point of the graph
+     */
+    private static void detach(CramCompressionRecord cramRecord) {
+        do {
+            cramRecord.setDetached(true);
+            cramRecord.setHasMateDownStream(false);
+            cramRecord.recordsToNextFragment = -1;
+        }
+        while ((cramRecord = cramRecord.next) != null);
+    }
+
+    /**
+     * Check if the reference has changed and create a new record factory using the new reference.
+     *
+     * @param samRecordReferenceIndex index of the new reference sequence
+     */
+    private void updateReferenceContext(final int samRecordReferenceIndex) {
+        if (refSeqIndex == REF_SEQ_INDEX_NOT_INITIALIZED) {
+            refSeqIndex = samRecordReferenceIndex;
+        } else
+        if (refSeqIndex != samRecordReferenceIndex) refSeqIndex = samRecordReferenceIndex;
+    }
+}

--- a/src/java/htsjdk/samtools/CRAMFileWriter.java
+++ b/src/java/htsjdk/samtools/CRAMFileWriter.java
@@ -15,63 +15,23 @@
  ******************************************************************************/
 package htsjdk.samtools;
 
-import htsjdk.samtools.cram.build.ContainerFactory;
-import htsjdk.samtools.cram.build.Cram2SamRecordFactory;
-import htsjdk.samtools.cram.build.CramIO;
-import htsjdk.samtools.cram.build.CramNormalizer;
-import htsjdk.samtools.cram.build.Sam2CramRecordFactory;
-import htsjdk.samtools.cram.common.CramVersions;
-import htsjdk.samtools.cram.common.Version;
 import htsjdk.samtools.cram.lossy.PreservationPolicy;
-import htsjdk.samtools.cram.lossy.QualityScorePreservation;
 import htsjdk.samtools.cram.ref.ReferenceSource;
-import htsjdk.samtools.cram.ref.ReferenceTracks;
-import htsjdk.samtools.cram.structure.Container;
-import htsjdk.samtools.cram.structure.ContainerIO;
-import htsjdk.samtools.cram.structure.CramCompressionRecord;
-import htsjdk.samtools.cram.structure.CramHeader;
-import htsjdk.samtools.cram.structure.Slice;
 import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.StringLineReader;
 
-import java.io.IOException;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 
 @SuppressWarnings("UnusedDeclaration")
 public class CRAMFileWriter extends SAMFileWriterImpl {
-    private static final int REF_SEQ_INDEX_NOT_INITIALIZED = -2;
-    static int DEFAULT_RECORDS_PER_SLICE = 10000;
-    private static final int DEFAULT_SLICES_PER_CONTAINER = 1;
-    private static final Version cramVersion = CramVersions.CRAM_v2_1;
-
-    private final String fileName;
-    private final List<SAMRecord> samRecords = new ArrayList<SAMRecord>();
-    private ContainerFactory containerFactory;
-    protected final int recordsPerSlice = DEFAULT_RECORDS_PER_SLICE;
-    protected final int containerSize = recordsPerSlice * DEFAULT_SLICES_PER_CONTAINER;
-
-    private final OutputStream outputStream;
+    private CRAMContainerStreamWriter cramContainerStream;
+    private final SAMFileHeader samFileHeader;
     private ReferenceSource source;
-    private int refSeqIndex = REF_SEQ_INDEX_NOT_INITIALIZED;
+    private final String fileName;
 
     private static final Log log = Log.getInstance(CRAMFileWriter.class);
-
-    private final SAMFileHeader samFileHeader;
-    private boolean preserveReadNames = true;
-    private QualityScorePreservation preservation = null;
-    private boolean captureAllTags = true;
-    private Set<String> captureTags = new TreeSet<String>();
-    private Set<String> ignoreTags = new TreeSet<String>();
-
-    private CRAMIndexer indexer;
-    private long offset;
 
     /**
      * Create a CRAMFileWriter on an output stream. Requires input records to be presorted to match the
@@ -123,265 +83,14 @@ public class CRAMFileWriter extends SAMFileWriterImpl {
      */
     public CRAMFileWriter(final OutputStream outputStream, final OutputStream indexOS, final boolean presorted,
                           final ReferenceSource source, final SAMFileHeader samFileHeader, final String fileName) {
-        this.outputStream = outputStream;
         this.samFileHeader = samFileHeader;
         this.fileName = fileName;
-        initCRAMWriter(indexOS, source, samFileHeader, presorted);
-    }
-
-    private void initCRAMWriter(final OutputStream indexOS, final ReferenceSource source, final SAMFileHeader samFileHeader, final boolean preSorted) {
-        this.source = source;
-        setSortOrder(samFileHeader.getSortOrder(), preSorted);
-        setHeader(samFileHeader);
-
         if (this.source == null) {
             this.source = new ReferenceSource(Defaults.REFERENCE_FASTA);
         }
-
-        containerFactory = new ContainerFactory(samFileHeader, recordsPerSlice);
-        if (indexOS != null) {
-            indexer = new CRAMIndexer(indexOS, samFileHeader);
-        }
-    }
-
-    /**
-     * Decide if the current container should be completed and flushed. The decision is based on a) number of records and b) if the
-     * reference sequence id has changed.
-     *
-     * @param nextRecord the record to be added into the current or next container
-     * @return true if the current container should be flushed and the following records should go into a new container; false otherwise.
-     */
-    protected boolean shouldFlushContainer(final SAMRecord nextRecord) {
-        return samRecords.size() >= containerSize || refSeqIndex != REF_SEQ_INDEX_NOT_INITIALIZED && refSeqIndex != nextRecord.getReferenceIndex();
-    }
-
-    private static void updateTracks(final List<SAMRecord> samRecords, final ReferenceTracks tracks) {
-        for (final SAMRecord samRecord : samRecords) {
-            if (samRecord.getAlignmentStart() != SAMRecord.NO_ALIGNMENT_START) {
-                int refPos = samRecord.getAlignmentStart();
-                int readPos = 0;
-                for (final CigarElement cigarElement : samRecord.getCigar().getCigarElements()) {
-                    if (cigarElement.getOperator().consumesReferenceBases()) {
-                        for (int elementIndex = 0; elementIndex < cigarElement.getLength(); elementIndex++)
-                            tracks.addCoverage(refPos + elementIndex, 1);
-                    }
-                    switch (cigarElement.getOperator()) {
-                        case M:
-                        case X:
-                        case EQ:
-                            for (int pos = readPos; pos < cigarElement.getLength(); pos++) {
-                                final byte readBase = samRecord.getReadBases()[readPos + pos];
-                                final byte refBase = tracks.baseAt(refPos + pos);
-                                if (readBase != refBase) tracks.addMismatches(refPos + pos, 1);
-                            }
-                            break;
-
-                        default:
-                            break;
-                    }
-
-                    readPos += cigarElement.getOperator().consumesReadBases() ? cigarElement.getLength() : 0;
-                    refPos += cigarElement.getOperator().consumesReferenceBases() ? cigarElement.getLength() : 0;
-                }
-            }
-        }
-    }
-
-    /**
-     * Complete the current container and flush it to the output stream.
-     *
-     * @throws IllegalArgumentException
-     * @throws IllegalAccessException
-     * @throws IOException
-     */
-    protected void flushContainer() throws IllegalArgumentException, IllegalAccessException, IOException {
-
-        final byte[] refs;
-        String refSeqName = null;
-        if (refSeqIndex == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) refs = new byte[0];
-        else {
-            final SAMSequenceRecord sequence = samFileHeader.getSequence(refSeqIndex);
-            refs = source.getReferenceBases(sequence, true);
-            refSeqName = sequence.getSequenceName();
-        }
-
-        int start = SAMRecord.NO_ALIGNMENT_START;
-        int stop = SAMRecord.NO_ALIGNMENT_START;
-        for (final SAMRecord r : samRecords) {
-            if (r.getAlignmentStart() == SAMRecord.NO_ALIGNMENT_START) continue;
-
-            if (start == SAMRecord.NO_ALIGNMENT_START) start = r.getAlignmentStart();
-
-            start = Math.min(r.getAlignmentStart(), start);
-            stop = Math.max(r.getAlignmentEnd(), stop);
-        }
-
-        ReferenceTracks tracks = null;
-        if (preservation != null && preservation.areReferenceTracksRequired()) {
-            tracks = new ReferenceTracks(refSeqIndex, refSeqName, refs);
-
-            tracks.ensureRange(start, stop - start + 1);
-            updateTracks(samRecords, tracks);
-        }
-
-        final List<CramCompressionRecord> cramRecords = new ArrayList<CramCompressionRecord>(samRecords.size());
-
-        final Sam2CramRecordFactory sam2CramRecordFactory = new Sam2CramRecordFactory(refs, samFileHeader, cramVersion);
-        sam2CramRecordFactory.preserveReadNames = preserveReadNames;
-        sam2CramRecordFactory.captureAllTags = captureAllTags;
-        sam2CramRecordFactory.captureTags.addAll(captureTags);
-        sam2CramRecordFactory.ignoreTags.addAll(ignoreTags);
-        containerFactory.setPreserveReadNames(preserveReadNames);
-
-        int index = 0;
-        int prevAlStart = start;
-        for (final SAMRecord samRecord : samRecords) {
-            final CramCompressionRecord cramRecord = sam2CramRecordFactory.createCramRecord(samRecord);
-            cramRecord.index = ++index;
-            cramRecord.alignmentDelta = samRecord.getAlignmentStart() - prevAlStart;
-            cramRecord.alignmentStart = samRecord.getAlignmentStart();
-            prevAlStart = samRecord.getAlignmentStart();
-
-            cramRecords.add(cramRecord);
-
-            if (preservation != null) preservation.addQualityScores(samRecord, cramRecord, tracks);
-            else if (cramRecord.qualityScores != SAMRecord.NULL_QUALS) cramRecord.setForcePreserveQualityScores(true);
-        }
-
-        if (sam2CramRecordFactory.getBaseCount() < 3 * sam2CramRecordFactory.getFeatureCount())
-            log.warn("Abnormally high number of mismatches, possibly wrong reference.");
-
-        {
-            if (samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.coordinate) {
-                // mating:
-                final Map<String, CramCompressionRecord> primaryMateMap = new TreeMap<String, CramCompressionRecord>();
-                final Map<String, CramCompressionRecord> secondaryMateMap = new TreeMap<String, CramCompressionRecord>();
-                for (final CramCompressionRecord r : cramRecords) {
-                    if (!r.isMultiFragment()) {
-                        r.setDetached(true);
-
-                        r.setHasMateDownStream(false);
-                        r.recordsToNextFragment = -1;
-                        r.next = null;
-                        r.previous = null;
-                    } else {
-                        final String name = r.readName;
-                        final Map<String, CramCompressionRecord> mateMap = r.isSecondaryAlignment() ? secondaryMateMap : primaryMateMap;
-                        final CramCompressionRecord mate = mateMap.get(name);
-                        if (mate == null) {
-                            mateMap.put(name, r);
-                        } else {
-                            CramCompressionRecord prev = mate;
-                            while (prev.next != null) prev = prev.next;
-                            prev.recordsToNextFragment = r.index - prev.index - 1;
-                            prev.next = r;
-                            r.previous = prev;
-                            r.previous.setHasMateDownStream(true);
-                            r.setHasMateDownStream(false);
-                            r.setDetached(false);
-                            r.previous.setDetached(false);
-                        }
-                    }
-                }
-
-                // mark unpredictable reads as detached:
-                for (final CramCompressionRecord cramRecord : cramRecords) {
-                    if (cramRecord.next == null || cramRecord.previous != null) continue;
-                    CramCompressionRecord last = cramRecord;
-                    while (last.next != null) last = last.next;
-
-                    if (cramRecord.isFirstSegment() && last.isLastSegment()) {
-
-                        final int templateLength = CramNormalizer.computeInsertSize(cramRecord, last);
-
-                        if (cramRecord.templateSize == templateLength) {
-                            last = cramRecord.next;
-                            while (last.next != null) {
-                                if (last.templateSize != -templateLength)
-                                    break;
-
-                                last = last.next;
-                            }
-                            if (last.templateSize != -templateLength) detach(cramRecord);
-                        }else detach(cramRecord);
-                    } else detach(cramRecord);
-                }
-
-                for (final CramCompressionRecord cramRecord : primaryMateMap.values()) {
-                    if (cramRecord.next != null) continue;
-                    cramRecord.setDetached(true);
-
-                    cramRecord.setHasMateDownStream(false);
-                    cramRecord.recordsToNextFragment = -1;
-                    cramRecord.next = null;
-                    cramRecord.previous = null;
-                }
-
-                for (final CramCompressionRecord cramRecord : secondaryMateMap.values()) {
-                    if (cramRecord.next != null) continue;
-                    cramRecord.setDetached(true);
-
-                    cramRecord.setHasMateDownStream(false);
-                    cramRecord.recordsToNextFragment = -1;
-                    cramRecord.next = null;
-                    cramRecord.previous = null;
-                }
-            }
-            else {
-                for (final CramCompressionRecord cramRecord : cramRecords) {
-                    cramRecord.setDetached(true);
-                }
-            }
-        }
-
-
-        {
-            /**
-             * The following passage is for paranoid mode only. When java is run with asserts on it will throw an {@link AssertionError} if
-             * read bases or quality scores of a restored SAM record mismatch the original. This is effectively a runtime round trip test.
-             */
-            @SuppressWarnings("UnusedAssignment") boolean assertsEnabled = false;
-            //noinspection AssertWithSideEffects,ConstantConditions
-            assert assertsEnabled = true;
-            //noinspection ConstantConditions
-            if (assertsEnabled) {
-                final Cram2SamRecordFactory f = new Cram2SamRecordFactory(samFileHeader);
-                for (int i = 0; i < samRecords.size(); i++) {
-                    final SAMRecord restoredSamRecord = f.create(cramRecords.get(i));
-                    assert (restoredSamRecord.getAlignmentStart() == samRecords.get(i).getAlignmentStart());
-                    assert (restoredSamRecord.getReferenceName().equals(samRecords.get(i).getReferenceName()));
-                    assert (restoredSamRecord.getReadString().equals(samRecords.get(i).getReadString()));
-                    assert (restoredSamRecord.getBaseQualityString().equals(samRecords.get(i).getBaseQualityString()));
-                }
-            }
-        }
-
-        final Container container = containerFactory.buildContainer(cramRecords);
-        for (final Slice slice : container.slices)
-            slice.setRefMD5(refs);
-        container.offset = offset;
-        offset += ContainerIO.writeContainer(cramVersion, container, outputStream);
-        if (indexer != null) {
-            for (final Slice slice : container.slices) {
-                indexer.processAlignment(slice);
-            }
-        }
-        samRecords.clear();
-    }
-
-    /**
-     * Traverse the graph and mark all segments as detached.
-     *
-     * @param cramRecord the starting point of the graph
-     */
-    private static void detach(CramCompressionRecord cramRecord) {
-        do {
-            cramRecord.setDetached(true);
-
-            cramRecord.setHasMateDownStream(false);
-            cramRecord.recordsToNextFragment = -1;
-        }
-        while ((cramRecord = cramRecord.next) != null);
+        setSortOrder(samFileHeader.getSortOrder(), presorted);
+        cramContainerStream = new CRAMContainerStreamWriter(outputStream, indexOS, source, samFileHeader, fileName);
+        setHeader(samFileHeader);
     }
 
     /**
@@ -390,65 +99,18 @@ public class CRAMFileWriter extends SAMFileWriterImpl {
      */
     @Override
     protected void writeAlignment(final SAMRecord alignment) {
-        if (shouldFlushContainer(alignment)) {
-            try {
-                flushContainer();
-            } catch (IOException e) {
-                throw new RuntimeIOException(e);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        updateReferenceContext(alignment.getReferenceIndex());
-
-        samRecords.add(alignment);
-    }
-
-    /**
-     * Check if the reference has changed and create a new record factory using the new reference.
-     *
-     * @param samRecordReferenceIndex index of the new reference sequence
-     */
-    private void updateReferenceContext(final int samRecordReferenceIndex) {
-        if (refSeqIndex == REF_SEQ_INDEX_NOT_INITIALIZED) {
-            refSeqIndex = samRecordReferenceIndex;
-        } else
-            if (refSeqIndex != samRecordReferenceIndex) refSeqIndex = samRecordReferenceIndex;
+        cramContainerStream.writeAlignment(alignment);
     }
 
     @Override
     protected void writeHeader(final String textHeader) {
-        // TODO: header must be written exactly once per writer life cycle.
-        final SAMFileHeader header = new SAMTextHeaderCodec().decode(new StringLineReader(textHeader), (fileName != null ? fileName : null));
-
-        containerFactory = new ContainerFactory(header, recordsPerSlice);
-
-        final CramHeader cramHeader = new CramHeader(cramVersion, fileName, header);
-        try {
-            offset = CramIO.writeCramHeader(cramHeader, outputStream);
-        } catch (final IOException e) {
-            throw new RuntimeException(e);
-        }
+        cramContainerStream.writeHeader(
+                new SAMTextHeaderCodec().decode(new StringLineReader(textHeader),fileName != null ? fileName : null));
     }
 
     @Override
     protected void finish() {
-        try {
-            if (!samRecords.isEmpty()) {
-                flushContainer();
-            }
-            CramIO.issueEOF(cramVersion, outputStream);
-            outputStream.flush();
-            if (indexer != null) {
-                indexer.finish();
-            }
-            outputStream.close();
-        } catch (final IOException e) {
-            throw new RuntimeIOException(e);
-        } catch (final IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        cramContainerStream.finish(true); // flush the last container and issue EOF
     }
 
     @Override
@@ -457,42 +119,38 @@ public class CRAMFileWriter extends SAMFileWriterImpl {
     }
 
     public boolean isPreserveReadNames() {
-        return preserveReadNames;
+        return cramContainerStream.isPreserveReadNames();
     }
 
     public void setPreserveReadNames(final boolean preserveReadNames) {
-        this.preserveReadNames = preserveReadNames;
+        cramContainerStream.setPreserveReadNames(preserveReadNames);
     }
 
     public List<PreservationPolicy> getPreservationPolicies() {
-        if (preservation == null) {
-            // set up greedy policy by default:
-            preservation = new QualityScorePreservation("*8");
-        }
-        return preservation.getPreservationPolicies();
+        return cramContainerStream.getPreservationPolicies();
     }
 
     public boolean isCaptureAllTags() {
-        return captureAllTags;
+        return cramContainerStream.isCaptureAllTags();
     }
 
     public void setCaptureAllTags(final boolean captureAllTags) {
-        this.captureAllTags = captureAllTags;
+        cramContainerStream.setCaptureAllTags(captureAllTags);
     }
 
     public Set<String> getCaptureTags() {
-        return captureTags;
+        return cramContainerStream.getCaptureTags();
     }
 
     public void setCaptureTags(final Set<String> captureTags) {
-        this.captureTags = captureTags;
+        cramContainerStream.setCaptureTags(captureTags);
     }
 
     public Set<String> getIgnoreTags() {
-        return ignoreTags;
+        return cramContainerStream.getIgnoreTags();
     }
 
     public void setIgnoreTags(final Set<String> ignoreTags) {
-        this.ignoreTags = ignoreTags;
+        cramContainerStream.setIgnoreTags(ignoreTags);
     }
 }

--- a/src/java/htsjdk/samtools/cram/build/CramIO.java
+++ b/src/java/htsjdk/samtools/cram/build/CramIO.java
@@ -33,6 +33,7 @@ import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BufferedLineReader;
 import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.RuntimeIOException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -99,6 +100,25 @@ public class CramIO {
             return ZERO_B_EOF_MARKER.length;
         }
         return 0;
+    }
+
+    /**
+     * Write a CRAM File header and a SAM Header to an output stream.
+     *
+     * @param cramVersion
+     * @param outStream
+     * @param samFileHeader
+     * @param cramID
+     * @return the offset in the stream after writing the headers
+     */
+
+    public static long writeHeader(final Version cramVersion, final OutputStream outStream, final SAMFileHeader samFileHeader, String cramID) {
+        final CramHeader cramHeader = new CramHeader(cramVersion, cramID, samFileHeader);
+        try {
+            return CramIO.writeCramHeader(cramHeader, outStream);
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
     }
 
     private static boolean streamEndsWith(final SeekableStream seekableStream, final byte[] marker) throws IOException {

--- a/src/java/htsjdk/samtools/cram/common/CramVersions.java
+++ b/src/java/htsjdk/samtools/cram/common/CramVersions.java
@@ -1,7 +1,11 @@
 package htsjdk.samtools.cram.common;
 
 public class CramVersions {
-
     public static final Version CRAM_v2_1 = new Version(2, 1, 0);
     public static final Version CRAM_v3 = new Version(3, 0, 0);
+
+    /**
+     * The default CRAM version when creating a new CRAM output file or stream.
+     */
+    public static final Version DEFAULT_CRAM_VERSION = CRAM_v2_1;
 }

--- a/src/tests/java/htsjdk/samtools/CRAMContainerStreamWriterTest.java
+++ b/src/tests/java/htsjdk/samtools/CRAMContainerStreamWriterTest.java
@@ -1,0 +1,184 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
+import htsjdk.samtools.seekablestream.SeekableMemoryStream;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.Log.LogLevel;
+import htsjdk.samtools.util.RuntimeIOException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class CRAMContainerStreamWriterTest {
+
+    @BeforeClass
+    public void initClass() {
+        Log.setGlobalLogLevel(LogLevel.ERROR);
+    }
+
+    private List<SAMRecord> createRecords(int count) {
+        final List<SAMRecord> list = new ArrayList<SAMRecord>(count);
+        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        if (builder.getHeader().getReadGroups().isEmpty()) {
+            throw new IllegalStateException("Read group expected in the header");
+        }
+
+        int posInRef = 1;
+        for (int i = 0; i < count / 2; i++) {
+            builder.addPair(Integer.toString(i), i % 2, posInRef += 1, posInRef += 3);
+        }
+        list.addAll(builder.getRecords());
+
+        Collections.sort(list, new SAMRecordCoordinateComparator());
+
+        return list;
+    }
+
+    private SAMFileHeader createSAMHeader(SAMFileHeader.SortOrder sortOrder) {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSortOrder(sortOrder);
+        header.addSequence(new SAMSequenceRecord("chr1", 123));
+        header.addSequence(new SAMSequenceRecord("chr2", 123));
+        SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("1");
+        header.addReadGroup(readGroupRecord);
+        return header;
+    }
+
+    private ReferenceSource createReferenceSource() {
+        final byte[] refBases = new byte[1024 * 1024];
+        Arrays.fill(refBases, (byte) 'A');
+        InMemoryReferenceSequenceFile rsf = new InMemoryReferenceSequenceFile();
+        rsf.add("chr1", refBases);
+        rsf.add("chr2", refBases);
+        return new ReferenceSource(rsf);
+    }
+
+    private void doTest(final List<SAMRecord> samRecords, final ByteArrayOutputStream outStream, final OutputStream indexStream) {
+        final SAMFileHeader header = createSAMHeader(SAMFileHeader.SortOrder.coordinate);
+        final ReferenceSource refSource = createReferenceSource();
+
+        final CRAMContainerStreamWriter containerStream = new CRAMContainerStreamWriter(outStream, indexStream, refSource, header, "test");
+        containerStream.writeHeader(header);
+
+        for (SAMRecord record : samRecords) {
+            containerStream.writeAlignment(record);
+        }
+        containerStream.finish(true); // finish and issue EOF
+
+        // read all the records back in
+        final CRAMFileReader cReader = new CRAMFileReader(null, new ByteArrayInputStream(outStream.toByteArray()), refSource);
+        final SAMRecordIterator iterator = cReader.getIterator();
+        int count = 0;
+        while (iterator.hasNext()) {
+            SAMRecord actualRecord = iterator.next();
+            count++;
+        }
+        Assert.assertEquals(count, samRecords.size());
+    }
+
+    @Test(description = "Test CRAMContainerStream no index")
+    public void testCRAMContainerStreamNoIndex() {
+        final List<SAMRecord> samRecords = createRecords(100);
+        final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        doTest(samRecords, outStream, null);
+    }
+
+    @Test(description = "Test CRAMContainerStream aggregating multiple partitions")
+    public void testCRAMContainerAggregatePartitions() throws IOException {
+        final SAMFileHeader header = createSAMHeader(SAMFileHeader.SortOrder.coordinate);
+        final ReferenceSource refSource = createReferenceSource();
+
+        // create a bunch of records and write them out to separate streams in groups
+        final int nRecs = 100;
+        final int recsPerPartition = 20;
+        final int nPartitions = nRecs/recsPerPartition;
+
+        final List<SAMRecord> samRecords = createRecords(nRecs);
+        final ArrayList<ByteArrayOutputStream> byteStreamArray = new ArrayList<>(nPartitions);
+
+        for (int partition = 0, recNum = 0; partition < nPartitions; partition++) {
+            byteStreamArray.add(partition, new ByteArrayOutputStream());
+            final CRAMContainerStreamWriter containerStream =
+                    new CRAMContainerStreamWriter(byteStreamArray.get(partition), null, refSource, header, "test");
+
+            // don't write a header for the intermediate streams
+            for (int i = 0; i <  recsPerPartition; i++) {
+                containerStream.writeAlignment(samRecords.get(recNum++));
+            }
+            containerStream.finish(false); // finish but don't issue EOF container
+        }
+
+        // now create the final aggregate file by concatenating the individual streams, but this
+        // time with a CRAM and SAM header at the front and an EOF container at the end
+        final ByteArrayOutputStream aggregateStream = new ByteArrayOutputStream();
+        final CRAMContainerStreamWriter aggregateContainerStreamWriter = new CRAMContainerStreamWriter(aggregateStream, null, refSource, header, "test");
+        aggregateContainerStreamWriter .writeHeader(header); // write out one CRAM and SAM header
+        for (int j = 0; j < nPartitions; j++) {
+            byteStreamArray.get(j).writeTo(aggregateStream);
+        }
+        aggregateContainerStreamWriter.finish(true);// write out the EOF container
+
+        // now iterate through all the records in the aggregate file
+        final CRAMFileReader cReader = new CRAMFileReader(null, new ByteArrayInputStream(aggregateStream.toByteArray()), refSource);
+        final SAMRecordIterator iterator = cReader.getIterator();
+        int count = 0;
+        while (iterator.hasNext()) {
+            Assert.assertEquals(iterator.next().toString(), samRecords.get(count).toString());
+            count++;
+        }
+        Assert.assertEquals(count, nRecs);
+    }
+
+    @Test(description = "Test CRAMContainerStream with index")
+    public void testCRAMContainerStreamWithIndex() throws IOException {
+        final List<SAMRecord> samRecords = createRecords(100);
+        final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        final ByteArrayOutputStream indexStream = new ByteArrayOutputStream();
+        doTest(samRecords, outStream, indexStream);
+        outStream.close();
+        indexStream.close();
+
+        // write the file out
+        final File cramTempFile = File.createTempFile("cramContainerStreamTest", ".cram");
+        cramTempFile.deleteOnExit();
+        final OutputStream cramFileStream = new FileOutputStream(cramTempFile);
+        cramFileStream.write(outStream.toByteArray());
+        cramFileStream.close();
+
+        // write the index out
+        final File indexTempFile = File.createTempFile("cramContainerStreamTest", ".bai");
+        indexTempFile.deleteOnExit();
+        OutputStream indexFileStream = new FileOutputStream(indexTempFile);
+        indexFileStream.write(indexStream.toByteArray());
+        indexFileStream.close();
+
+        final ReferenceSource refSource = createReferenceSource();
+        final CRAMFileReader reader = new CRAMFileReader(
+                cramTempFile,
+                indexTempFile,
+                refSource,
+                ValidationStringency.SILENT);
+        final CloseableIterator<SAMRecord> iterator = reader.query(1, 10, 10, true);
+        int count = 0;
+        while (iterator.hasNext()) {
+            SAMRecord actualRecord = iterator.next();
+            count++;
+        }
+        Assert.assertEquals(count, 2);
+    }
+
+}

--- a/src/tests/java/htsjdk/samtools/CRAMFileIndexTest.java
+++ b/src/tests/java/htsjdk/samtools/CRAMFileIndexTest.java
@@ -274,15 +274,15 @@ public class CRAMFileIndexTest {
         final SamReader reader = SamReaderFactory.makeDefault().open(bamFile);
         final SAMRecordIterator iterator = reader.iterator();
         // to reduce granularity let's use this hacky approach:
-        int previousValue = CRAMFileWriter.DEFAULT_RECORDS_PER_SLICE ;
-        CRAMFileWriter.DEFAULT_RECORDS_PER_SLICE = nofReadsPerContainer;
+        int previousValue = CRAMContainerStreamWriter.DEFAULT_RECORDS_PER_SLICE ;
+        CRAMContainerStreamWriter.DEFAULT_RECORDS_PER_SLICE = nofReadsPerContainer;
         CRAMFileWriter writer = new CRAMFileWriter(baos, source, reader.getFileHeader(), bamFile.getName());
         while (iterator.hasNext()) {
             SAMRecord record = iterator.next();
             writer.addAlignment(record);
         }
         writer.close();
-        CRAMFileWriter.DEFAULT_RECORDS_PER_SLICE = previousValue;
+        CRAMContainerStreamWriter.DEFAULT_RECORDS_PER_SLICE = previousValue;
         return baos.toByteArray();
     }
 }


### PR DESCRIPTION
This PR factors out the code (from CRAMFileWriter) that bundles SAMRecords into CRAM containers , and repackages it in a new class CRAMContainerStreamWriter, which exposes an API for finer grained control over the writing of the CRAM file header, SAMFileHeader, and EOF container blocks than is possible with CRAMFileWriter. There is no net  new functionality; CRAMFileWriter delegates to the new class.
