### PR TITLE
Clean up Genotype JEXL Filtering

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/GenotypeJEXLContext.java
+++ b/src/java/htsjdk/variant/variantcontext/GenotypeJEXLContext.java
@@ -6,7 +6,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Created by bimber on 3/21/2016.
+ *
+ * @author bbimber
+ *
+ * implements the JEXL context for Genotype; this saves us from
+ * having to generate a JEXL context lookup map everytime we want to evaluate an expression.
+ *
  */
 public class GenotypeJEXLContext extends VariantJEXLContext {
     private Genotype g;

--- a/src/java/htsjdk/variant/variantcontext/GenotypeJEXLContext.java
+++ b/src/java/htsjdk/variant/variantcontext/GenotypeJEXLContext.java
@@ -1,0 +1,53 @@
+package htsjdk.variant.variantcontext;
+
+import htsjdk.variant.vcf.VCFConstants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by bimber on 3/21/2016.
+ */
+public class GenotypeJEXLContext extends VariantJEXLContext {
+    private Genotype g;
+
+    private interface AttributeGetter {
+        public Object get(Genotype g);
+    }
+
+    private static Map<String, AttributeGetter> attrs = new HashMap<String, AttributeGetter>();
+
+    static {
+        attrs.put("g", new AttributeGetter() { public Object get(Genotype g) { return g; }});
+        attrs.put(VCFConstants.GENOTYPE_KEY, new AttributeGetter() { public Object get(Genotype g) { return g.getGenotypeString(); }});
+
+        attrs.put("isHom", new AttributeGetter() { public Object get(Genotype g) { return g.isHom() ? "1" : "0"; }});
+        attrs.put("isHomRef", new AttributeGetter() { public Object get(Genotype g) { return g.isHomRef() ? "1" : "0"; }});
+        attrs.put("isHet", new AttributeGetter() { public Object get(Genotype g) { return g.isHet() ? "1" : "0"; }});
+        attrs.put("isHomVar", new AttributeGetter() { public Object get(Genotype g) { return g.isHomVar() ? "1" : "0"; }});
+        attrs.put("isCalled", new AttributeGetter() { public Object get(Genotype g) { return g.isCalled() ? "1" : "0"; }});
+        attrs.put("isNoCall", new AttributeGetter() { public Object get(Genotype g) { return g.isNoCall() ? "1" : "0"; }});
+        attrs.put("isMixed", new AttributeGetter() { public Object get(Genotype g) { return g.isMixed() ? "1" : "0"; }});
+        attrs.put("isAvailable", new AttributeGetter() { public Object get(Genotype g) { return g.isAvailable() ? "1" : "0"; }});
+        attrs.put("isPassFT", new AttributeGetter() { public Object get(Genotype g) { return g.isFiltered() ? "0" : "1"; }});
+        attrs.put(VCFConstants.GENOTYPE_FILTER_KEY, new AttributeGetter() { public Object get(Genotype g) { return g.isFiltered()?  g.getFilters() : "PASS"; }});
+        attrs.put(VCFConstants.GENOTYPE_QUALITY_KEY, new AttributeGetter() { public Object get(Genotype g) { return g.getGQ(); }});
+    }
+
+    public GenotypeJEXLContext(VariantContext vc, Genotype g) {
+        super(vc);
+        this.g = g;
+    }
+
+    public Object get(String name) {
+        //should matching genotype attributes always supersede vc?
+        if ( attrs.containsKey(name) ) { // dynamic resolution of name -> value via map
+            return attrs.get(name).get(g);
+        } else if ( g.hasAnyAttribute(name) ) {
+            return g.getAnyAttribute(name);
+        } else if ( g.getFilters().contains(name) ) {
+            return "1";
+        } else
+            return super.get(name);
+    }
+}

--- a/src/java/htsjdk/variant/variantcontext/GenotypeJEXLContext.java
+++ b/src/java/htsjdk/variant/variantcontext/GenotypeJEXLContext.java
@@ -20,23 +20,23 @@ public class GenotypeJEXLContext extends VariantJEXLContext {
         public Object get(Genotype g);
     }
 
-    private static Map<String, AttributeGetter> attrs = new HashMap<String, AttributeGetter>();
+    private static Map<String, AttributeGetter> attributes = new HashMap<String, AttributeGetter>();
 
     static {
-        attrs.put("g", new AttributeGetter() { public Object get(Genotype g) { return g; }});
-        attrs.put(VCFConstants.GENOTYPE_KEY, new AttributeGetter() { public Object get(Genotype g) { return g.getGenotypeString(); }});
+        attributes.put("g", (Genotype g) -> g);
+        attributes.put(VCFConstants.GENOTYPE_KEY, Genotype::getGenotypeString);
 
-        attrs.put("isHom", new AttributeGetter() { public Object get(Genotype g) { return g.isHom() ? "1" : "0"; }});
-        attrs.put("isHomRef", new AttributeGetter() { public Object get(Genotype g) { return g.isHomRef() ? "1" : "0"; }});
-        attrs.put("isHet", new AttributeGetter() { public Object get(Genotype g) { return g.isHet() ? "1" : "0"; }});
-        attrs.put("isHomVar", new AttributeGetter() { public Object get(Genotype g) { return g.isHomVar() ? "1" : "0"; }});
-        attrs.put("isCalled", new AttributeGetter() { public Object get(Genotype g) { return g.isCalled() ? "1" : "0"; }});
-        attrs.put("isNoCall", new AttributeGetter() { public Object get(Genotype g) { return g.isNoCall() ? "1" : "0"; }});
-        attrs.put("isMixed", new AttributeGetter() { public Object get(Genotype g) { return g.isMixed() ? "1" : "0"; }});
-        attrs.put("isAvailable", new AttributeGetter() { public Object get(Genotype g) { return g.isAvailable() ? "1" : "0"; }});
-        attrs.put("isPassFT", new AttributeGetter() { public Object get(Genotype g) { return g.isFiltered() ? "0" : "1"; }});
-        attrs.put(VCFConstants.GENOTYPE_FILTER_KEY, new AttributeGetter() { public Object get(Genotype g) { return g.isFiltered()?  g.getFilters() : "PASS"; }});
-        attrs.put(VCFConstants.GENOTYPE_QUALITY_KEY, new AttributeGetter() { public Object get(Genotype g) { return g.getGQ(); }});
+        attributes.put("isHom", (Genotype g) -> g.isHom() ? "1" : "0");
+        attributes.put("isHomRef", (Genotype g) -> g.isHomRef() ? "1" : "0");
+        attributes.put("isHet", (Genotype g) -> g.isHet() ? "1" : "0");
+        attributes.put("isHomVar", (Genotype g) -> g.isHomVar() ? "1" : "0");
+        attributes.put("isCalled", (Genotype g) -> g.isCalled() ? "1" : "0");
+        attributes.put("isNoCall", (Genotype g) -> g.isNoCall() ? "1" : "0");
+        attributes.put("isMixed", (Genotype g) -> g.isMixed() ? "1" : "0");
+        attributes.put("isAvailable", (Genotype g) -> g.isAvailable() ? "1" : "0");
+        attributes.put("isPassFT", (Genotype g) -> g.isFiltered() ? "0" : "1");
+        attributes.put(VCFConstants.GENOTYPE_FILTER_KEY, (Genotype g) -> g.isFiltered()?  g.getFilters() : "PASS");
+        attributes.put(VCFConstants.GENOTYPE_QUALITY_KEY, Genotype::getGQ);
     }
 
     public GenotypeJEXLContext(VariantContext vc, Genotype g) {
@@ -46,8 +46,8 @@ public class GenotypeJEXLContext extends VariantJEXLContext {
 
     public Object get(String name) {
         //should matching genotype attributes always supersede vc?
-        if ( attrs.containsKey(name) ) { // dynamic resolution of name -> value via map
-            return attrs.get(name).get(g);
+        if ( attributes.containsKey(name) ) { // dynamic resolution of name -> value via map
+            return attributes.get(name).get(g);
         } else if ( g.hasAnyAttribute(name) ) {
             return g.getAnyAttribute(name);
         } else if ( g.getFilters().contains(name) ) {

--- a/src/java/htsjdk/variant/variantcontext/JEXLMap.java
+++ b/src/java/htsjdk/variant/variantcontext/JEXLMap.java
@@ -130,10 +130,10 @@ class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
         } catch (Exception e) {
             // if exception happens because variable is undefined (i.e. field in expression is not present), evaluate to FALSE
             // todo - might be safer if we explicitly checked for an exception type, but Apache's API doesn't seem to have that ability
-            if (e.getMessage().contains("undefined variable"))
+            if (e.getMessage() != null && e.getMessage().contains("undefined variable"))
                 jexl.put(exp,false);
             else
-                throw new IllegalArgumentException(String.format("Invalid JEXL expression detected for %s with message %s", exp.name, e.getMessage()));
+                throw new IllegalArgumentException(String.format("Invalid JEXL expression detected for %s with message %s", exp.name, (e.getMessage() == null ? "no message" : e.getMessage())));
         }
     }
 

--- a/src/java/htsjdk/variant/variantcontext/JEXLMap.java
+++ b/src/java/htsjdk/variant/variantcontext/JEXLMap.java
@@ -1,12 +1,11 @@
 package htsjdk.variant.variantcontext;
 
-import htsjdk.variant.utils.GeneralUtils;
 import htsjdk.variant.variantcontext.VariantContextUtils.JexlVCMatchExp;
-import htsjdk.variant.vcf.VCFConstants;
 import org.apache.commons.jexl2.JexlContext;
 import org.apache.commons.jexl2.MapContext;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -55,17 +54,14 @@ class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
      *
      */
     private void createContext() {
-        // QUESTION: the original code could have created a new VariantJEXLContext with a null vc.
-        // i dont think this is right, though i have no idea if vc could actually be null
-        if ( vc != null ) {
-            if (g == null) {
-                jContext = new VariantJEXLContext(vc);
-            } else {
-                jContext = new GenotypeJEXLContext(vc, g);
-            }
+        if ( vc == null ) {
+            jContext = new MapContext(Collections.emptyMap());
+        }
+        else if (g == null) {
+            jContext = new VariantJEXLContext(vc);
         }
         else {
-            jContext = new MapContext(new HashMap<String, Object>());
+            jContext = new GenotypeJEXLContext(vc, g);
         }
     }
 

--- a/src/java/htsjdk/variant/variantcontext/JEXLMap.java
+++ b/src/java/htsjdk/variant/variantcontext/JEXLMap.java
@@ -55,68 +55,17 @@ class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
      *
      */
     private void createContext() {
-        if ( g == null ) {
-            // todo -- remove dependancy on g to the entire system
-            jContext = new VariantJEXLContext(vc);
-        } else {
-            //
-            // this whole branch is here just to support G jexl operations
-            //
-            Map<String, Object> infoMap = new HashMap<String, Object>();
-
-            if ( vc != null ) {
-                // create a mapping of what we know about the variant context, its Chromosome, positions, etc.
-                infoMap.put("CHROM", vc.getChr());
-                infoMap.put("POS", vc.getStart());
-                infoMap.put("TYPE", vc.getType().toString());
-                infoMap.put("QUAL", String.valueOf(vc.getPhredScaledQual()));
-
-                // add alleles
-                infoMap.put("ALLELES", GeneralUtils.join(";", vc.getAlleles()));
-                infoMap.put("N_ALLELES", String.valueOf(vc.getNAlleles()));
-
-                // add attributes
-                addAttributesToMap(infoMap, vc.getAttributes());
-
-                // add filter fields
-                infoMap.put("FILTER", vc.isFiltered() ? "1" : "0");
-                for ( Object filterCode : vc.getFilters() ) {
-                    infoMap.put(String.valueOf(filterCode), "1");
-                }
-
-                // add genotype-specific fields
-                // TODO -- implement me when we figure out a good way to represent this
-                //    for ( Genotype g : vc.getGenotypes().values() ) {
-                //        String prefix = g.getSampleName() + ".";
-                //        addAttributesToMap(infoMap, g.getAttributes(), prefix);
-                //        infoMap.put(prefix + "GT", g.getGenotypeString());
-                //    }
-
-                // add specific genotype if one is provided
-                infoMap.put(VCFConstants.GENOTYPE_KEY, g.getGenotypeString());
-                infoMap.put("isHom", g.isHom() ? "1" : "0");
-                infoMap.put("isHomRef", g.isHomRef() ? "1" : "0");
-                infoMap.put("isHet", g.isHet() ? "1" : "0");
-                infoMap.put("isHomVar", g.isHomVar() ? "1" : "0");
-                infoMap.put("isCalled", g.isCalled()? "1" : "0");
-                infoMap.put("isNoCall", g.isNoCall()? "1" : "0");
-                infoMap.put("isMixed", g.isMixed()? "1" : "0");
-                infoMap.put("isAvailable", g.isAvailable()? "1" : "0");
-                infoMap.put("isPassFT", g.isFiltered()? "0" : "1");
-                infoMap.put(VCFConstants.GENOTYPE_FILTER_KEY, g.isFiltered()?  g.getFilters() : "PASS");
-
-                infoMap.put(VCFConstants.GENOTYPE_QUALITY_KEY, g.getGQ());
-                if ( g.hasDP() )
-                    infoMap.put(VCFConstants.DEPTH_KEY, g.getDP());
-                for ( Entry<String, Object> e : g.getExtendedAttributes().entrySet() ) {
-                    if ( e.getValue() != null && !e.getValue().equals(VCFConstants.MISSING_VALUE_v4) )
-                        infoMap.put(e.getKey(), e.getValue());
-                }
+        // QUESTION: the original code could have created a new VariantJEXLContext with a null vc.
+        // i dont think this is right, though i have no idea if vc could actually be null
+        if ( vc != null ) {
+            if (g == null) {
+                jContext = new VariantJEXLContext(vc);
+            } else {
+                jContext = new GenotypeJEXLContext(vc, g);
             }
-
-            // create the internal context that we can evaluate expressions against
-
-            jContext = new MapContext(infoMap);
+        }
+        else {
+            jContext = new MapContext(new HashMap<String, Object>());
         }
     }
 

--- a/src/java/htsjdk/variant/variantcontext/VariantJEXLContext.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantJEXLContext.java
@@ -52,22 +52,21 @@ class VariantJEXLContext implements JexlContext {
         public Object get(VariantContext vc);
     }
 
-    private static Map<String, AttributeGetter> x = new HashMap<String, AttributeGetter>();
+    private static Map<String, AttributeGetter> attributes = new HashMap<String, AttributeGetter>();
 
     static {
-        x.put("vc",   new AttributeGetter() { public Object get(VariantContext vc) { return vc; }});
-        x.put("CHROM",   new AttributeGetter() { public Object get(VariantContext vc) { return vc.getChr(); }});
-        x.put("POS",     new AttributeGetter() { public Object get(VariantContext vc) { return vc.getStart(); }});
-        x.put("TYPE",    new AttributeGetter() { public Object get(VariantContext vc) { return vc.getType().toString(); }});
-        x.put("QUAL",    new AttributeGetter() { public Object get(VariantContext vc) { return -10 * vc.getLog10PError(); }});
-        x.put("ALLELES", new AttributeGetter() { public Object get(VariantContext vc) { return vc.getAlleles(); }});
-        x.put("N_ALLELES", new AttributeGetter() { public Object get(VariantContext vc) { return vc.getNAlleles(); }});
-        x.put("FILTER",    new AttributeGetter() { public Object get(VariantContext vc) { return vc.isFiltered() ? "1" : "0"; }});
+        attributes.put("vc", (VariantContext vc) -> vc);
+        attributes.put("CHROM", VariantContext::getChr);
+        attributes.put("POS", VariantContext::getStart);
+        attributes.put("TYPE", (VariantContext vc) -> vc.getType().toString());
+        attributes.put("QUAL", (VariantContext vc) -> -10 * vc.getLog10PError());
+        attributes.put("ALLELES", VariantContext::getAlleles);
+        attributes.put("N_ALLELES", VariantContext::getNAlleles);
+        attributes.put("FILTER", (VariantContext vc) -> vc.isFiltered() ? "1" : "0");
 
-//        x.put("GT",        new AttributeGetter() { public Object get(VariantContext vc) { return g.getGenotypeString(); }});
-        x.put("homRefCount",  new AttributeGetter() { public Object get(VariantContext vc) { return vc.getHomRefCount(); }});
-        x.put("hetCount",     new AttributeGetter() { public Object get(VariantContext vc) { return vc.getHetCount(); }});
-        x.put("homVarCount",  new AttributeGetter() { public Object get(VariantContext vc) { return vc.getHomVarCount(); }});
+        attributes.put("homRefCount", VariantContext::getHomRefCount);
+        attributes.put("hetCount", VariantContext::getHetCount);
+        attributes.put("homVarCount", VariantContext::getHomVarCount);
     }
 
     public VariantJEXLContext(VariantContext vc) {
@@ -76,8 +75,8 @@ class VariantJEXLContext implements JexlContext {
 
     public Object get(String name) {
         Object result = null;
-        if ( x.containsKey(name) ) { // dynamic resolution of name -> value via map
-            result = x.get(name).get(vc);
+        if ( attributes.containsKey(name) ) { // dynamic resolution of name -> value via map
+            result = attributes.get(name).get(vc);
         } else if ( vc.hasAttribute(name)) {
             result = vc.getAttribute(name);
         } else if ( vc.getFilters().contains(name) ) {

--- a/src/java/htsjdk/variant/variantcontext/VariantJEXLContext.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantJEXLContext.java
@@ -37,12 +37,11 @@ import java.util.Map;
  *
  * Class VariantJEXLContext
  *
- * implements the JEXML context for VariantContext; this saves us from
- * having to generate a JEXML context lookup map everytime we want to evaluate an expression.
+ * implements the JEXL context for VariantContext; this saves us from
+ * having to generate a JEXL context lookup map everytime we want to evaluate an expression.
  *
  * This is package protected, only classes in variantcontext should have access to it.
  *
- * // todo -- clean up to remove or better support genotype filtering 
  */
 
 class VariantJEXLContext implements JexlContext {

--- a/src/tests/java/htsjdk/variant/variantcontext/VariantJEXLContextUnitTest.java
+++ b/src/tests/java/htsjdk/variant/variantcontext/VariantJEXLContextUnitTest.java
@@ -49,7 +49,6 @@ import java.util.Map;
  * Test out parts of the VariantJEXLContext and GenotypeJEXLContext
  */
 public class VariantJEXLContextUnitTest extends VariantBaseTest {
-    private static final Log LOG = Log.getInstance(VariantJEXLContextUnitTest.class);
 
     private static String expression = "QUAL > 500.0";
     private static VariantContextUtils.JexlVCMatchExp exp;
@@ -124,10 +123,6 @@ public class VariantJEXLContextUnitTest extends VariantBaseTest {
 
         // Create the JEXL Maps using the combinations above of vc* and geno*
         map = new JEXLMap(jexlTests,vcPass, genoPass);
-        for (JexlVCMatchExp m : map.keySet()) {
-            LOG.info(m.exp);
-            LOG.info(String.valueOf(map.get(m)));
-        }
         // make sure the context has a value
         Assert.assertTrue(!map.isEmpty());
         Assert.assertEquals(map.size(), 5);


### PR DESCRIPTION
I am hoping someone more familiar with JEXL in htsjdk could do a quick review of what i'm proposing to see if this looks reasonable.  As noted in your code, genotype-level JEXL filtering is supported, but not implemented very cleanly.  I tried to improve that and also make it more consistent w/ the context available for VariantContext.

Here's a related GATK forum thread:

http://gatkforums.broadinstitute.org/gatk/discussion/comment/28654#Comment_28654