### PR TITLE
Provide a method that for each source contig gives the set of destination contigs used in liftover.

### DIFF
--- a/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
+++ b/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -44,10 +45,12 @@ public class LiftOverTest {
     private static final File CHAIN_FILE = new File(TEST_DATA_DIR, "hg18ToHg19.over.chain");
 
     private LiftOver liftOver;
+    Map<String, Set<String>> contigMap;
 
     @BeforeClass
     public void initLiftOver() {
         liftOver = new LiftOver(CHAIN_FILE);
+        contigMap = liftOver.getContigMap();
     }
 
     @Test(dataProvider = "testIntervals")
@@ -454,5 +457,12 @@ public class LiftOverTest {
             newChainMap.put(chain.id, chain);
         }
         Assert.assertEquals(newChainMap, originalChainMap);
+    }
+
+    @Test(dataProvider = "testIntervals")
+    public void testGetContigMap(final Interval in, final Interval expected) {
+        if (expected != null) {
+            Assert.assertTrue(contigMap.get(in.getContig()).contains(expected.getContig()));
+        }
     }
 }


### PR DESCRIPTION
### Description

This method will give the destination contigs are used when mapping positions in a source contig.  This method allows `LiftoverVcf` to be more intelligent about memory usage (https://github.com/broadinstitute/picard/pull/525).

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary

