### PR TITLE
CRAM index code/test refactoring.

### DIFF
--- a/src/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -67,7 +67,7 @@ import java.util.TreeSet;
  * In both cases, processAlignment is called for each cram slice and
  * finish() is called at the end.
  */
-public class CRAMIndexer {
+public class CRAMBAIIndexer {
 
     // The number of references (chromosomes) in the BAM file
     private final int numReferences;
@@ -86,7 +86,7 @@ public class CRAMIndexer {
      * @param output     binary BAM Index (.bai) file
      * @param fileHeader header for the corresponding bam file
      */
-    public CRAMIndexer(final File output, final SAMFileHeader fileHeader) {
+    public CRAMBAIIndexer(final File output, final SAMFileHeader fileHeader) {
 
         numReferences = fileHeader.getSequenceDictionary().size();
         indexBuilder = new BAMIndexBuilder(fileHeader);
@@ -99,7 +99,7 @@ public class CRAMIndexer {
      * @param output     Index will be written here.  output will be closed when finish() method is called.
      * @param fileHeader header for the corresponding bam file.
      */
-    public CRAMIndexer(final OutputStream output, final SAMFileHeader fileHeader) {
+    public CRAMBAIIndexer(final OutputStream output, final SAMFileHeader fileHeader) {
 
         numReferences = fileHeader.getSequenceDictionary().size();
         indexBuilder = new BAMIndexBuilder(fileHeader);
@@ -430,7 +430,7 @@ public class CRAMIndexer {
         if (cramHeader.getSamFileHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
             throw new SAMException("Expecting a coordinate sorted file.");
         }
-        final CRAMIndexer indexer = new CRAMIndexer(output, cramHeader.getSamFileHeader());
+        final CRAMBAIIndexer indexer = new CRAMBAIIndexer(output, cramHeader.getSamFileHeader());
 
         int totalRecords = 0;
         Container container = null;

--- a/src/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -17,7 +17,6 @@ import htsjdk.samtools.cram.structure.CramCompressionRecord;
 import htsjdk.samtools.cram.structure.Slice;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
-import htsjdk.samtools.util.StringLineReader;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -58,7 +57,7 @@ public class CRAMContainerStreamWriter {
     private Set<String> captureTags = new TreeSet<String>();
     private Set<String> ignoreTags = new TreeSet<String>();
 
-    private CRAMIndexer indexer;
+    private CRAMBAIIndexer indexer;
     private long offset;
 
     /**
@@ -83,7 +82,7 @@ public class CRAMContainerStreamWriter {
         this.source = source;
         containerFactory = new ContainerFactory(samFileHeader, recordsPerSlice);
         if (indexStream != null) {
-            indexer = new CRAMIndexer(indexStream, samFileHeader);
+            indexer = new CRAMBAIIndexer(indexStream, samFileHeader);
         }
     }
 

--- a/src/java/htsjdk/samtools/cram/CRAIIndex.java
+++ b/src/java/htsjdk/samtools/cram/CRAIIndex.java
@@ -1,6 +1,6 @@
 package htsjdk.samtools.cram;
 
-import htsjdk.samtools.CRAMIndexer;
+import htsjdk.samtools.CRAMBAIIndexer;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.cram.structure.Slice;
@@ -27,10 +27,7 @@ public class CRAIIndex {
     public static final String CRAI_INDEX_SUFFIX = ".crai";
 
     public static void writeIndex(final OutputStream os, final List<CRAIEntry> index) throws IOException {
-        for (final CRAIEntry e : index) {
-            os.write(e.toString().getBytes());
-            os.write('\n');
-        }
+        index.stream().forEach(e -> e.writeToStream(os));
     }
 
     public static List<CRAIEntry> readIndex(final InputStream is) throws CRAIIndexException {
@@ -40,7 +37,7 @@ public class CRAIIndex {
         try {
             while (scanner.hasNextLine()) {
                 final String line = scanner.nextLine();
-                final CRAIEntry entry = CRAIEntry.fromCraiLine(line);
+                final CRAIEntry entry = new CRAIEntry(line);
                 list.add(entry);
             }
         } finally {
@@ -132,7 +129,7 @@ public class CRAIIndex {
         header.setSequenceDictionary(dictionary);
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final CRAMIndexer indexer = new CRAMIndexer(baos, header);
+        final CRAMBAIIndexer indexer = new CRAMBAIIndexer(baos, header);
 
         for (final CRAIEntry entry : full) {
             final Slice slice = new Slice();

--- a/src/tests/java/htsjdk/samtools/CRAMBAIIndexerTest.java
+++ b/src/tests/java/htsjdk/samtools/CRAMBAIIndexerTest.java
@@ -42,7 +42,7 @@ public class CRAMBAIIndexerTest {
         samFileHeader.addSequence(new SAMSequenceRecord("2", 10));
         samFileHeader.addSequence(new SAMSequenceRecord("3", 10));
         ByteArrayOutputStream indexBAOS = new ByteArrayOutputStream();
-        CRAMIndexer indexer = new CRAMIndexer(indexBAOS, samFileHeader);
+        CRAMBAIIndexer indexer = new CRAMBAIIndexer(indexBAOS, samFileHeader);
         int recordsPerContainer = 3;
         ContainerFactory containerFactory = new ContainerFactory(samFileHeader, recordsPerContainer);
         List<CramCompressionRecord> records = new ArrayList<>();

--- a/src/tests/java/htsjdk/samtools/CRAMComplianceTest.java
+++ b/src/tests/java/htsjdk/samtools/CRAMComplianceTest.java
@@ -66,18 +66,12 @@ public class CRAMComplianceTest {
         File refFile;
         File cramFile_21;
         File cramFile_30;
-        File embedCramFile;
-        File norefCramFile;
-        File refCramFile;
 
         public TestCase(File root, String name) {
             bamFile = new File(root, name + ".sam");
             refFile = new File(root, name.split("#")[0] + ".fa");
             cramFile_21 = new File(root, name + ".2.1.cram");
             cramFile_30 = new File(root, name + ".3.0.cram");
-            embedCramFile = new File(root, name + ".embed.cram");
-            norefCramFile = new File(root, name + ".noref.cram");
-            refCramFile = new File(root, name + ".ref.cram");
         }
     }
 
@@ -85,10 +79,7 @@ public class CRAMComplianceTest {
     public void test(String name) throws IOException {
         TestCase t = new TestCase(new File("testdata/htsjdk/samtools/cram/"), name);
 
-        ReferenceSource source = null;
-        if (t.refFile.exists())
-            source = new ReferenceSource(t.refFile);
-
+        ReferenceSource source = new ReferenceSource(t.refFile);
         SamReader reader = SamReaderFactory.make().validationStringency(ValidationStringency.SILENT).open(t.bamFile);
 
         final SAMRecordIterator samRecordIterator = reader.iterator();
@@ -112,33 +103,31 @@ public class CRAMComplianceTest {
             Assert.assertTrue(cramFileReaderIterator.hasNext());
             SAMRecord restored = cramFileReaderIterator.next();
             Assert.assertNotNull(restored);
-            assertSameRecords(CramVersions.CRAM_v3.major, samRecord, restored);
+            assertSameRecords(CramVersions.DEFAULT_CRAM_VERSION.major, samRecord, restored);
         }
         Assert.assertFalse(cramFileReaderIterator.hasNext());
 
-        if (t.cramFile_21.exists()) {
-            cramFileReader = new CRAMFileReader(new FileInputStream(t.cramFile_21), (SeekableStream)null, source, ValidationStringency.SILENT);
-            cramFileReaderIterator = cramFileReader.getIterator();
-            for (SAMRecord samRecord : samRecords) {
-                Assert.assertTrue(cramFileReaderIterator.hasNext());
-                SAMRecord restored = cramFileReaderIterator.next();
-                Assert.assertNotNull(restored);
-                assertSameRecords(CramVersions.CRAM_v2_1.major, samRecord, restored);
-            }
-            Assert.assertFalse(cramFileReaderIterator.hasNext());
+        //v2.1 test
+        cramFileReader = new CRAMFileReader(new FileInputStream(t.cramFile_21), (SeekableStream)null, source, ValidationStringency.SILENT);
+        cramFileReaderIterator = cramFileReader.getIterator();
+        for (SAMRecord samRecord : samRecords) {
+            Assert.assertTrue(cramFileReaderIterator.hasNext());
+            SAMRecord restored = cramFileReaderIterator.next();
+            Assert.assertNotNull(restored);
+            assertSameRecords(CramVersions.CRAM_v2_1.major, samRecord, restored);
         }
+        Assert.assertFalse(cramFileReaderIterator.hasNext());
 
-        if (t.cramFile_30.exists()) {
-            cramFileReader = new CRAMFileReader(new FileInputStream(t.cramFile_30), (SeekableStream)null, source, ValidationStringency.SILENT);
-            cramFileReaderIterator = cramFileReader.getIterator();
-            for (SAMRecord samRecord : samRecords) {
-                Assert.assertTrue(cramFileReaderIterator.hasNext());
-                SAMRecord restored = cramFileReaderIterator.next();
-                Assert.assertNotNull(restored);
-                assertSameRecords(CramVersions.CRAM_v3.major, samRecord, restored);
-            }
-            Assert.assertFalse(cramFileReaderIterator.hasNext());
+        //v3.0 test
+        cramFileReader = new CRAMFileReader(new FileInputStream(t.cramFile_30), (SeekableStream)null, source, ValidationStringency.SILENT);
+        cramFileReaderIterator = cramFileReader.getIterator();
+        for (SAMRecord samRecord : samRecords) {
+            Assert.assertTrue(cramFileReaderIterator.hasNext());
+            SAMRecord restored = cramFileReaderIterator.next();
+            Assert.assertNotNull(restored);
+            assertSameRecords(CramVersions.CRAM_v3.major, samRecord, restored);
         }
+        Assert.assertFalse(cramFileReaderIterator.hasNext());
     }
 
     private void assertSameRecords(int majorVersion, SAMRecord record1, SAMRecord record2) {
@@ -147,16 +136,14 @@ public class CRAMComplianceTest {
         Assert.assertEquals(record2.getReferenceName(), record1.getReferenceName());
         Assert.assertEquals(record2.getAlignmentStart(), record1.getAlignmentStart());
 
-        {
-            /**
-             * Known issue: CRAM v2.1 doesn't handle reads with missing bases correctly. This causes '*' bases to arise when reading CRAM.
-             * Skipping the base comparison asserts.
-             */
-            if (record1.getReadBases() == SAMRecord.NULL_SEQUENCE && majorVersion < CramVersions.CRAM_v3.major)
-                ;
-            else
-                Assert.assertEquals(record2.getReadBases(), record1.getReadBases());
+        /**
+         * Known issue: CRAM v2.1 doesn't handle reads with missing bases correctly. This
+         * causes '*' bases to arise when reading CRAM. Skipping the base comparison asserts.
+         */
+        if (record1.getReadBases() != SAMRecord.NULL_SEQUENCE || majorVersion >= CramVersions.CRAM_v3.major) {
+            Assert.assertEquals(record2.getReadBases(), record1.getReadBases());
         }
+
         Assert.assertEquals(record2.getBaseQualities(), record1.getBaseQualities());
     }
 

--- a/src/tests/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
+++ b/src/tests/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
@@ -27,15 +27,15 @@ import java.util.Map;
 import java.util.TreeSet;
 
 /**
- * A collection of tests for CRAM index write/read that use BAMFileIndexTest/index_test.bam file as the source of the test data.
+ * A collection of tests for CRAM BAI index write/read that use BAMFileIndexTest/index_test.bam file as the source of the test data.
  * The test will create a BAI index of the cram file before hand.
  * The scan* tests check that for every records in the BAM file the query returns the same records from the CRAM file.
  * Created by Vadim on 14/03/2015.
  */
-public class CRAMFileIndexTest {
+public class CRAMFileBAIIndexTest {
     private final File BAM_FILE = new File("testdata/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
-    private File cramFile = new File("testdata/htsjdk/samtools/BAMFileIndexTest/index_test.cram");
-    private File indexFile = new File("testdata/htsjdk/samtools/BAMFileIndexTest/index_test.cram.bai");
+    private File cramFile;
+    private File indexFile;
     private byte[] cramBytes;
     private byte[] baiBytes;
     private ReferenceSource source;
@@ -45,6 +45,8 @@ public class CRAMFileIndexTest {
     private int nofReadsPerContainer = 1000 ;
 
 
+    // Mixes testing queryAlignmentStart with each CRAMFileReaderConstructor
+    // Separate into individual tests
     @Test
     public void testConstructors () throws IOException {
         CRAMFileReader reader = new CRAMFileReader(cramFile, indexFile, source, ValidationStringency.SILENT);
@@ -91,6 +93,7 @@ public class CRAMFileIndexTest {
         reader.close();
     }
 
+    // this test is the same as the ones above in testConstructors
     @Test
     public void test_chrM_1500_location() throws IOException {
         CRAMFileReader reader = new CRAMFileReader(cramFile, indexFile, source);
@@ -139,7 +142,6 @@ public class CRAMFileIndexTest {
         final File CRAMFile = new File("testdata/htsjdk/samtools/cram/auxf#values.3.0.cram");
         final File refFile = new File("testdata/htsjdk/samtools/cram/auxf.fa");
         ReferenceSource refSource = new ReferenceSource(refFile);
-        File indexFile = null;
 
         long start = 0;
         long end = CRAMFile.length();
@@ -262,7 +264,7 @@ public class CRAMFileIndexTest {
         fos.write(cramBytes);
         fos.close();
 
-        CRAMIndexer.createIndex(new SeekableFileStream(cramFile), indexFile, null, ValidationStringency.STRICT);
+        CRAMBAIIndexer.createIndex(new SeekableFileStream(cramFile), indexFile, null, ValidationStringency.STRICT);
         baiBytes = readFile(indexFile);
     }
 

--- a/src/tests/java/htsjdk/samtools/CRAMFileWriterTest.java
+++ b/src/tests/java/htsjdk/samtools/CRAMFileWriterTest.java
@@ -40,7 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class CramFileWriterTest {
+public class CRAMFileWriterTest {
 
     @BeforeClass
     public void initClass() {
@@ -261,7 +261,7 @@ public class CramFileWriterTest {
         try (final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(reference).open(input);
              final SAMFileWriter writer = new SAMFileWriterFactory().makeWriter(reader.getFileHeader().clone(), false, outputFile, reference)) {
             for (SAMRecord rec : reader) {
-                    writer.addAlignment(rec);
+                writer.addAlignment(rec);
             }
         }
 

--- a/src/tests/java/htsjdk/samtools/SAMFileReaderTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFileReaderTest.java
@@ -82,7 +82,6 @@ public class SAMFileReaderTest {
         return testFiles;
     }
 
-
     @Test(dataProvider = "NoIndexCRAMTest")
     public void CRAMNoIndexTest(final String inputFile, final String referenceFile) {
         final File input = new File(TEST_DATA_DIR, inputFile);
@@ -133,17 +132,8 @@ public class SAMFileReaderTest {
         else if (inputFile.endsWith(".bam")) Assert.assertEquals(factory.bamRecordsCreated, i);
     }
 
-    @DataProvider(name = "cramNegativeTestCases")
-    public Object[][] cramTestNegativeCases() {
-        final Object[][] scenarios = new Object[][]{
-                {"cram_with_bai_index.cram",},
-                {"cram_with_crai_index.cram"},
-        };
-        return scenarios;
-    }
-
-    @Test(dataProvider = "cramNegativeTestCases", expectedExceptions=IllegalStateException.class)
-    public void testReferenceRequiredForCRAM(final String inputFile) {
+    @Test(dataProvider = "cramTestCases", expectedExceptions=IllegalStateException.class)
+    public void testReferenceRequiredForCRAM(final String inputFile, final String ignoredReferenceFile) {
         final File input = new File(TEST_DATA_DIR, inputFile);
         final SamReader reader = SamReaderFactory.makeDefault().open(input);
         for (final SAMRecord rec : reader) {
@@ -151,7 +141,7 @@ public class SAMFileReaderTest {
         CloserUtil.close(reader);
     }
 
-    @DataProvider(name = "cramPositiveTestCases")
+    @DataProvider(name = "cramTestCases")
     public Object[][] cramTestPositiveCases() {
         final Object[][] scenarios = new Object[][]{
                 {"cram_with_bai_index.cram", "hg19mini.fasta"},
@@ -160,7 +150,7 @@ public class SAMFileReaderTest {
         return scenarios;
     }
 
-    @Test(dataProvider = "cramPositiveTestCases")
+    @Test(dataProvider = "cramTestCases")
     public void testIterateCRAMWithIndex(final String inputFile, final String referenceFile) {
         final File input = new File(TEST_DATA_DIR, inputFile);
         final File reference = new File(TEST_DATA_DIR, referenceFile);

--- a/src/tests/java/htsjdk/samtools/cram/CRAIEntryTest.java
+++ b/src/tests/java/htsjdk/samtools/cram/CRAIEntryTest.java
@@ -47,7 +47,7 @@ public class CRAIEntryTest {
         final int sliceSise = counter++;
 
         final String line = String.format("%d\t%d\t%d\t%d\t%d\t%d", sequenceId, alignmentStart, alignmentSpan, containerOffset, sliceOffset, sliceSise);
-        final CRAIEntry entry = CRAIEntry.fromCraiLine(line);
+        final CRAIEntry entry = new CRAIEntry(line);
         Assert.assertNotNull(entry);
         Assert.assertEquals(entry.sequenceId, sequenceId);
         Assert.assertEquals(entry.alignmentStart, alignmentStart);
@@ -74,7 +74,6 @@ public class CRAIEntryTest {
         Assert.assertTrue(CRAIEntry.intersect(newEntry(1, 1), newEntry(1, 2)));
         Assert.assertTrue(CRAIEntry.intersect(newEntry(2, 1), newEntry(1, 2)));
     }
-
 
     @Test
     public void testIntersetcsOvertlaping() {


### PR DESCRIPTION
Proposed refactoring of some existing CRAM indexing code and tests, both as prep for https://github.com/samtools/htsjdk/issues/433 and to better align the CRAM test classes with the code being tested; proposed removal of some unused code; some minor test bug fixes. No net new functionality.

Summary of changes:

- CRAMIndexer - Renamed to CRAMBAIIndexer to better reflect it's intent; all of the code is for generating BAI indices from a CRAM file (and some of the test code for this class is already in a file
called CRAMBAIIndexerTest).

- CRAIIndex - Removed two public methods (findLastAlignedEntry and getLeftMost) that were only referenced by their test code in CRAIIndexTest. (Are these useful to keep as public methods - htsjdk never uses .crai indices directly other than to convert them to .bai ?)

- SamIndexes - Propose to delete. The methods in this class are all for directly opening or discerning between .bai and .crai files/streams, but are not used by htsjdk to do this and are not used anywhere in htsjdk other than SamIndexesTest. Is it worth maintaining these as public methods ?

- SamIndexesTest - Propose to delete. Contains tests for the unused the methods in SamIndexes, with the exception of two tests that were using intermediate methods in SamIndexes to test CRAIIndex methods; those two tests have been moved to CRAIIndexTest and changed to call CRAIndex directly.

- CRAMComplianceTest - Removed some unnecessary/unused code (all tests remain) and renamed -> CRAMRoundTripTest, since all of the code is for testing round tripping between BAM and CRAM v2.1/v3.0.

- CramFileWriterTest - Renamed ->CRAMFileWriterTest to match the case-sense of the other files and the class it contains. Moved one general round-trip test into CRAMRoundTripTests.

- CRAMFileWriterWithIndexTest - Propose to delete. There are two tests in here; one was moved to CRAMFileIndexTest. The other one (testUnnecessaryIO) seems overly complicated and unnatural. I'm not sure what its testing for; is there a useful test here ?
