### PR TITLE
moving SRA tests to their own test group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: true
 jdk:
   - oraclejdk8
 install: ant
-script: ant all test
+script: ant all test sra-test
 after_success:
   - echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'";
     echo "JAVA_HOME='$JAVA_HOME'";

--- a/build.xml
+++ b/build.xml
@@ -119,31 +119,45 @@
     </target>
 
     <!-- TEST -->
+    <macrodef name="run-test">
+        <attribute name="excludedTestGroups" default=""/>
+        <attribute name="includedTestGroups" default=""/>
+        <sequential>
+                <taskdef resource="testngtasks" classpathref="classpath"/>
+                <testng suitename="htsjdk-tests" classpathref="classpath" outputdir="${test.output}"
+                        failureproperty="tests.failed" excludedgroups="@{excludedTestGroups}" groups="@{includedTestGroups}"
+                        workingDir="${basedir}"
+                        verbose="${testng.verbosity}">
+                    <classpath>
+                        <pathelement path="${classes}"/>
+                        <pathelement path="${classes.test}"/>
+                        <pathelement path="${scripts}"/>
+                    </classpath>
+                    <classfileset dir="${classes.test}">
+                        <include name="**/Test*.class"/>
+                        <include name="**/*Test.class"/>
+                    </classfileset>
+                    <jvmarg value="-Xmx2G"/>
+                </testng>
+                <junitreport todir="${dist}/test" >
+                    <fileset dir="${test.output}">
+                        <include name="*.xml"/>
+                    </fileset>
+                    <report format="noframes" todir="${dist}/test" styledir="etc/test"/>
+                </junitreport>
+                <copy file="etc/test/testng.css" todir="${dist}/test" overwrite="true"/>
+                <fail if="tests.failed" message="There were failed unit tests"/>
+        </sequential>
+    </macrodef>
+
     <target name="test" depends="compile, set_excluded_test_groups" description="Run unit tests">
-        <taskdef resource="testngtasks" classpathref="classpath"/>
-        <testng suitename="htsjdk-tests" classpathref="classpath" outputdir="${test.output}"
-                failureproperty="tests.failed" excludedgroups="${excludedTestGroups}" workingDir="${basedir}"
-                verbose="${testng.verbosity}">
-            <classpath>
-                <pathelement path="${classes}"/>
-                <pathelement path="${classes.test}"/>
-                <pathelement path="${scripts}"/>
-            </classpath>
-            <classfileset dir="${classes.test}">
-                <include name="**/Test*.class"/>
-                <include name="**/*Test.class"/>
-            </classfileset>
-            <jvmarg value="-Xmx2G"/>
-        </testng>
-        <junitreport todir="${dist}/test" >
-            <fileset dir="${test.output}">
-                <include name="*.xml"/>
-            </fileset>
-            <report format="noframes" todir="${dist}/test" styledir="etc/test"/>
-        </junitreport>
-        <copy file="etc/test/testng.css" todir="${dist}/test" overwrite="true"/>
-        <fail if="tests.failed" message="There were failed unit tests"/>
+            <run-test excludedTestGroups="${excludedTestGroups}, sra"/>
     </target>
+
+    <target name="sra-test" depends="compile, set_excluded_test_groups" description="Run SRA unit tests">
+        <run-test includedTestGroups="sra" excludedTestGroups="${excludedTestGroups}"/>
+    </target>
+
 
     <target name="single-test"
             depends="compile, compile-tests"

--- a/src/tests/java/htsjdk/samtools/sra/AbstractSRATest.java
+++ b/src/tests/java/htsjdk/samtools/sra/AbstractSRATest.java
@@ -1,0 +1,57 @@
+package htsjdk.samtools.sra;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.NoSuchElementException;
+
+@Test(groups = "sra")
+public abstract class AbstractSRATest {
+
+    @BeforeMethod
+    public final void assertSRAIsSupported(){
+        if(!SRAAccession.isSupported()){
+            throw new SkipException("Skipping SRA Test because SRA native code is unavailable.");
+        }
+    }
+
+    /**
+     * Exhaust the iterator and check that it produce the expected number of mapped and unmapped reads.
+     * Also checks that the hasNext() agrees with the actual results of next() for the given iterator.
+     * @param expectedNumMapped expected number of mapped reads, specify -1 to skip this check
+     * @param expectedNumUnmapped expected number of unmapped reads, specify -1 to skip this check
+     */
+    static void assertCorrectCountsOfMappedAndUnmappedRecords(SAMRecordIterator samRecordIterator,
+                                                                        int expectedNumMapped, int expectedNumUnmapped) {
+        int numMapped = 0, numUnmapped = 0;
+        while (true) {
+            boolean hasRecord = samRecordIterator.hasNext();
+            SAMRecord record;
+            try {
+                record = samRecordIterator.next();
+                Assert.assertNotNull(record);
+                Assert.assertTrue(hasRecord); // exception is not thrown if we came to this point
+            } catch (final NoSuchElementException e) {
+                Assert.assertFalse(hasRecord);
+                break;
+            }
+
+            if (record.getReadUnmappedFlag()) {
+                numUnmapped++;
+            } else {
+                numMapped++;
+            }
+        }
+
+        if (expectedNumMapped != -1) {
+            Assert.assertEquals(numMapped, expectedNumMapped);
+        }
+        if (expectedNumUnmapped != -1) {
+            Assert.assertEquals(numUnmapped, expectedNumUnmapped);
+        }
+    }
+}

--- a/src/tests/java/htsjdk/samtools/sra/SRAAccessionTest.java
+++ b/src/tests/java/htsjdk/samtools/sra/SRAAccessionTest.java
@@ -1,7 +1,5 @@
 package htsjdk.samtools.sra;
 
-import htsjdk.samtools.sra.SRAAccession;
-
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -9,10 +7,10 @@ import org.testng.annotations.Test;
 /**
  * Tests for SRAAccession logic
  */
-public class SRAAccessionTest {
+public class SRAAccessionTest extends AbstractSRATest {
 
     @DataProvider(name = "isValidAccData")
-    public Object[][] getIsValidAccData() {
+    private Object[][] getIsValidAccData() {
         return new Object[][] {
             { "SRR000123", true },
             { "DRR000001", true },
@@ -25,8 +23,6 @@ public class SRAAccessionTest {
 
     @Test(dataProvider = "isValidAccData")
     public void testIsValidAcc(String accession, boolean isValid) {
-        if (!SRAAccession.isSupported()) return;
-
         Assert.assertEquals(isValid, SRAAccession.isValid(accession));
     }
 

--- a/src/tests/java/htsjdk/samtools/sra/SRAIndexTest.java
+++ b/src/tests/java/htsjdk/samtools/sra/SRAIndexTest.java
@@ -35,11 +35,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -47,16 +45,14 @@ import java.util.Set;
  *
  * Created by andrii.nikitiuk on 10/28/15.
  */
-public class SRAIndexTest {
+public class SRAIndexTest extends AbstractSRATest {
     private static final SRAAccession DEFAULT_ACCESSION = new SRAAccession("SRR1298981");
     private static final int LAST_BIN_LEVEL = GenomicIndexUtil.LEVEL_STARTS.length - 1;
     private static final int SRA_BIN_OFFSET = GenomicIndexUtil.LEVEL_STARTS[LAST_BIN_LEVEL];
 
     @Test
     public void testLevelSize() {
-        if (!SRAAccession.isSupported()) return;
-
-        SRAIndex index = getIndex(DEFAULT_ACCESSION);
+        final SRAIndex index = getIndex(DEFAULT_ACCESSION);
         Assert.assertEquals(index.getLevelSize(0), GenomicIndexUtil.LEVEL_STARTS[1] - GenomicIndexUtil.LEVEL_STARTS[0]);
 
         Assert.assertEquals(index.getLevelSize(LAST_BIN_LEVEL), GenomicIndexUtil.MAX_BINS - GenomicIndexUtil.LEVEL_STARTS[LAST_BIN_LEVEL] - 1);
@@ -64,15 +60,13 @@ public class SRAIndexTest {
 
     @Test
     public void testLevelForBin() {
-        if (!SRAAccession.isSupported()) return;
-
-        SRAIndex index = getIndex(DEFAULT_ACCESSION);
-        Bin bin = new Bin(0, SRA_BIN_OFFSET);
+        final SRAIndex index = getIndex(DEFAULT_ACCESSION);
+        final Bin bin = new Bin(0, SRA_BIN_OFFSET);
         Assert.assertEquals(index.getLevelForBin(bin), LAST_BIN_LEVEL);
     }
 
     @DataProvider(name = "testBinLocuses")
-    public Object[][] createDataForBinLocuses() {
+    private Object[][] createDataForBinLocuses() {
         return new Object[][] {
                 {DEFAULT_ACCESSION, 0, 0, 1, SRAIndex.SRA_BIN_SIZE},
                 {DEFAULT_ACCESSION, 0, 1, SRAIndex.SRA_BIN_SIZE + 1, SRAIndex.SRA_BIN_SIZE * 2}
@@ -81,35 +75,31 @@ public class SRAIndexTest {
 
     @Test(dataProvider = "testBinLocuses")
     public void testBinLocuses(SRAAccession acc, int reference, int binIndex, int firstLocus, int lastLocus) {
-        if (!SRAAccession.isSupported()) return;
-
-        SRAIndex index = getIndex(acc);
-        Bin bin = new Bin(reference, SRA_BIN_OFFSET + binIndex);
+        final SRAIndex index = getIndex(acc);
+        final Bin bin = new Bin(reference, SRA_BIN_OFFSET + binIndex);
 
         Assert.assertEquals(index.getFirstLocusInBin(bin), firstLocus);
         Assert.assertEquals(index.getLastLocusInBin(bin), lastLocus);
     }
 
     @DataProvider(name = "testBinOverlappings")
-    public Object[][] createDataForBinOverlappings() {
+    private Object[][] createDataForBinOverlappings() {
         return new Object[][] {
-                {DEFAULT_ACCESSION, 0, 1, SRAIndex.SRA_BIN_SIZE, new HashSet<Integer>(Arrays.asList(0))},
-                {DEFAULT_ACCESSION, 0, SRAIndex.SRA_BIN_SIZE + 1, SRAIndex.SRA_BIN_SIZE * 2, new HashSet<Integer>(Arrays.asList(1))},
-                {DEFAULT_ACCESSION, 0, SRAIndex.SRA_BIN_SIZE + 1, SRAIndex.SRA_BIN_SIZE * 3, new HashSet<Integer>(Arrays.asList(1, 2))},
-                {DEFAULT_ACCESSION, 0, SRAIndex.SRA_BIN_SIZE * 2, SRAIndex.SRA_BIN_SIZE * 2 + 1, new HashSet<Integer>(Arrays.asList(1, 2))}
+                {DEFAULT_ACCESSION, 0, 1, SRAIndex.SRA_BIN_SIZE, new HashSet<>(Arrays.asList(0))},
+                {DEFAULT_ACCESSION, 0, SRAIndex.SRA_BIN_SIZE + 1, SRAIndex.SRA_BIN_SIZE * 2, new HashSet<>(Arrays.asList(1))},
+                {DEFAULT_ACCESSION, 0, SRAIndex.SRA_BIN_SIZE + 1, SRAIndex.SRA_BIN_SIZE * 3, new HashSet<>(Arrays.asList(1, 2))},
+                {DEFAULT_ACCESSION, 0, SRAIndex.SRA_BIN_SIZE * 2, SRAIndex.SRA_BIN_SIZE * 2 + 1, new HashSet<>(Arrays.asList(1, 2))}
         };
     }
 
 
     @Test(dataProvider = "testBinOverlappings")
     public void testBinOverlappings(SRAAccession acc, int reference, int firstLocus, int lastLocus, Set<Integer> binNumbers) {
-        if (!SRAAccession.isSupported()) return;
-
-        SRAIndex index = getIndex(acc);
-        Iterator<Bin> binIterator = index.getBinsOverlapping(reference, firstLocus, lastLocus).iterator();
-        Set<Integer> binNumbersFromIndex = new HashSet<Integer>();
+        final SRAIndex index = getIndex(acc);
+        final Iterator<Bin> binIterator = index.getBinsOverlapping(reference, firstLocus, lastLocus).iterator();
+        final Set<Integer> binNumbersFromIndex = new HashSet<>();
         while (binIterator.hasNext()) {
-            Bin bin = binIterator.next();
+            final Bin bin = binIterator.next();
             binNumbersFromIndex.add(bin.getBinNumber() - SRA_BIN_OFFSET);
         }
 
@@ -117,7 +107,7 @@ public class SRAIndexTest {
     }
 
     @DataProvider(name = "testSpanOverlappings")
-    public Object[][] createDataForSpanOverlappings() {
+    private Object[][] createDataForSpanOverlappings() {
         return new Object[][] {
                 {DEFAULT_ACCESSION, 0, 1, SRAIndex.SRA_BIN_SIZE, new long[] {0, SRAIndex.SRA_CHUNK_SIZE} },
                 {DEFAULT_ACCESSION, 0, SRAIndex.SRA_BIN_SIZE * 2, SRAIndex.SRA_BIN_SIZE * 2 + 1, new long[]{0, SRAIndex.SRA_CHUNK_SIZE} },
@@ -127,16 +117,10 @@ public class SRAIndexTest {
 
     @Test(dataProvider = "testSpanOverlappings")
     public void testSpanOverlappings(SRAAccession acc, int reference, int firstLocus, int lastLocus, long[] spanCoordinates) {
-        if (!SRAAccession.isSupported()) return;
-
-        SRAIndex index = getIndex(acc);
-        BAMFileSpan span = index.getSpanOverlapping(reference, firstLocus, lastLocus);
+        final SRAIndex index = getIndex(acc);
+        final BAMFileSpan span = index.getSpanOverlapping(reference, firstLocus, lastLocus);
 
         long[] coordinatesFromIndex = span.toCoordinateArray();
-        List<Long> coordinatesListFromIndex = new ArrayList<Long>();
-        for (long coordinate : coordinatesFromIndex) {
-            coordinatesListFromIndex.add(coordinate);
-        }
 
         Assert.assertTrue(Arrays.equals(coordinatesFromIndex, spanCoordinates),
                 "Coordinates mismatch. Expected: " + Arrays.toString(spanCoordinates) +
@@ -144,7 +128,7 @@ public class SRAIndexTest {
     }
 
     private SRAIndex getIndex(SRAAccession acc) {
-        SRAFileReader reader = new SRAFileReader(acc);
+        final SRAFileReader reader = new SRAFileReader(acc);
         return (SRAIndex) reader.getIndex();
     }
 }

--- a/src/tests/java/htsjdk/samtools/sra/SRALazyRecordTest.java
+++ b/src/tests/java/htsjdk/samtools/sra/SRALazyRecordTest.java
@@ -11,21 +11,19 @@ import org.testng.annotations.Test;
 /**
  * Tests for SRA extension of SAMRecord objects which load fields on demand
  */
-public class SRALazyRecordTest {
+public class SRALazyRecordTest extends AbstractSRATest {
     private static final SRAAccession DEFAULT_ACCESSION = new SRAAccession("SRR1298981");
 
     @DataProvider(name = "serializationTestData")
-    public Object[][] getSerializationTestData() {
+    private Object[][] getSerializationTestData() {
         return new Object[][] {
                 { DEFAULT_ACCESSION }
         };
     }
 
     @Test(dataProvider = "serializationTestData")
-    public void testSerialization(SRAAccession accession) throws Exception {
-        if (!SRAAccession.isSupported()) return;
-        
-        SRAFileReader reader = new SRAFileReader(accession);
+    public void testSerialization(final SRAAccession accession) throws Exception {
+        final SRAFileReader reader = new SRAFileReader(accession);
         final SAMRecord initialSAMRecord = reader.getIterator().next();
         reader.close();
 
@@ -36,13 +34,11 @@ public class SRALazyRecordTest {
 
     @Test
     public void testCloneAndEquals() throws Exception {
-        if (!SRAAccession.isSupported()) return;
-        
-        SRAFileReader reader = new SRAFileReader(DEFAULT_ACCESSION);
+        final SRAFileReader reader = new SRAFileReader(DEFAULT_ACCESSION);
         final SAMRecord record = reader.getIterator().next();
         reader.close();
 
-        SAMRecord newRecord = (SAMRecord)record.clone();
+        final SAMRecord newRecord = (SAMRecord)record.clone();
         Assert.assertFalse(record == newRecord);
         Assert.assertNotSame(record, newRecord);
         Assert.assertEquals(record, newRecord);

--- a/src/tests/java/htsjdk/samtools/sra/SRAQueryTest.java
+++ b/src/tests/java/htsjdk/samtools/sra/SRAQueryTest.java
@@ -1,41 +1,35 @@
 package htsjdk.samtools.sra;
 
-import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.SamInputResource;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.NoSuchElementException;
-
-public class SRAQueryTest {
+public class SRAQueryTest extends AbstractSRATest {
 
     @DataProvider(name = "testUnmappedCounts")
-    public Object[][] createDataForUnmappedCounts() {
+    private Object[][] createDataForUnmappedCounts() {
         return new Object[][] {
                 {"SRR2096940", 498}
         };
     }
 
     @Test(dataProvider = "testUnmappedCounts")
-    public void testUnmappedCounts(String acc, int numberUnalignments) {
-        if (!SRAAccession.isSupported()) return;
-
+    public void testUnmappedCounts(String acc, int expectedNumUnmapped) {
         SamReader reader = SamReaderFactory.make().validationStringency(ValidationStringency.SILENT).open(
                 SamInputResource.of(new SRAAccession(acc))
         );
 
         final SAMRecordIterator samRecordIterator = reader.queryUnmapped();
 
-        checkAlignedUnalignedCountsByIterator(samRecordIterator, 0, numberUnalignments);
+        assertCorrectCountsOfMappedAndUnmappedRecords(samRecordIterator, 0, expectedNumUnmapped);
     }
 
     @DataProvider(name = "testReferenceAlignedCounts")
-    public Object[][] createDataForReferenceAlignedCounts() {
+    private Object[][] createDataForReferenceAlignedCounts() {
         return new Object[][] {
                 {"SRR2096940", "CM000681.1", 0, 10591},
                 {"SRR2096940", "CM000681.1", 55627015, 10591},
@@ -44,20 +38,18 @@ public class SRAQueryTest {
     }
 
     @Test(dataProvider = "testReferenceAlignedCounts")
-    public void testReferenceAlignedCounts(String acc, String reference, int refernceStart, int numberAlignments) {
-        if (!SRAAccession.isSupported()) return;
-
+    public void testReferenceAlignedCounts(String acc, String reference, int referenceStart, int expectedNumMapped) {
         SamReader reader = SamReaderFactory.make().validationStringency(ValidationStringency.SILENT).open(
                 SamInputResource.of(new SRAAccession(acc))
         );
 
-        final SAMRecordIterator samRecordIterator = reader.queryAlignmentStart(reference, refernceStart);
+        final SAMRecordIterator samRecordIterator = reader.queryAlignmentStart(reference, referenceStart);
 
-        checkAlignedUnalignedCountsByIterator(samRecordIterator, numberAlignments, 0);
+        assertCorrectCountsOfMappedAndUnmappedRecords(samRecordIterator, expectedNumMapped, 0);
     }
 
     @DataProvider(name = "testQueryCounts")
-    public Object[][] createDataForQueryCounts() {
+    private Object[][] createDataForQueryCounts() {
         return new Object[][] {
                 {"SRR2096940", "CM000681.1", 0, 59128983, true, 10591, 0},
                 {"SRR2096940", "CM000681.1", 55627015, 59128983, true, 10591, 0},
@@ -67,50 +59,15 @@ public class SRAQueryTest {
     }
 
     @Test(dataProvider = "testQueryCounts")
-    public void testQueryCounts(String acc, String reference, int refernceStart, int referenceEnd, boolean contained, int numberAlignments, int numberUnalignment) {
-        if (!SRAAccession.isSupported()) return;
-
+    public void testQueryCounts(String acc, String reference, int referenceStart, int referenceEnd, boolean contained, int expectedNumMapped, int expectedNumUnmapped) {
         SamReader reader = SamReaderFactory.make().validationStringency(ValidationStringency.SILENT).open(
                 SamInputResource.of(new SRAAccession(acc))
         );
 
-        final SAMRecordIterator samRecordIterator = reader.query(reference, refernceStart, referenceEnd, contained);
+        final SAMRecordIterator samRecordIterator = reader.query(reference, referenceStart, referenceEnd, contained);
 
-        checkAlignedUnalignedCountsByIterator(samRecordIterator, numberAlignments, numberUnalignment);
+        assertCorrectCountsOfMappedAndUnmappedRecords(samRecordIterator, expectedNumMapped, expectedNumUnmapped);
     }
 
-    private void checkAlignedUnalignedCountsByIterator(SAMRecordIterator samRecordIterator,
-                                                       int numberAlignments, int numberUnalignments) {
-        int countAlignments = 0, countUnalignments = 0;
-        while (true) {
-            boolean hasRecord = samRecordIterator.hasNext();
-            SAMRecord record = null;
-            try {
-                record = samRecordIterator.next();
-                Assert.assertTrue(hasRecord); // exception is not thrown if we came to this point
-            } catch (NoSuchElementException e) {
-                Assert.assertFalse(hasRecord);
-            }
-
-            Assert.assertEquals(hasRecord, record != null);
-
-            if (record == null) {
-                break;
-            }
-
-            if (record.getReadUnmappedFlag()) {
-                countUnalignments++;
-            } else {
-                countAlignments++;
-            }
-        }
-
-        if (numberAlignments != -1) {
-            Assert.assertEquals(numberAlignments, countAlignments);
-        }
-        if (numberUnalignments != -1) {
-            Assert.assertEquals(numberUnalignments, countUnalignments);
-        }
-    }
 
 }

--- a/src/tests/java/htsjdk/samtools/sra/SRAReferenceTest.java
+++ b/src/tests/java/htsjdk/samtools/sra/SRAReferenceTest.java
@@ -6,9 +6,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class SRAReferenceTest {
+public class SRAReferenceTest extends AbstractSRATest {
     @DataProvider(name = "testReference")
-    public Object[][] createDataForReference() {
+    private Object[][] createDataForReference() {
         return new Object[][] {
                 {"SRR2096940", "CM000681.1", 95001, 95050, "AGATGATTCAGTCTCACCAAGAACACTGAAAGTCACATGGCTACCAGCAT"},
         };
@@ -16,10 +16,8 @@ public class SRAReferenceTest {
 
     @Test(dataProvider = "testReference")
     public void testReference(String acc, String refContig, int refStart, int refStop, String refBases) {
-        if (!SRAAccession.isSupported()) return;
-
-        ReferenceSequenceFile refSeqFile = new SRAIndexedSequenceFile(new SRAAccession(acc));
-        ReferenceSequence refSeq = refSeqFile.getSubsequenceAt(refContig, refStart, refStop);
+        final ReferenceSequenceFile refSeqFile = new SRAIndexedSequenceFile(new SRAAccession(acc));
+        final ReferenceSequence refSeq = refSeqFile.getSubsequenceAt(refContig, refStart, refStop);
         Assert.assertEquals(new String(refSeq.getBases()), refBases);
     }
 }


### PR DESCRIPTION
removing SRA tests from `ant test` and moving them to their own `ant sra-test` target

   this should isolate SRA tests so that they can no longer fail during a picard release
   
once #461 and  #442 are fixed they should be moved back into the standard `ant test`

- added a new ant target sra-test which exclusively runs the sra tests
- made all SRA test classes descend from a new `AbstractSRATest` base class
  - this ensures they are all set in the appropriate test group
  - each SRA test method will run `assertSRAIsSupported()` and be skipped if it is not
    - removed the newly redundant checks in every SRA test
 - pulled `checkAlignedUnalignedCountsByIterator` up into the base class to remove duplicated code

- updated .travis.yml to run sra-test after the rest of the tests

fixes #436 and #459 