### PR TITLE
fastq serializeable

### DIFF
--- a/src/java/htsjdk/samtools/fastq/BasicFastqWriter.java
+++ b/src/java/htsjdk/samtools/fastq/BasicFastqWriter.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.util.IOUtil;
 
 import java.io.File;
+import java.io.Flushable;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
@@ -34,7 +35,7 @@ import java.io.PrintStream;
  * In general FastqWriterFactory should be used so that AsyncFastqWriter can be enabled, but there are some
  * cases in which that behavior is explicitly not wanted.
  */
-public class BasicFastqWriter implements FastqWriter {
+public class BasicFastqWriter implements FastqWriter,Flushable {
     private final String path;
     private final PrintStream writer;
 
@@ -55,6 +56,7 @@ public class BasicFastqWriter implements FastqWriter {
         this(null, writer);
     }
 
+    @Override
     public void write(final FastqRecord rec) {
         writer.print(FastqConstants.SEQUENCE_HEADER);
         writer.println(rec.getReadHeader());
@@ -67,10 +69,12 @@ public class BasicFastqWriter implements FastqWriter {
         }
     }
 
+    @Override
     public void flush() {
         writer.flush();
     }
 
+    @Override
     public void close() {
         writer.close();
     }

--- a/src/java/htsjdk/samtools/fastq/FastqReader.java
+++ b/src/java/htsjdk/samtools/fastq/FastqReader.java
@@ -156,6 +156,7 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
      */
     public File getFile() { return fastqFile ; }
 
+    @Override
     public void close() {
         try {
             reader.close();

--- a/src/java/htsjdk/samtools/fastq/FastqRecord.java
+++ b/src/java/htsjdk/samtools/fastq/FastqRecord.java
@@ -23,11 +23,13 @@
  */
 package htsjdk.samtools.fastq;
 
+import java.io.Serializable;
+
 /**
  * Represents a fastq record, fairly literally, i.e. without any conversion.
  */
-public class FastqRecord {
-
+public class FastqRecord implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final String seqHeaderPrefix;
     private final String seqLine;
     private final String qualHeaderPrefix;
@@ -41,6 +43,15 @@ public class FastqRecord {
         this.seqLine = seqLine ;
         this.qualLine = qualLine ;
     }
+    
+    /** copy constructor */
+    public FastqRecord(final FastqRecord other) {
+        if( other == null ) throw new IllegalArgumentException("new FastqRecord(null)");
+        this.seqHeaderPrefix = other.seqHeaderPrefix;
+        this.seqLine = other.seqLine;
+        this.qualHeaderPrefix = other.qualHeaderPrefix;
+        this.qualLine = other.qualLine;
+    }
 
     /** @return the read name */
     public String getReadHeader() { return seqHeaderPrefix; }
@@ -52,7 +63,6 @@ public class FastqRecord {
     public String getBaseQualityString() { return qualLine; }
     /** shortcut to getReadString().length() */
     public int length() { return this.seqLine==null?0:this.seqLine.length();}
-    
     
     @Override
     public int hashCode() {

--- a/src/tests/java/htsjdk/samtools/fastq/FastqWriterTest.java
+++ b/src/tests/java/htsjdk/samtools/fastq/FastqWriterTest.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Pierre Lindenbaum PhD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.fastq;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import htsjdk.samtools.util.TestUtil;
+
+import java.io.File;
+import java.util.ArrayList;
+
+/**
+ * test fastq
+ */
+public class FastqWriterTest {
+    private static final File TEST_DATA_DIR = new File("testdata/htsjdk/samtools/util/QualityEncodingDetectorTest");
+
+    @DataProvider(name = "fastqsource")
+    public Object[][] createTestData() {
+        return new Object[][]{
+                {"solexa_full_range_as_solexa.fastq"},
+                {"5k-30BB2AAXX.3.aligned.sam.fastq"}
+        };
+    }
+
+    @Test(dataProvider = "fastqsource")
+    public void testReadReadWriteFastq(final String basename) throws Exception {
+        final File tmpFile = File.createTempFile("test.", ".fastq");
+        tmpFile.deleteOnExit();
+        final FastqReader fastqReader = new FastqReader(new File(TEST_DATA_DIR,basename));
+        final FastqWriterFactory writerFactory = new FastqWriterFactory();
+        final FastqWriter fastqWriter = writerFactory.newWriter(tmpFile);
+        for(final FastqRecord rec: fastqReader) fastqWriter.write(rec);
+        fastqWriter.close();
+        fastqReader.close();
+    }
+    
+    @Test(dataProvider = "fastqsource")
+    public void testFastqSerialize(final String basename) throws Exception {
+        //write 
+        final ArrayList<FastqRecord> records = new ArrayList<>();
+        final FastqReader fastqReader = new FastqReader(new File(TEST_DATA_DIR,basename));
+        for(final FastqRecord rec: fastqReader) {
+            records.add(rec);
+            if(records.size()>100) break;
+        }
+        fastqReader.close();
+        Assert.assertEquals(TestUtil.serializeAndDeserialize(records),records);
+    }
+}


### PR DESCRIPTION
 * Serialize FASTQ record (answer to https://github.com/samtools/htsjdk/issues/445 )
 * clone+ copy constructor for fastq record
 *  BasicFastqWriter is java.io.Flushable
 * added @Override to close/flush in BasicFastqWriter and FastqReader
 * added a test for fastq
