### PR TITLE
AsynchronousLineReader should terminate worker thread

### DIFF
--- a/src/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -213,6 +213,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
     private void readHeader() throws IOException {
         InputStream is = null;
         PositionalBufferedStream pbs = null;
+        SOURCE source = null;
         try {
             is = ParsingUtils.openInputStream(path);
             if (path.endsWith("gz")) {
@@ -220,11 +221,12 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
                 is = new GZIPInputStream(new BufferedInputStream(is));
             }
             pbs = new PositionalBufferedStream(is);
-            final SOURCE source = codec.makeSourceFromStream(pbs);
+            source = codec.makeSourceFromStream(pbs);
             header = codec.readHeader(source);
         } catch (Exception e) {
             throw new TribbleException.MalformedFeatureFile("Unable to parse header with error: " + e.getMessage(), path, e);
         } finally {
+            if (source != null) codec.close(source);
             if (pbs != null) pbs.close();
             else if (is != null) is.close();
         }

--- a/src/java/htsjdk/tribble/readers/AsynchronousLineReader.java
+++ b/src/java/htsjdk/tribble/readers/AsynchronousLineReader.java
@@ -1,12 +1,15 @@
 package htsjdk.tribble.readers;
 
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.Log;
 import htsjdk.tribble.TribbleException;
 
 import java.io.Reader;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A LineReader implementation that delegates the work of reading and fetching lines to another thread.  The thread terminates when it
@@ -16,19 +19,25 @@ import java.util.concurrent.TimeUnit;
  */
 public class AsynchronousLineReader implements LineReader {
     public static final int DEFAULT_NUMBER_LINES_BUFFER = 100;
-    
+    private static final Log log = Log.getInstance(AsynchronousLineReader.class);
+
     private final LongLineBufferedReader bufferedReader;
     private final BlockingQueue<String> lineQueue;
-    private final Thread worker;
-    private volatile Throwable workerException = null;
-    private volatile boolean eofReached = false;
+
+    private final Worker workerRunnable;
+    private final Thread workerThread;
+
+    private final AtomicReference<Throwable> workerException = new AtomicReference<>(null);
+    private final AtomicBoolean eofReached = new AtomicBoolean(false);
 
     public AsynchronousLineReader(final Reader reader, final int lineReadAheadSize) {
         bufferedReader = new LongLineBufferedReader(reader);
-        lineQueue = new LinkedBlockingQueue<String>(lineReadAheadSize);
-        worker = new Thread(new Worker());
-        worker.setDaemon(true);
-        worker.start();
+        lineQueue = new LinkedBlockingQueue<>(lineReadAheadSize);
+        workerRunnable = new Worker();
+        workerThread = new Thread(workerRunnable, "LineReader");
+        workerThread.setDaemon(true);
+        workerThread.start();
+        log.info("started");
     }
 
     public AsynchronousLineReader(final Reader reader) {
@@ -41,9 +50,9 @@ public class AsynchronousLineReader implements LineReader {
             // Continually poll until we get a result, unless the underlying reader is finished.
             for (; ; ) {
                 checkAndThrowIfWorkerException();
-                final String pollResult = this.lineQueue.poll(100, TimeUnit.MILLISECONDS); // Not ideal for small files.
+                final String pollResult = this.lineQueue.poll(100L, TimeUnit.MILLISECONDS); // Not ideal for small files.
                 if (pollResult == null) {
-                    if (eofReached) {
+                    if (eofReached.get()) {
                         checkAndThrowIfWorkerException();
                         return lineQueue.poll(); // If there is nothing left, returns null as expected.  Otherwise, grabs next element.
                     }
@@ -57,41 +66,58 @@ public class AsynchronousLineReader implements LineReader {
     }
 
     private void checkAndThrowIfWorkerException() {
-        if (workerException != null) {
-            throw new TribbleException("Exception encountered in worker thread.", workerException);
+        final Throwable t = this.workerException.get();//copy to a temp so that it does not get reset in the meantime
+        if (t != null) {
+            throw new TribbleException("Exception encountered in workerThread thread.", t);
         }
     }
 
     @Override
     public void close() {
-        this.worker.interrupt(); // Allow the worker to close gracefully.
-    } 
+        workerRunnable.terminate();
+        workerThread.interrupt(); // Allow the workerThread to close gracefully.
+        try {
+            workerThread.join();  //wait for the workerThread to actually finish
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();  //remember that we got interrupted
+        }
+        //now that the workerThread is dead, we can close the buffer
+        CloserUtil.close(bufferedReader);
+        log.info("closed");
+    }
 
     private class Worker implements Runnable {
+        private AtomicBoolean terminate = new AtomicBoolean(false);
+
+        /**
+         * Indicate to this thread that it should stop.
+         */
+        public void terminate() {
+            terminate.set(true);
+        }
+
         @Override
         public void run() {
             try {
-                for (; ; ) {
-                    final String line = bufferedReader.readLine();
-                    if (line == null) {
-                        eofReached = true;
-                        break;
-                    } else {
-                        try {
-                            lineQueue.put(line);
-                        } catch (final InterruptedException e) {
-                            /**
-                             * A thread interruption is not an exceptional state: it means a {@link AsynchronousLineReader#close();} has 
-                             * been called, so shut down gracefully.
-                             */
-                            break;
+                while (! terminate.get()) {
+                    try {
+                        while (true) {
+                            final String line = bufferedReader.readLine();
+                            if (line == null) {
+                                eofReached.set(true);
+                                terminate.set(true);
+                                break;
+                            } else {
+                                lineQueue.put(line);
+                            }
                         }
+                    } catch (final InterruptedException e) {
+                        // Reset interrupt status
+                        Thread.interrupted();
                     }
                 }
             } catch (final Throwable e) {
-                AsynchronousLineReader.this.workerException = e;
-            } finally {
-                CloserUtil.close(AsynchronousLineReader.this.bufferedReader);
+                workerException.compareAndSet(null, e);
             }
         }
     }

--- a/src/java/htsjdk/variant/example/PrintVariantsExample.java
+++ b/src/java/htsjdk/variant/example/PrintVariantsExample.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.Options;
@@ -80,11 +81,13 @@ public final class PrintVariantsExample {
             }
 
             final ProgressLogger pl = new ProgressLogger(log, 1000000);
-            for (final VariantContext vc : reader.iterator()) {
-                if (writer != null){
-                    writer.add(vc);
+            try(final CloseableTribbleIterator<VariantContext> iterator = reader.iterator()) {
+                for (final VariantContext vc : iterator) {
+                    if (writer != null) {
+                        writer.add(vc);
+                    }
+                    pl.record(vc.getContig(), vc.getStart());
                 }
-                pl.record(vc.getContig(), vc.getStart());
             }
         }
 

--- a/src/tests/java/htsjdk/tribble/readers/AsynchronousLineReaderTest.java
+++ b/src/tests/java/htsjdk/tribble/readers/AsynchronousLineReaderTest.java
@@ -30,5 +30,6 @@ public class AsynchronousLineReaderTest {
                 Assert.assertEquals(nextLine, reader.readLine());
             }
             Assert.assertNull(reader.readLine());
+            reader.close();
         }
 }


### PR DESCRIPTION
### Description

AsynchronousLineReader did not terminate the worker thread properly which resulted in errors like https://github.com/broadinstitute/gatk/issues/1638 (where the worker kept trying to read from a stream after it was supposed to be terminated).

Note: the AsynchronousLineReader is actually still very slow, slower than syncIO (which is a shame). This PR does not address this - only the thread and resource leakage.

Also added:
- closing the reader in `TribbleIndexedFeatureReader.readHeader` - it was left open which is always a problem but particularly when you have multiple threads
- closing resources in AsynchronousLineReaderTest.java and PrintVariantsExample.java

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

