### PR TITLE
Fix perf bug in IndexedFastaSequenceFile.

### DIFF
--- a/src/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
+++ b/src/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
@@ -230,7 +230,7 @@ public class IndexedFastaSequenceFile extends AbstractFastaSequenceFile implemen
 
         long startOffset = ((start-1)/basesPerLine)*bytesPerLine + (start-1)%basesPerLine;
         // Cast to long so the second argument cannot overflow a signed integer.
-        final long minBufferSize = Math.min((long) Defaults.NON_ZERO_BUFFER_SIZE, (long)(length % basesPerLine + 2) * (long)bytesPerLine);
+        final long minBufferSize = Math.min((long) Defaults.NON_ZERO_BUFFER_SIZE, (long)(length / basesPerLine + 2) * (long)bytesPerLine);
         if (minBufferSize > Integer.MAX_VALUE) throw new SAMException("Buffer is too large: " +  minBufferSize);
 
         // Allocate a buffer for reading in sequence data.


### PR DESCRIPTION
Fix for perf regression described in https://github.com/samtools/htsjdk/issues/471,  which was introduced in https://github.com/samtools/htsjdk/pull/252. Affects the size of the read buffer used when reading fasta files. I don't see any obvious way to write a test to verify this programmatically.