### PR TITLE
extended Tuple to a ComparableTuple so it can be used in a Histogram

### DIFF
--- a/src/java/htsjdk/samtools/util/ComparableTuple.java
+++ b/src/java/htsjdk/samtools/util/ComparableTuple.java
@@ -1,0 +1,28 @@
+package htsjdk.samtools.util;
+
+/**
+ * A simple extension of the Tuple class that, for comparable Types, allows comparing Tuples of non-null elements.
+ * <p>
+ * The comparison will compare the first arguments and if equal (compareTo returns 0) compare the second arguments.
+ *
+ * @author farjoun
+ */
+public class ComparableTuple<A extends Comparable<A>, B extends Comparable<B>> extends Tuple<A, B> implements Comparable<ComparableTuple<A, B>> {
+
+    public ComparableTuple(final A a, final B b) {
+        super(a, b);
+
+        if (a == null || b == null) {
+            throw new IllegalArgumentException("ComparableTuple's behavior is undefined when containing a null.");
+        }
+    }
+
+    @Override
+    public int compareTo(final ComparableTuple<A, B> o) {
+        int retval = a.compareTo(o.a);
+        if (retval == 0) {
+            retval = b.compareTo(o.b);
+        }
+        return retval;
+    }
+}

--- a/src/java/htsjdk/samtools/util/Tuple.java
+++ b/src/java/htsjdk/samtools/util/Tuple.java
@@ -13,4 +13,30 @@ public class Tuple<A, B> {
         this.a = a;
         this.b = b;
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final Tuple<?, ?> tuple = (Tuple<?, ?>) o;
+
+        if (a != null ? !a.equals(tuple.a) : tuple.a != null) return false;
+        return !(b != null ? !b.equals(tuple.b) : tuple.b != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = a != null ? a.hashCode() : 0;
+        result = 31 * result + (b != null ? b.hashCode() : 0);
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + a + ", " + b + "]";
+    }
+
 }

--- a/src/tests/java/htsjdk/samtools/util/ComparableTupleTest.java
+++ b/src/tests/java/htsjdk/samtools/util/ComparableTupleTest.java
@@ -1,0 +1,64 @@
+package htsjdk.samtools.util;
+
+import htsjdk.variant.variantcontext.Allele;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Created by farjoun on 1/28/16.
+ */
+public class ComparableTupleTest {
+
+    private enum Tenum {
+        Hi,
+        Bye,
+        Ciao
+    }
+
+    private Allele A = Allele.create("A", false);
+    private Allele Aref = Allele.create("A", true);
+    private Allele G = Allele.create("G", false);
+
+    @DataProvider(name = "testComparableTupleData")
+    public Object[][] testComparableTupleData() {
+        return new Object[][]{
+                new Object[]{new ComparableTuple<>(1, 2), new ComparableTuple<>(1, 1), 2 - 1},
+                new Object[]{new ComparableTuple<>(1, 2), new ComparableTuple<>(2, 2), 1 - 2},
+                new Object[]{new ComparableTuple<>(1, 2), new ComparableTuple<>(1, 2), 0},
+
+                new Object[]{new ComparableTuple<>(1, "hi"), new ComparableTuple<>(1, "bye"), "hi".compareTo("bye")},
+                new Object[]{new ComparableTuple<>(1, "hi"), new ComparableTuple<>(2, "bye"), 1 - 2},
+                new Object[]{new ComparableTuple<>(1, "hi"), new ComparableTuple<>(1, "hi"), 0},
+
+                new Object[]{new ComparableTuple<>(A, Tenum.Hi), new ComparableTuple<>(Aref, Tenum.Bye), A.compareTo(Aref)},
+                new Object[]{new ComparableTuple<>(Aref, Tenum.Hi), new ComparableTuple<>(Aref, Tenum.Bye), Tenum.Hi.compareTo(Tenum.Bye)},
+                new Object[]{new ComparableTuple<>(Aref, Tenum.Hi), new ComparableTuple<>(Aref, Tenum.Hi), 0},
+                new Object[]{new ComparableTuple<>(Aref, Tenum.Hi), new ComparableTuple<>(G, Tenum.Ciao), Aref.compareTo(G)},
+                new Object[]{new ComparableTuple<>(A, Tenum.Ciao), new ComparableTuple<>(G, Tenum.Hi), A.compareTo(G)}
+        };
+    }
+
+    @Test(dataProvider = "testComparableTupleData")
+    public void testComparableTuple(final ComparableTuple lhs, final ComparableTuple rhs, final int result) {
+        Assert.assertEquals(lhs.compareTo(rhs), result);
+    }
+
+
+    @DataProvider(name = "testComparableTupleNullData")
+    public Object[][] testComparableTupleNullData() {
+        return new Object[][]{
+                new Object[]{new ComparableTuple<>(null, 2), new ComparableTuple<>(1, 1)},
+                new Object[]{new ComparableTuple<>(1, null), new ComparableTuple<>(1, 1)},
+                new Object[]{new ComparableTuple<>(null, null), new ComparableTuple<>(1, 1)},
+                new Object[]{new ComparableTuple<>(1, 2), new ComparableTuple<>(null, 1)},
+                new Object[]{new ComparableTuple<>(1, 2), new ComparableTuple<>(2, null)},
+                new Object[]{new ComparableTuple<>(1, 2), new ComparableTuple<>(null, null)},
+        };
+    }
+
+    @Test(dataProvider = "testComparableTupleNullData", expectedExceptions = IllegalArgumentException.class)
+    public void testComparableTuple(final ComparableTuple lhs, final ComparableTuple rhs) {
+        lhs.compareTo(rhs);
+    }
+}

--- a/src/tests/java/htsjdk/samtools/util/TupleTest.java
+++ b/src/tests/java/htsjdk/samtools/util/TupleTest.java
@@ -1,0 +1,62 @@
+package htsjdk.samtools.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Created by farjoun on 1/29/16.
+ */
+public class TupleTest {
+
+    @Test
+    public void testEquals() throws Exception {
+        Assert.assertEquals(new Tuple<>(1, "hi"), new Tuple<>(1, "hi"));
+
+        Assert.assertEquals(new Tuple<>(1, null), new Tuple<>(1, null));
+        Assert.assertEquals(new Tuple<>(null, "hi"), new Tuple<>(null, "hi"));
+        Assert.assertEquals(new Tuple<>(null, null), new Tuple<>(null, null));
+
+
+        Assert.assertNotSame(new Tuple<Integer, Integer>(1, null), new Tuple<Integer, String>(1, null));
+        Assert.assertNotSame(new Tuple<Integer, String>(null, "hi"), new Tuple<String, String>(null, "hi"));
+        Assert.assertNotSame(new Tuple<Integer, Integer>(null, null), new Tuple<Integer, String>(null, null));
+
+
+        Assert.assertNotSame(new Tuple<>(1, "hi"), new Tuple<>(1, "bye"));
+        Assert.assertNotSame(new Tuple<>(2, "hi"), new Tuple<>(1, "hi"));
+        Assert.assertNotSame(new Tuple<>(2, "hi"), new Tuple<>(1, null));
+        Assert.assertNotSame(new Tuple<>(2, "hi"), new Tuple<>(null, "hi"));
+
+    }
+
+    @Test
+    public void testHashCode() throws Exception {
+        Assert.assertEquals(new Tuple<>(1, "hi").hashCode(), new Tuple<>(1, "hi").hashCode());
+
+        Assert.assertEquals(new Tuple<>(1, null).hashCode(), new Tuple<>(1, null).hashCode());
+        Assert.assertEquals(new Tuple<>(null, "hi").hashCode(), new Tuple<>(null, "hi").hashCode());
+        Assert.assertEquals(new Tuple<>(null, null).hashCode(), new Tuple<>(null, null).hashCode());
+
+        //even though these are of different types, the value is null and so I have to make these equal...
+        Assert.assertEquals(new Tuple<Integer, Integer>(1, null).hashCode(), new Tuple<Integer, String>(1, null).hashCode());
+        Assert.assertEquals(new Tuple<Integer, String>(null, "hi").hashCode(), new Tuple<String, String>(null, "hi").hashCode());
+        Assert.assertEquals(new Tuple<Integer, Integer>(null, null).hashCode(), new Tuple<Integer, String>(null, null).hashCode());
+
+        Assert.assertNotSame(new Tuple<>(1, "hi").hashCode(), new Tuple<>(1, "bye").hashCode());
+        Assert.assertNotSame(new Tuple<>(2, "hi").hashCode(), new Tuple<>(1, "hi").hashCode());
+        Assert.assertNotSame(new Tuple<>(2, "hi").hashCode(), new Tuple<>(1, null).hashCode());
+        Assert.assertNotSame(new Tuple<>(2, "hi").hashCode(), new Tuple<>(null, "hi").hashCode());
+
+    }
+
+    @Test
+    public void testToString() throws Exception {
+        Assert.assertEquals(new Tuple<>(1, 2).toString(), "[1, 2]");
+        Assert.assertEquals(new Tuple<>(1, "hi!").toString(), "[1, hi!]");
+        Assert.assertEquals(new Tuple<>(1, new Tuple<>(2, 3)).toString(), "[1, [2, 3]]");
+
+        Assert.assertEquals(new Tuple<>(1, null).toString(), "[1, null]");
+        Assert.assertEquals(new Tuple<>(null, null).toString(), "[null, null]");
+
+    }
+}


### PR DESCRIPTION

- add equals, toString, and hashCode to Tuple
- extend Tuple to ComparableTuple for when the Types are themselves Comparable

This makes it possible to use ComparableTuple in the Histogram class.

