### PR TITLE
public reg2bin

### DIFF
--- a/src/java/htsjdk/samtools/BinningIndexBuilder.java
+++ b/src/java/htsjdk/samtools/BinningIndexBuilder.java
@@ -174,7 +174,7 @@ public class BinningIndexBuilder {
     }
 
     private int computeIndexingBin(final FeatureToBeIndexed feature) {
-        // reg2bin has zero-based, half-open API
+        // regionToBin has zero-based, half-open API
         final int start = feature.getStart()-1;
         int end = feature.getEnd();
         if (end <= 0) {
@@ -182,6 +182,6 @@ public class BinningIndexBuilder {
             // then treat this as a one base feature for indexing purposes.
             end = start + 1;
         }
-        return GenomicIndexUtil.reg2bin(start, end);
+        return GenomicIndexUtil.regionToBin(start, end);
     }
 }

--- a/src/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -247,7 +247,7 @@ public class CRAMBAIIndexer {
         }
 
         private int computeIndexingBin(final Slice slice) {
-            // reg2bin has zero-based, half-open API
+            // regionToBin has zero-based, half-open API
             final int alignmentStart = slice.alignmentStart - 1;
             int alignmentEnd = slice.alignmentStart + slice.alignmentSpan - 1;
             if (alignmentEnd <= alignmentStart) {
@@ -255,7 +255,7 @@ public class CRAMBAIIndexer {
                 // then treat this as a one base alignment for indexing purposes.
                 alignmentEnd = alignmentStart + 1;
             }
-            return GenomicIndexUtil.reg2bin(alignmentStart, alignmentEnd);
+            return GenomicIndexUtil.regionToBin(alignmentStart, alignmentEnd);
         }
 
 

--- a/src/java/htsjdk/samtools/GenomicIndexUtil.java
+++ b/src/java/htsjdk/samtools/GenomicIndexUtil.java
@@ -54,11 +54,11 @@ public class GenomicIndexUtil {
 
     /**
      * calculate the bin given an alignment in [beg,end)
-     * Copied from SAM spec.
+     * Described in "The Human Genome Browser at UCSC. Kent & al. doi: 10.1101/gr.229102 "
      * @param beg 0-based start of read (inclusive)
      * @param end 0-based end of read (exclusive)
      */
-    static int reg2bin(final int beg, int end)
+    public static int regionToBin(final int beg, int end)
     {
         --end;
 
@@ -70,9 +70,9 @@ public class GenomicIndexUtil {
         return 0;
     }
 
-    // TODO: It is disturbing that reg2bin is 0-based, but regionToBins is 1-based.
+    // TODO: It is disturbing that regionToBins is 0-based, but regionToBins is 1-based.
     // TODO: It is also suspicious that regionToBins decrements endPos.  Test it!
-    // TODO: However end is decremented in reg2bin so perhaps there is no conflict.
+    // TODO: However end is decremented in regionToBins so perhaps there is no conflict.
     /**
      * Get candidate bins for the specified region
      * @param startPos 1-based start of target region, inclusive.

--- a/src/java/htsjdk/samtools/SAMRecord.java
+++ b/src/java/htsjdk/samtools/SAMRecord.java
@@ -1520,7 +1520,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return indexing bin based on alignment start & end.
      */
     int computeIndexingBin() {
-        // reg2bin has zero-based, half-open API
+        // regionToBin has zero-based, half-open API
         final int alignmentStart = getAlignmentStart()-1;
         int alignmentEnd = getAlignmentEnd();
         if (alignmentEnd <= 0) {
@@ -1528,7 +1528,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             // then treat this as a one base alignment for indexing purposes.
             alignmentEnd = alignmentStart + 1;
         }
-        return GenomicIndexUtil.reg2bin(alignmentStart, alignmentEnd);
+        return GenomicIndexUtil.regionToBin(alignmentStart, alignmentEnd);
     }
 
     /**

--- a/src/java/htsjdk/samtools/SAMUtils.java
+++ b/src/java/htsjdk/samtools/SAMUtils.java
@@ -415,10 +415,10 @@ public final class SAMUtils {
      *
      * @param beg 0-based start of read (inclusive)
      * @param end 0-based end of read (exclusive)
-     * @deprecated Use GenomicIndexUtil.reg2bin
+     * @deprecated Use GenomicIndexUtil.regionToBin
      */
     static int reg2bin(final int beg, final int end) {
-        return GenomicIndexUtil.reg2bin(beg, end);
+        return GenomicIndexUtil.regionToBin(beg, end);
     }
 
     /**

--- a/src/tests/java/htsjdk/samtools/GenomicIndexUtilTest.java
+++ b/src/tests/java/htsjdk/samtools/GenomicIndexUtilTest.java
@@ -1,0 +1,50 @@
+package htsjdk.samtools;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for GenomicIndexUtil.
+ */
+public class GenomicIndexUtilTest {
+
+    @Test(dataProvider = "testRegionToBinDataProvider")
+    public void testRegionToBin(final int beg, final int end, final int bin) {
+        Assert.assertEquals(GenomicIndexUtil.regionToBin(beg, end), bin);
+    }
+
+    @DataProvider(name = "testRegionToBinDataProvider")
+    public Object[][] testRegionToBinDataProvider() {
+        return new Object[][] {
+                {0, 0, 0},
+                {1, 1, 4681},
+                {0, 1<<14, 4681},
+                {0, (1<<14)+1, 585},
+                
+                {1<<14, 1<<14, 585},
+                {(1<<14)+1, (1<<14)+1, 4682},
+                {1<<14, 1<<17, 585},
+                {1<<14, (1<<17)+1, 73},
+
+                {1<<17, 1<<17, 73},
+                {(1<<17)+1, (1<<17)+1, 4689},
+                {1<<17, 1<<20, 73},
+                {1<<17, (1<<20)+1, 9},
+
+                {1<<20, 1<<20, 9},
+                {(1<<20)+1, (1<<20)+1, 4745},
+                {1<<20, 1<<23, 9},
+                {1<<20, (1<<23)+1, 1},
+
+                {1<<23, 1<<23, 1},
+                {(1<<23)+1, (1<<23)+1, 5193},
+                {1<<23, 1<<26, 1},
+                {1<<23, (1<<26)+1, 0},
+
+                {1<<26, 1<<26, 0},
+                {(1<<26)+1, (1<<26)+1, 8777},
+                {1<<26, 1<<26+1, 2}
+        };
+    }
+}


### PR DESCRIPTION
### Description

Moved GenomicIndexUtil.reg2bin to public

I'm inserting genomic data in a sql database just like in the UCSC tables : there is a 'bin' index ( http://genomewiki.ucsc.edu/index.php/Bin_indexing_system )

making  `GenomicIndexUtil.reg2bin` public allows me to get the 'bin' index . 

### Checklist

- [ x] Code compiles correctly
- [ x] New tests covering changes and new functionality
- [ x] All tests passing
- [ x] Extended the README / documentation, if necessary

