### PR TITLE
squid:S2131, squid:S1158 - Primitives should not be boxed just for St…

### DIFF
--- a/src/java/htsjdk/samtools/Defaults.java
+++ b/src/java/htsjdk/samtools/Defaults.java
@@ -92,13 +92,13 @@ public class Defaults {
 
     /** Gets a boolean system property, prefixed with "samjdk." using the default if the property does not exist. */
     private static boolean getBooleanProperty(final String name, final boolean def) {
-        final String value = getStringProperty(name, new Boolean(def).toString());
+        final String value = getStringProperty(name, Boolean.toString(def));
         return Boolean.parseBoolean(value);
     }
 
     /** Gets an int system property, prefixed with "samjdk." using the default if the property does not exist. */
     private static int getIntProperty(final String name, final int def) {
-        final String value = getStringProperty(name, new Integer(def).toString());
+        final String value = getStringProperty(name, Integer.toString(def));
         return Integer.parseInt(value);
     }
 

--- a/src/java/htsjdk/samtools/SAMRecordQueryHashComparator.java
+++ b/src/java/htsjdk/samtools/SAMRecordQueryHashComparator.java
@@ -63,6 +63,6 @@ public class SAMRecordQueryHashComparator extends SAMRecordQueryNameComparator {
 
     /** Compares the hash values for two records. */
     private int compareHashes(final SAMRecord lhs, final SAMRecord rhs) {
-        return new Integer(this.hasher.hashUnencodedChars(lhs.getReadName())).compareTo(this.hasher.hashUnencodedChars(rhs.getReadName()));
+        return Integer.compare(this.hasher.hashUnencodedChars(lhs.getReadName()), this.hasher.hashUnencodedChars(rhs.getReadName()));
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S2131 - Primitives should not be boxed just for "String" conversion
squid:S1158 - Primitive wrappers should not be instantiated only for "toString" or "compareTo" calls

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1158

Please let me know if you have any questions.

M-Ezzat