### PR TITLE
.github/ directory for ISSUE_TEMPLATE.md PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,10 @@
 ### Verify
-Can you see anything in the logs? Can you debug why this happens? **Send a pull request**! Bug fixes and documentation fixes are very welcome.
-
+Can you see anything in the logs? 
 Make sure your issue is not already in the [htsjdk issue tracker](https://github.com/samtools/htsjdk/issues?q=)
 
 ### Subject of the issue
 Describe your issue here.
-Provide **screenshots** where appropriate.
+Provide **screenshots** , **stacktrace** , **logs** where appropriate.
 
 ### Your environment
 * version of htsjdk
@@ -13,11 +12,10 @@ Provide **screenshots** where appropriate.
 * which OS
 
 ### Steps to reproduce
-Tell us how to reproduce this issue. Include a short code snippet to demonstrate the problem.
+Tell us how to reproduce this issue. If possible, include a short code snippet to demonstrate the problem.
 
 ### Expected behaviour
 Tell us what should happen
 
 ### Actual behaviour
 Tell us what happens instead
-

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+### Verify
+Can you see anything in the logs? Can you debug why this happens? **Send a pull request**! Bug fixes and documentation fixes are very welcome.
+
+Make sure your issue is not already in the [htsjdk issue tracker](https://github.com/samtools/htsjdk/issues?q=)
+
+### Subject of the issue
+Describe your issue here.
+Provide **screenshots** where appropriate.
+
+### Your environment
+* version of htsjdk
+* version of java
+* which OS
+
+### Steps to reproduce
+Tell us how to reproduce this issue. Include a short code snippet to demonstrate the problem.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+### Description
+
+Please explain the changes you made here.
+Explain the **motivation** for making this change. What existing problem does the pull request solve?
+
+### Checklist
+
+- [ ] Code compiles correctly
+- [ ] All tests passing
+- [ ] Extended the README / documentation, if necessary
+- [ ] code formatting
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@ Explain the **motivation** for making this change. What existing problem does th
 ### Checklist
 
 - [ ] Code compiles correctly
+- [ ] New tests covering changes and new functionality
 - [ ] All tests passing
 - [ ] Extended the README / documentation, if necessary
-- [ ] code formatting
-


### PR DESCRIPTION
created a `.github` directory containing 

* PULL_REQUEST_TEMPLATE
* ISSUE_TEMPLATE.md

as described in the github blog last week : https://github.com/blog/2111-issue-and-pull-request-templates

I didn't put a CONTRIBUTING.md because I'm not the best person to describe the code formatting style :-)

> It's hard to solve a problem when important details are missing. Now project maintainers can add templates for Issues and Pull Requests to projects, helping contributors add the right details at the start of a thread.