### PR TITLE
Adding downstream build badges to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Build Status](https://travis-ci.org/samtools/htsjdk.svg?branch=master)](https://travis-ci.org/samtools/htsjdk)
+Status of master branch build: [![Build Status](https://travis-ci.org/samtools/htsjdk.svg?branch=master)](https://travis-ci.org/samtools/htsjdk)
+
+Status of downstream projects automatically built on top of the current htsjdk master branch. See [gatk-jenkins](https://gatk-jenkins.broadinstitute.org/view/HTSJDK%20Release%20Tests/) for detailed logs. Failure may indicate problems  in htsjdk, but may also be due to expected incompatibilities between versions, or unrelated failures in downstream projects.
+- [Picard](https://github.com/broadinstitute/picard):  [![Build Status](https://gatk-jenkins.broadinstitute.org/buildStatus/icon?job=picard-on-htsjdk-master)](https://gatk-jenkins.broadinstitute.org/job/picard-on-htsjdk-master/)
+- [GATK 4](https://github.com/broadinstitute/gatk): [![Build Status](https://gatk-jenkins.broadinstitute.org/buildStatus/icon?job=gatk-on-htsjdk-master)](https://gatk-jenkins.broadinstitute.org/job/gatk-on-htsjdk-master/)
 
 ## A Java API for high-throughput sequencing data (HTS) formats.  
 


### PR DESCRIPTION
Adding badges for the gatk4 and picard tests running on htsjdk master's branch.  This is intended to assist with #568.  Tests should also be able to be manually invoked on a given htsjdk branch by anyone with github push access to gatk.  In the future this should be amended to include htsjdk committers but may be a setup hassle.

See also https://github.com/broadinstitute/gatk/issues/1705