### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/src/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/java/htsjdk/samtools/BAMFileReader.java
@@ -927,6 +927,8 @@ class BAMFileReader extends SamReader.ReaderImplementation {
                     // Either found a good record, or else keep scanning SAMRecords
                     case OVERLAPPING: return
                             (contained ? FilteringIteratorState.CONTINUE_ITERATION : FilteringIteratorState.MATCHES_FILTER);
+                    default:
+                        break;
                 }
             }
             // Went past the last interval

--- a/src/java/htsjdk/samtools/DuplicateScoringStrategy.java
+++ b/src/java/htsjdk/samtools/DuplicateScoringStrategy.java
@@ -80,6 +80,8 @@ public class DuplicateScoringStrategy {
                         score += SAMUtils.getMateCigar(record).getReferenceLength();
                     }
                     break;
+                default:
+                    break;
             }
 
             storedScore = score;

--- a/src/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -167,6 +167,8 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
                 return new SAMRecordDuplicateComparator();
             case unsorted:
                 return null;
+            default:
+                break;
         }
         throw new IllegalStateException("sortOrder should not be null");
     }

--- a/src/java/htsjdk/samtools/TextTagCodec.java
+++ b/src/java/htsjdk/samtools/TextTagCodec.java
@@ -65,6 +65,8 @@ public class TextTagCodec {
             case 'S':
             case 'I':
                 tagType = 'i';
+            default:
+                break;
         }
         if (tagType == 'H') {
             // H should never happen anymore.

--- a/src/java/htsjdk/samtools/cram/build/CramNormalizer.java
+++ b/src/java/htsjdk/samtools/cram/build/CramNormalizer.java
@@ -284,6 +284,8 @@ public class CramNormalizer {
                 case RefSkip.operator:
                     posInSeq += ((RefSkip) variation).getLength();
                     break;
+                default:
+                    break;
             }
         }
         for (; posInRead <= readLength

--- a/src/java/htsjdk/samtools/cram/encoding/rans/D04.java
+++ b/src/java/htsjdk/samtools/cram/encoding/rans/D04.java
@@ -79,6 +79,8 @@ class D04 {
                         Constants.TF_SHIFT);
                 out.put(c);
                 break;
+            default:
+                break;
         }
 
         out.position(0);

--- a/src/java/htsjdk/samtools/cram/encoding/rans/E04.java
+++ b/src/java/htsjdk/samtools/cram/encoding/rans/E04.java
@@ -31,6 +31,8 @@ class E04 {
                         syms[0xFF & in.get(in_size - (i))]);
             case 0:
                 break;
+            default:
+                break;
         }
         for (i = (in_size & ~3); i > 0; i -= 4) {
             final int c3 = 0xFF & in.get(i - 1);

--- a/src/java/htsjdk/samtools/cram/lossy/QualityScorePreservation.java
+++ b/src/java/htsjdk/samtools/cram/lossy/QualityScorePreservation.java
@@ -178,6 +178,8 @@ public class QualityScorePreservation {
                 return -1;
             case PRESERVE:
                 return score;
+            default:
+                break;
 
         }
         throw new RuntimeException("Unknown quality score treatment type: "

--- a/src/java/htsjdk/samtools/util/QualityEncodingDetector.java
+++ b/src/java/htsjdk/samtools/util/QualityEncodingDetector.java
@@ -389,6 +389,8 @@ public class QualityEncodingDetector {
                                 return FastqQualityFormat.Illumina;
                             case SAM:
                                 return FastqQualityFormat.Standard;
+                            default:
+                                break;
                         }
                     } else if (possibleFormats.equals(EnumSet.of(FastqQualityFormat.Standard, FastqQualityFormat.Solexa))) {
                         return FastqQualityFormat.Standard;

--- a/src/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/java/htsjdk/tribble/index/IndexFactory.java
@@ -274,6 +274,8 @@ public class IndexFactory {
             case LINEAR:        return createLinearIndex(inputFile, codec);
             // Tabix index initialization requires additional information, so this construction method won't work.
             case TABIX:         throw new UnsupportedOperationException("Tabix indices cannot be created through a generic interface");
+            default:
+                break;
         }
         throw new IllegalArgumentException("Unrecognized IndexType " + type);
     }

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -437,6 +437,8 @@ public class VariantContextWriterBuilder {
 
                 writer = createBCFWriter(null, outStream);
                 break;
+            default:
+                break;
         }
 
         if (this.options.contains(Options.USE_ASYNC_IO))


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat