### PR TITLE
XML serialization (marshalling ) of SAM with JAXB

### DIFF
--- a/src/java/htsjdk/samtools/Cigar.java
+++ b/src/java/htsjdk/samtools/Cigar.java
@@ -29,6 +29,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
 /**
  * A list of CigarElements, which describes how a read aligns with the reference.
  * E.g. the Cigar string 10M1D25M means
@@ -38,6 +43,7 @@ import java.util.List;
  *
  * c.f. http://samtools.sourceforge.net/SAM1.pdf for complete CIGAR specification.
  */
+@XmlRootElement(name="cigar")
 public class Cigar implements Serializable, Iterable<CigarElement> {
     public static final long serialVersionUID = 1L;
 
@@ -50,6 +56,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
         this.cigarElements.addAll(cigarElements);
     }
 
+    @XmlElement(name="element")
     public List<CigarElement> getCigarElements() {
         return Collections.unmodifiableList(cigarElements);
     }
@@ -66,6 +73,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
         return cigarElements.size();
     }
 
+    @XmlTransient
     public boolean isEmpty() {
         return cigarElements.isEmpty();
     }
@@ -73,6 +81,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
     /**
      * @return The number of reference bases that the read covers, excluding padding.
      */
+    @XmlTransient
     public int getReferenceLength() {
         int length = 0;
         for (final CigarElement element : cigarElements) {
@@ -114,6 +123,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
     /**
      * @return The number of read bases that the read covers.
      */
+    @XmlTransient
     public int getReadLength() {
         return getReadLength(cigarElements);
     }
@@ -305,26 +315,31 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
     }
     
     /** returns the first cigar element */
+    @XmlTransient
     public CigarElement getFirstCigarElement() {
         return isEmpty() ? null : this.cigarElements.get(0); 
     }
     
     /** returns the last cigar element */
+    @XmlTransient
     public CigarElement getLastCigarElement() {
         return isEmpty() ? null : this.cigarElements.get(this.numCigarElements() - 1 ); 
     }
     
     /** returns true if the cigar string starts With a clipping operator */
+    @XmlTransient
     public boolean isLeftClipped() {
         return !isEmpty() && isClippingOperator(getFirstCigarElement().getOperator());
     }
 
     /** returns true if the cigar string ends With a clipping operator */
+    @XmlTransient
     public boolean isRightClipped() {
         return !isEmpty() && isClippingOperator(getLastCigarElement().getOperator());
     }
 
     /** returns true if the cigar is clipped */
+    @XmlTransient
     public boolean isClipped() {
         return isLeftClipped() || isRightClipped();
     }

--- a/src/java/htsjdk/samtools/Cigar.java
+++ b/src/java/htsjdk/samtools/Cigar.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
@@ -56,7 +55,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
         this.cigarElements.addAll(cigarElements);
     }
 
-    @XmlElement(name="element")
+    @XmlElement(name="cigarUnit")
     public List<CigarElement> getCigarElements() {
         return Collections.unmodifiableList(cigarElements);
     }

--- a/src/java/htsjdk/samtools/CigarElement.java
+++ b/src/java/htsjdk/samtools/CigarElement.java
@@ -32,7 +32,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * One component of a cigar string.  The component comprises the operator, and the number of bases to which
  * the  operator applies.
  */
-@XmlRootElement(name="element")
+@XmlRootElement(name="CigarUnit")
 public class CigarElement implements Serializable {
     public static final long serialVersionUID = 1L;
 
@@ -51,12 +51,12 @@ public class CigarElement implements Serializable {
         this.operator = operator;
     }
 
-    @XmlAttribute(name="size")
+    @XmlAttribute(name="operationLength")//ga4gh
     public int getLength() {
         return length;
     }
 
-    @XmlAttribute(name="op")
+    @XmlAttribute(name="operation")//ga4gh
     public CigarOperator getOperator() {
         return operator;
     }

--- a/src/java/htsjdk/samtools/CigarElement.java
+++ b/src/java/htsjdk/samtools/CigarElement.java
@@ -25,25 +25,38 @@ package htsjdk.samtools;
 
 import java.io.Serializable;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
 /**
  * One component of a cigar string.  The component comprises the operator, and the number of bases to which
  * the  operator applies.
  */
+@XmlRootElement(name="element")
 public class CigarElement implements Serializable {
     public static final long serialVersionUID = 1L;
 
     private final int length;
     private final CigarOperator operator;
 
+    @SuppressWarnings("unused")
+    /* constructor for XML serialization */
+    private CigarElement()
+        {
+        this(1,CigarOperator.P);
+        }
+    
     public CigarElement(final int length, final CigarOperator operator) {
         this.length = length;
         this.operator = operator;
     }
 
+    @XmlAttribute(name="size")
     public int getLength() {
         return length;
     }
 
+    @XmlAttribute(name="op")
     public CigarOperator getOperator() {
         return operator;
     }

--- a/src/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/java/htsjdk/samtools/SAMFileHeader.java
@@ -38,11 +38,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
 /**
  * Header information from a SAM or BAM file.
  */
+@XmlRootElement(name="sam-header")
 public class SAMFileHeader extends AbstractSAMHeaderRecord
 {
+    private static final long serialVersionUID = 1L;
     public static final String VERSION_TAG = "VN";
     public static final String SORT_ORDER_TAG = "SO";
     public static final String GROUP_ORDER_TAG = "GO";
@@ -56,6 +64,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     public static final Set<String> STANDARD_TAGS =
             new HashSet<String>(Arrays.asList(VERSION_TAG, SORT_ORDER_TAG, GROUP_ORDER_TAG));
 
+    @XmlTransient
     Set<String> getStandardTags() {
         return STANDARD_TAGS;
     }
@@ -120,18 +129,23 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         setAttribute(VERSION_TAG, CURRENT_VERSION);
     }
 
+    @XmlAttribute(name="version")
     public String getVersion() {
         return (String) getAttribute("VN");
     }
 
+    @XmlAttribute(name="creator")
     public String getCreator() {
         return (String) getAttribute("CR");
     }
 
+    @XmlElement(name="dictionary")
     public SAMSequenceDictionary getSequenceDictionary() {
         return mSequenceDictionary;
     }
 
+    @XmlElementWrapper(name="read-groups")
+    @XmlElement(name="read-group")
     public List<SAMReadGroupRecord> getReadGroups() {
         return Collections.unmodifiableList(mReadGroups);
     }
@@ -197,6 +211,8 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         mReadGroupMap.put(readGroup.getReadGroupId(), readGroup);
     }
 
+    @XmlElementWrapper(name="program-records")
+    @XmlElement(name="program-record")
     public List<SAMProgramRecord> getProgramRecords() {
         return Collections.unmodifiableList(mProgramRecords);
     }
@@ -241,6 +257,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         throw new IllegalStateException("Surprising number of SAMProgramRecords");
     }
 
+    @XmlAttribute(name="sort-order")
     public SortOrder getSortOrder() {
         final String so = getAttribute("SO");
         if (so == null || so.equals("unknown")) {
@@ -253,6 +270,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         setAttribute("SO", so.name());
     }
 
+    @XmlAttribute(name="group-order")
     public GroupOrder getGroupOrder() {
         if (getAttribute("GO") == null) {
             return GroupOrder.none;
@@ -275,6 +293,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
      *
      * Invalid header lines may appear in value but are not stored in the SAMFileHeader object.
      */
+    @XmlTransient
     public String getTextHeader() {
         return textHeader;
     }
@@ -283,6 +302,8 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         this.textHeader = textHeader;
     }
 
+    @XmlElementWrapper(name="comments")
+    @XmlElement(name="comment")
     public List<String> getComments() {
         return Collections.unmodifiableList(mComments);
     }
@@ -305,6 +326,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         }
     }
 
+    @XmlTransient
     public List<SAMValidationError> getValidationErrors() {
         return Collections.unmodifiableList(mValidationErrors);
     }

--- a/src/java/htsjdk/samtools/SAMProgramRecord.java
+++ b/src/java/htsjdk/samtools/SAMProgramRecord.java
@@ -29,12 +29,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * In-memory representation of @PG SAM header record.
  */
-@XmlRootElement(name="program-record")
+@XmlRootElement(name="Program")
 public class SAMProgramRecord extends AbstractSAMHeaderRecord {
     private static final long serialVersionUID = 1L;
     public static final String PROGRAM_GROUP_ID_TAG = "ID";
@@ -49,6 +50,7 @@ public class SAMProgramRecord extends AbstractSAMHeaderRecord {
                     PROGRAM_VERSION_TAG,
                     COMMAND_LINE_TAG,
                     PREVIOUS_PROGRAM_GROUP_ID_TAG)) );
+    
     /** private constructor for xml serialization */
     @SuppressWarnings("unused")
     private SAMProgramRecord() {
@@ -65,6 +67,7 @@ public class SAMProgramRecord extends AbstractSAMHeaderRecord {
         }
     }
 
+    @XmlElement(name="id")
     public String getId() {
         return getProgramGroupId();
     }
@@ -73,6 +76,7 @@ public class SAMProgramRecord extends AbstractSAMHeaderRecord {
         return mProgramGroupId;
     }
 
+    @XmlElement(name="name")
     public String getProgramName() {
         return (String)getAttribute(PROGRAM_NAME_TAG);
     }
@@ -81,6 +85,7 @@ public class SAMProgramRecord extends AbstractSAMHeaderRecord {
         setAttribute(PROGRAM_NAME_TAG, name);
     }
 
+    @XmlElement(name="version")
     public String getProgramVersion() {
         return (String)getAttribute(PROGRAM_VERSION_TAG);
     }
@@ -89,6 +94,7 @@ public class SAMProgramRecord extends AbstractSAMHeaderRecord {
         setAttribute(PROGRAM_VERSION_TAG, version);
     }
 
+    @XmlElement(name="commandLine")
     public String getCommandLine() {
         return (String)getAttribute(COMMAND_LINE_TAG);
     }
@@ -97,6 +103,7 @@ public class SAMProgramRecord extends AbstractSAMHeaderRecord {
         setAttribute(COMMAND_LINE_TAG, commandLine);
     }
 
+    @XmlElement(name="prevProgramId")
     public String getPreviousProgramGroupId() {
         return (String)getAttribute(PREVIOUS_PROGRAM_GROUP_ID_TAG);
     }

--- a/src/java/htsjdk/samtools/SAMProgramRecord.java
+++ b/src/java/htsjdk/samtools/SAMProgramRecord.java
@@ -29,10 +29,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
 /**
  * In-memory representation of @PG SAM header record.
  */
+@XmlRootElement(name="program-record")
 public class SAMProgramRecord extends AbstractSAMHeaderRecord {
+    private static final long serialVersionUID = 1L;
     public static final String PROGRAM_GROUP_ID_TAG = "ID";
     public static final String PROGRAM_NAME_TAG = "PN";
     public static final String PROGRAM_VERSION_TAG = "VN";
@@ -45,7 +49,11 @@ public class SAMProgramRecord extends AbstractSAMHeaderRecord {
                     PROGRAM_VERSION_TAG,
                     COMMAND_LINE_TAG,
                     PREVIOUS_PROGRAM_GROUP_ID_TAG)) );
-
+    /** private constructor for xml serialization */
+    @SuppressWarnings("unused")
+    private SAMProgramRecord() {
+    }
+    
     public SAMProgramRecord(final String programGroupId) {
         this.mProgramGroupId = programGroupId;
     }

--- a/src/java/htsjdk/samtools/SAMReadGroupRecord.java
+++ b/src/java/htsjdk/samtools/SAMReadGroupRecord.java
@@ -32,12 +32,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * Header information about a read group.
  */
-@XmlRootElement(name="read-group")
+@XmlRootElement(name="ReadGroup")
 public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
 {
     private static final long serialVersionUID = 1L;
@@ -126,6 +127,8 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
     public String getDescription() { return getAttribute(DESCRIPTION_TAG); }
     public void setDescription(final String description) { setAttribute(DESCRIPTION_TAG, description); }
 
+    
+    @XmlElement(name="predictedInsertSize")//ga4gh
     public Integer getPredictedMedianInsertSize() {
         final String stringRep = getAttribute(PREDICTED_MEDIAN_INSERT_SIZE_TAG);
         if (stringRep == null) return null;

--- a/src/java/htsjdk/samtools/SAMReadGroupRecord.java
+++ b/src/java/htsjdk/samtools/SAMReadGroupRecord.java
@@ -126,7 +126,6 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
 
     public String getDescription() { return getAttribute(DESCRIPTION_TAG); }
     public void setDescription(final String description) { setAttribute(DESCRIPTION_TAG, description); }
-
     
     @XmlElement(name="predictedInsertSize")//ga4gh
     public Integer getPredictedMedianInsertSize() {

--- a/src/java/htsjdk/samtools/SAMReadGroupRecord.java
+++ b/src/java/htsjdk/samtools/SAMReadGroupRecord.java
@@ -32,11 +32,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
 /**
  * Header information about a read group.
  */
+@XmlRootElement(name="read-group")
 public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
 {
+    private static final long serialVersionUID = 1L;
     private String mReadGroupId = null;
     public static final String READ_GROUP_ID_TAG = "ID";
     public static final String SEQUENCING_CENTER_TAG = "CN";
@@ -65,6 +69,11 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
                     PROGRAM_GROUP_TAG, PREDICTED_MEDIAN_INSERT_SIZE_TAG, PLATFORM_TAG, PLATFORM_MODEL_TAG,
                     PLATFORM_UNIT_TAG, READ_GROUP_SAMPLE_TAG));
 
+    /** private constructor for XML serialization */
+    @SuppressWarnings("unused")
+    private SAMReadGroupRecord() {
+    }
+    
     public SAMReadGroupRecord(final String id) { mReadGroupId = id; }
 
     public SAMReadGroupRecord(final String id, final SAMReadGroupRecord srcProgramRecord) {

--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -38,6 +38,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlValue;
+
 
 /**
  * Java binding for a SAM file record.  c.f. http://samtools.sourceforge.net/SAM1.pdf
@@ -107,6 +114,7 @@ import java.util.Set;
  * @author alecw@broadinstitute.org
  * @author mishali.naik@intel.com
  */
+@XmlRootElement(name="read")
 public class SAMRecord implements Cloneable, Locatable, Serializable {
     public static final long serialVersionUID = 1L;
 
@@ -195,10 +203,16 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /** Transient Map of attributes for use by anyone. */
     private transient Map<Object,Object> transientAttributes;
 
+    /* used for xml serialization */
+    @SuppressWarnings("unused")
+    private SAMRecord() {
+    }
+    
     public SAMRecord(final SAMFileHeader header) {
         mHeader = header;
     }
 
+    @XmlElement(name="name")
     public String getReadName() {
         return mReadName;
     }
@@ -208,6 +222,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * it may be faster.
      * @return length not including a null terminator.
      */
+    @XmlTransient
     public int getReadNameLength() {
         return mReadName.length();
     }
@@ -219,6 +234,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return read sequence as a string of ACGTN=.
      */
+    @XmlElement(name="sequence")
     public String getReadString() {
         final byte[] readBases = getReadBases();
         if (readBases.length == 0) {
@@ -243,6 +259,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * byte[] and call setReadBases() or call setReadString().
      * @return read sequence as ASCII bytes ACGTN=.
      */
+    @XmlTransient
     public byte[] getReadBases() {
         return mReadBases;
     }
@@ -255,6 +272,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * This method is preferred over getReadBases().length, because for BAMRecord it may be faster.
      * @return number of bases in the read.
      */
+    @XmlTransient
     public int getReadLength() {
         return getReadBases().length;
     }
@@ -262,6 +280,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return Base qualities, encoded as a FASTQ string.
      */
+    @XmlElement(name="qualities")
     public String getBaseQualityString() {
         if (Arrays.equals(NULL_QUALS, getBaseQualities())) {
             return NULL_QUALS_STRING;
@@ -282,6 +301,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * byte[] and call setBaseQualities() or call setBaseQualityString().
      * @return Base qualities, as binary phred scores (not ASCII).
      */
+    @XmlTransient
     public byte[] getBaseQualities() {
         return mBaseQualities;
     }
@@ -294,6 +314,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * If the original base quality scores have been store in the "OQ" tag will return the numeric
      * score as a byte[]
      */
+    @XmlTransient
     public byte[] getOriginalBaseQualities() {
         final String oqString = (String) getAttribute("OQ");
         if (oqString != null && oqString.length() > 0) {
@@ -334,6 +355,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return Reference name, or NO_ALIGNMENT_REFERENCE_NAME (*) if the record has no reference name
      */
+    @XmlElement(name="reference")
     public String getReferenceName() { return mReferenceName; }
 
     /**
@@ -386,6 +408,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws IllegalStateException if the reference index cannot be resolved because the SAMFileHeader for the
      * record is null.
      */
+    @XmlTransient
     public Integer getReferenceIndex() {
         if (null == mReferenceIndex) {
             // try to resolve the reference index
@@ -437,6 +460,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return Mate reference name, or NO_ALIGNMENT_REFERENCE_NAME (*) if the record has no mate reference name
      */
+    @XmlElement(name="mate-reference")
     public String getMateReferenceName() {
         return mMateReferenceName;
     }
@@ -490,6 +514,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws IllegalStateException if the mate reference index cannot be resolved because the SAMFileHeader for the
      * record is null.
      */
+    @XmlTransient
     public Integer getMateReferenceIndex() {
         if (null == mMateReferenceIndex) {
             // try to resolve the reference index
@@ -541,6 +566,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return 1-based inclusive leftmost position of the clipped sequence, or 0 if there is no position.
      */
+    @XmlElement(name="start")
     public int getAlignmentStart() {
         return mAlignmentStart;
     }
@@ -559,6 +585,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return 1-based inclusive rightmost position of the clipped sequence, or 0 read if unmapped.
      */
+    @XmlTransient
     public int getAlignmentEnd() {
         if (getReadUnmappedFlag()) {
             return NO_ALIGNMENT_START;
@@ -577,6 +604,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      *
      * Invalid to call on an unmapped read.
      */
+    @XmlTransient
     public int getUnclippedStart() {
         return SAMUtils.getUnclippedStart(getAlignmentStart(), getCigar());
     }
@@ -588,6 +616,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      *
      * Invalid to call on an unmapped read.
      */
+    @XmlTransient
     public int getUnclippedEnd() {
         return SAMUtils.getUnclippedEnd(getAlignmentEnd(), getCigar());
     }
@@ -705,6 +734,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return 1-based inclusive leftmost position of the clipped mate sequence, or 0 if there is no position.
      */
+    @XmlElement(name="mate-start")
     public int getMateAlignmentStart() {
         return mMateAlignmentStart;
     }
@@ -717,6 +747,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return insert size (difference btw 5' end of read & 5' end of mate), if possible, else 0.
      * Negative if mate maps to lower position than read.
      */
+    @XmlElement(name="tlen")
     public int getInferredInsertSize() {
         return mInferredInsertSize;
     }
@@ -728,6 +759,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return phred scaled mapping quality.  255 implies valid mapping but quality is hard to compute.
      */
+    @XmlElement(name="mapq")
     public int getMappingQuality() {
         return mMappingQuality;
     }
@@ -736,6 +768,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         mMappingQuality = value;
     }
 
+    @XmlTransient
     public String getCigarString() {
         if (mCigarString == null && getCigar() != null) {
             mCigarString = TextCigarCodec.encode(getCigar());
@@ -758,6 +791,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * Cigar and call setCigar() or call setCigarString()
      * @return Cigar object for the read, or null if there is none.
      */
+    @XmlElement(name="cigar")
     public Cigar getCigar() {
         if (mCigar == null && mCigarString != null) {
             mCigar = TextCigarCodec.decode(mCigarString);
@@ -775,6 +809,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * This method is preferred over getCigar().getNumElements(), because for BAMRecord it may be faster.
      * @return number of cigar elements (number + operator) in the cigar string.
      */
+    @XmlTransient
     public int getCigarLength() {
         return getCigar().numCigarElements();
     }
@@ -804,6 +839,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * the given ID.or 3) this record has no SAMFileHeader
      * @throws ClassCastException if RG tag does not have a String value.
      */
+    @XmlTransient
     public SAMReadGroupRecord getReadGroup() {
         final String rgId = (String)getAttribute(SAMTagUtil.getSingleton().RG);
         if (rgId == null || getHeader() == null) {
@@ -816,6 +852,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * It is preferable to use the get*Flag() methods that handle the flag word symbolically.
      */
+    @XmlElement(name="flags")
     public int getFlags() {
         return mFlags;
     }
@@ -829,6 +866,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the read is paired in sequencing, no matter whether it is mapped in a pair.
      */
+    @XmlTransient
     public boolean getReadPairedFlag() {
         return (mFlags & SAMFlag.READ_PAIRED.flag) != 0;
     }
@@ -842,6 +880,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the read is mapped in a proper pair (depends on the protocol, normally inferred during alignment).
      */
+    @XmlTransient
     public boolean getProperPairFlag() {
         requireReadPaired();
         return getProperPairFlagUnchecked();
@@ -854,6 +893,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the query sequence itself is unmapped.
      */
+    @XmlTransient
     public boolean getReadUnmappedFlag() {
         return (mFlags & SAMFlag.READ_UNMAPPED.flag) != 0;
     }
@@ -861,6 +901,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the mate is unmapped.
      */
+    @XmlTransient
     public boolean getMateUnmappedFlag() {
         requireReadPaired();
         return getMateUnmappedFlagUnchecked();
@@ -873,6 +914,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * strand of the query (false for forward; true for reverse strand).
      */
+    @XmlTransient
     public boolean getReadNegativeStrandFlag() {
         return (mFlags & SAMFlag.READ_REVERSE_STRAND.flag) != 0;
     }
@@ -880,6 +922,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * strand of the mate (false for forward; true for reverse strand).
      */
+    @XmlTransient
     public boolean getMateNegativeStrandFlag() {
         requireReadPaired();
         return getMateNegativeStrandFlagUnchecked();
@@ -892,6 +935,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the read is the first read in a pair.
      */
+    @XmlTransient
     public boolean getFirstOfPairFlag() {
         requireReadPaired();
         return getFirstOfPairFlagUnchecked();
@@ -904,6 +948,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the read is the second read in a pair.
      */
+    @XmlTransient
     public boolean getSecondOfPairFlag() {
         requireReadPaired();
         return getSecondOfPairFlagUnchecked();
@@ -916,6 +961,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the alignment is not primary (a read having split hits may have multiple primary alignment records).
      */
+    @XmlTransient
     public boolean getNotPrimaryAlignmentFlag() {
         return (mFlags & SAMFlag.NOT_PRIMARY_ALIGNMENT.flag) != 0;
     }
@@ -923,6 +969,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the alignment is supplementary (TODO: further explanation?).
      */
+    @XmlTransient
     public boolean getSupplementaryAlignmentFlag() {
         return (mFlags & SAMFlag.SUPPLEMENTARY_ALIGNMENT.flag) != 0;
     }
@@ -930,6 +977,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the read fails platform/vendor quality checks.
      */
+    @XmlTransient
     public boolean getReadFailsVendorQualityCheckFlag() {
         return (mFlags & SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK.flag) != 0;
     }
@@ -937,6 +985,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * the read is either a PCR duplicate or an optical duplicate.
      */
+    @XmlTransient
     public boolean getDuplicateReadFlag() {
         return (mFlags & SAMFlag.DUPLICATE_READ.flag) != 0;
     }
@@ -1040,6 +1089,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * Tests if this record is either a secondary and/or supplementary alignment;
      * equivalent to {@code (getNotPrimaryAlignmentFlag() || getSupplementaryAlignmentFlag())}.
      */
+    @XmlTransient
     public boolean isSecondaryOrSupplementary() {
         return getNotPrimaryAlignmentFlag() || getSupplementaryAlignmentFlag();
     }
@@ -1051,7 +1101,8 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             mFlags &= ~bit;
         }
     }
-
+    
+    @XmlTransient
     public ValidationStringency getValidationStringency() {
         return mValidationStringency;
     }
@@ -1441,6 +1492,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return reference name, null if this is unmapped
      */
     @Override
+    @XmlTransient
     public String getContig() {
         if( getReadUnmappedFlag()) {
             return null;
@@ -1454,6 +1506,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return 1-based inclusive leftmost position of the clipped sequence, or 0 if there is no position.
      */
     @Override
+    @XmlTransient
     public int getStart() {
         return getAlignmentStart();
     }
@@ -1463,6 +1516,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return 1-based inclusive rightmost position of the clipped sequence, or 0 read if unmapped.
      */
     @Override
+    @XmlTransient
     public int getEnd() {
         return getAlignmentEnd();
     }
@@ -1470,19 +1524,44 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * Tag name and value of an attribute, for getAttributes() method.
      */
+    @XmlRootElement(name="attr")
     public static class SAMTagAndValue {
+        @XmlTransient
         public final String tag;
+        @XmlTransient
         public final Object value;
 
+        /** empty ctor for xml serialization */
+        @SuppressWarnings("unused")
+        private SAMTagAndValue() {
+            this("","");
+        }
+        
         public SAMTagAndValue(final String tag, final Object value) {
             this.tag = tag;
             this.value = value;
         }
+        
+        @XmlTransient
+        public String getTag() {
+            return tag;
+        }
+        @XmlTransient
+        public Object getValue() {
+            return value;
+        }
+        @XmlValue
+        public String getValueAsString() {
+            return new TextTagCodec().encode(this.tag, this.value);
+        }
+        
     }
 
     /**
      * @return list of {tag, value} tuples
      */
+    @XmlElementWrapper(name="attributes")
+    @XmlElement(name="attribute")
     public List<SAMTagAndValue> getAttributes() {
         SAMBinaryTagAndValue binaryAttributes = getBinaryAttributes();
         final List<SAMTagAndValue> ret = new ArrayList<SAMTagAndValue>();
@@ -1494,6 +1573,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         return ret;
     }
 
+    @XmlTransient
     Integer getIndexingBin() {
         return mIndexingBin;
     }
@@ -1541,6 +1621,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * written. Any record that does not have a header at the time it is added to the writer will be updated to use the
      * header associated with the writer.
      */
+    @XmlTransient
     public SAMFileHeader getHeader() {
         return mHeader;
     }
@@ -1594,6 +1675,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * for BAMRecords that have not been eagerDecoded(), and for which none of the data in the variable-length
      * portion has been changed.
      */
+    @XmlTransient
     public byte[] getVariableBinaryRepresentation() {
         return null;
     }
@@ -1696,6 +1778,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * reference sequence. Note that clipped portions of the read and inserted and
      * deleted bases (vs. the reference) are not represented in the alignment blocks.
      */
+    @XmlTransient
     public List<AlignmentBlock> getAlignmentBlocks() {
         if (this.mAlignmentBlocks == null) {
             this.mAlignmentBlocks = SAMUtils.getAlignmentBlocks(getCigar(), getAlignmentStart(), "read cigar");
@@ -1794,6 +1877,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return null if valid.  If invalid, returns a list of error messages.
      *
      */
+    @XmlTransient
     public List<SAMValidationError> isValid() {
         return isValid(false);
     }
@@ -2010,6 +2094,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * whence it came. 
      * @return The file source.  Note that the reader will be null if not activated using SAMFileReader.enableFileSource().
      */
+    @XmlTransient
     public SAMFileSource getFileSource() {
         return mFileSource;
     }
@@ -2169,10 +2254,12 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      Returns the record in the SAM line-based text format.  Fields are
      separated by '\t' characters, and the String is terminated by '\n'.
      */
+    @XmlTransient
     public String getSAMString() {
         return SAMTextWriter.getSAMString(this);
     }
 
+    @XmlTransient
     public String getPairedReadName() {
         final StringBuilder builder = new StringBuilder(64);
         builder.append(getReadName());
@@ -2189,6 +2276,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /** 
      * shortcut to <pre>SAMFlag.getFlags( this.getFlags() );</pre>
      * @returns a set of SAMFlag associated to this sam record */
+    @XmlTransient
     public final Set<SAMFlag> getSAMFlags() {
         return SAMFlag.getFlags(this.getFlags());
     }

--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -114,7 +113,7 @@ import javax.xml.bind.annotation.XmlValue;
  * @author alecw@broadinstitute.org
  * @author mishali.naik@intel.com
  */
-@XmlRootElement(name="read")
+@XmlRootElement(name="readAlignment")
 public class SAMRecord implements Cloneable, Locatable, Serializable {
     public static final long serialVersionUID = 1L;
 
@@ -234,7 +233,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return read sequence as a string of ACGTN=.
      */
-    @XmlElement(name="sequence")
+    @XmlElement(name="alignedSequence")//ga4gh
     public String getReadString() {
         final byte[] readBases = getReadBases();
         if (readBases.length == 0) {
@@ -280,7 +279,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return Base qualities, encoded as a FASTQ string.
      */
-    @XmlElement(name="qualities")
+    @XmlElement(name="alignedQuality")//ga4gh
     public String getBaseQualityString() {
         if (Arrays.equals(NULL_QUALS, getBaseQualities())) {
             return NULL_QUALS_STRING;
@@ -355,7 +354,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return Reference name, or NO_ALIGNMENT_REFERENCE_NAME (*) if the record has no reference name
      */
-    @XmlElement(name="reference")
+    @XmlElement(name="fragmentName")//ga4gh
     public String getReferenceName() { return mReferenceName; }
 
     /**
@@ -460,7 +459,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return Mate reference name, or NO_ALIGNMENT_REFERENCE_NAME (*) if the record has no mate reference name
      */
-    @XmlElement(name="mate-reference")
+    @XmlElement(name="mate-fragmentName")
     public String getMateReferenceName() {
         return mMateReferenceName;
     }
@@ -566,7 +565,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return 1-based inclusive leftmost position of the clipped sequence, or 0 if there is no position.
      */
-    @XmlElement(name="start")
+    @XmlElement(name="position")//ga4gh
     public int getAlignmentStart() {
         return mAlignmentStart;
     }
@@ -734,7 +733,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return 1-based inclusive leftmost position of the clipped mate sequence, or 0 if there is no position.
      */
-    @XmlElement(name="mate-start")
+    @XmlElement(name="mate-position")
     public int getMateAlignmentStart() {
         return mMateAlignmentStart;
     }
@@ -747,7 +746,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return insert size (difference btw 5' end of read & 5' end of mate), if possible, else 0.
      * Negative if mate maps to lower position than read.
      */
-    @XmlElement(name="tlen")
+    @XmlElement(name="fragmentLength")//ga4gh
     public int getInferredInsertSize() {
         return mInferredInsertSize;
     }
@@ -759,7 +758,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * @return phred scaled mapping quality.  255 implies valid mapping but quality is hard to compute.
      */
-    @XmlElement(name="mapq")
+    @XmlElement(name="mappingQuality")//ga4gh
     public int getMappingQuality() {
         return mMappingQuality;
     }
@@ -1531,7 +1530,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         @XmlTransient
         public final Object value;
 
-        /** empty ctor for xml serialization */
+        /** empty constructor for xml serialization */
         @SuppressWarnings("unused")
         private SAMTagAndValue() {
             this("","");

--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -201,7 +201,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 
     /** Transient Map of attributes for use by anyone. */
     private transient Map<Object,Object> transientAttributes;
-
+    
     /* used for xml serialization */
     @SuppressWarnings("unused")
     private SAMRecord() {
@@ -1100,7 +1100,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             mFlags &= ~bit;
         }
     }
-    
+
     @XmlTransient
     public ValidationStringency getValidationStringency() {
         return mValidationStringency;

--- a/src/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -165,6 +165,7 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
         return true;
     }
 
+    @SuppressWarnings("unused")
     private URI makeURI(final String s) throws URISyntaxException {
         URI uri = new URI(s);
         if (uri.getScheme() == null) {

--- a/src/java/htsjdk/samtools/SAMXmlWriter.java
+++ b/src/java/htsjdk/samtools/SAMXmlWriter.java
@@ -1,0 +1,197 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools;
+
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.ProgressLoggerInterface;
+import htsjdk.samtools.util.RuntimeIOException;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+/**
+ * Writer for text-format SAM files.
+ */
+public class SAMXmlWriter implements SAMFileWriter {
+
+    /** output stream */
+    private final Writer out;
+    /** XML stream */
+    private XMLStreamWriter xw;
+    /** xml stream writer doesn't close the underlying stream */
+    private final boolean close_stream_at_end;
+    /** xml fragment (don't print XML header ) */
+    private final boolean xml_fragment;
+   /** progress */
+    private ProgressLoggerInterface progress = null;
+    /** sam file header */
+    private final SAMFileHeader header;
+    /** xml marshaller */
+   private Marshaller marshaller;
+    
+    /**
+     * Constructs a SAMTextWriter that writes to a File.
+     * @param file Where to write the output.
+     */
+    public SAMXmlWriter(final SAMFileHeader header,final File file) {
+        try {
+            this.header = header;
+            final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newFactory();
+            this.out = new FileWriter(file);
+            this.xw = xmlOutputFactory.createXMLStreamWriter(this.out);
+            this.close_stream_at_end = true;
+            this.xml_fragment = false;
+            writeHeader();
+        } catch (Exception e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+    
+    /**
+     * Constructs a SAMTextWriter that writes to a File.
+     * @param file Where to write the output.
+     */
+    public SAMXmlWriter(final SAMFileHeader header,final XMLStreamWriter xwriter) {
+        try {
+            this.header = header;
+            this.out = null;
+            this.xw = xwriter;
+            this.close_stream_at_end = false;
+            this.xml_fragment = true;
+            writeHeader();
+        } catch (Exception e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /**
+     * Constructs a SAMTextWriter that writes to a File.
+     * @param file Where to write the output.
+     */
+    public SAMXmlWriter(final SAMFileHeader header,final OutputStream outputStream) {
+        try {
+            this.header = header;
+            final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newFactory();
+            this.out = new PrintWriter(outputStream);
+            this.xw = xmlOutputFactory.createXMLStreamWriter(this.out);
+            this.close_stream_at_end = false;
+            this.xml_fragment = true;
+            writeHeader();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    
+    private void writeHeader()
+        {
+        try {
+            JAXBContext context = JAXBContext.newInstance(SAMFileHeader.class,SAMRecord.class);
+            this.marshaller = context.createMarshaller();
+            this.marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+            if(!this.xml_fragment) this.xw.writeStartDocument("UTF-8", "1.0");
+            this.xw.writeStartElement("sam-file");
+            this.marshaller.marshal(this.header, this.xw);
+            this.xw.writeStartElement("reads");
+        } catch (JAXBException err)
+            {
+            throw new RuntimeException("Java IO/XML error",err);
+            }
+        catch (XMLStreamException err)
+            {
+            throw new RuntimeException("Java IO/XML error",err);
+            }
+        catch (Throwable e) {
+           e.printStackTrace();
+           throw new RuntimeException("Java IO/XML error",e);
+        }
+        }
+
+    @Override
+    public void addAlignment(final SAMRecord alignment) {
+        if(this.xw==null) throw new IllegalStateException("xml stream closed");
+        try {
+            this.marshaller.marshal(alignment, this.xw);
+        } catch (JAXBException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    @Override
+    public SAMFileHeader getFileHeader() {
+        return this.header;
+    }
+
+    @Override
+    public void setProgressLogger(final ProgressLoggerInterface progress) {
+        this.progress = progress;
+    }
+
+    @Override
+    public void close() {
+       
+        if( this.xw != null)
+            {
+            try {
+                this.xw.writeEndElement();//reads
+                this.xw.writeEndElement();//sam file
+                if(!this.xml_fragment) this.xw.writeEndDocument();
+                this.xw.flush();
+                this.xw=null;
+            }
+            catch(XMLStreamException err)
+                {
+                throw new RuntimeIOException(err);
+                }
+            }
+        if( this.close_stream_at_end )
+            {
+            CloserUtil.close(this.out);
+            }
+    }
+    
+    public static void main(String[] args) throws Exception {
+        SamReader samReader = SamReaderFactory.makeDefault().open(new File(args[0]));
+        SAMXmlWriter w = new SAMXmlWriter(samReader.getFileHeader(), System.out);
+        SAMRecordIterator iter= samReader.iterator();
+        while(iter.hasNext()) w.addAlignment(iter.next());
+        w.close();
+    }
+}
+    
+    
+
+
+   

--- a/src/java/htsjdk/samtools/SAMXmlWriter.java
+++ b/src/java/htsjdk/samtools/SAMXmlWriter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2009 The Broad Institute
+ * Copyright (c) 2015 Pierre Lindenbaum @yokofakun Institut du Thorax Nantes France
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/tests/java/htsjdk/samtools/SAMXmlWriterTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMXmlWriterTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2009 The Broad Institute
+ * Copyright (c) 2015 Pierre Lindenbaum @yokofakun Institut du Thorax Nantes France
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,11 +23,9 @@
  */
 package htsjdk.samtools;
 
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import htsjdk.samtools.SAMFileReaderTest.SAMRecordFactoryTester;
 import htsjdk.samtools.util.CloserUtil;
 
 import java.io.File;


### PR DESCRIPTION
## About JAXB
Adding a few annotations for the XML binding API (JAXB) doesn't change the behavior of htsjdk and add it allows to serialize/marshall a SAM file to XML without writing a specific tool, to use the objects as a source of XSLT transformation (http://blog.bdoughan.com/2012/11/using-jaxb-with-xslt-to-produce-html.html ) . Some 3rd party implementation of JAXB allows to write as JSON (http://stackoverflow.com/questions/19158056).

with the current changes , we can quickly build a (Jersey) REST server writing BAM as XML, JSON, text.... https://jersey.java.net/documentation/1.19/xml.html

## Code change

* I've added some `@XMLElement`, `@XMLAttribute` ... to the fields I want to serialize. I tried to use the names defined by the GA4GH. 
* `@XMLTransient` to fields/methods that should not be serialized to XML (e.g: SamRecord.getValidationStringency() )
* some **empty** **private** constructors (required by JAXB) e.g: 
```java
    /* used for xml serialization */
    @SuppressWarnings("unused")
    private SAMRecord() {
    }
```
* A `SAMXmlWriter implements SAMFileWriter` write a XML file from a SAM.
* A test SAMXmlWriterTest

### Example
here is a file produced by the test.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sam-file>
  <sam-header group-order="none" sort-order="unsorted" version="1.0">
    <comments/>
    <program-records/>
    <read-groups>
      <read-group>
        <sample>Hi,Mom!</sample>
      </read-group>
    </read-groups>
    <dictionary>
      <Reference index="0" length="101">chr1</Reference>
      <Reference index="1" length="101">chr2</Reference>
      <Reference index="2" length="101">chr3</Reference>
    </dictionary>
  </sam-header>
  <reads>
    <readAlignment>
      <position>1</position>
      <attributes>
        <attribute>RG:Z:0</attribute>
      </attributes>
      <alignedQuality>)'.*.+2,))</alignedQuality>
      <cigar>
        <cigarUnit operationLength="10" operation="M"/>
      </cigar>
      <flags>73</flags>
      <fragmentLength>0</fragmentLength>
      <mappingQuality>255</mappingQuality>
      <mate-position>0</mate-position>
      <mate-fragmentName>*</mate-fragmentName>
      <name>A</name>
      <alignedSequence>CAACAGAAGC</alignedSequence>
      <fragmentName>chr2</fragmentName>
    </readAlignment>
(...)
  </reads>
</sam-file>
```

## Misc

* I've not considered XML->object (unmarshalling) because there are too many non-empty constructors.
* if the PR is accepted, I'll do the same for VCF


