### PR TITLE
Remove non-ascii character from comment.  Was breaking compile on certain machines

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
+++ b/src/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
@@ -364,7 +364,7 @@ public class GenotypeLikelihoods {
      * for aP = 0...N
      *  for aP-1 = 0...aP
      *      ...
-     *      for a1 = 0..…a2
+     *      for a1 = 0...a2
      *          a1,a2..aP
      *
      * This is implemented recursively:


### PR DESCRIPTION
### Description

On a recent change, a non-ascii character '…' (the character for elipsis) was inserted in a comment.
This is breaking the compile of the target compile-variant on one of our unix hosts:
