### PR TITLE
squid:S2162 - equals methods should be symmetric and work for subclasses

### DIFF
--- a/src/java/htsjdk/samtools/Bin.java
+++ b/src/java/htsjdk/samtools/Bin.java
@@ -77,8 +77,7 @@ public class Bin implements Comparable<Bin> {
     @Override
     public boolean equals(final Object other) {
         if(other == null) return false;
-        if(!(other instanceof Bin)) return false;
-
+        if(this.getClass() != other.getClass()) return false;
         final Bin otherBin = (Bin)other;
         return this.referenceSequence == otherBin.referenceSequence && this.binNumber == otherBin.binNumber;
     }

--- a/src/java/htsjdk/samtools/Cigar.java
+++ b/src/java/htsjdk/samtools/Cigar.java
@@ -255,7 +255,8 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Cigar)) return false;
+        if (o == null) return false;
+        if (this.getClass() != o.getClass()) return false;
 
         final Cigar cigar = (Cigar) o;
 

--- a/src/java/htsjdk/samtools/CigarElement.java
+++ b/src/java/htsjdk/samtools/CigarElement.java
@@ -51,7 +51,8 @@ public class CigarElement implements Serializable {
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof CigarElement)) return false;
+        if (o == null) return false;
+        if (this.getClass() != o.getClass()) return false;
 
         final CigarElement that = (CigarElement) o;
 

--- a/src/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -176,7 +176,8 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof SAMSequenceRecord)) return false;
+        if (o == null) return false;
+        if (this.getClass() != o.getClass()) return false;
 
         final SAMSequenceRecord that = (SAMSequenceRecord) o;
 

--- a/src/java/htsjdk/samtools/cram/common/Version.java
+++ b/src/java/htsjdk/samtools/cram/common/Version.java
@@ -52,7 +52,9 @@ public class Version implements Comparable<Version> {
      */
     @Override
     public boolean equals(final Object obj) {
-        if (obj == null || !(obj instanceof Version)) return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
+
         final Version version = (Version) obj;
         return major == version.major && minor == version.minor;
     }

--- a/src/java/htsjdk/samtools/cram/encoding/huffman/codec/HuffmanIntegerEncoding.java
+++ b/src/java/htsjdk/samtools/cram/encoding/huffman/codec/HuffmanIntegerEncoding.java
@@ -90,7 +90,8 @@ public class HuffmanIntegerEncoding implements Encoding<Integer> {
 
     @Override
     public boolean equals(final Object obj) {
-        if (obj instanceof HuffmanIntegerEncoding) {
+        if (obj == null) return false;
+        if (this.getClass() == obj.getClass()) {
             final HuffmanIntegerEncoding foe = (HuffmanIntegerEncoding) obj;
             return Arrays.equals(bitLengths, foe.bitLengths) && Arrays.equals(values, foe.values);
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/BaseQualityScore.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/BaseQualityScore.java
@@ -58,8 +58,8 @@ public class BaseQualityScore implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof BaseQualityScore))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final BaseQualityScore v = (BaseQualityScore) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/Bases.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/Bases.java
@@ -60,8 +60,8 @@ public class Bases implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof Bases))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final Bases bases = (Bases) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/Deletion.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/Deletion.java
@@ -61,8 +61,8 @@ public class Deletion implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof Deletion))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final Deletion deleteion = (Deletion) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/HardClip.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/HardClip.java
@@ -59,8 +59,8 @@ public class HardClip implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof HardClip))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final HardClip hardClip = (HardClip) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/InsertBase.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/InsertBase.java
@@ -52,8 +52,8 @@ public class InsertBase implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof InsertBase))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final InsertBase insertBase = (InsertBase) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/Insertion.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/Insertion.java
@@ -60,8 +60,8 @@ public class Insertion implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof Insertion))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final Insertion insertion = (Insertion) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/Padding.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/Padding.java
@@ -60,8 +60,8 @@ public class Padding implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof Padding))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final Padding padding = (Padding) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/ReadBase.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/ReadBase.java
@@ -60,8 +60,8 @@ public class ReadBase implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof ReadBase))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final ReadBase readBase = (ReadBase) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/RefSkip.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/RefSkip.java
@@ -60,8 +60,8 @@ public class RefSkip implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof RefSkip))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final RefSkip refSkip = (RefSkip) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/Scores.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/Scores.java
@@ -63,8 +63,8 @@ public class Scores implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof Scores))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final Scores scores = (Scores) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/SoftClip.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/SoftClip.java
@@ -61,8 +61,8 @@ public class SoftClip implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof SoftClip))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final SoftClip softClip = (SoftClip) obj;
 

--- a/src/java/htsjdk/samtools/cram/encoding/readfeatures/Substitution.java
+++ b/src/java/htsjdk/samtools/cram/encoding/readfeatures/Substitution.java
@@ -84,8 +84,8 @@ public class Substitution implements Serializable, ReadFeature {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof Substitution))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final Substitution substitution = (Substitution) obj;
 

--- a/src/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -104,7 +104,8 @@ public class CramCompressionRecord {
     @SuppressWarnings("SimplifiableIfStatement")
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof CramCompressionRecord)) return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final CramCompressionRecord cramRecord = (CramCompressionRecord) obj;
 

--- a/src/java/htsjdk/samtools/cram/structure/ReadTag.java
+++ b/src/java/htsjdk/samtools/cram/structure/ReadTag.java
@@ -154,8 +154,8 @@ public class ReadTag implements Comparable<ReadTag> {
 
     @Override
     public boolean equals(final Object obj) {
-        if (!(obj instanceof ReadTag))
-            return false;
+        if (obj == null) return false;
+        if (this.getClass() != obj.getClass()) return false;
 
         final ReadTag foe = (ReadTag) obj;
         return key.equals(foe.key) && (value == null && foe.value == null || value != null && value.equals(foe.value));

--- a/src/java/htsjdk/samtools/metrics/StringHeader.java
+++ b/src/java/htsjdk/samtools/metrics/StringHeader.java
@@ -51,7 +51,8 @@ public class StringHeader implements Header {
 
     /** Checks equality on the value of the header. */
     public boolean equals(Object o) {
-        if (o != null && o instanceof StringHeader) {
+        if (o == null) return false;
+        if (this.getClass() == o.getClass()) {
             StringHeader that = (StringHeader) o;
             if (this.value == null) {
                 return that.value == null;

--- a/src/java/htsjdk/samtools/reference/FastaSequenceIndex.java
+++ b/src/java/htsjdk/samtools/reference/FastaSequenceIndex.java
@@ -99,14 +99,12 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
      * @return True if index has the same entries as other instance, in the same order
      */
     public boolean equals(Object other) {
-        if(!(other instanceof FastaSequenceIndex))
-            return false;
-
         if (this == other) return true;
+        if (other == null) return false;
+        if(this.getClass() != other.getClass()) return false;
 
         FastaSequenceIndex otherIndex = (FastaSequenceIndex)other;
-        if(this.size() != otherIndex.size())
-            return false;
+        if(this.size() != otherIndex.size()) return false;
 
         Iterator<FastaSequenceIndexEntry> iter = this.iterator();
         Iterator<FastaSequenceIndexEntry> otherIter = otherIndex.iterator();
@@ -303,11 +301,16 @@ class FastaSequenceIndexEntry {
      * @return True if each has the same name, location, size, basesPerLine and bytesPerLine
      */
     public boolean equals(Object other) {
-        if(!(other instanceof FastaSequenceIndexEntry))
+        if (this == other) {
+            return true;
+        }
+        if (other == null) {
             return false;
-
-        if (this == other) return true;
-
+        }
+        if (this.getClass() != other.getClass()) {
+            return false;
+        }
+        
         FastaSequenceIndexEntry otherEntry = (FastaSequenceIndexEntry)other;
         return (contig.equals(otherEntry.contig) && size == otherEntry.size && location == otherEntry.location
         && basesPerLine == otherEntry.basesPerLine && bytesPerLine == otherEntry.bytesPerLine);

--- a/src/java/htsjdk/samtools/util/Histogram.java
+++ b/src/java/htsjdk/samtools/util/Histogram.java
@@ -155,7 +155,7 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
     /** Checks that the labels and values in the two histograms are identical. */
     public boolean equals(final Object o) {
         return o != null &&
-                (o instanceof Histogram) &&
+                (this.getClass() == o.getClass()) &&
                 ((Histogram) o).binLabel.equals(this.binLabel) &&
                 ((Histogram) o).valueLabel.equals(this.valueLabel) &&
                 super.equals(o);

--- a/src/java/htsjdk/samtools/util/Interval.java
+++ b/src/java/htsjdk/samtools/util/Interval.java
@@ -159,12 +159,12 @@ public class Interval implements Comparable<Interval>, Cloneable, Locatable {
 
     /** Equals method that agrees with {@link #compareTo(Interval)}. */
     public boolean equals(final Object other) {
-        if (!(other instanceof Interval)) return false;
-        else if (this == other) return true;
-        else {
-            Interval that = (Interval)other;
-            return (this.compareTo(that) == 0);
-        }
+        if (this == other) return true;
+        if (other == null) return false;
+        if (this.getClass() != other.getClass()) return false;
+
+        Interval that = (Interval)other;
+        return (this.compareTo(that) == 0);
     }
 
     @Override

--- a/src/java/htsjdk/samtools/util/IntervalTreeMap.java
+++ b/src/java/htsjdk/samtools/util/IntervalTreeMap.java
@@ -85,9 +85,9 @@ public class IntervalTreeMap<T>
 
     @SuppressWarnings("rawtypes")
 	public boolean equals(final Object o) {
-        if (!(o instanceof IntervalTreeMap)) {
-            return false;
-        }
+        if (o == null) return false;
+        if (this.getClass() != o.getClass()) return false;
+
         return mSequenceMap.equals(((IntervalTreeMap)o).mSequenceMap);
     }
 

--- a/src/java/htsjdk/tribble/gelitext/GeliTextFeature.java
+++ b/src/java/htsjdk/tribble/gelitext/GeliTextFeature.java
@@ -137,7 +137,8 @@ public class GeliTextFeature implements Feature {
 
     private static double Epsilon = 0.0001;
     public boolean equals(Object o) {
-        if (!(o instanceof GeliTextFeature)) return false;
+        if (o == null) return false;
+        if (this.getClass() != o.getClass()) return false;
         GeliTextFeature other = (GeliTextFeature)o;
         if (!Arrays.equals(likelihoods,other.likelihoods)) return false;
         if (!contig.equals(other.contig)) return false;

--- a/src/java/htsjdk/tribble/index/Block.java
+++ b/src/java/htsjdk/tribble/index/Block.java
@@ -75,7 +75,9 @@ public class Block {
 
     public boolean equals(final Object obj) {
         if ( this == obj ) return true;
-        if ( ! (obj instanceof Block) ) return false;
+        if (obj == null) return false;
+        if ( this.getClass() != obj.getClass() ) return false;
+
         final Block otherBlock = (Block)obj;
         return this.startPosition == otherBlock.startPosition && this.size == otherBlock.size;
     }

--- a/src/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -277,7 +277,9 @@ public class LinearIndex extends AbstractIndex {
 
         public boolean equals(final Object obj) {
             if (this == obj) return true;
-            if (!(obj instanceof ChrIndex)) return false;
+            if (obj == null) return false;
+            if (this.getClass() != obj.getClass()) return false;
+
             final ChrIndex other = (ChrIndex) obj;
             return binWidth == other.binWidth
                     && longestFeature == other.longestFeature

--- a/src/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/java/htsjdk/variant/variantcontext/Allele.java
@@ -451,7 +451,9 @@ public class Allele implements Comparable<Allele>, Serializable {
      * @return true if these alleles are equal
      */
     public boolean equals(Object other) {
-        return ( ! (other instanceof Allele) ? false : equals((Allele)other, false) );
+        if (other == null) return false;
+        if (this.getClass() != other.getClass()) return false;
+        else return equals((Allele)other, false);
     }
 
     /**

--- a/src/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
+++ b/src/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
@@ -141,7 +141,10 @@ public class GenotypeLikelihoods {
         //check for self-comparison
         if ( this == aThat ) return true;
 
-        if ( !(aThat instanceof GenotypeLikelihoods) ) return false;
+        if (aThat == null) return false;
+
+        if ( this.getClass() != aThat.getClass() ) return false;
+
         GenotypeLikelihoods that = (GenotypeLikelihoods)aThat;
 
         // now a proper field-by-field evaluation can be made.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 - "equals" methods should be symmetric and work for subclasses

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162

Please let me know if you have any questions.

M-Ezzat