### PR TITLE
Added a method to retrieve reference sequences as Strings in addition to as byte[]s.

### DIFF
--- a/src/java/htsjdk/samtools/reference/ReferenceSequence.java
+++ b/src/java/htsjdk/samtools/reference/ReferenceSequence.java
@@ -24,6 +24,8 @@
 
 package htsjdk.samtools.reference;
 
+import htsjdk.samtools.util.StringUtil;
+
 /**
  * Wrapper around a reference sequence that has been read from a reference file.
  *
@@ -59,6 +61,16 @@ public class ReferenceSequence {
      * held interally.  Do not modify it!!!
      */
     public byte[] getBases() { return bases; }
+
+    /**
+     * Returns the bases represented by this ReferenceSequence as a String. Since this will copy the bases
+     * and convert them to two-byte characters, this should not be used on very long reference sequences,
+     * but as a convenience when manipulating short sequences returned by
+     * {@link ReferenceSequenceFile#getSubsequenceAt(String, long, long)}
+     *
+     * @return The set of bases represented by this ReferenceSequence, as a String
+     */
+    public String getBaseString() { return StringUtil.bytesToString(bases); }
 
     /** Gets the 0-based index of this contig in the source file from which it came. */
     public int getContigIndex() { return contigIndex; }


### PR DESCRIPTION
### Description

I got tired of writing:
`StringUtil.bytesAsString(ref.getSubsequenceAt(chrom, start, end).getBases())`
all over the place when retrieving small sequences that need to be converted to Strings for output to various files, and decided it would be nice to be able to write:
`ref.getSubsequenceAt(chrom, start, end).getBaseString())`

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

