### PR TITLE
Throw on unrecognized CRAM encoding tag.

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/DataReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/DataReaderFactory.java
@@ -56,9 +56,7 @@ public class DataReaderFactory {
                 final DataSeries dataSeries = field.getAnnotation(DataSeries.class);
                 final EncodingKey key = dataSeries.key();
                 final DataSeriesType type = dataSeries.type();
-                if (header.encodingMap.get(key) == null) {
-                    log.debug("Encoding not found for key: " + key);
-                } else {
+                if (header.encodingMap.get(key) != null) {
                     try {
                         field.set(reader,
                                 createReader(type, header.encodingMap.get(key), bitInputStream, inputMap));

--- a/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
@@ -17,6 +17,7 @@
  */
 package htsjdk.samtools.cram.structure;
 
+import htsjdk.samtools.cram.CRAMException;
 import htsjdk.samtools.cram.encoding.ExternalCompressor;
 import htsjdk.samtools.cram.encoding.NullEncoding;
 import htsjdk.samtools.cram.io.ITF8;
@@ -170,8 +171,7 @@ public class CompressionHeader {
                 final String key = new String(new byte[]{buffer.get(), buffer.get()});
                 final EncodingKey encodingKey = EncodingKey.byFirstTwoChars(key);
                 if (encodingKey == null) {
-                    log.debug("Unknown encoding key: " + key);
-                    continue;
+                    throw new CRAMException("Unknown encoding key: " + key);
                 }
 
                 final EncodingID id = EncodingID.values()[buffer.get()];


### PR DESCRIPTION
### Description
Fixes https://github.com/samtools/htsjdk/issues/549. Change the CRAM reader to throw when it sees an encoding tag it doesn't recognize.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

The CRAM code currently logs and ignores unrecognized encoding tags, but we really should throw if we ever see one of these.

This is a purely defensive change - I don't really know of a way to force this condition.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary

