### PR TITLE
Proposal: A plugin system for prediction parser.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -176,6 +176,7 @@
             <fileset dir="${classes}" includes ="htsjdk/samtools/**/*.*"/>
             <fileset dir="${classes}" includes="htsjdk/tribble/**/*.*"/>
             <fileset dir="${classes}" includes="htsjdk/variant/**/*.*"/>
+            <fileset dir="etc" includes="META-INF/**/*.*"/>
             <manifest>
                 <attribute name="Implementation-Version" value="${htsjdk-version}(${repository.revision})"/>
                 <attribute name="Implementation-Vendor" value="Broad Institute"/>

--- a/etc/META-INF/services/htsjdk.variant.prediction.PredictionParserFactory
+++ b/etc/META-INF/services/htsjdk.variant.prediction.PredictionParserFactory
@@ -1,0 +1,1 @@
+htsjdk.variant.prediction.DefaultPredictionParserFactory

--- a/src/java/htsjdk/variant/prediction/DefaultPredictionParserFactory.java
+++ b/src/java/htsjdk/variant/prediction/DefaultPredictionParserFactory.java
@@ -1,0 +1,38 @@
+package htsjdk.variant.prediction;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** default prediction parser factory */
+public class DefaultPredictionParserFactory implements PredictionParserFactory {
+    @Override
+    public String getName() { return "Default";}
+    @Override
+    public String getVersion() { return "1.0";}
+    @Override
+    public String getDescription() { return "Default Prediction Parser for htsjdk. Does nothing.";}
+    @Override
+    public PredictionParser createParser(final VCFHeader header) {
+      return new PredictionParserImpl();
+    }
+    @Override
+    public Map<String,String> getProperties() {
+      return Collections.emptyMap();
+    }
+    
+    
+    private class PredictionParserImpl implements PredictionParser {
+      @Override
+      public PredictionParserFactory getFactory() {
+      return DefaultPredictionParserFactory.this;
+      }
+      /** get available predictions for this variant */
+      @Override
+      public List<Prediction> parse(final VariantContext ctx) {
+	return Collections.emptyList();
+      }
+    }
+  }

--- a/src/java/htsjdk/variant/prediction/Prediction.java
+++ b/src/java/htsjdk/variant/prediction/Prediction.java
@@ -1,0 +1,32 @@
+package htsjdk.variant.prediction;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import java.util.Optional;
+import java.util.Map;
+import java.util.Set;
+
+/** One Prediction */
+public interface Prediction {
+  /** the variant for this prediction */
+  public VariantContext getVariantContext();
+  /** alt allele for this prediction */
+  public Optional<Allele> getAlt();
+  /** Sequence Ontology terms */
+  public Set<SOTerm> getSOTerms();
+  
+    
+  public String getGeneName();
+  public String getGeneAccession();
+  public String getGeneId();
+  public String getTranscriptName();
+  public String getTranscriptAccession();
+  public String getTranscriptId();
+  public String getProteinName();
+  public String getProteinAccession();
+  public String getProteinId();
+  public Integer getPositionInCDna();
+  public Integer getPositionProtein();
+  public String getRefCodon();
+  public String getAlCodon();
+  public Map<String,Object> getProperties();
+  }

--- a/src/java/htsjdk/variant/prediction/PredictionParser.java
+++ b/src/java/htsjdk/variant/prediction/PredictionParser.java
@@ -1,0 +1,12 @@
+package htsjdk.variant.prediction;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import java.util.List;
+
+/** parses a variant context  and return a list of Prediction */
+public interface PredictionParser {
+  /** get owner factory */
+  public PredictionParserFactory getFactory();
+  /** get available predictions for this variant */
+  public List<Prediction> parse(final VariantContext ctx);
+  }

--- a/src/java/htsjdk/variant/prediction/PredictionParserFactory.java
+++ b/src/java/htsjdk/variant/prediction/PredictionParserFactory.java
@@ -1,0 +1,21 @@
+package htsjdk.variant.prediction;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import java.util.Map;
+import java.util.List;
+
+
+/** parses a variant context  and return a list of Prediction */
+public interface PredictionParserFactory {
+  /** factory name : e.g. VEP */
+  public String getName();
+  /** factory version */
+  public String getVersion();
+  /** factory version */
+  public String getDescription();
+  /** get a description of the associated properties in a prediction */
+  public Map<String,String> getProperties();
+  /** create a prediction parser from the VCF header */
+  public PredictionParser createParser(final VCFHeader header);
+  }

--- a/src/java/htsjdk/variant/prediction/SOTerm.java
+++ b/src/java/htsjdk/variant/prediction/SOTerm.java
@@ -1,0 +1,8 @@
+package htsjdk.variant.prediction;
+
+/** Sequence Ontology Term */
+public interface SOTerm {
+  public String getName();
+  public String getAccession();
+  public boolean isDescendantOf(final SOTerm parent);
+}

--- a/src/tests/java/htsjdk/variant/prediction/PredictionParserTest.java
+++ b/src/tests/java/htsjdk/variant/prediction/PredictionParserTest.java
@@ -1,0 +1,35 @@
+package htsjdk.variant.prediction;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFFileReader;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import java.io.File;
+import java.util.Map;
+import java.util.List;
+import java.util.ServiceLoader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class PredictionParserTest {
+    @Test
+    public void testDefaultPredctionParser() {
+	boolean foundOneParser=false;
+        final ServiceLoader<PredictionParserFactory> loader = ServiceLoader.load(PredictionParserFactory.class);
+        for(final PredictionParserFactory parserFactory:loader) {
+	  final File inputFileVcf = new File("testdata/htsjdk/tribble/tabix/testTabixIndex.vcf");
+	  
+	  final VCFFileReader reader = new VCFFileReader(inputFileVcf, false);
+	  PredictionParser parser = parserFactory.createParser(reader.getFileHeader());
+	  for(final VariantContext ctx:reader) {
+	  parser.parse(ctx);
+	  }
+	  reader.close();
+	  foundOneParser = true;
+        }
+        Assert.assertTrue(foundOneParser);
+        
+    }
+
+
+}


### PR DESCRIPTION
I'd like to have a standard system to parse VCF/INFO data produced by a prediction tools like VEP or SnpEff.

I quickly wrote a plugin system using java.util.ServiceLoader

This is a first draft. I don't want to write to much things if you don't like the idea :-)

 * The loaded interface is : **PredictionParserFactory**: it creates a **PredictionParser** from a VCFHeader (to find & decode the `##INFO=` header)
* A **PredictionParser** creates a  `List<Prediction>` from a **VariantContext**.
* A **Prediction** contains a Set of SequenceOntology terms, gene-name, transcript-name, etc...

I've added a **DefaultPredictionParserFactory** (which does nothing) and a test in **PredictionParserTest**. 

I've added `META-INF/services` for the ServiceLoader inside the htsjdk.jar that will load the minimal DefaultPredictionParserFactory.

your opinion ? :-)
