### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/java/htsjdk/samtools/BAMFileReader.java
@@ -504,7 +504,7 @@ class BAMFileReader extends SamReader.ReaderImplementation {
                 source);
 
         final int sequenceCount = stream.readInt();
-        if (samFileHeader.getSequenceDictionary().size() > 0) {
+        if (!samFileHeader.getSequenceDictionary().isEmpty()) {
             // It is allowed to have binary sequences but no text sequences, so only validate if both are present
             if (sequenceCount != samFileHeader.getSequenceDictionary().size()) {
                 throw new SAMFormatException("Number of sequences in text header (" +

--- a/src/java/htsjdk/samtools/BAMIndexMetaData.java
+++ b/src/java/htsjdk/samtools/BAMIndexMetaData.java
@@ -64,7 +64,7 @@ public class BAMIndexMetaData {
     BAMIndexMetaData(List<Chunk> chunkList) {
         noCoordinateRecords = 0;
 
-        if (chunkList == null || chunkList.size() == 0) {
+        if (chunkList == null || chunkList.isEmpty()) {
             // System.out.println("No metadata chunks");
         } else if (chunkList.size() != 2) {
             throw new SAMException("Unexpected number of metadata chunks " + (chunkList.size()));

--- a/src/java/htsjdk/samtools/HighAccuracyDownsamplingIterator.java
+++ b/src/java/htsjdk/samtools/HighAccuracyDownsamplingIterator.java
@@ -163,7 +163,7 @@ class HighAccuracyDownsamplingIterator extends DownsamplingIterator {
         this.bufferedRecords = recs.iterator();
         this.totalTemplates += templatesRead;
         this.keptTemplates  += names.size();
-        return recs.size() > 0;
+        return !recs.isEmpty();
     }
 
     /**

--- a/src/java/htsjdk/samtools/SAMLineParser.java
+++ b/src/java/htsjdk/samtools/SAMLineParser.java
@@ -179,7 +179,7 @@ public class SAMLineParser {
             reportErrorParsingLine("= is not a valid value for "
                     + fieldName + " field.");
         }
-        if (this.mFileHeader.getSequenceDictionary().size() != 0) {
+        if (!this.mFileHeader.getSequenceDictionary().isEmpty()) {
             if (this.mFileHeader.getSequence(rname) == null) {
                 reportErrorParsingLine(fieldName
                         + " '" + rname + "' not found in any SQ record");
@@ -220,7 +220,7 @@ public class SAMLineParser {
             reportErrorParsingLine("Too many fields in SAM text record.");
         }
         for (int i = 0; i < numFields; ++i) {
-            if (mFields[i].length() == 0) {
+            if (mFields[i].isEmpty()) {
                 reportErrorParsingLine("Empty field at position " + i + " (zero-based)");
             }
         }

--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -297,7 +297,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      */
     public byte[] getOriginalBaseQualities() {
         final String oqString = (String) getAttribute("OQ");
-        if (oqString != null && oqString.length() > 0) {
+        if (oqString != null && !oqString.isEmpty()) {
             return SAMUtils.fastqToPhred(oqString);
         }
         else {
@@ -1975,7 +1975,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             */
                 if (firstOnly) return ret;
             }
-            if (getHeader() != null && getHeader().getSequenceDictionary().size() == 0) {
+            if (getHeader() != null && getHeader().getSequenceDictionary().isEmpty()) {
                 if (ret == null) ret = new ArrayList<SAMValidationError>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.MISSING_SEQUENCE_DICTIONARY, "Empty sequence dictionary.", getReadName()));
                 if (firstOnly) return ret;
@@ -2016,7 +2016,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             if (fz == null) {
                 final String cq = (String)getAttribute(SAMTagUtil.getSingleton().CQ);
                 final String cs = (String)getAttribute(SAMTagUtil.getSingleton().CS);
-                if (cq == null || cq.length() == 0 || cs == null || cs.length() == 0) {
+                if (cq == null || cq.isEmpty() || cs == null || cs.isEmpty()) {
                     if (ret == null) ret = new ArrayList<SAMValidationError>();
                     ret.add(new SAMValidationError(SAMValidationError.Type.EMPTY_READ,
                             "Zero-length read without FZ, CS or CQ tag", getReadName()));
@@ -2055,7 +2055,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             if (firstOnly) return ret;
         }
 
-        if (ret == null || ret.size() == 0) {
+        if (ret == null || ret.isEmpty()) {
             return null;
         }
         return ret;
@@ -2102,7 +2102,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_ALIGNMENT_START, buildMessage("Alignment start should != 0 because reference name != *.", isMate), getReadName()));
                 if (firstOnly) return ret;
             }
-            if (getHeader() != null && getHeader().getSequenceDictionary().size() > 0) {
+            if (getHeader() != null && !getHeader().getSequenceDictionary().isEmpty()) {
                 final SAMSequenceRecord sequence =
                         (referenceIndex != null? getHeader().getSequence(referenceIndex): getHeader().getSequence(referenceName));
                 if (sequence == null) {

--- a/src/java/htsjdk/samtools/SAMUtils.java
+++ b/src/java/htsjdk/samtools/SAMUtils.java
@@ -433,7 +433,7 @@ public final class SAMUtils {
     public static void processValidationErrors(final List<SAMValidationError> validationErrors,
                                                final long samRecordIndex,
                                                final ValidationStringency validationStringency) {
-        if (validationErrors != null && validationErrors.size() > 0) {
+        if (validationErrors != null && !validationErrors.isEmpty()) {
             for (final SAMValidationError validationError : validationErrors) {
                 validationError.setRecordNumber(samRecordIndex);
             }
@@ -528,7 +528,7 @@ public final class SAMUtils {
     public static void chainSAMProgramRecord(final SAMFileHeader header, final SAMProgramRecord program) {
 
         final List<SAMProgramRecord> pgs = header.getProgramRecords();
-        if (pgs.size() > 0) {
+        if (!pgs.isEmpty()) {
             final List<String> referencedIds = new ArrayList<String>();
             for (final SAMProgramRecord pg : pgs) {
                 if (pg.getPreviousProgramGroupId() != null) {

--- a/src/java/htsjdk/samtools/SamFileHeaderMerger.java
+++ b/src/java/htsjdk/samtools/SamFileHeaderMerger.java
@@ -592,7 +592,7 @@ public class SamFileHeaderMerger {
             }
         }
         // Append anything left in holder.
-        if (holder.size() != 0) {
+        if (!holder.isEmpty()) {
             resultingDict.addAll(holder);
         }
         return new SAMSequenceDictionary(resultingDict);

--- a/src/java/htsjdk/samtools/TextualBAMIndexWriter.java
+++ b/src/java/htsjdk/samtools/TextualBAMIndexWriter.java
@@ -110,7 +110,7 @@ class TextualBAMIndexWriter implements BAMIndexWriter {
                 continue;
             }
             pw.print("  Ref " + reference + " bin " + bin.getBinNumber() + " has n_chunk= " + chunkList.size());
-            if (chunkList.size() == 0) {
+            if (chunkList.isEmpty()) {
                  pw.println();
             }
             for (final Chunk c : chunkList) {

--- a/src/java/htsjdk/samtools/cram/lossy/QualityScorePreservation.java
+++ b/src/java/htsjdk/samtools/cram/lossy/QualityScorePreservation.java
@@ -75,7 +75,7 @@ public class QualityScorePreservation {
     private static List<PreservationPolicy> parsePolicies(final String spec) {
         final List<PreservationPolicy> policyList = new ArrayList<PreservationPolicy>();
         for (final String string : spec.split("-")) {
-            if (string.length() == 0)
+            if (string.isEmpty())
                 continue;
             final PreservationPolicy policy = parseSinglePolicy(string);
             policyList.add(policy);

--- a/src/java/htsjdk/samtools/fastq/FastqRecord.java
+++ b/src/java/htsjdk/samtools/fastq/FastqRecord.java
@@ -36,9 +36,9 @@ public class FastqRecord implements Serializable {
     private final String qualLine;
 
     public FastqRecord(final String seqHeaderPrefix, final String seqLine, final String qualHeaderPrefix, final String qualLine) {
-        if (seqHeaderPrefix != null && seqHeaderPrefix.length() > 0) this.seqHeaderPrefix = seqHeaderPrefix;
+        if (seqHeaderPrefix != null && !seqHeaderPrefix.isEmpty()) this.seqHeaderPrefix = seqHeaderPrefix;
         else this.seqHeaderPrefix = null;
-        if (qualHeaderPrefix != null && qualHeaderPrefix.length() > 0) this.qualHeaderPrefix = qualHeaderPrefix;
+        if (qualHeaderPrefix != null && !qualHeaderPrefix.isEmpty()) this.qualHeaderPrefix = qualHeaderPrefix;
         else this.qualHeaderPrefix = null;
         this.seqLine = seqLine ;
         this.qualLine = qualLine ;

--- a/src/java/htsjdk/samtools/metrics/MetricsFile.java
+++ b/src/java/htsjdk/samtools/metrics/MetricsFile.java
@@ -81,7 +81,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
 
     /** Returns the histogram contained in the metrics file if any. */
     public Histogram<HKEY> getHistogram() {
-        if (histograms.size() > 0) return this.histograms.get(0);
+        if (!histograms.isEmpty()) return this.histograms.get(0);
         else return null;
     }
 
@@ -382,7 +382,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
 
                             for (int i=0; i<fields.length; ++i) {
                                 Object value = null;
-                                if (values[i] != null && values[i].length() > 0) {
+                                if (values[i] != null && !values[i].isEmpty()) {
                                     value = formatter.parseObject(values[i], fields[i].getType());
                                 }
 

--- a/src/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -67,7 +67,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
                 final BufferedLineReader reader = new BufferedLineReader(Files.newInputStream(dictionary));
                 final SAMFileHeader header = codec.decode(reader,
                         dictionary.toString());
-                if (header.getSequenceDictionary() != null && header.getSequenceDictionary().size() > 0) {
+                if (header.getSequenceDictionary() != null && !header.getSequenceDictionary().isEmpty()) {
                     this.sequenceDictionary = header.getSequenceDictionary();
                 }
                 reader.close();

--- a/src/java/htsjdk/samtools/util/BufferedLineReader.java
+++ b/src/java/htsjdk/samtools/util/BufferedLineReader.java
@@ -98,7 +98,7 @@ public class BufferedLineReader implements LineReader {
         if (peekedLine == null) {
             return -1;
         }
-        if (peekedLine.length() == 0) {
+        if (peekedLine.isEmpty()) {
             return '\n';
         }
         return peekedLine.charAt(0);

--- a/src/java/htsjdk/samtools/util/CigarUtil.java
+++ b/src/java/htsjdk/samtools/util/CigarUtil.java
@@ -167,7 +167,7 @@ public class CigarUtil {
     }
 
     private static boolean isValidCigar(SAMRecord rec, Cigar cigar, boolean isOldCigar) {
-        if (cigar == null || cigar.getCigarElements() == null || cigar.getCigarElements().size() == 0) {
+        if (cigar == null || cigar.getCigarElements() == null || cigar.getCigarElements().isEmpty()) {
             if (isOldCigar) {
                 if (rec.getReadUnmappedFlag()) {
                     // don't bother to warn since this does occur for PE reads
@@ -185,7 +185,7 @@ public class CigarUtil {
 
         }
         final List<SAMValidationError> validationErrors = cigar.isValid(rec.getReadName(), -1);
-        if (validationErrors != null && validationErrors.size() != 0) {
+        if (validationErrors != null && !validationErrors.isEmpty()) {
             log.error("Invalid cigar for read " + rec +
                 (isOldCigar ? " " : " for new cigar with clipped adapter ") +
                  " (" + rec.getCigarString() + "/" + cigar.toString()  + ") " +

--- a/src/java/htsjdk/samtools/util/DiskBackedQueue.java
+++ b/src/java/htsjdk/samtools/util/DiskBackedQueue.java
@@ -87,7 +87,7 @@ public class DiskBackedQueue<E> implements Queue<E> {
         if (maxRecordsInRam < 0) {
             throw new IllegalArgumentException("maxRecordsInRamQueue must be >= 0");
         }
-        if (tmpDirs == null || tmpDirs.size() == 0) {
+        if (tmpDirs == null || tmpDirs.isEmpty()) {
             throw new IllegalArgumentException("At least one temp directory must be provided.");
         }
         for (final File tmpDir : tmpDirs) IOUtil.assertDirectoryIsWritable(tmpDir);

--- a/src/java/htsjdk/samtools/util/FormatUtil.java
+++ b/src/java/htsjdk/samtools/util/FormatUtil.java
@@ -159,7 +159,7 @@ public class FormatUtil {
 
     /** Parses a String into a boolean, as per the above convention that true = Y and false = N. */
     public boolean parseBoolean(String value) {
-        if (value == null || value.length() == 0) return false;
+        if (value == null || value.isEmpty()) return false;
         char ch = Character.toUpperCase(value.charAt(0));
         return (ch == 'Y');
     }

--- a/src/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/java/htsjdk/samtools/util/IntervalList.java
@@ -240,7 +240,7 @@ public class IntervalList implements Iterable<Interval> {
             }
         }
 
-        if (toBeMerged.size() > 0) unique.add(merge(toBeMerged, concatenateNames));
+        if (!toBeMerged.isEmpty()) unique.add(merge(toBeMerged, concatenateNames));
         return unique;
     }
 
@@ -447,7 +447,7 @@ public class IntervalList implements Iterable<Interval> {
             // Then read in the intervals
             final FormatUtil format = new FormatUtil();
             do {
-                if (line.trim().length() == 0) continue; // skip over blank lines
+                if (line.trim().isEmpty()) continue; // skip over blank lines
 
                 // Make sure we have the right number of fields
                 final String[] fields = line.split("\t");

--- a/src/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
+++ b/src/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
@@ -84,10 +84,10 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
     }
 
     /** Returns true if we are tracking no records, false otherwise */
-    public boolean isEmpty() { return (blocks.size() == 0  || this.blocks.getFirst().isEmpty()); }
+    public boolean isEmpty() { return (blocks.isEmpty() || this.blocks.getFirst().isEmpty()); }
 
     /** Returns true if we can return the next record (it has been examined). */
-    public boolean canEmit() { return (this.blocks.size() != 0 && this.blocks.getFirst().canEmit()); }
+    public boolean canEmit() { return (!this.blocks.isEmpty() && this.blocks.getFirst().canEmit()); }
 
     /**
      * Add the given SAMRecordIndex to the buffer.  The records must be added in order.
@@ -103,7 +103,7 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
             throw new SAMException("The records were added out of order");
         }
         // If necessary, create a new block, using as much ram as available up to its total size
-        if (this.blocks.size() == 0 || !this.blocks.getLast().canAdd()) {
+        if (this.blocks.isEmpty() || !this.blocks.getLast().canAdd()) {
             // once ram is given to a block, we can't give it to another block (until some is recovered from the head of the queue)
             final int blockRam = Math.min(this.blockSize, this.availableRecordsInMemory);
             this.availableRecordsInMemory = this.availableRecordsInMemory - blockRam;

--- a/src/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/java/htsjdk/samtools/util/SequenceUtil.java
@@ -848,7 +848,7 @@ public class SequenceUtil {
                     boolean matched = match.find();
                     if (matched) {
                         String mg;
-                        if (((mg = match.group(1)) != null) && (mg.length() > 0)) {
+                        if (((mg = match.group(1)) != null) && (!mg.isEmpty())) {
                             // It's a number , meaning a series of matches
                             final int num = Integer.parseInt(mg);
                             for (int i = 0; i < num; i++) {
@@ -859,7 +859,7 @@ public class SequenceUtil {
                                 }
                                 basesMatched++;
                             }
-                        } else if (((mg = match.group(2)) != null) && (mg.length() > 0)) {
+                        } else if (((mg = match.group(2)) != null) && (!mg.isEmpty())) {
                             // It's a single nucleotide, meaning a mismatch
                             if (basesMatched < cigElLen) {
                                 ret[outIndex++] = StringUtil.charToByte(mg.charAt(0));
@@ -868,7 +868,7 @@ public class SequenceUtil {
                                 throw new IllegalStateException("Should never happen.");
                             }
                             basesMatched++;
-                        } else if (((mg = match.group(3)) != null) && (mg.length() > 0)) {
+                        } else if (((mg = match.group(3)) != null) && (!mg.isEmpty())) {
                             // It's a deletion, starting with a caret
                             // don't include caret
                             if (includeReferenceBasesForDeletions) {
@@ -1061,7 +1061,7 @@ public class SequenceUtil {
     public static List<byte[]> generateAllKmers(final int length) {
         final List<byte[]> sofar = new LinkedList<byte[]>();
 
-        if (sofar.size() == 0) {
+        if (sofar.isEmpty()) {
             sofar.add(new byte[length]);
         }
 

--- a/src/java/htsjdk/samtools/util/StringUtil.java
+++ b/src/java/htsjdk/samtools/util/StringUtil.java
@@ -40,7 +40,7 @@ public class StringUtil {
      * @return String that concatenates the result of each item's to String method for all items in objs, with separator between each of them.
      */
     public static <T> String join(final String separator, final Collection<T> objs) {
-        if (objs.size() == 0) {
+        if (objs.isEmpty()) {
             return "";
         }
 
@@ -95,7 +95,7 @@ public class StringUtil {
         if (nTokens < maxTokens)
         {
             final String trailingString = aString.substring(start);
-            if (trailingString.length() > 0)
+            if (!trailingString.isEmpty())
             {
                 tokens[nTokens++] = trailingString;
             }
@@ -134,7 +134,7 @@ public class StringUtil {
         }
         // Add the trailing string,  if it is not empty.
         final String trailingString = aString.substring(start);
-        if (trailingString.length() > 0)
+        if (!trailingString.isEmpty())
         {
             tokens[nTokens++] = trailingString;
         }

--- a/src/java/htsjdk/tribble/bed/BEDCodec.java
+++ b/src/java/htsjdk/tribble/bed/BEDCodec.java
@@ -68,7 +68,7 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
     @Override
     public BEDFeature decode(String line) {
 
-        if (line.trim().length() == 0) {
+        if (line.trim().isEmpty()) {
             return null;
         }
 
@@ -134,7 +134,7 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
         // Strand
         if (tokenCount > 5) {
             String strandString = tokens[5].trim();
-            char strand = (strandString.length() == 0)
+            char strand = (strandString.isEmpty())
                     ? ' ' : strandString.charAt(0);
 
             if (strand == '-') {

--- a/src/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
+++ b/src/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
@@ -64,9 +64,9 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
 
     public void addFeature(final Feature feature, final long filePosition) {
         // if we don't have a chrIndex yet, or if the last one was for the previous contig, create a new one
-        if (chrList.size() == 0 || !chrList.getLast().getName().equals(feature.getChr())) {
+        if (chrList.isEmpty() || !chrList.getLast().getName().equals(feature.getChr())) {
             // if we're creating a new chrIndex (not the first), make sure to dump the intervals to the old chrIndex
-            if (chrList.size() != 0)
+            if (!chrList.isEmpty())
                 addIntervalsToLastChr(filePosition);
 
             // create a new chr index for the current contig
@@ -75,11 +75,11 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
         }
 
         // if we're about to overflow the current bin, make a new one
-        if (featureCount >= featuresPerInterval || intervals.size() == 0) {
+        if (featureCount >= featuresPerInterval || intervals.isEmpty()) {
             final MutableInterval i = new MutableInterval();
             i.setStart(feature.getStart());
             i.setStartFilePosition(filePosition);
-            if( intervals.size() > 0) intervals.get(intervals.size()-1).setEndFilePosition(filePosition);
+            if(!intervals.isEmpty()) intervals.get(intervals.size()-1).setEndFilePosition(filePosition);
             featureCount = 0; // reset the feature count
             intervals.add(i);
         }

--- a/src/java/htsjdk/tribble/index/interval/IntervalTreeIndex.java
+++ b/src/java/htsjdk/tribble/index/interval/IntervalTreeIndex.java
@@ -138,7 +138,7 @@ public class IntervalTreeIndex extends AbstractIndex {
             final List<Interval> intervals = tree.findOverlapping(new Interval(start, end));
 
             // save time (and save throwing an exception) if the blocks are empty, return now
-            if (intervals == null || intervals.size() == 0) return new ArrayList<Block>();
+            if (intervals == null || intervals.isEmpty()) return new ArrayList<Block>();
 
             final Block[] blocks = new Block[intervals.size()];
             int idx = 0;

--- a/src/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
+++ b/src/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
@@ -66,9 +66,9 @@ public class LinearIndexCreator  extends TribbleIndexCreator {
      */
     public void addFeature(final Feature feature, final long filePosition) {
         // fi we don't have a chrIndex yet, or if the last one was for the previous contig, create a new one
-        if (chrList.size() == 0 || !chrList.getLast().getName().equals(feature.getChr())) {
+        if (chrList.isEmpty() || !chrList.getLast().getName().equals(feature.getChr())) {
             // if we're creating a new chrIndex (not the first), make sure to dump the blocks to the old chrIndex
-            if (chrList.size() != 0)
+            if (!chrList.isEmpty())
                 for (int x = 0; x < blocks.size(); x++) {
                     blocks.get(x).setEndPosition((x + 1 == blocks.size()) ? filePosition : blocks.get(x + 1).getStartPosition());
                     chrList.getLast().addBlock(blocks.get(x));

--- a/src/java/htsjdk/tribble/readers/TabixReader.java
+++ b/src/java/htsjdk/tribble/readers/TabixReader.java
@@ -316,7 +316,7 @@ public class TabixReader {
                     String alt;
                     alt = end >= 0 ? s.substring(beg, end) : s.substring(beg);
                     if (col == 4) { // REF
-                        if (alt.length() > 0) intv.end = intv.beg + alt.length();
+                        if (!alt.isEmpty()) intv.end = intv.beg + alt.length();
                     } else if (col == 8) { // INFO
                         int e_off = -1, i = alt.indexOf("END=");
                         if (i == 0) e_off = 4;

--- a/src/java/htsjdk/variant/bcf2/BCF2Codec.java
+++ b/src/java/htsjdk/variant/bcf2/BCF2Codec.java
@@ -354,7 +354,7 @@ public final class BCF2Codec extends BinaryFeatureCodec<VariantContext> {
 
         builder.alleles(alleles);
 
-        assert ref.length() > 0;
+        assert !ref.isEmpty();
 
         return alleles;
     }

--- a/src/java/htsjdk/variant/bcf2/BCF2Utils.java
+++ b/src/java/htsjdk/variant/bcf2/BCF2Utils.java
@@ -169,7 +169,7 @@ public final class BCF2Utils {
     }
 
     public static boolean isCollapsedString(final String s) {
-        return s.length() > 0 && s.charAt(0) == ',';
+        return !s.isEmpty() && s.charAt(0) == ',';
     }
 
     /**

--- a/src/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -103,7 +103,7 @@ public final class CommonInfo implements Serializable {
     }
 
     public boolean isFiltered() {
-        return filters == null ? false : filters.size() > 0;
+        return filters == null ? false : !filters.isEmpty();
     }
 
     public boolean isNotFiltered() {
@@ -207,7 +207,7 @@ public final class CommonInfo implements Serializable {
     public void putAttributes(Map<String, ?> map) {
         if ( map != null ) {
             // for efficiency, we can skip the validation if the map is empty
-            if ( attributes.size() == 0 ) {
+            if (attributes.isEmpty()) {
                 if ( attributes == NO_ATTRIBUTES ) // immutable -> mutable
                     attributes = new HashMap<String, Object>();
                 attributes.putAll(map);

--- a/src/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1259,7 +1259,7 @@ public class VariantContext implements Feature, Serializable {
             ArrayList<Integer> observedACs = new ArrayList<Integer>();
 
             // if there are alternate alleles, record the relevant tags
-            if ( getAlternateAlleles().size() > 0 ) {
+            if (!getAlternateAlleles().isEmpty()) {
                 for ( Allele allele : getAlternateAlleles() ) {
                     observedACs.add(getCalledChrCount(allele));
                 }

--- a/src/java/htsjdk/variant/variantcontext/VariantContextComparator.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContextComparator.java
@@ -32,7 +32,7 @@ public class VariantContextComparator implements Comparator<VariantContext> {
 	private final Map<String, Integer> contigIndexLookup;
 
 	public VariantContextComparator(final List<String> contigs) {
-		if (contigs.size() == 0) throw new IllegalArgumentException("One or more contigs must be in the contig list.");
+		if (contigs.isEmpty()) throw new IllegalArgumentException("One or more contigs must be in the contig list.");
 
 		final Map<String, Integer> protoContigIndexLookup = new HashMap<String, Integer>();
 		int index = 0;
@@ -53,7 +53,7 @@ public class VariantContextComparator implements Comparator<VariantContext> {
 	 *
 	 */
 	public VariantContextComparator(final Collection<VCFContigHeaderLine> headerLines) {
-		if (headerLines.size() == 0) throw new IllegalArgumentException("One or more header lines must be in the header line collection.");
+		if (headerLines.isEmpty()) throw new IllegalArgumentException("One or more header lines must be in the header line collection.");
 
 		final Map<String, Integer> protoContigIndexLookup = new HashMap<String, Integer>();
 		for (final VCFContigHeaderLine headerLine : headerLines) {

--- a/src/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -127,7 +127,7 @@ public class VariantContextUtils {
             attributes.put(VCFConstants.ALLELE_NUMBER_KEY, AN);
 
             // if there are alternate alleles, record the relevant tags
-            if ( vc.getAlternateAlleles().size() > 0 ) {
+            if (!vc.getAlternateAlleles().isEmpty()) {
                 ArrayList<Double> alleleFreqs = new ArrayList<Double>();
                 ArrayList<Integer> alleleCounts = new ArrayList<Integer>();
                 ArrayList<Integer> foundersAlleleCounts = new ArrayList<Integer>();

--- a/src/java/htsjdk/variant/variantcontext/writer/BCF2Encoder.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/BCF2Encoder.java
@@ -114,7 +114,7 @@ public final class BCF2Encoder {
     }
 
     public final void encodeTyped(List<? extends Object> v, final BCF2Type type) throws IOException {
-        if ( type == BCF2Type.CHAR && v.size() != 0 ) {
+        if ( type == BCF2Type.CHAR && !v.isEmpty()) {
             final String s = BCF2Utils.collapseStringList((List<String>) v);
             v = stringToBytes(s);
         }

--- a/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -177,7 +177,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
                 while ( arrayIndex < strings.length )
                     sampleNames.add(strings[arrayIndex++]);
 
-                if ( sawFormatTag && sampleNames.size() == 0 )
+                if ( sawFormatTag && sampleNames.isEmpty())
                     throw new TribbleException.InvalidHeader("The FORMAT field was provided but there is no genotype/sample data");
 
                 // If we're performing sample name remapping and there is exactly one sample specified in the header, replace

--- a/src/java/htsjdk/variant/vcf/VCF3Codec.java
+++ b/src/java/htsjdk/variant/vcf/VCF3Codec.java
@@ -109,7 +109,7 @@ public class VCF3Codec extends AbstractVCFCodec {
         if ( filterString.equals(VCFConstants.PASSES_FILTERS_v3) )
             return new ArrayList<String>(fFields);
 
-        if ( filterString.length() == 0 )
+        if (filterString.isEmpty())
             generateException("The VCF specification requires a valid filter status");
 
         // do we have the filter string cached?

--- a/src/java/htsjdk/variant/vcf/VCFCodec.java
+++ b/src/java/htsjdk/variant/vcf/VCFCodec.java
@@ -134,7 +134,7 @@ public class VCFCodec extends AbstractVCFCodec {
             return Collections.emptyList();
         if ( filterString.equals(VCFConstants.PASSES_FILTERS_v3) )
             generateException(VCFConstants.PASSES_FILTERS_v3 + " is an invalid filter name in vcf4", lineNo);
-        if ( filterString.length() == 0 )
+        if (filterString.isEmpty())
             generateException("The VCF specification requires a valid filter status: filter was " + filterString, lineNo);
 
         // do we have the filter string cached?

--- a/src/java/htsjdk/variant/vcf/VCFHeaderLine.java
+++ b/src/java/htsjdk/variant/vcf/VCFHeaderLine.java
@@ -136,7 +136,7 @@ public class VCFHeaderLine implements Comparable, Serializable {
      * @return true if the line is a VCF meta data line, or false if it is not
      */
     public static boolean isHeaderLine(String line) {
-        return line != null && line.length() > 0 && VCFHeader.HEADER_INDICATOR.equals(line.substring(0,1));
+        return line != null && !line.isEmpty() && VCFHeader.HEADER_INDICATOR.equals(line.substring(0,1));
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat