### PR TITLE
Fix SamLocusIterator when missing base quality string is provided

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
@@ -449,7 +449,7 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
                 final int readOffset = readStart + i - 1;
 
                 // if the quality score cutoff is met, accumulate the base info
-                if (dontCheckQualities || baseQualities[readOffset] >= minQuality) {
+                if (dontCheckQualities || baseQualities.length == 0 || baseQualities[readOffset] >= minQuality) {
                     // 0-based offset from the aligned position of the first base in the read to the aligned position of the current base.
                     final int refOffset = refStart + i - accOffset;
                     accumulator.get(refOffset).add(rec, readOffset);

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -93,6 +93,27 @@ public class SamLocusIteratorTest {
         }
     }
 
+    @Test
+    public void testMissingQualityString() {
+
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        for (int i = 0; i < coverage; i++) {
+
+            builder.addFrag("record" + i, 0, startPosition, true, false, "36M", "*", 0);
+        }
+        final SamLocusIterator sli = createSamLocusIterator(builder);
+
+        // make sure we accumulated depth of 2 for each position
+        int pos = 165;
+        for (final SamLocusIterator.LocusInfo li : sli) {
+            Assert.assertEquals(pos++, li.getPosition());
+            Assert.assertEquals(2, li.getRecordAndPositions().size());
+        }
+
+    }
+
     /**
      * Test the emit uncovered loci, with both including or not indels
      */


### PR DESCRIPTION
### Description

This PR fixes issue #611 by checking for the missing base quality string "*" when using SamLocusIterator to iterate over SAMRecords. There's also a new test that targets this scenario.

