### PR TITLE
split async samtools and tribble options

### DIFF
--- a/src/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -44,7 +44,7 @@ public class SAMFileWriterFactory implements Cloneable {
     private boolean createIndex = defaultCreateIndexWhileWriting;
     private static boolean defaultCreateMd5File = Defaults.CREATE_MD5;
     private boolean createMd5File = defaultCreateMd5File;
-    private boolean useAsyncIo = Defaults.USE_ASYNC_IO;
+    private boolean useAsyncIo = Defaults.USE_ASYNC_IO_FOR_SAMTOOLS;
     private int asyncOutputBufferSize = AsyncSAMFileWriter.DEFAULT_QUEUE_SIZE;
     private int bufferSize = Defaults.BUFFER_SIZE;
     private File tmpDir;

--- a/src/java/htsjdk/samtools/example/PrintReadsExample.java
+++ b/src/java/htsjdk/samtools/example/PrintReadsExample.java
@@ -31,6 +31,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
@@ -95,12 +97,8 @@ public final class PrintReadsExample {
                 ' ' + System.getProperty("os.arch") + "; " + System.getProperty("java.vm.name") +
                 ' ' + System.getProperty("java.runtime.version") +
                 ' ' + (DeflaterFactory.usingIntelDeflater() ? "IntelDeflater" : "JdkDeflater"));
-        log.info("CREATE_INDEX:" + Defaults.CREATE_INDEX +
-                ' ' + "CREATE_MD5:" + Defaults.CREATE_MD5 +
-                ' ' + "USE_ASYNC_IO:" + Defaults.USE_ASYNC_IO +
-                ' ' + "BUFFER_SIZE:" + Defaults.BUFFER_SIZE +
-                ' ' + "COMPRESSION_LEVEL:" + Defaults.COMPRESSION_LEVEL +
-                ' ' + "NON_ZERO_BUFFER_SIZE:" + Defaults.NON_ZERO_BUFFER_SIZE +
-                ' ' + "CUSTOM_READER_FACTORY:" + Defaults.CUSTOM_READER_FACTORY);
+
+        final List<String> list = Defaults.allDefaults().entrySet().stream().map(e -> e.getKey() + ':' + e.getValue()).collect(Collectors.toList());
+        log.info(String.join(" ", list));
     }
 }

--- a/src/java/htsjdk/samtools/fastq/FastqWriterFactory.java
+++ b/src/java/htsjdk/samtools/fastq/FastqWriterFactory.java
@@ -10,7 +10,7 @@ import java.io.File;
  * @author Tim Fennell
  */
 public class FastqWriterFactory {
-    boolean useAsyncIo = Defaults.USE_ASYNC_IO;
+    boolean useAsyncIo = Defaults.USE_ASYNC_IO_FOR_SAMTOOLS;
     boolean createMd5  = Defaults.CREATE_MD5;
 
     /** Sets whether or not to use async io (i.e. a dedicated thread per writer. */

--- a/src/java/htsjdk/tribble/readers/LineReaderUtil.java
+++ b/src/java/htsjdk/tribble/readers/LineReaderUtil.java
@@ -26,11 +26,11 @@ public class LineReaderUtil {
      * returned.
      */
     public static LineReader fromBufferedStream(final InputStream stream) {
-        return fromBufferedStream(stream, Defaults.USE_ASYNC_IO ? LineReaderOption.ASYNCHRONOUS : LineReaderOption.SYNCHRONOUS);
+        return fromBufferedStream(stream, Defaults.USE_ASYNC_IO_FOR_TRIBBLE ? LineReaderOption.ASYNCHRONOUS : LineReaderOption.SYNCHRONOUS);
     }
 
     public static LineReader fromStringReader(final StringReader reader) {
-        return fromStringReader(reader, Defaults.USE_ASYNC_IO ? LineReaderOption.ASYNCHRONOUS : LineReaderOption.SYNCHRONOUS);
+        return fromStringReader(reader, Defaults.USE_ASYNC_IO_FOR_TRIBBLE ? LineReaderOption.ASYNCHRONOUS : LineReaderOption.SYNCHRONOUS);
     }
 
     public static LineReader fromStringReader(final StringReader stringReader, final LineReaderOption lineReaderOption) {

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -131,8 +131,9 @@ public class VariantContextWriterBuilder {
      * Default constructor.  Adds <code>USE_ASYNC_IO</code> to the Options if it is present in Defaults.
      */
     public VariantContextWriterBuilder() {
-        if (Defaults.USE_ASYNC_IO)
+        if (Defaults.USE_ASYNC_IO_FOR_TRIBBLE) {
             options.add(Options.USE_ASYNC_IO);
+        }
     }
 
     /**

--- a/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterFactory.java
+++ b/src/java/htsjdk/variant/variantcontext/writer/VariantContextWriterFactory.java
@@ -56,7 +56,7 @@ public class VariantContextWriterFactory {
     public static final EnumSet<Options> NO_OPTIONS = EnumSet.noneOf(Options.class);
 
     static {
-        if (Defaults.USE_ASYNC_IO) {
+        if (Defaults.USE_ASYNC_IO_FOR_TRIBBLE) {
             DEFAULT_OPTIONS.add(Options.USE_ASYNC_IO);
         }
     }

--- a/src/tests/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/tests/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -26,6 +26,10 @@ package htsjdk.samtools;
 import htsjdk.samtools.cram.build.CramIO;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.variant.variantcontext.writer.AsyncVariantContextWriter;
+import htsjdk.variant.variantcontext.writer.Options;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -292,4 +296,22 @@ public class SAMFileWriterFactoryTest {
         verifyWriterOutput(outputFile, new ReferenceSource(referenceFile), nRecs, true);
     }
 
+    @Test
+    public void testAsync() throws IOException {
+        final SAMFileWriterFactory builder = new SAMFileWriterFactory();
+
+        final File outputFile = prepareOutputFile(BamFileIoUtils.BAM_FILE_EXTENSION);
+        final SAMFileHeader header = new SAMFileHeader();
+        final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
+        final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
+
+        SAMFileWriter writer = builder.makeWriter(header, false, outputFile, referenceFile);
+        Assert.assertEquals(writer instanceof AsyncSAMFileWriter, Defaults.USE_ASYNC_IO_FOR_SAMTOOLS, "testAsync default");
+
+        writer = builder.setUseAsyncIo(true).makeWriter(header, false, outputFile, referenceFile);
+        Assert.assertTrue(writer instanceof AsyncSAMFileWriter, "testAsync option=set");
+
+        writer = builder.setUseAsyncIo(false).makeWriter(header, false, outputFile, referenceFile);
+        Assert.assertFalse(writer instanceof AsyncSAMFileWriter, "testAsync option=unset");
+    }
 }

--- a/src/tests/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -186,7 +186,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
                 .setOutputFile(vcf);
 
         VariantContextWriter writer = builder.build();
-        Assert.assertEquals(writer instanceof AsyncVariantContextWriter, Defaults.USE_ASYNC_IO, "testAsync default");
+        Assert.assertEquals(writer instanceof AsyncVariantContextWriter, Defaults.USE_ASYNC_IO_FOR_TRIBBLE, "testAsync default");
 
         writer = builder.setOption(Options.USE_ASYNC_IO).build();
         Assert.assertTrue(writer instanceof AsyncVariantContextWriter, "testAsync option=set");


### PR DESCRIPTION
### Description

This PR takes over from https://github.com/samtools/htsjdk/pull/528 and splits `USE_ASYNC_IO` into 2 options, `USE_ASYNC_IO_FOR_SAMTOOLS` and `USE_ASYNC_IO_FOR_TRIBBLE` because clients like GATK want more fine grained controls and also the performance characteristics of samtools vs tribble are very different (see  https://github.com/samtools/htsjdk/pull/528) for examples and timings.

@droazen can you review? @yfarjoun FYI