### PR TITLE
adding null check when determining isRelease

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,7 @@ dependencies {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-
-final isRelease = versionDetails().commitDistance == 0
+final isRelease = Boolean.getBoolean("release")
 version = isRelease ? gitVersion() : gitVersion() + "-SNAPSHOT"
 
 logger.info("build for version:" + version)


### PR DESCRIPTION
### Description
This should fix a gradle issue that can manifest in forks of htsjdk.  Fix for #605 

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


adding an explicit check for null when determining isRelease
this happens in the case of a fork of the repo with no tags