### PR TITLE
remove asynchronous reading from Tribble LineReaderUtil

### DIFF
--- a/src/java/htsjdk/tribble/TabixFeatureReader.java
+++ b/src/java/htsjdk/tribble/TabixFeatureReader.java
@@ -128,7 +128,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
     public CloseableTribbleIterator<T> iterator() throws IOException {
         final InputStream is = new BlockCompressedInputStream(ParsingUtils.openInputStream(path));
         final PositionalBufferedStream stream = new PositionalBufferedStream(is);
-        final LineReader reader = LineReaderUtil.fromBufferedStream(stream, LineReaderUtil.LineReaderOption.SYNCHRONOUS);
+        final LineReader reader = LineReaderUtil.fromBufferedStream(stream);
         return new FeatureIterator<T>(reader, 0, Integer.MAX_VALUE);
     }
 

--- a/src/java/htsjdk/tribble/readers/LineReaderUtil.java
+++ b/src/java/htsjdk/tribble/readers/LineReaderUtil.java
@@ -1,9 +1,7 @@
 package htsjdk.tribble.readers;
 
-import htsjdk.samtools.Defaults;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.RuntimeIOException;
-import htsjdk.tribble.TribbleException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,79 +14,48 @@ import java.io.StringReader;
  * @author mccowan
  */
 public class LineReaderUtil {
-    public enum LineReaderOption {
-        ASYNCHRONOUS, SYNCHRONOUS
-    }
+    public static LineReader fromStringReader(final StringReader stringReader) {
+        return new LineReader() {
+            final LongLineBufferedReader reader = new LongLineBufferedReader(stringReader);
 
-    /**
-     * Like {@link #fromBufferedStream(java.io.InputStream, LineReaderUtil.LineReaderOption)}, but the synchronicity
-     * option is determined by {@link htsjdk.samtools.Defaults}: if asynchronous I/O is enabled, an asynchronous line reader will be
-     * returned.
-     */
-    public static LineReader fromBufferedStream(final InputStream stream) {
-        return fromBufferedStream(stream, Defaults.USE_ASYNC_IO ? LineReaderOption.ASYNCHRONOUS : LineReaderOption.SYNCHRONOUS);
-    }
+            @Override
+            public String readLine() {
+                try {
+                    return reader.readLine();
+                } catch (IOException e) {
+                    throw new RuntimeIOException(e);
+                }
+            }
 
-    public static LineReader fromStringReader(final StringReader reader) {
-        return fromStringReader(reader, Defaults.USE_ASYNC_IO ? LineReaderOption.ASYNCHRONOUS : LineReaderOption.SYNCHRONOUS);
-    }
-
-    public static LineReader fromStringReader(final StringReader stringReader, final LineReaderOption lineReaderOption) {
-        switch (lineReaderOption) {
-            case ASYNCHRONOUS:
-                return new AsynchronousLineReader(stringReader);
-            case SYNCHRONOUS:
-                return new LineReader() {
-                    final LongLineBufferedReader reader = new LongLineBufferedReader(stringReader);
-
-                    @Override
-                    public String readLine() {
-                        try {
-                            return reader.readLine();
-                        } catch (IOException e) {
-                            throw new RuntimeIOException(e);
-                        }
-                    }
-
-                    @Override
-                    public void close() {
-                        CloserUtil.close(reader);
-                    }
-                };
-            default:
-                throw new TribbleException(String.format("Unrecognized LineReaderUtil option: %s.", lineReaderOption));
-        }
+            @Override
+            public void close() {
+                CloserUtil.close(reader);
+            }
+        };
     }
 
     /**
      * Convenience factory for composing a LineReader from an InputStream.
      */
-    public static LineReader fromBufferedStream(final InputStream bufferedStream, final LineReaderOption option) {
+    public static LineReader fromBufferedStream(final InputStream bufferedStream) {
         final InputStreamReader bufferedInputStreamReader = new InputStreamReader(bufferedStream);
-        switch (option) {
-            case ASYNCHRONOUS:
-                return new AsynchronousLineReader(bufferedInputStreamReader);
-            case SYNCHRONOUS:
-                return new LineReader() {
-                    final LongLineBufferedReader reader = new LongLineBufferedReader(bufferedInputStreamReader);
+        return new LineReader() {
+            final LongLineBufferedReader reader = new LongLineBufferedReader(bufferedInputStreamReader);
 
-                    @Override
-                    public String readLine() {
-                        try {
-                            return reader.readLine();
-                        } catch (IOException e) {
-                            throw new RuntimeIOException(e);
-                        }
-                    }
+            @Override
+            public String readLine() {
+                try {
+                    return reader.readLine();
+                } catch (IOException e) {
+                    throw new RuntimeIOException(e);
+                }
+            }
 
-                    @Override
-                    public void close() {
-                        CloserUtil.close(reader);
-                    }
-                };
-            default:
-                throw new TribbleException(String.format("Unrecognized LineReaderUtil option: %s.", option));
-        }
+            @Override
+            public void close() {
+                CloserUtil.close(reader);
+            }
+        };
     }
 
 }

--- a/src/java/htsjdk/variant/bcf2/BCF2Codec.java
+++ b/src/java/htsjdk/variant/bcf2/BCF2Codec.java
@@ -171,7 +171,7 @@ public final class BCF2Codec extends BinaryFeatureCodec<VariantContext> {
                 error("Couldn't read all of the bytes specified in the header length = " + headerSizeInBytes);
 
             final PositionalBufferedStream bps = new PositionalBufferedStream(new ByteArrayInputStream(headerBytes));
-            final LineIterator lineIterator = new LineIteratorImpl(LineReaderUtil.fromBufferedStream(bps, LineReaderUtil.LineReaderOption.SYNCHRONOUS));
+            final LineIterator lineIterator = new LineIteratorImpl(LineReaderUtil.fromBufferedStream(bps));
             final VCFCodec headerParser = new VCFCodec();
             this.header = (VCFHeader) headerParser.readActualHeader(lineIterator);
             bps.close();

--- a/src/tests/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/tests/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -64,7 +64,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     private VCFHeader createHeader(String headerStr) {
         VCFCodec codec = new VCFCodec();
         VCFHeader header = (VCFHeader) codec.readActualHeader(new LineIteratorImpl(LineReaderUtil.fromStringReader(
-                new StringReader(headerStr), LineReaderUtil.LineReaderOption.SYNCHRONOUS)));
+                new StringReader(headerStr))));
         Assert.assertEquals(header.getMetaDataInInputOrder().size(), VCF4headerStringCount);
         return header;
     }


### PR DESCRIPTION
### Description

This PR removes asynchronous reading from Tribble. The reason is that performance was very bad. I got hit by it here: https://github.com/broadinstitute/gatk/issues/1597 and it can easily be reproduced. 

To see the problem, run the PrintVariantsExample (from #527 ) 

like this (sync IO):
```
java -Dsamjdk.use_async_io=false -cp dist/htsjdk-2.1.1.jar htsjdk.variant.example.PrintVariantsExample dbsnp_138.b37.excluding_sites_after_129.chr1_4.vcf
```

and then like this (async IO)
```
java -Dsamjdk.use_async_io=true -cp dist/htsjdk-2.1.1.jar htsjdk.variant.example.PrintVariantsExample dbsnp_138.b37.excluding_sites_after_129.chr1_4.vcf
```

(pick a file for which this takes at least a few seconds). On my Mac, the results are dramatic - asych is 25% *slower* (async IO is supposed to be faster!)

This PR removes async from tribble readers. With this change, performance of the two commandlines above is the same (reviewer should verify that)