### PR TITLE
made 'isEnabled' static

### DIFF
--- a/src/java/htsjdk/samtools/util/Log.java
+++ b/src/java/htsjdk/samtools/util/Log.java
@@ -72,7 +72,7 @@ public final class Log {
     }
 
     /** Returns true if the specified log level is enabled otherwise false. */
-    public final boolean isEnabled(final LogLevel level) {
+    public static final boolean isEnabled(final LogLevel level) {
         return level.ordinal() <= globalLogLevel.ordinal();
     }
 


### PR DESCRIPTION
### Description
This allows one to check the VERBOSITY level of the run without instantiating a new Log. 
In a utility class I'd like to  log only if the VERBOSITY is "DEBUG" and since the code is rather "deep" I do not wish to instantiate a Log just to check the VERBOSITY.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary

