### PR TITLE
Remove the ".dirty" from htsjdk jar names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 final isRelease = Boolean.getBoolean("release")
-version = isRelease ? gitVersion() : gitVersion() + "-SNAPSHOT"
+final gitVersion = gitVersion().replaceAll(".dirty", "")
+version = isRelease ? gitVersion : gitVersion + "-SNAPSHOT"
 
 logger.info("build for version:" + version)
 group = 'com.github.samtools'


### PR DESCRIPTION
The current build.gradle adds a ".dirty" to the jar name when
running "gradle jar" when there are untracked files, even if there
are no uncommitted changes and the working directory is otherwise
clean. This is misleading, since "dirty" implies that the build
contains uncommitted changes, but untracked files do not affect
the build at all. Rather than cause confusion, let's just strip
out ".dirty" from the name for now.