### PR TITLE
Add a method to expose whether the stream is positioned at the end of a BGZF block.

### DIFF
--- a/src/java/htsjdk/samtools/util/BlockCompressedInputStream.java
+++ b/src/java/htsjdk/samtools/util/BlockCompressedInputStream.java
@@ -133,6 +133,14 @@ public class BlockCompressedInputStream extends InputStream implements LocationA
     }
 
     /**
+     * @return <code>true</code> if the stream is at the end of a BGZF block,
+     * <code>false</code> otherwise.
+     */
+    public boolean endOfBlock() {
+        return (mCurrentBlock != null && mCurrentOffset == mCurrentBlock.length);
+    }
+
+    /**
      * Closes the underlying InputStream or RandomAccessFile
      */
     public void close()

--- a/src/tests/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
+++ b/src/tests/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
@@ -63,6 +63,14 @@ public class BlockCompressedOutputStreamTest {
         for(int i = 0; (line = reader.readLine()) != null; ++i) {
             Assert.assertEquals(line + "\n", linesWritten.get(i));
         }
+
+        final BlockCompressedInputStream bcis2 = new BlockCompressedInputStream(f);
+        int available = bcis2.available();
+        Assert.assertFalse(bcis2.endOfBlock(), "Should not be at end of block");
+        Assert.assertTrue(available > 0);
+        byte[] buffer = new byte[available];
+        Assert.assertEquals(bcis2.read(buffer), available, "Should read to end of block");
+        Assert.assertTrue(bcis2.endOfBlock(), "Should be at end of block");
     }
 
     @Test


### PR DESCRIPTION
### Description

Add a method to BlockCompressedInputStream to expose whether the stream is positioned at the end of a BGZF block. This is needed by Hadoop-BAM (and GATK4 indirectly via its dependency on Hadoop-BAM) to add support for reading block compressed VCF files in parallel. See https://github.com/HadoopGenomics/Hadoop-BAM/issues/68 and https://github.com/HadoopGenomics/Hadoop-BAM/pull/70. /cc @akiezun 

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
