### PR TITLE
add coverage reports, online and offline. Add coveralls badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,11 @@ cache:
     - $HOME/.m2
 jdk:
   - oraclejdk8
-script: ./gradlew test testSRA testIntelDeflater
+script: ./gradlew jacocoTestReport testSRA testIntelDeflater;
 after_success:
   - echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'";
     echo "JAVA_HOME='$JAVA_HOME'";
+    ./gradlew coveralls;
     if [ "$TRAVIS_BRANCH" == "master" ]; then
        ./gradlew uploadArchives;
     fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Status of master branch build: [![Build Status](https://travis-ci.org/samtools/htsjdk.svg?branch=master)](https://travis-ci.org/samtools/htsjdk)
+Status of master branch build: [![Coverage Status](https://coveralls.io/repos/github/samtools/htsjdk/badge.svg?branch=master)](https://coveralls.io/github/samtools/htsjdk?branch=master)
+[![Build Status](https://travis-ci.org/samtools/htsjdk.svg?branch=master)](https://travis-ci.org/samtools/htsjdk)
 
 Status of downstream projects automatically built on top of the current htsjdk master branch. See [gatk-jenkins](https://gatk-jenkins.broadinstitute.org/view/HTSJDK%20Release%20Tests/) for detailed logs. Failure may indicate problems  in htsjdk, but may also be due to expected incompatibilities between versions, or unrelated failures in downstream projects.
 - [Picard](https://github.com/broadinstitute/picard):  [![Build Status](https://gatk-jenkins.broadinstitute.org/buildStatus/icon?job=picard-on-htsjdk-master)](https://gatk-jenkins.broadinstitute.org/job/picard-on-htsjdk-master/)
@@ -41,6 +42,11 @@ Example gradle usage from the htsjdk root directory:
 
  ./gradlew test --tests "*AlleleUnitTest" --debug-jvm
  ```
+
+- run tests and collect coverage information (report will be in `build/reports/jacoco/test/html/index.html`)
+```
+./gradlew jacocoTestReport
+```
 
  - clean the project directory
  ```

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,30 @@ plugins {
     id "java"
     id 'maven'
     id 'signing'
+    id 'jacoco'
     id 'com.palantir.git-version' version '0.5.1'
     id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id "com.github.kt3k.coveralls" version "2.6.3"
 }
 
 repositories {
     mavenCentral()
+}
+
+jacocoTestReport {
+    dependsOn test
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports after running tests."
+    additionalSourceDirs = files(sourceSets.main.allJava.srcDirs)
+
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
+}
+
+jacoco {
+    toolVersion = "0.7.5.201505241946"
 }
 
 dependencies {


### PR DESCRIPTION
### Description

This PR adds coverage collection (offline using jacoco and online using coveralls) and a coverage badge to the README. Now that we're on gradle this was super easy.

The online coverage reports are here: https://coveralls.io/github/samtools/htsjdk

To collect coverage offline use `./gradlew jacocoTestReport` and then open `build/reports/jacoco/test/html/index.html`

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


