### PR TITLE
squid:S2063 - Comparators should be Serializable

### DIFF
--- a/src/java/htsjdk/samtools/MergingSamRecordIterator.java
+++ b/src/java/htsjdk/samtools/MergingSamRecordIterator.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.CloseableIterator;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -201,7 +202,8 @@ public class MergingSamRecordIterator implements CloseableIterator<SAMRecord> {
      * sequence dictionary.  I hate the fact that this extends SAMRecordCoordinateComparator, but it avoids
      * more copy & paste.
      */
-    private class MergedSequenceDictionaryCoordinateOrderComparator extends SAMRecordCoordinateComparator {
+    private class MergedSequenceDictionaryCoordinateOrderComparator extends SAMRecordCoordinateComparator implements Serializable {
+        private static final long serialVersionUID = 1L;
 
         public int fileOrderCompare(final SAMRecord samRecord1, final SAMRecord samRecord2) {
             final int referenceIndex1 = getReferenceIndex(samRecord1);

--- a/src/java/htsjdk/samtools/SAMHeaderRecordComparator.java
+++ b/src/java/htsjdk/samtools/SAMHeaderRecordComparator.java
@@ -24,6 +24,7 @@ package htsjdk.samtools;
  * THE SOFTWARE.
  */
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
@@ -31,7 +32,8 @@ import java.util.Comparator;
  * in the comparison to the constructor. Null attribute values (i.e., those attributes not present in the
  * record) sort behind those that have values.
  */
-public class SAMHeaderRecordComparator<T extends AbstractSAMHeaderRecord> implements Comparator<T> {
+public class SAMHeaderRecordComparator<T extends AbstractSAMHeaderRecord> implements Comparator<T>, Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private final String[] attributes;
 

--- a/src/java/htsjdk/samtools/SAMRecordCoordinateComparator.java
+++ b/src/java/htsjdk/samtools/SAMRecordCoordinateComparator.java
@@ -23,6 +23,8 @@
  */
 package htsjdk.samtools;
 
+import java.io.Serializable;
+
 /**
  * Comparator for sorting SAMRecords by coordinate.  Note that the header is required because
  * the order of sequences in the header defines the major sort order.
@@ -38,7 +40,9 @@ package htsjdk.samtools;
  * if A < B && B < C, then A < C
  *
  */
-public class SAMRecordCoordinateComparator implements SAMRecordComparator {
+public class SAMRecordCoordinateComparator implements SAMRecordComparator, Serializable {
+    private static final long serialVersionUID = 1L;
+
     public int compare(final SAMRecord samRecord1, final SAMRecord samRecord2) {
         int cmp = fileOrderCompare(samRecord1, samRecord2);
         if (cmp != 0) {

--- a/src/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
+++ b/src/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +40,9 @@ import java.util.Map;
  *
  * @author nhomer
  */
-public class SAMRecordDuplicateComparator implements SAMRecordComparator {
+public class SAMRecordDuplicateComparator implements SAMRecordComparator, Serializable {
+    private static final long serialVersionUID = 1L;
+
     /** An enum to provide type-safe keys for transient attributes the comparator puts on SAMRecords. */
     private static enum Attr {
         LibraryId, ReadCoordinate, MateCoordinate

--- a/src/java/htsjdk/samtools/SAMRecordQueryHashComparator.java
+++ b/src/java/htsjdk/samtools/SAMRecordQueryHashComparator.java
@@ -25,6 +25,8 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.Murmur3;
 
+import java.io.Serializable;
+
 /**
  * SAMRecord comparator that provides an ordering based on a hash of the queryname. Has
  * the useful property that reads with the same name will be grouped together, but that
@@ -34,7 +36,9 @@ import htsjdk.samtools.util.Murmur3;
  *
  * @author Tim Fennell
  */
-public class SAMRecordQueryHashComparator extends SAMRecordQueryNameComparator {
+public class SAMRecordQueryHashComparator extends SAMRecordQueryNameComparator implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final Murmur3 hasher = new Murmur3(42);
 
     /**

--- a/src/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
+++ b/src/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
@@ -23,10 +23,13 @@
  */
 package htsjdk.samtools;
 
+import java.io.Serializable;
+
 /**
  * Comparator for "queryname" ordering of SAMRecords.
  */
-public class SAMRecordQueryNameComparator implements SAMRecordComparator {
+public class SAMRecordQueryNameComparator implements SAMRecordComparator, Serializable {
+    private static final long serialVersionUID = 1L;
 
     public int compare(final SAMRecord samRecord1, final SAMRecord samRecord2) {
         int cmp = fileOrderCompare(samRecord1, samRecord2);

--- a/src/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/java/htsjdk/samtools/util/IntervalList.java
@@ -33,6 +33,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -733,7 +734,9 @@ public class IntervalList implements Iterable<Interval> {
  * Comparator that orders intervals based on their sequence index, by coordinate
  * then by strand and finally by name.
  */
-class IntervalCoordinateComparator implements Comparator<Interval> {
+class IntervalCoordinateComparator implements Comparator<Interval>, Serializable {
+    private static final long serialVersionUID = 1L;
+
     private final SAMFileHeader header;
 
     /** Constructs a comparator using the supplied sequence header. */

--- a/src/java/htsjdk/samtools/util/LocusComparator.java
+++ b/src/java/htsjdk/samtools/util/LocusComparator.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
@@ -30,7 +31,8 @@ import java.util.Comparator;
  *
  * @author Doug Voet (dvoet at broadinstitute dot org)
  */
-public class LocusComparator<T extends Locus> implements Comparator<T> {
+public class LocusComparator<T extends Locus> implements Comparator<T>, Serializable {
+    private static final long serialVersionUID = 1L;
 
     public int compare(T thing1, T thing2) {
         int refCompare = thing1.getSequenceIndex() - thing2.getSequenceIndex();

--- a/src/java/htsjdk/samtools/util/Murmur3.java
+++ b/src/java/htsjdk/samtools/util/Murmur3.java
@@ -30,11 +30,15 @@
  */
 package htsjdk.samtools.util;
 
+import java.io.Serializable;
+
 /**
  * Provides an implementation of the Murmur3_32 hash algorithm that has desirable properties in terms of randomness
  * and uniformity of the distribution of output values that make it a useful hashing algorithm for downsampling.
  */
-public final class Murmur3 {
+public final class Murmur3 implements Serializable{
+    private static final long serialVersionUID = 1L;
+
     private final int seed ;
 
     /** Constructs a Murmur3 hash with the given seed. */

--- a/src/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/java/htsjdk/samtools/util/SortingCollection.java
@@ -32,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -501,7 +502,8 @@ public class SortingCollection<T> implements Iterable<T> {
         }
     }
 
-    class PeekFileRecordIteratorComparator implements Comparator<PeekFileRecordIterator> {
+    class PeekFileRecordIteratorComparator implements Comparator<PeekFileRecordIterator>, Serializable {
+        private static final long serialVersionUID = 1L;
 
         public int compare(final PeekFileRecordIterator lhs, final PeekFileRecordIterator rhs) {
             final int result = comparator.compare(lhs.peek(), rhs.peek());

--- a/src/java/htsjdk/samtools/util/SortingLongCollection.java
+++ b/src/java/htsjdk/samtools/util/SortingLongCollection.java
@@ -31,6 +31,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -332,7 +333,8 @@ public class SortingLongCollection {
         }
     }
 
-    private static class PeekFileValueIteratorComparator implements Comparator<PeekFileValueIterator> {
+    private static class PeekFileValueIteratorComparator implements Comparator<PeekFileValueIterator>, Serializable {
+        private static final long serialVersionUID = 1L;
 
         public int compare(final PeekFileValueIterator it1, final PeekFileValueIterator it2) {
             if (it1.peek() < it2.peek()) {

--- a/src/java/htsjdk/variant/variantcontext/VariantContextComparator.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContextComparator.java
@@ -4,6 +4,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.variant.vcf.VCFContigHeaderLine;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,7 +19,8 @@ import java.util.Set;
  * A Comparator that orders VariantContexts by the ordering of the contigs/chromosomes in the List
  * provided at construction time, then by start position with each contig/chromosome.
  */
-public class VariantContextComparator implements Comparator<VariantContext> {
+public class VariantContextComparator implements Comparator<VariantContext>, Serializable {
+	private static final long serialVersionUID = 1L;
 
 	public static List<String> getSequenceNameList(final SAMSequenceDictionary dictionary) {
 		final List<String> list = new ArrayList<String>();

--- a/src/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
@@ -28,6 +28,7 @@ package htsjdk.variant.variantcontext.writer;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Queue;
 import java.util.Set;
@@ -182,7 +183,9 @@ abstract class SortingVariantContextWriterBase implements VariantContextWriter {
         }
     }
 
-    private static class VariantContextComparator implements Comparator<VCFRecord> {
+    private static class VariantContextComparator implements Comparator<VCFRecord>, Serializable {
+        private static final long serialVersionUID = 1L;
+
         public int compare(VCFRecord r1, VCFRecord r2) {
             return r1.vc.getStart() - r2.vc.getStart();
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:S2063 - Comparators should be "Serializable"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2063

Please let me know if you have any questions.

M-Ezzat