### PR TITLE
SamReaderFactory fixes for SAM/CRAM files on URL and SeekableStream input resources.

### DIFF
--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableStreamFactory.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableStreamFactory.java
@@ -76,6 +76,8 @@ public class SeekableStreamFactory{
                 return new SeekableHTTPStream(url);
             } else if (path.startsWith("ftp:")) {
                 return new SeekableFTPStream(new URL(path));
+            } else if (path.startsWith("file:")) {
+                return new SeekableFileStream(new File(new URL(path).getPath()));
             } else {
                 return new SeekableFileStream(new File(path));
             }

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamFactoryTest.java
@@ -1,9 +1,16 @@
 package htsjdk.samtools.seekablestream;
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
 public class SeekableStreamFactoryTest {
+    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+
     @Test
     public void testIsFilePath() throws Exception {
         Assert.assertEquals(SeekableStreamFactory.isFilePath("x"), true);
@@ -12,4 +19,26 @@ public class SeekableStreamFactoryTest {
         Assert.assertEquals(SeekableStreamFactory.isFilePath("https://broadinstitute.org"), false);
         Assert.assertEquals(SeekableStreamFactory.isFilePath("ftp://broadinstitute.org"), false);
     }
+
+    @DataProvider(name="getStreamForData")
+    public Object[][] getStreamForData() throws Exception {
+        return new Object[][] {
+                { new File(TEST_DATA_DIR, "BAMFileIndexTest/index_test.bam").getAbsolutePath(),
+                        new File(TEST_DATA_DIR, "BAMFileIndexTest/index_test.bam").getAbsolutePath() },
+                { new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath(),
+                        new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath() },
+                { new URL("file://" + new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath()).toExternalForm(),
+                        new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath() },
+                { new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam").toExternalForm(),
+                        new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam").toExternalForm() },
+                { new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam.bai").toExternalForm(),
+                       new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam.bai").toExternalForm() }
+        };
+    }
+
+    @Test(dataProvider = "getStreamForData")
+    public void testGetStreamFor(final String path, final String expectedPath) throws IOException {
+        Assert.assertEquals(SeekableStreamFactory.getInstance().getStreamFor(path).getSource(), expectedPath);
+    }
+
 }


### PR DESCRIPTION
# Description

Fix for https://github.com/samtools/htsjdk/issues/614

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


…t