### PR TITLE
Header SO:sorted instead of SO:coordinate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,7 @@ dependencies {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-
-final isRelease = versionDetails().commitDistance == 0
+final isRelease = Boolean.getBoolean("release")
 version = isRelease ? gitVersion() : gitVersion() + "-SNAPSHOT"
 
 logger.info("build for version:" + version)

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -246,6 +246,10 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         if (so == null || so.equals("unknown")) {
             return SortOrder.unsorted;
         }
+        /* some BAM are wrongly using 'sorted'  e.g.: http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeCaltechRnaSeq/wgEncodeCaltechRnaSeqGm12891R2x75Il200AlignsRep2V2.bam  (2016-05-17) . For now, we have only see this with version:1.0 */
+        if (so.equals("sorted") && "1.0".equals(getVersion())) {
+            return SortOrder.coordinate;
+        }
         return SortOrder.valueOf((String) so);
     }
 

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -468,4 +468,14 @@ public class ValidateSamFileTest {
         Assert.assertFalse(results.isEmpty());
         Assert.assertEquals(results.get(SAMValidationError.Type.MATES_ARE_SAME_END.getHistogramString()).getValue(), 2.0);
     }
+
+    /* bam using 'SO:sorted' instead of 'SO:coordinate' e.g. http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeCaltechRnaSeq/wgEncodeCaltechRnaSeqGm12891R2x75Il200AlignsRep2V2.bam (2016-05-17) */
+    @Test
+    public void testSortedOrder() throws Exception {
+        final String header = "@HD	VN:1.0	SO:sorted";
+        final InputStream strm = new ByteArrayInputStream(StringUtil.stringToBytes(header));
+        final SamReader samReader = SamReaderFactory.makeDefault().open(SamInputResource.of(strm));
+        Assert.assertTrue(samReader.getFileHeader().getSortOrder() == SAMFileHeader.SortOrder.coordinate);
+    }
+
 }


### PR DESCRIPTION
### Description

Some old BAMs contain a wrong SO field in the SAM header. e.g: http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeCaltechRnaSeq/wgEncodeCaltechRnaSeqGm12891R2x75Il200AlignsRep2V2.bam 

this BAM use 'sorted' instead of 'coordinate'

```
$ curl -s "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeCaltechRnaSeq/wgEncodeCaltechRnaSeqGm12891R2x75Il200AlignsRep2V2.bam"  | samtools view -H - | head
@HD	VN:1.0	SO:sorted
@SQ	SN:chr1	LN:249250621
@SQ	SN:chr10	LN:135534747
@SQ	SN:chr11	LN:135006516
@SQ	SN:chr12	LN:133851895
@SQ	SN:chr13	LN:115169878
@SQ	SN:chr14	LN:107349540
@SQ	SN:chr15	LN:102531392
@SQ	SN:chr16	LN:90354753
@SQ	SN:chr17	LN:81195210
```

I've modified SamFileHeader.getSortOrder(), if SO is "sorted" and the version is "1.0"  the SortOrder.coordinate is returned.

This PR also contains lbergelson 's  https://github.com/samtools/htsjdk/pull/606

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

