### PR TITLE
Updating docs to replace outdated java 1.6 -> 1.8

### DIFF
--- a/building.html
+++ b/building.html
@@ -19,19 +19,7 @@
 			<h3>Java version</h3>
 			<section>
 
-			<p>Building HTSJDK library requires Java 1.6.  It may
-			be built with the Java 1.7 compiler, but for maximum compatibility with Java 1.6 JVM,
-			you should compile using the Java 1.6 libraries.  This can be done in one of the
-			following ways:</p>
-			<ul>
-				<li>Set an environment variable JAVA6_HOME that points to your Java 1.6
-				installation.</li>
-				<li>Pass to ant the argument -Djava6.home=<path> where <path> is the directory of your Java
-				1.6 installation.</li>
-			</ul>
-			<p>If you do not have Java 1.6 installed on your build machine, you may supply the
-			location of you Java 1.7 installation instead, but there may be problems running code
-			compiled this way on Java 1.6 JVMs.
+			<p>Building HTSJDK library requires Java 1.8.
 			</p>
 			</section>
 


### PR DESCRIPTION
### Description
Updating the documentation site to say we need java 1.8 instead of 1.6.

### Checklist
- [ x ] Extended the README / documentation, if necessary
