### PR TITLE
Disable the IntelDeflater for now, since we can't publish to maven central with a dependency on an intel-gkl snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ repositories {
 
     // Include the Broad artifactory for intel-gkl snapshots. This is temporary
     // until intel-gkl is available on maven central.
-    maven {
-        url "https://artifactory.broadinstitute.org/artifactory/libs-snapshot/"
-    }
+    //maven {
+    //    url "https://artifactory.broadinstitute.org/artifactory/libs-snapshot/"
+    //}
 }
 
 jacocoTestReport {
@@ -47,7 +47,9 @@ dependencies {
     compile "org.apache.commons:commons-compress:1.4.1"
     compile "org.tukaani:xz:1.5"
     compile "gov.nih.nlm.ncbi:ngs-java:1.2.2"
-    compile "com.intel:intel-gkl:0.0.1-20160525.160915-2"
+
+    // Disabled until intel-gkl is in maven central
+    // compile "com.intel:intel-gkl:0.0.1-20160525.160915-2"
 
     testCompile "org.testng:testng:6.9.9"
 }

--- a/src/main/java/htsjdk/samtools/util/zip/DeflaterFactory.java
+++ b/src/main/java/htsjdk/samtools/util/zip/DeflaterFactory.java
@@ -23,7 +23,7 @@
  */
 package htsjdk.samtools.util.zip;
 
-import com.intel.gkl.compression.IntelDeflater;
+// import com.intel.gkl.compression.IntelDeflater;
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMException;
 
@@ -52,6 +52,8 @@ public class DeflaterFactory {
     static {
         boolean intelDeflaterLibrarySuccessfullyLoaded = false;
 
+        // Disabled until the intel-gkl library is available on maven central
+        /*
         try {
             if (Defaults.TRY_USE_INTEL_DEFLATER) {
                 @SuppressWarnings("unchecked")
@@ -71,7 +73,7 @@ public class DeflaterFactory {
                 IllegalAccessException | InstantiationException | InvocationTargetException e ) {
             intelDeflaterConstructor = null;
         }
-
+        */
         usingIntelDeflater = intelDeflaterConstructor != null && intelDeflaterLibrarySuccessfullyLoaded;
     }
 

--- a/src/test/java/htsjdk/samtools/util/IntelDeflaterTest.java
+++ b/src/test/java/htsjdk/samtools/util/IntelDeflaterTest.java
@@ -72,7 +72,8 @@ public class IntelDeflaterTest {
         return retVal.iterator();
     }
 
-    @Test(dataProvider = "TestIntelDeflaterIsLoadedData", groups={"intel"}, expectedExceptions = IllegalAccessError.class)
+    // TODO: re-enable once the IntelDeflater is re-activated
+    @Test(dataProvider = "TestIntelDeflaterIsLoadedData", groups={"intel"}, expectedExceptions = IllegalAccessError.class, enabled = false)
     public void TestIntelDeflatorIsLoaded(final File inputFile, final Boolean eagerlyDecode,final Integer compressionLevel) throws IOException,IllegalAccessError {
         Log log = Log.getInstance(IntelDeflaterTest.class);
         Log.setGlobalLogLevel(Log.LogLevel.INFO);


### PR DESCRIPTION
The necessary code is still intact, albeit commented out, so it's easy to re-enable in branches for experimentation purposes.