### PR TITLE
Escape quotes in VCF header values

### DIFF
--- a/src/java/htsjdk/variant/vcf/VCFHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFHeaderLine.java
@@ -158,9 +158,17 @@ public class VCFHeaderLine implements Comparable, Serializable {
             builder.append("=");
             builder.append(entry.getValue().toString().contains(",") ||
                            entry.getValue().toString().contains(" ") ||
-                           entry.getKey().equals("Description") ? "\""+ entry.getValue() + "\"" : entry.getValue());
+                           entry.getKey().equals("Description") ? "\""+ escapeQuotes(entry.getValue().toString()) + "\"" : entry.getValue());
         }
         builder.append(">");
         return builder.toString();
+    }
+
+    private static String escapeQuotes(final String value) {
+        // java escaping in a string literal makes this harder to read than it should be
+        // without string literal escaping and quoting the regex would be: replaceAll( ([^\])" , $1\" )
+        // ie replace: something that's not a backslash ([^\]) followed by a double quote
+        // with: the thing that wasn't a backslash ($1), followed by a backslash, followed by a double quote
+        return value.replaceAll("([^\\\\])\"", "$1\\\\\"");
     }
 }

--- a/src/tests/java/htsjdk/variant/vcf/VCFHeaderLineUnitTest.java
+++ b/src/tests/java/htsjdk/variant/vcf/VCFHeaderLineUnitTest.java
@@ -1,0 +1,43 @@
+package htsjdk.variant.vcf;
+
+import htsjdk.variant.VariantBaseTest;
+import org.testng.annotations.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class VCFHeaderLineUnitTest extends VariantBaseTest {
+
+    @Test
+    public void testEncodeVCFHeaderLineWithUnescapedQuotes() {
+
+        final Map<String, String> attributes = new LinkedHashMap<>();
+        attributes.put("ID", "VariantFiltration");
+        attributes.put("CommandLineOptions", "filterName=[ANNOTATION] filterExpression=[ANNOTATION == \"NA\" || ANNOTATION <= 2.0]");
+
+        final String encodedAttributes = VCFHeaderLine.toStringEncoding(attributes);
+        assertNotNull(encodedAttributes);
+
+        final String expectedEncoding = "<ID=VariantFiltration,CommandLineOptions=\"filterName=[ANNOTATION] filterExpression=[ANNOTATION == \\\"NA\\\" || ANNOTATION <= 2.0]\">";
+        assertEquals(encodedAttributes, expectedEncoding);
+    }
+
+
+    @Test
+    public void testEncodeVCFHeaderLineWithEscapedQuotes() {
+
+        final Map<String, String> attributes = new LinkedHashMap<>();
+        attributes.put("ID", "VariantFiltration");
+        attributes.put("CommandLineOptions", "filterName=[ANNOTATION] filterExpression=[ANNOTATION == \\\"NA\\\" || ANNOTATION <= 2.0]");
+
+        final String encodedAttributes = VCFHeaderLine.toStringEncoding(attributes);
+        assertNotNull(encodedAttributes);
+
+        final String expectedEncoding = "<ID=VariantFiltration,CommandLineOptions=\"filterName=[ANNOTATION] filterExpression=[ANNOTATION == \\\"NA\\\" || ANNOTATION <= 2.0]\">";
+        assertEquals(encodedAttributes, expectedEncoding);
+    }
+
+}


### PR DESCRIPTION
This is a small change that protects against writing unescaped quotes in VCF header lines, which can cause files written with htsjdk to fail validation.

For some attribute values in VCF header lines, htsjdk currently wraps the string value with double quotes. However, if the value passed in itself contains double quotes, this results in unquoted or unbalanced quotes in the resulting VCF header line. An example tool that can cause this issue is GATK VariantFiltration, which creates VCF header lines (of the form "GATKCommandLine=") with broken quotes if run with a JEXL expression that contains double quotes.

The VCF spec states that double quotes can be escaped with a backlash. This change automatically does this when necessary. 

Included a couple of unit tests of the functionality as well as an end-to-end test that proves you can write out and read a file with escaped quotes, and then re-write and read it without runaway escaping. 