### PR TITLE
packaging the intel deflator into the published jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,10 @@ libraryDependencies += "org.testng" % "testng" % "6.8.8"
 
 unmanagedBase := baseDirectory.value
 
+mappings in (Compile, packageBin) ++= Seq(
+  (baseDirectory.value / "lib/jni/libIntelDeflater.so") -> "lib/jni/libIntelDeflator.so"
+)
+
 javaSource in Compile := baseDirectory.value / "src/java"
 
 javaSource in Test := baseDirectory.value / "src/tests"


### PR DESCRIPTION
including the intel deflator in the published jar, it appears in the jar as `lib/jni/libIntelDeflator.so`
