### PR TITLE
adding a useAsynchronousIO flag to SamReaderFactory

### DIFF
--- a/src/java/htsjdk/samtools/BAMIndexMetaData.java
+++ b/src/java/htsjdk/samtools/BAMIndexMetaData.java
@@ -218,7 +218,7 @@ public class BAMIndexMetaData {
      */
     static public void printIndexStats(final File inputBamFile) {
         try {
-            final BAMFileReader bam = new BAMFileReader(inputBamFile, null, false, ValidationStringency.SILENT, new DefaultSAMRecordFactory());
+            final BAMFileReader bam = new BAMFileReader(inputBamFile, null, false, false, ValidationStringency.SILENT, new DefaultSAMRecordFactory());
             if (!bam.hasIndex()) {
                 throw new SAMException("No index for bam file " + inputBamFile);
             }

--- a/src/java/htsjdk/samtools/SAMFileReader.java
+++ b/src/java/htsjdk/samtools/SAMFileReader.java
@@ -74,6 +74,7 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
     private BAMIndex mIndex = null;
     private SAMRecordFactory samRecordFactory = new DefaultSAMRecordFactory();
     private ReaderImplementation mReader = null;
+    private boolean useAsyncIO = Defaults.USE_ASYNC_IO_FOR_SAMTOOLS;
 
     private File samFile = null;
 
@@ -200,6 +201,13 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
         }
         mReader = null;
         mIndex = null;
+    }
+
+    /**
+     * If true, this reader will use asynchronous IO.
+     */
+    public void setUseAsyncIO(final boolean useAsyncIO) {
+        this.useAsyncIO = useAsyncIO;
     }
 
     /**
@@ -593,7 +601,7 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
         try {
             if (streamLooksLikeBam(strm)) {
                 mIsBinary = true;
-                mReader = new BAMFileReader(strm, indexFile, eagerDecode, validationStringency, this.samRecordFactory);
+                mReader = new BAMFileReader(strm, indexFile, eagerDecode,  useAsyncIO, validationStringency, this.samRecordFactory);
             } else {
                 throw new SAMFormatException("Unrecognized file format: " + strm);
             }
@@ -609,7 +617,7 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
         try {
             if (streamLooksLikeBam(strm)) {
                 mIsBinary = true;
-                mReader = new BAMFileReader(strm, indexStream, eagerDecode, validationStringency, this.samRecordFactory);
+                mReader = new BAMFileReader(strm, indexStream, eagerDecode, useAsyncIO, validationStringency, this.samRecordFactory);
             } else {
                 throw new SAMFormatException("Unrecognized file format: " + strm);
             }
@@ -645,10 +653,10 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
                 mIsBinary = true;
                 if (file == null || !file.isFile()) {
                     // Handle case in which file is a named pipe, e.g. /dev/stdin or created by mkfifo
-                    mReader = new BAMFileReader(bufferedStream, indexFile, eagerDecode, validationStringency, this.samRecordFactory);
+                    mReader = new BAMFileReader(bufferedStream, indexFile, eagerDecode, useAsyncIO, validationStringency, this.samRecordFactory);
                 } else {
                     bufferedStream.close();
-                    mReader = new BAMFileReader(file, indexFile, eagerDecode, validationStringency, this.samRecordFactory);
+                    mReader = new BAMFileReader(file, indexFile, eagerDecode, useAsyncIO,  validationStringency, this.samRecordFactory);
                 }
             } else if (BlockCompressedInputStream.isValidFile(bufferedStream)) {
                 mIsBinary = false;


### PR DESCRIPTION
### Description

To help with implementing asynchronous BAM decompression (see https://github.com/samtools/htsjdk/pull/576), I added a flag to SamReaderFactory. Previously the synchronous/asynchronous status was always taken from `Defaults.USE_ASYNC_IO_FOR_SAMTOOLS` which did not provide enough control to clients. In particular, in GATK we do want asynchronous BAM decompression when reading from regular file system but not from HDFS.

This functionality setting on the factory already exists for `SAMFileWriterFactory` and `FastqWriterFactory`. 

This PR is a bit unusual in that it does not actually add asynchronous reading. It only enables the flag to be set on the factory rather than be always taken from `Defaults`. The actual implementation will be in https://github.com/samtools/htsjdk/pull/576. This PR enables clients like Hadoop-BAM to selectively pre-switch to synchronous IO to future-proof them.

@droazen please review. @tomwhite if this goes in, will you be able to switch to sync IO using this API?

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary

