### PR TITLE
make field 'long processed' volatile

### DIFF
--- a/src/java/htsjdk/samtools/util/AbstractProgressLogger.java
+++ b/src/java/htsjdk/samtools/util/AbstractProgressLogger.java
@@ -12,13 +12,13 @@ import java.text.NumberFormat;
  * Concrete subclasses must provide the logger
  */
 abstract public class AbstractProgressLogger implements ProgressLoggerInterface {
-    protected final int n;
-    protected final String verb;
-    protected final String noun;
+    private final int n;
+    private final String verb;
+    private final String noun;
     private final long startTime = System.currentTimeMillis();
     private final NumberFormat fmt = new DecimalFormat("#,###");
     private final NumberFormat timeFmt = new DecimalFormat("00");
-    private volatile long processed = 0;
+    private long processed = 0;
     // Set to -1 until the first record is added
     private long lastStartTime = -1;
 
@@ -93,7 +93,7 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
     }
 
     /** Returns the count of records processed. */
-    public long getCount() { return this.processed; }
+    public synchronized long getCount() { return this.processed; }
 
     /** Returns the number of seconds since progress tracking began. */
     public long getElapsedSeconds() { return (System.currentTimeMillis() - this.startTime) / 1000; }

--- a/src/java/htsjdk/samtools/util/AbstractProgressLogger.java
+++ b/src/java/htsjdk/samtools/util/AbstractProgressLogger.java
@@ -18,7 +18,7 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
     private final long startTime = System.currentTimeMillis();
     private final NumberFormat fmt = new DecimalFormat("#,###");
     private final NumberFormat timeFmt = new DecimalFormat("00");
-    private long processed = 0;
+    private volatile long processed = 0;
     // Set to -1 until the first record is added
     private long lastStartTime = -1;
 


### PR DESCRIPTION
Make field 'long processed' volatile to provide atomic read in getCount()

According to Java Language Specification, "Programmers are encouraged to declare shared 64-bit values as volatile or synchronize their programs correctly to avoid possible complications."
https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.7

It is enough to make the field 'processed' volatile in AbstractProgressLogger to provide thread safety.