### PR TITLE
Split the two FilteringIterators into two differently named Iterators

### DIFF
--- a/src/java/htsjdk/samtools/filter/FilteringIterator.java
+++ b/src/java/htsjdk/samtools/filter/FilteringIterator.java
@@ -1,38 +1,8 @@
-/*
- * The MIT License
- *
- * Copyright (c) 2009 The Broad Institute
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
 package htsjdk.samtools.filter;
 
-import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMRecordIterator;
-import htsjdk.samtools.SamPairUtil;
-import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.PeekableIterator;
 
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 
 /**
  * Filtering Iterator which takes a filter and an iterator and iterates through only those records
@@ -41,114 +11,19 @@ import java.util.NoSuchElementException;
  * $Id$
  *
  * @author Kathleen Tibbetts
+ *
+ * use {@link FilteringSamIterator} instead
  */
-public class FilteringIterator implements CloseableIterator<SAMRecord> {
 
-    private final PeekableIterator<SAMRecord> iterator;
-    private final SamRecordFilter filter;
-    private boolean filterReadPairs = false;
-    private SAMRecord next = null;
+@Deprecated /** use {@link FilteringSamIterator} instead **/
+public class FilteringIterator extends FilteringSamIterator{
 
-    /**
-     * Constructor
-     *
-     * @param iterator     the backing iterator
-     * @param filter       the filter (which may be a FilterAggregator)
-     * @param filterByPair if true, filter reads in pairs
-     */
-    public FilteringIterator(final Iterator<SAMRecord> iterator, final SamRecordFilter filter,
-                             final boolean filterByPair) {
-
-        if (filterByPair && iterator instanceof SAMRecordIterator) {
-            ((SAMRecordIterator)iterator).assertSorted(SAMFileHeader.SortOrder.queryname);
-        }
-
-        this.iterator = new PeekableIterator<SAMRecord>(iterator);
-        this.filter = filter;
-        this.filterReadPairs = filterByPair;
-        next = getNextRecord();
+    public FilteringIterator(final Iterator<SAMRecord> iterator, final SamRecordFilter filter, final boolean filterByPair) {
+        super(iterator, filter, filterByPair);
     }
 
-    /**
-     * Constructor
-     *
-     * @param iterator the backing iterator
-     * @param filter   the filter (which may be a FilterAggregator)
-     */
     public FilteringIterator(final Iterator<SAMRecord> iterator, final SamRecordFilter filter) {
-        this.iterator = new PeekableIterator<SAMRecord>(iterator);
-        this.filter = filter;
-        next = getNextRecord();
+        super(iterator, filter);
     }
 
-    /**
-     * Returns true if the iteration has more elements.
-     *
-     * @return true if the iteration has more elements.  Otherwise returns false.
-     */
-    public boolean hasNext() {
-        return next != null;
-    }
-
-    /**
-     * Returns the next element in the iteration.
-     *
-     * @return the next element in the iteration
-     * @throws java.util.NoSuchElementException
-     *
-     */
-    public SAMRecord next() {
-        if (next == null) {
-            throw new NoSuchElementException("Iterator has no more elements.");
-        }
-        final SAMRecord result = next;
-        next = getNextRecord();
-        return result;
-    }
-
-    /**
-     * Required method for Iterator API.
-     *
-     * @throws UnsupportedOperationException
-     */
-    public void remove() {
-        throw new UnsupportedOperationException("Remove() not supported by FilteringIterator");
-    }
-
-    public void close() {
-        CloserUtil.close(iterator);
-    }
-
-    /**
-     * Gets the next record from the underlying iterator that passes the filter
-     *
-     * @return SAMRecord    the next filter-passing record
-     */
-    private SAMRecord getNextRecord() {
-
-        while (iterator.hasNext()) {
-            final SAMRecord record = iterator.next();
-
-            if (filterReadPairs && record.getReadPairedFlag() && record.getFirstOfPairFlag() &&
-                iterator.hasNext()) {
-
-                SamPairUtil.assertMate(record, iterator.peek());
-
-                if (filter.filterOut(record, iterator.peek())) {
-                    // skip second read
-                    iterator.next();
-                } else {
-                    return record;
-                }
-            } else if (filterReadPairs && record.getReadPairedFlag() &&
-                record.getSecondOfPairFlag()) {
-                // assume that we did a pass(first, second) and it passed the filter
-                return record;
-            } else if (!filter.filterOut(record)) {
-                return record;
-            }
-        }
-
-        return null;
-    }
 }

--- a/src/java/htsjdk/samtools/filter/FilteringIterator.java
+++ b/src/java/htsjdk/samtools/filter/FilteringIterator.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package htsjdk.samtools.filter;
 
 import htsjdk.samtools.SAMRecord;

--- a/src/java/htsjdk/samtools/filter/FilteringSamIterator.java
+++ b/src/java/htsjdk/samtools/filter/FilteringSamIterator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2009 The Broad Institute
+ * Copyright (c) 2016 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package htsjdk.samtools.filter;
 
 import htsjdk.samtools.SAMFileHeader;

--- a/src/java/htsjdk/samtools/filter/FilteringSamIterator.java
+++ b/src/java/htsjdk/samtools/filter/FilteringSamIterator.java
@@ -1,0 +1,154 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.filter;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SamPairUtil;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.PeekableIterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Filtering Iterator which takes a filter and an iterator and iterates through only those records
+ * which are not rejected by the filter.
+ * <p/>
+ * $Id$
+ *
+ * @author Kathleen Tibbetts
+ */
+public class FilteringSamIterator implements CloseableIterator<SAMRecord> {
+
+    private final PeekableIterator<SAMRecord> iterator;
+    private final SamRecordFilter filter;
+    private boolean filterReadPairs = false;
+    private SAMRecord next = null;
+
+    /**
+     * Constructor
+     *
+     * @param iterator     the backing iterator
+     * @param filter       the filter (which may be a FilterAggregator)
+     * @param filterByPair if true, filter reads in pairs
+     */
+    public FilteringSamIterator(final Iterator<SAMRecord> iterator, final SamRecordFilter filter,
+                                final boolean filterByPair) {
+
+        if (filterByPair && iterator instanceof SAMRecordIterator) {
+            ((SAMRecordIterator)iterator).assertSorted(SAMFileHeader.SortOrder.queryname);
+        }
+
+        this.iterator = new PeekableIterator<SAMRecord>(iterator);
+        this.filter = filter;
+        this.filterReadPairs = filterByPair;
+        next = getNextRecord();
+    }
+
+    /**
+     * Constructor
+     *
+     * @param iterator the backing iterator
+     * @param filter   the filter (which may be a FilterAggregator)
+     */
+    public FilteringSamIterator(final Iterator<SAMRecord> iterator, final SamRecordFilter filter) {
+        this.iterator = new PeekableIterator<SAMRecord>(iterator);
+        this.filter = filter;
+        next = getNextRecord();
+    }
+
+    /**
+     * Returns true if the iteration has more elements.
+     *
+     * @return true if the iteration has more elements.  Otherwise returns false.
+     */
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    /**
+     * Returns the next element in the iteration.
+     *
+     * @return the next element in the iteration
+     * @throws java.util.NoSuchElementException
+     *
+     */
+    public SAMRecord next() {
+        if (next == null) {
+            throw new NoSuchElementException("Iterator has no more elements.");
+        }
+        final SAMRecord result = next;
+        next = getNextRecord();
+        return result;
+    }
+
+    /**
+     * Required method for Iterator API.
+     *
+     * @throws UnsupportedOperationException
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("Remove() not supported by FilteringSamIterator");
+    }
+
+    public void close() {
+        CloserUtil.close(iterator);
+    }
+
+    /**
+     * Gets the next record from the underlying iterator that passes the filter
+     *
+     * @return SAMRecord    the next filter-passing record
+     */
+    private SAMRecord getNextRecord() {
+
+        while (iterator.hasNext()) {
+            final SAMRecord record = iterator.next();
+
+            if (filterReadPairs && record.getReadPairedFlag() && record.getFirstOfPairFlag() &&
+                iterator.hasNext()) {
+
+                SamPairUtil.assertMate(record, iterator.peek());
+
+                if (filter.filterOut(record, iterator.peek())) {
+                    // skip second read
+                    iterator.next();
+                } else {
+                    return record;
+                }
+            } else if (filterReadPairs && record.getReadPairedFlag() &&
+                record.getSecondOfPairFlag()) {
+                // assume that we did a pass(first, second) and it passed the filter
+                return record;
+            } else if (!filter.filterOut(record)) {
+                return record;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/java/htsjdk/samtools/util/SamLocusIterator.java
+++ b/src/java/htsjdk/samtools/util/SamLocusIterator.java
@@ -31,7 +31,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.filter.AggregateFilter;
 import htsjdk.samtools.filter.DuplicateReadFilter;
-import htsjdk.samtools.filter.FilteringIterator;
+import htsjdk.samtools.filter.FilteringSamIterator;
 import htsjdk.samtools.filter.SamRecordFilter;
 import htsjdk.samtools.filter.SecondaryOrSupplementaryFilter;
 
@@ -224,7 +224,7 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
             tempIterator = samReader.iterator();
         }
         if (samFilters != null) {
-            tempIterator = new FilteringIterator(tempIterator, new AggregateFilter(samFilters));
+            tempIterator = new FilteringSamIterator(tempIterator, new AggregateFilter(samFilters));
         }
         samIterator = new PeekableIterator<SAMRecord>(tempIterator);
         return this;

--- a/src/java/htsjdk/samtools/util/SamRecordIntervalIteratorFactory.java
+++ b/src/java/htsjdk/samtools/util/SamRecordIntervalIteratorFactory.java
@@ -79,10 +79,10 @@ public class SamRecordIntervalIteratorFactory {
 
     /**
      * Halt iteration after a read is encountered that starts after the given sequence and position.
-     * Note that most of this code is copied from FilteringIterator.  It would be nice just to override getNextRecord,
-     * but that method is called FilteringIterator ctor, so the stopAfter members can't be initialized before
+     * Note that most of this code is copied from FilteringSamIterator.  It would be nice just to override getNextRecord,
+     * but that method is called FilteringSamIterator ctor, so the stopAfter members can't be initialized before
      * it is called.
-     * FilteringIterator ctor could take a boolean "advance" that would tell it whether or not to call getNextRecord
+     * FilteringSamIterator ctor could take a boolean "advance" that would tell it whether or not to call getNextRecord
      * in the ctor, so that it could be delayed in the subclass.  If this pattern happens again, we should do that.
      */
     private class StopAfterFilteringIterator implements CloseableIterator<SAMRecord> {
@@ -132,7 +132,7 @@ public class SamRecordIntervalIteratorFactory {
          * @throws UnsupportedOperationException
          */
         public void remove() {
-            throw new UnsupportedOperationException("Remove() not supported by FilteringIterator");
+            throw new UnsupportedOperationException("Remove() not supported by FilteringSamIterator");
         }
 
         public void close() {

--- a/src/java/htsjdk/samtools/util/Tuple.java
+++ b/src/java/htsjdk/samtools/util/Tuple.java
@@ -22,8 +22,8 @@ public class Tuple<A, B> {
         final Tuple<?, ?> tuple = (Tuple<?, ?>) o;
 
         if (a != null ? !a.equals(tuple.a) : tuple.a != null) return false;
-        return !(b != null ? !b.equals(tuple.b) : tuple.b != null);
 
+        return !(b != null ? !b.equals(tuple.b) : tuple.b != null);
     }
 
     @Override
@@ -38,5 +38,4 @@ public class Tuple<A, B> {
     public String toString() {
         return "[" + a + ", " + b + "]";
     }
-
 }

--- a/src/java/htsjdk/variant/variantcontext/filter/FilteringIterator.java
+++ b/src/java/htsjdk/variant/variantcontext/filter/FilteringIterator.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
 package htsjdk.variant.variantcontext.filter;
 
 import htsjdk.variant.variantcontext.VariantContext;

--- a/src/java/htsjdk/variant/variantcontext/filter/FilteringIterator.java
+++ b/src/java/htsjdk/variant/variantcontext/filter/FilteringIterator.java
@@ -1,35 +1,8 @@
-/*
- * The MIT License
- *
- * Copyright (c) 2015 The Broad Institute
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
-
 package htsjdk.variant.variantcontext.filter;
 
-import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.CloserUtil;
 import htsjdk.variant.variantcontext.VariantContext;
 
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 
 /**
  * A filtering iterator for VariantContexts that takes a base iterator and a VariantContextFilter.
@@ -37,91 +10,13 @@ import java.util.NoSuchElementException;
  * The iterator returns all the variantcontexts for which the filter's function "test" returns true (and only those)
  *
  * @author Yossi Farjoun
+ *
+ * use {@link FilteringVariantContextIterator} instead
  */
-public class FilteringIterator implements CloseableIterator<VariantContext>, Iterable<VariantContext>{
-    private final Iterator<VariantContext> iterator;
-    private final VariantContextFilter filter;
-    private VariantContext next = null;
 
-    /**
-     * Constructor of an iterator based on the provided iterator and predicate. The resulting
-     * records will be all those VariantContexts from iterator for which filter.test( . ) is true
-     *
-     * @param iterator the backing iterator
-     * @param filter   the filter
-     */
+@Deprecated
+public class FilteringIterator extends FilteringVariantContextIterator{
     public FilteringIterator(final Iterator<VariantContext> iterator, final VariantContextFilter filter) {
-        this.iterator = iterator;
-        this.filter = filter;
-        next = getNextVC();
-    }
-
-    @Override
-    public void close() {
-        CloserUtil.close(iterator);
-    }
-
-    /**
-     * Returns true if the iteration has more elements.
-     *
-     * @return true if the iteration has more elements.  Otherwise returns false.
-     */
-    @Override
-    public boolean hasNext() {
-        return next != null;
-    }
-
-    /**
-     * Returns the next element in the iteration.
-     *
-     * @return the next element in the iteration
-     * @throws NoSuchElementException if there are no more elements to return
-     *
-     */
-    @Override
-    public VariantContext next() throws NoSuchElementException {
-        if (next == null) {
-            throw new NoSuchElementException("Iterator has no more elements.");
-        }
-        final VariantContext result = next;
-        next = getNextVC();
-        return result;
-    }
-
-    /**
-     * Required method for Iterator API.
-     *
-     * @throws UnsupportedOperationException since it is unsupported here.
-     */
-    @Override
-    public void remove() {
-        throw new UnsupportedOperationException("Remove() not supported by FilteringIterator");
-    }
-
-    /**
-     * Gets the next record from the underlying iterator that passes the filter
-     *
-     * @return VariantContext the next filter-passing record
-     */
-    private VariantContext getNextVC() {
-
-        while (iterator.hasNext()) {
-            final VariantContext record = iterator.next();
-
-            if (filter.test(record)) {
-                return record;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * function to satisfy the Iterable interface
-     *
-     * @return itself since the class inherits from Iterator
-     */
-    @Override
-    public Iterator<VariantContext> iterator() {
-        return this;
+        super(iterator, filter);
     }
 }

--- a/src/java/htsjdk/variant/variantcontext/filter/FilteringVariantContextIterator.java
+++ b/src/java/htsjdk/variant/variantcontext/filter/FilteringVariantContextIterator.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2015 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package htsjdk.variant.variantcontext.filter;
+
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.variant.variantcontext.VariantContext;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * A filtering iterator for VariantContexts that takes a base iterator and a VariantContextFilter.
+ *
+ * The iterator returns all the variantcontexts for which the filter's function "test" returns true (and only those)
+ *
+ * @author Yossi Farjoun
+ */
+public class FilteringVariantContextIterator implements CloseableIterator<VariantContext>, Iterable<VariantContext>{
+    private final Iterator<VariantContext> iterator;
+    private final VariantContextFilter filter;
+    private VariantContext next = null;
+
+    /**
+     * Constructor of an iterator based on the provided iterator and predicate. The resulting
+     * records will be all those VariantContexts from iterator for which filter.test( . ) is true
+     *
+     * @param iterator the backing iterator
+     * @param filter   the filter
+     */
+    public FilteringVariantContextIterator(final Iterator<VariantContext> iterator, final VariantContextFilter filter) {
+        this.iterator = iterator;
+        this.filter = filter;
+        next = getNextVC();
+    }
+
+    @Override
+    public void close() {
+        CloserUtil.close(iterator);
+    }
+
+    /**
+     * Returns true if the iteration has more elements.
+     *
+     * @return true if the iteration has more elements.  Otherwise returns false.
+     */
+    @Override
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    /**
+     * Returns the next element in the iteration.
+     *
+     * @return the next element in the iteration
+     * @throws NoSuchElementException if there are no more elements to return
+     *
+     */
+    @Override
+    public VariantContext next() throws NoSuchElementException {
+        if (next == null) {
+            throw new NoSuchElementException("Iterator has no more elements.");
+        }
+        final VariantContext result = next;
+        next = getNextVC();
+        return result;
+    }
+
+    /**
+     * Required method for Iterator API.
+     *
+     * @throws UnsupportedOperationException since it is unsupported here.
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("Remove() not supported by FilteringVariantContextIterator");
+    }
+
+    /**
+     * Gets the next record from the underlying iterator that passes the filter
+     *
+     * @return VariantContext the next filter-passing record
+     */
+    private VariantContext getNextVC() {
+
+        while (iterator.hasNext()) {
+            final VariantContext record = iterator.next();
+
+            if (filter.test(record)) {
+                return record;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * function to satisfy the Iterable interface
+     *
+     * @return itself since the class inherits from Iterator
+     */
+    @Override
+    public Iterator<VariantContext> iterator() {
+        return this;
+    }
+}

--- a/src/tests/java/htsjdk/variant/variantcontext/filter/FilteringVariantContextIteratorTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/filter/FilteringVariantContextIteratorTest.java
@@ -33,10 +33,10 @@ import org.testng.annotations.Test;
 import java.io.File;
 
 /**
- * Tests for testing the (VariantContext)FilteringIterator, and the HeterozygosityFilter
+ * Tests for testing the (VariantContext)FilteringVariantContextIterator, and the HeterozygosityFilter
  */
 
-public class FilteringIteratorTest {
+public class FilteringVariantContextIteratorTest {
     final File testDir = new File("testdata/htsjdk/variant");
 
     @DataProvider
@@ -57,7 +57,7 @@ public class FilteringIteratorTest {
 
         final File vcf = new File(testDir,"ex2.vcf");
         final VCFFileReader vcfReader = new VCFFileReader(vcf, false);
-        final FilteringIterator filteringIterator = new FilteringIterator(vcfReader.iterator(), filter);
+        final FilteringVariantContextIterator filteringIterator = new FilteringVariantContextIterator(vcfReader.iterator(), filter);
         int count = 0;
 
         for(final VariantContext vc : filteringIterator) {
@@ -82,7 +82,7 @@ public class FilteringIteratorTest {
         final VCFFileReader vcfReader = new VCFFileReader(vcf, false);
         final HeterozygosityFilter heterozygosityFilter = new HeterozygosityFilter(true, sample);
 
-        new FilteringIterator(vcfReader.iterator(), heterozygosityFilter).next();
+        new FilteringVariantContextIterator(vcfReader.iterator(), heterozygosityFilter).next();
     }
 }
 

--- a/src/tests/java/htsjdk/variant/variantcontext/filter/HeterozygosityFilterTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/filter/HeterozygosityFilterTest.java
@@ -108,7 +108,7 @@ public class HeterozygosityFilterTest {
 
     @Test(dataProvider = "variantsProvider")
     public void testFilteringIterator(final Iterator<VariantContext> vcs, final int[] passingPositions) {
-        final Iterator<VariantContext> filteringIterator = new FilteringIterator(vcs, new HeterozygosityFilter(true, "test"));
+        final Iterator<VariantContext> filteringIterator = new FilteringVariantContextIterator(vcs, new HeterozygosityFilter(true, "test"));
 
         int i = 0;
         while (filteringIterator.hasNext()) {

--- a/src/tests/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilterTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilterTest.java
@@ -59,7 +59,7 @@ public class JavascriptVariantFilterTest {
             vcfReader.close();
             return;
         }
-        final FilteringIterator iter = new FilteringIterator(vcfReader.iterator(), filter);
+        final FilteringVariantContextIterator iter = new FilteringVariantContextIterator(vcfReader.iterator(), filter);
         int count = 0;
         while (iter.hasNext()) {
             iter.next();


### PR DESCRIPTION
### Description
There are two very different FilteringIterators in htsjdk, SAM and VariantContext flavored ones. This is confusing and can lead to very verbose code when one wants to use both in the same class. 

This PR renames these two iterators FilteringSamIterator and FilteringVariantContextIterator while keeping the "old" FilteringIterators as @Deprecated but accessible subclasses. This makes it possible to remove these classes later, once folks have shifted over to using the explicitly named iterators.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
