### PR TITLE
Utility methods on CloseableIterator to make life a little easier.

### DIFF
--- a/src/java/htsjdk/samtools/util/CloseableIterator.java
+++ b/src/java/htsjdk/samtools/util/CloseableIterator.java
@@ -42,8 +42,6 @@ import java.util.stream.StreamSupport;
  * 2) When hasNext() returns false, the iterator implementation should automatically close itself.
  *    The latter makes it somewhat safer for consumers to use the for loop syntax for iteration:
  *    for (Type obj : getCloseableIterator()) { ... }
- * 
- * We do not inherit from java.io.Closeable because IOExceptions are a pain to deal with.
  */
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {
     /** Should be implemented to close/release any underlying resources. */
@@ -53,12 +51,13 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
     default List<T> toList() {
         final List<T> list = new ArrayList<>();
         while (hasNext()) list.add(next());
+        close();
         return list;
     }
 
     /** Returns a Stream that will consume from the underlying iterator. */
     default Stream<T> stream() {
         final Spliterator<T> s = Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED);
-        return StreamSupport.stream(s, false);
+        return StreamSupport.stream(s, false).onClose(this::close);
     }
 }

--- a/src/java/htsjdk/samtools/util/CloseableIterator.java
+++ b/src/java/htsjdk/samtools/util/CloseableIterator.java
@@ -24,7 +24,13 @@
 package htsjdk.samtools.util;
 
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * This interface is used by iterators that use releasable resources during iteration.
@@ -40,6 +46,19 @@ import java.util.Iterator;
  * We do not inherit from java.io.Closeable because IOExceptions are a pain to deal with.
  */
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {
+    /** Should be implemented to close/release any underlying resources. */
+    void close();
 
-    public void close();
+    /** Consumes the contents of the iterator and returns it as a List. */
+    default List<T> toList() {
+        final List<T> list = new ArrayList<>();
+        while (hasNext()) list.add(next());
+        return list;
+    }
+
+    /** Returns a Stream that will consume from the underlying iterator. */
+    default Stream<T> stream() {
+        final Spliterator<T> s = Spliterators.spliteratorUnknownSize(this, Spliterator.ORDERED);
+        return StreamSupport.stream(s, false);
+    }
 }

--- a/src/tests/java/htsjdk/samtools/util/CloseableIteratorTest.java
+++ b/src/tests/java/htsjdk/samtools/util/CloseableIteratorTest.java
@@ -1,0 +1,31 @@
+package htsjdk.samtools.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CloseableIteratorTest {
+    @Test
+    public void testToList() {
+        final List<Integer> expected = Arrays.asList(1,2,3,4,5);
+        final PeekableIterator<Integer> peeky = new PeekableIterator<>(expected.iterator());
+        final List<Integer> actual = peeky.toList();
+
+        Assert.assertEquals(actual, expected);
+        Assert.assertEquals(peeky.toList(), new ArrayList<>()); // Should be empty the second time
+    }
+
+    @Test
+    public void testToStream() {
+        final List<Integer> inputs = Arrays.asList(1,2,3,4,5);
+        final PeekableIterator<Integer> peeky = new PeekableIterator<>(inputs.iterator());
+        final List<Integer> expected = inputs.stream().map(i -> i*2).collect(Collectors.toList());
+        final List<Integer> actual   = peeky.stream().map(i -> i*2).collect(Collectors.toList());
+
+        Assert.assertEquals(actual, expected);
+    }
+}


### PR DESCRIPTION
### Description

Scala has spoiled me, and I'm tired of Java's iterators being second class citizens.  This commit adds a pair of default methods to `CloseableIterator` which will benefit most iterators in htsjdk, and allows easy transformation to a `List` and a `Stream`.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

