### PR TITLE
htsjdk/samtools/Defaults and security manager

### DIFF
--- a/src/java/htsjdk/samtools/Defaults.java
+++ b/src/java/htsjdk/samtools/Defaults.java
@@ -85,9 +85,15 @@ public class Defaults {
         CUSTOM_READER_FACTORY = getStringProperty("custom_reader", "");
     }
 
-    /** Gets a string system property, prefixed with "samjdk." using the default if the property does not exist. */
+    /** Gets a string system property, prefixed with "samjdk." using the default 
+     * if the property does not exist or if the java.security manager raises an exception for
+     * applications started with  -Djava.security.manager  . */
     private static String getStringProperty(final String name, final String def) {
-        return System.getProperty("samjdk." + name, def);
+        try {
+            return System.getProperty("samjdk." + name, def);
+        } catch (final java.security.AccessControlException error) {
+            return def;
+        }
     }
 
     /** Gets a boolean system property, prefixed with "samjdk." using the default if the property does not exist. */

--- a/src/java/htsjdk/samtools/Defaults.java
+++ b/src/java/htsjdk/samtools/Defaults.java
@@ -2,6 +2,8 @@ package htsjdk.samtools;
 
 import java.io.File;
 
+import htsjdk.samtools.util.Log;
+
 /**
  * Embodies defaults for global values that affect how the SAM JDK operates. Defaults are encoded in the class
  * and are also overridable using system properties.
@@ -9,6 +11,8 @@ import java.io.File;
  * @author Tim Fennell
  */
 public class Defaults {
+    private static Log log = Log.getInstance(Defaults.class);
+    
     /** Should BAM index files be created when writing out coordinate sorted BAM files?  Default = false. */
     public static final boolean CREATE_INDEX;
 
@@ -92,6 +96,7 @@ public class Defaults {
         try {
             return System.getProperty("samjdk." + name, def);
         } catch (final java.security.AccessControlException error) {
+            log.warn(error,"java Security Manager forbids 'System.getProperty(\"" + name + "\")' , returning default value: " + def );
             return def;
         }
     }


### PR DESCRIPTION
### Description

I want to use my tool https://github.com/lindenb/jvarkit/wiki/VCFFilterJS in galaxy. Users will provide a custom javascript script and I must run this jar using a sandboxed environment ( -**Djava.security.manager** ) to prevent the evil users from accessing the filesystem.
But **htsjdk.samtools.Defaults** calls `System.getProperty` and raises an exception.

```
$ gunzip -c input.vcf.gz |  java  -Djava.security.manager -jar dist/vcffilterjs.jar -e 'variant.getStart()!=2' 
(...)
java.lang.ExceptionInInitializerError
	at htsjdk.tribble.readers.LineReaderUtil.fromBufferedStream(LineReaderUtil.java:29)
	at com.github.lindenb.jvarkit.util.vcf.VcfIteratorImpl.<init>(VcfIteratorImpl.java:25)
	at com.github.lindenb.jvarkit.util.vcf.VCFUtils.createVcfIteratorFromStream(VCFUtils.java:243)
	at com.github.lindenb.jvarkit.tools.vcffilterjs.AbstractVCFFilterJS.openVcfIterator(AbstractVCFFilterJS.java:490)
	at com.github.lindenb.jvarkit.tools.vcffilterjs.AbstractVCFFilterJS.doVcfToVcf(AbstractVCFFilterJS.java:390)
	at com.github.lindenb.jvarkit.tools.vcffilterjs.VCFFilterJS.call(VCFFilterJS.java:159)
	at com.github.lindenb.jvarkit.tools.vcffilterjs.AbstractVCFFilterJS.call(AbstractVCFFilterJS.java:509)
	at com.github.lindenb.jvarkit.tools.vcffilterjs.AbstractVCFFilterJS.call(AbstractVCFFilterJS.java:32)
	at com.github.lindenb.jvarkit.util.command.Command.instanceMainWithExceptions(Command.java:549)
	at com.github.lindenb.jvarkit.util.command.Command.instanceMain(Command.java:586)
	at com.github.lindenb.jvarkit.util.command.Command.instanceMainWithExit(Command.java:592)
	at com.github.lindenb.jvarkit.tools.vcffilterjs.VCFFilterJS.main(VCFFilterJS.java:164)
Caused by: java.security.AccessControlException: access denied ("java.util.PropertyPermission" "samjdk.create_index" "read")
	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:457)
	at java.security.AccessController.checkPermission(AccessController.java:884)
	at java.lang.SecurityManager.checkPermission(SecurityManager.java:549)
	at java.lang.SecurityManager.checkPropertyAccess(SecurityManager.java:1294)
	at java.lang.System.getProperty(System.java:753)
	at htsjdk.samtools.Defaults.getStringProperty(Defaults.java:90)
	at htsjdk.samtools.Defaults.getBooleanProperty(Defaults.java:95)
	at htsjdk.samtools.Defaults.<clinit>(Defaults.java:70)
	... 12 more
```
 In htsjdk/samtools/Defaults I've surrounded with a catch **java.security.AccessControlException**.

with the new version:

```
gunzip -c input.vcf.gz |  java  -Djava.security.manager -jar dist/vcffilterjs.jar -e 'variant.getStart()!=2'  > /dev/null && echo "OK"
OK
```


### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [X] Extended the README / documentation, if necessary

