### PR TITLE
skip failing SRA test native code is unavailable

### DIFF
--- a/src/tests/java/htsjdk/samtools/sra/SRALazyRecordTest.java
+++ b/src/tests/java/htsjdk/samtools/sra/SRALazyRecordTest.java
@@ -23,6 +23,8 @@ public class SRALazyRecordTest {
 
     @Test(dataProvider = "serializationTestData")
     public void testSerialization(SRAAccession accession) throws Exception {
+        if (!SRAAccession.isSupported()) return;
+        
         SRAFileReader reader = new SRAFileReader(accession);
         final SAMRecord initialSAMRecord = reader.getIterator().next();
         reader.close();
@@ -34,6 +36,8 @@ public class SRALazyRecordTest {
 
     @Test
     public void testCloneAndEquals() throws Exception {
+        if (!SRAAccession.isSupported()) return;
+        
         SRAFileReader reader = new SRAFileReader(DEFAULT_ACCESSION);
         final SAMRecord record = reader.getIterator().next();
         reader.close();


### PR DESCRIPTION
adding code to skip an SRA test if the SRA native code is unavailable.