### PR TITLE
Histogram - made not extend TreeSet, make Bin static, add tests

### DIFF
--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -131,8 +131,8 @@ public class SamFileValidator {
 
         if (errorsByType.getCount() > 0) {
             // Convert to a histogram with String IDs so that WARNING: or ERROR: can be prepended to the error type.
-            final Histogram<String> errorsAndWarningsByType = new Histogram<String>("Error Type", "Count");
-            for (final Histogram<SAMValidationError.Type>.Bin bin : errorsByType.values()) {
+            final Histogram<String> errorsAndWarningsByType = new Histogram<>("Error Type", "Count");
+            for (final Histogram.Bin<Type> bin : errorsByType.values()) {
                 errorsAndWarningsByType.increment(bin.getId().getHistogramString(), bin.getValue());
             }
             final MetricsFile<ValidationMetrics, String> metricsFile = new MetricsFile<ValidationMetrics, String>();

--- a/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
+++ b/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
@@ -49,16 +49,18 @@ import java.util.TreeSet;
  * @author Tim Fennell
  */
 public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
     public static final String MAJOR_HEADER_PREFIX = "## ";
     public static final String MINOR_HEADER_PREFIX = "# ";
     public static final String SEPARATOR = "\t";
     public static final String HISTO_HEADER = "## HISTOGRAM\t";
     public static final String METRIC_HEADER = "## METRICS CLASS\t";
 
-    private final Set<String> columnLabels = new HashSet<String>();
-    private final List<Header> headers = new ArrayList<Header>();
-    private final List<BEAN> metrics = new ArrayList<BEAN>();
-    private final List<Histogram<HKEY>> histograms = new ArrayList<Histogram<HKEY>>();
+    private final Set<String> columnLabels = new HashSet<>();
+    private final List<Header> headers = new ArrayList<>();
+    private final List<BEAN> metrics = new ArrayList<>();
+    private final List<Histogram<HKEY>> histograms = new ArrayList<>();
 
     /** Adds a header to the collection of metrics. */
     public void addHeader(Header h) { this.headers.add(h); }
@@ -267,7 +269,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
             out.append(key.toString());
 
             for (final Histogram<HKEY> histo : nonEmptyHistograms) {
-                final Histogram<HKEY>.Bin bin = histo.get(key);
+                final Histogram.Bin<HKEY> bin = histo.get(key);
                 final double value = (bin == null ? 0 : bin.getValue());
 
                 out.append(SEPARATOR);
@@ -537,7 +539,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
      * @return list of beans from the file.
      */
     public static <T extends MetricBase> List<T> readBeans(final File file) {
-        final MetricsFile<T, Comparable<?>> metricsFile = new MetricsFile<T, Comparable<?>>();
+        final MetricsFile<T, ?> metricsFile = new MetricsFile<>();
         final Reader in = IOUtil.openFileForBufferedReading(file);
         metricsFile.read(in);
         CloserUtil.close(in);
@@ -549,7 +551,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
      */
     public static List<Header> readHeaders(final File file) {
         try {
-            final MetricsFile<MetricBase, Comparable<?>> metricsFile = new MetricsFile<MetricBase, Comparable<?>>();
+            final MetricsFile<MetricBase, ?> metricsFile = new MetricsFile<>();
             metricsFile.read(new FileReader(file));
             return metricsFile.getHeaders();
         } catch (FileNotFoundException e) {
@@ -562,8 +564,8 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
      */
     public static boolean areMetricsEqual(final File file1, final File file2) {
         try {
-            final MetricsFile<MetricBase, Comparable<?>> mf1 = new MetricsFile<MetricBase, Comparable<?>>();
-            final MetricsFile<MetricBase, Comparable<?>> mf2 = new MetricsFile<MetricBase, Comparable<?>>();
+            final MetricsFile<MetricBase, ?> mf1 = new MetricsFile<>();
+            final MetricsFile<MetricBase, ?> mf2 = new MetricsFile<>();
             mf1.read(new FileReader(file1));
             mf2.read(new FileReader(file2));
             return mf1.areMetricsEqual(mf2);
@@ -578,8 +580,8 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
      */
     public static boolean areMetricsAndHistogramsEqual(final File file1, final File file2) {
         try {
-            final MetricsFile<MetricBase, Comparable<?>> mf1 = new MetricsFile<MetricBase, Comparable<?>>();
-            final MetricsFile<MetricBase, Comparable<?>> mf2 = new MetricsFile<MetricBase, Comparable<?>>();
+            final MetricsFile<MetricBase, ?> mf1 = new MetricsFile<>();
+            final MetricsFile<MetricBase, ?> mf2 = new MetricsFile<>();
             mf1.read(new FileReader(file1));
             mf2.read(new FileReader(file2));
 

--- a/src/main/java/htsjdk/samtools/util/Histogram.java
+++ b/src/main/java/htsjdk/samtools/util/Histogram.java
@@ -24,15 +24,8 @@
 
 package htsjdk.samtools.util;
 
-import htsjdk.samtools.util.Histogram.Bin;
 import java.io.Serializable;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.TreeMap;
+import java.util.*;
 
 import static java.lang.Math.*;
 
@@ -42,26 +35,31 @@ import static java.lang.Math.*;
  *
  * @author Tim Fennell
  */
-public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
+public final class Histogram<K extends Comparable> implements Serializable {
+    private static final long serialVersionUID = 1L;
     private String binLabel   = "BIN";
     private String valueLabel = "VALUE";
+    private final NavigableMap<K, Bin<K>> map;
 
     /** Constructs a new Histogram with default bin and value labels. */
-    public Histogram() { }
+    public Histogram() {
+        this.map = new TreeMap<>();
+    }
 
     /** Constructs a new Histogram with supplied bin and value labels. */
     public Histogram(final String binLabel, final String valueLabel) {
+        this();
         this.binLabel = binLabel;
         this.valueLabel = valueLabel;
     }
 
     /** Constructs a new Histogram that'll use the supplied comparator to sort keys. */
-    public Histogram(final Comparator<K> comparator) {
-        super(comparator);
+    public Histogram(final Comparator<? super K> comparator) {
+        this.map = new TreeMap<>(comparator);
     }
 
     /** Constructor that takes labels for the bin and values and a comparator to sort the bins. */
-    public Histogram(final String binLabel, final String valueLabel, final Comparator<K> comparator) {
+    public Histogram(final String binLabel, final String valueLabel, final Comparator<? super K> comparator) {
         this(comparator);
         this.binLabel = binLabel;
         this.valueLabel = valueLabel;
@@ -69,13 +67,14 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
 
     /** Copy constructor for a histogram. */
     public Histogram(final Histogram<K> in) {
-        super(in);
+        this.map = new TreeMap<>(in.map);
         this.binLabel = in.binLabel;
         this.valueLabel = in.valueLabel;
     }
 
     /** Represents a bin in the Histogram. */
-    public class Bin implements Serializable{
+    public static class Bin<K> implements Serializable{
+        private static final long serialVersionUID = 1L;
         private final K id;
         private double value = 0;
 
@@ -89,14 +88,16 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
         public double getValue() { return value; }
 
         /** Returns the String format for the value in the bin. */
+        @Override
         public String toString() { return String.valueOf(this.value); }
 
         /** Checks the equality of the bin by ID and value. */
+        @Override
         public boolean equals(final Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            final Bin bin = (Bin) o;
+            final Bin<K> bin = (Bin<K>) o;
 
             if (Double.compare(bin.value, value) != 0) return false;
             if (!id.equals(bin.id)) return false;
@@ -126,7 +127,7 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
     /** Prefill the histogram with the supplied set of bins. */
     public void prefillBins(final K... ids) {
         for (final K id : ids) {
-            put(id, new Bin(id));
+            map.put(id, new Bin<>(id));
         }
     }
 
@@ -137,10 +138,10 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
 
     /** Increments the value in the designated bin by the supplied increment. */
     public void increment(final K id, final double increment) {
-        Bin bin = get(id);
+        Bin<K> bin = map.get(id);
         if (bin == null) {
-            bin = new Bin(id);
-            put(id, bin);
+            bin = new Bin<>(id);
+            map.put(id, bin);
         }
 
         bin.value += increment;
@@ -153,12 +154,26 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
     public void setValueLabel(final String valueLabel) { this.valueLabel = valueLabel; }
 
     /** Checks that the labels and values in the two histograms are identical. */
+    @Override
     public boolean equals(final Object o) {
+        if (o == this) {
+            return true;
+        }
         return o != null &&
                 (o instanceof Histogram) &&
                 ((Histogram) o).binLabel.equals(this.binLabel) &&
                 ((Histogram) o).valueLabel.equals(this.valueLabel) &&
-                super.equals(o);
+                ((Histogram) o).map.equals(this.map);
+    }
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(binLabel, valueLabel, map);
     }
 
     /**
@@ -169,7 +184,7 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
         // Could use simply getSum() / getCount(), but that would require iterating over the
         // values() set twice, which seems inefficient given how simply the computation is.
         double product=0, totalCount=0;
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : map.values()) {
             final double idValue = bin.getIdValue();
             final double count   = bin.getValue();
 
@@ -182,10 +197,11 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
 
     /**
      * Returns the sum of the products of the histgram bin ids and the number of entries in each bin.
+     * Note: This is only supported if this histogram stores instances of Number.
      */
     public double getSum() {
         double total = 0;
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : map.values()) {
             total += bin.getValue() * bin.getIdValue();
         }
 
@@ -197,7 +213,7 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
      */
     public double getSumOfValues() {
         double total = 0;
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : map.values()) {
             total += bin.getValue();
         }
 
@@ -210,7 +226,7 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
         double count = 0;
         double total = 0;
 
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : map.values()) {
             final double localCount = bin.getValue();
             final double value = bin.getIdValue();
 
@@ -228,7 +244,27 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
         return (getSumOfValues() / size());
     }
 
-	/**
+    /**
+     * Returns the size of this histogram.
+     */
+    public int size() {
+        return map.size();
+    }
+
+    /**
+     * Returns the comparator used to order the keys in this histogram, or
+     * {@code null} if this histogram uses the {@linkplain Comparable
+     * natural ordering} of its keys.
+     *
+     * @return the comparator used to order the keys in this histogram,
+     *         or {@code null} if this histogram uses the natural ordering
+     *         of its keys
+     */
+    public Comparator<? super K> comparator() {
+        return map.comparator();
+    }
+
+    /**
 	 * Calculates the median bin size
 	 */
 	public double getMedianBinSize() {
@@ -236,8 +272,8 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
 			return 0;
 		}
 
-		final List<Double> binValues = new ArrayList<Double>();
-		for (final Bin bin : values()) {
+		final List<Double> binValues = new ArrayList<>();
+		for (final Bin<K> bin : values()) {
 			binValues.add(bin.getValue());
 		}
 		Collections.sort(binValues);
@@ -252,11 +288,20 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
 	}
 
     /**
+     * Returns a {@link Collection} view of the values contained in this histogram.
+     * The collection's iterator returns the values in ascending order
+     * of the corresponding keys.
+     */
+    public Collection<Bin<K>> values() {
+        return map.values();
+    }
+
+    /**
      * Calculates the standard deviation of the bin size
      */
     public double getStandardDeviationBinSize(final double mean) {
         double total = 0;
-        for(final Bin bin : values()) {
+        for(final Bin<K> bin : values()) {
             total += Math.pow(bin.getValue() - mean, 2);
         }
         return Math.sqrt(total / (Math.max(1,values().size()-1)));
@@ -268,13 +313,13 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
      * @param percentile a value between 0 and 1
      * @return the bin value in which the percentile falls
      */
-    public double getPercentile(double percentile) {
+    public double getPercentile(final double percentile) {
         if (percentile <= 0) throw new IllegalArgumentException("Cannot query percentiles of 0 or below");
         if (percentile >= 1) throw new IllegalArgumentException("Cannot query percentiles of 1 or above");
 
         double total = getCount();
         double sofar = 0;
-        for (Bin bin : values()) {
+        for (Bin<K> bin : values()) {
             sofar += bin.getValue();
             if (sofar / total >= percentile) return bin.getIdValue();
         }
@@ -285,12 +330,13 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
     /**
      * Returns the cumulative probability of observing a value <= v when sampling the
      * distribution represented by this histogram.
+     * @throws UnsupportedOperationException if this histogram does not store instances of Number
      */
     public double getCumulativeProbability(final double v) {
         double count = 0;
         double total = 0;
 
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : values()) {
             final double binValue = bin.getIdValue();
             if (binValue <= v) count += bin.getValue();
             total += bin.getValue();
@@ -319,7 +365,7 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
 
         Double midLowValue  = null;
         Double midHighValue = null;
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : values()) {
             total += bin.getValue();
             if (midLowValue  == null && total >= midLow)  midLowValue  = bin.getIdValue();
             if (midHighValue == null && total >= midHigh) midHighValue = bin.getIdValue();
@@ -332,8 +378,8 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
     /** Gets the median absolute deviation of the distribution. */
     public double getMedianAbsoluteDeviation() {
         final double median = getMedian();
-        final Histogram<Double> deviations = new Histogram<Double>();
-        for (final Bin bin : values()) {
+        final Histogram<Double> deviations = new Histogram<>();
+        for (final Bin<K> bin : values()) {
             final double dev = abs(bin.getIdValue() - median);
             deviations.increment(dev, bin.getValue());
         }
@@ -350,17 +396,18 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
         return 1.4826 * getMedianAbsoluteDeviation();
     }
 
-    /** Returns id of the Bin that's the mode of the distribution (i.e. the largest bin). */
+    /** Returns id of the Bin that's the mode of the distribution (i.e. the largest bin).
+     * @throws UnsupportedOperationException if this histogram does not store instances of Number
+     */
     public double getMode() {
-
         return getModeBin().getIdValue();
     }
 
     /** Returns the Bin that's the mode of the distribution (i.e. the largest bin). */
-    private Bin getModeBin() {
-        Bin modeBin = null;
+    private Bin<K> getModeBin() {
+        Bin<K> modeBin = null;
 
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : values()) {
             if (modeBin == null || modeBin.value < bin.value) {
                 modeBin = bin;
             }
@@ -370,17 +417,25 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
     }
 
 
+    /**
+     * Returns the key with the lowest count.
+     * @throws UnsupportedOperationException if this histogram does not store instances of Number
+     */
     public double getMin() {
-        return firstEntry().getValue().getIdValue();
+        return map.firstEntry().getValue().getIdValue();
     }
 
+    /**
+     * Returns the key with the highest count.
+     * @throws UnsupportedOperationException if this histogram does not store instances of Number
+     */
     public double getMax() {
-        return lastEntry().getValue().getIdValue();
+        return map.lastEntry().getValue().getIdValue();
     }
 
     public double getCount() {
         double count = 0;
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : values()) {
             count += bin.value;
         }
 
@@ -391,7 +446,7 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
     public double getGeometricMean() {
         double total = 0;
         double count = 0;
-        for (final Bin bin : values()) {
+        for (final Bin<K> bin : values()) {
             total += bin.value * log(bin.getIdValue());
             count += bin.value;
         }
@@ -407,14 +462,14 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
             return;
         }
 
-        final Bin modeBin = getModeBin();
+        final Bin<K> modeBin = getModeBin();
         final double mode = modeBin.getIdValue();
         final double sizeOfModeBin = modeBin.getValue();
         final double minimumBinSize = sizeOfModeBin/tailLimit;
-        Histogram<K>.Bin lastBin = null;
+        Bin<K> lastBin = null;
 
-        final List<K> binsToKeep = new ArrayList<K>();
-        for (Histogram<K>.Bin bin : values()) {
+        final List<K> binsToKeep = new ArrayList<>();
+        for (Bin<K> bin : values()) {
             double binId = ((Number)bin.getId()).doubleValue();
 
             if (binId <= mode) {
@@ -431,17 +486,28 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
 
         final Object keys[] = keySet().toArray();
         for (Object binId : keys) {
-            if (!binsToKeep.contains((K)binId)) {
+            if (!binsToKeep.contains(binId)) {
                 remove(binId);
             }
         }
+    }
+
+    private Bin<K> remove(final Object key) {
+        return map.remove(key);
+    }
+
+    /**
+     * Returns true if this histogram has no data in in, false otherwise.
+     */
+    public boolean isEmpty() {
+        return map.isEmpty();
     }
 
     /**
      * Trims the histogram so that only bins <= width are kept.
      */
     public void trimByWidth(final int width) {
-        final Iterator<K> it = descendingKeySet().iterator();
+        final Iterator<K> it = map.descendingKeySet().iterator();
         while (it.hasNext()) {
 
             if (((Number)it.next()).doubleValue() > width) {
@@ -455,14 +521,14 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
      * Throws an exception if the bins don't match up exactly
      * @param divisorHistogram
      * @return
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException if the keySet of this histogram is not equal to the keySet of the given divisorHistogram
      */
-    public Histogram<K> divideByHistogram(final Histogram<K> divisorHistogram) throws IllegalArgumentException{
-        Histogram<K> output = new Histogram<K>();
-        if (!this.keySet().equals(divisorHistogram.keySet()))  throw new IllegalArgumentException("Attempting to divide Histograms with non-identical bins");
+    public Histogram<K> divideByHistogram(final Histogram<K> divisorHistogram) {
+        final Histogram<K> output = new Histogram<K>();
+        if (!this.keySet().equals(divisorHistogram.keySet())) throw new IllegalArgumentException("Attempting to divide Histograms with non-identical bins");
         for (final K key : this.keySet()){
-            Bin dividend = this.get(key);
-            Bin divisor = divisorHistogram.get(key);
+            final Bin<K> dividend = this.get(key);
+            final Bin<K> divisor = divisorHistogram.get(key);
             output.increment(key, dividend.getValue()/divisor.getValue());
         }
         return output;
@@ -476,5 +542,26 @@ public class Histogram<K extends Comparable> extends TreeMap<K, Bin> {
         for (final K key : addHistogram.keySet()){
             this.increment(key, addHistogram.get(key).getValue());
         }
+    }
+
+    /**
+     * Retrieves the bin associated with the given key.
+     */
+    public Bin<K> get(final K key) {
+        return map.get(key);
+    }
+
+    /**
+     * Returns the set of keys for this histogram.
+     */
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    /**
+     * Return whether this histogram contains the given key.
+     */
+    public boolean containsKey(final K key){
+        return map.containsKey(key);
     }
 }

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -332,7 +332,7 @@ public class ValidateSamFileTest {
     public void testQualityFormatValidation() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault().open(new File("./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/illumina-as-standard.bam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
-        final Histogram<String>.Bin bin = results.get(SAMValidationError.Type.INVALID_QUALITY_FORMAT.getHistogramString());
+        final Histogram.Bin<String> bin = results.get(SAMValidationError.Type.INVALID_QUALITY_FORMAT.getHistogramString());
         final double value = bin.getValue();
         Assert.assertEquals(value, 1.0);
     }

--- a/src/test/java/htsjdk/samtools/util/HistogramTest.java
+++ b/src/test/java/htsjdk/samtools/util/HistogramTest.java
@@ -5,17 +5,18 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
 
 import static java.lang.Math.abs;
+import static java.lang.StrictMath.pow;
 
-/**
- *
- */
 public class HistogramTest {
 
     @Test(dataProvider = "histogramData")
     public void testHistogramFunctions(final int[] values, final double mean, final double stdev, final Integer trimByWidth) {
-        final Histogram<Integer> histo = new Histogram<Integer>();
+        final Histogram<Integer> histo = new Histogram<>();
         for (int value : values) {
             histo.increment(value);
         }
@@ -42,15 +43,283 @@ public class HistogramTest {
 
     @Test
     public void testGeometricMean() {
-        final int[] is = new int[] {4,4,4,4,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8};
-        final Histogram<Integer> histo = new Histogram<Integer>();
+        final int[] is = {4,4,4,4,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8};
+        final Histogram<Integer> histo = new Histogram<>();
         for (final int i : is) histo.increment(i);
         Assert.assertTrue(abs(histo.getGeometricMean() - 6.216797) < 0.00001);
     }
 
+    @Test
+    public void testGetSum() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getSum(), (double)(2*4+3*5), 0.000001);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testGetSumBlowup() {
+        final String[] is = {"foo", "foo", "bar"};
+        final Histogram<String> histo = new Histogram<>();
+        for (final String i : is) histo.increment(i);
+        histo.getSum();//blow up
+    }
+
+    @Test
+    public void testGetSumOfValues() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getSumOfValues(), (double)(2+3), 0.000001);
+    }
+
+    @Test
+    public void testGetMeanBinSize() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getMeanBinSize(), (2+3)/2.0, 0.000001);
+    }
+
+    @Test
+    public void testGetStandardDeviationBinSize() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        final double std = Math.sqrt((pow(2.0-2.5, 2)+pow(3.0-2.5, 2.0))); //sample variance so dividing by 1
+        Assert.assertEquals(histo.getStandardDeviationBinSize(histo.getMeanBinSize()), std, 0.000001);
+    }
+
+    @Test
+    public void testGetKeySet() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+
+        Assert.assertEquals(histo.keySet(), new HashSet<>(Arrays.asList(4,5)));
+    }
+
+    @Test
+    public void testLabelsAndComparator() {
+        final String[] is = {"a", "B", "a"};
+        final Histogram<String> histo = new Histogram<>("FOO", "BAR", String.CASE_INSENSITIVE_ORDER);
+        for (final String i : is) histo.increment(i);
+        Assert.assertEquals(histo.get("a").getValue(), 2.0);
+        Assert.assertEquals(histo.get("B").getValue(), 1.0);
+        Assert.assertEquals(histo.get("a").getId(), "a");
+        Assert.assertEquals(histo.get("B").getId(), "B");
+    }
+
+
+    @Test
+    public void testPrefillBins() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        Assert.assertEquals(histo.get(4), null);
+        Assert.assertEquals(histo.get(5), null);
+        histo.prefillBins(4);
+        Assert.assertEquals(histo.get(4).getValue(),0.0);
+        Assert.assertEquals(histo.get(5), null);
+
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.get(4).getValue(),2.0);
+        Assert.assertEquals(histo.get(5).getValue(),3.0);
+    }
+
+    @Test
+    public void testLabels() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>("FOO", "BAR");
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getBinLabel(),"FOO");
+        Assert.assertEquals(histo.getValueLabel(),"BAR");
+    }
+
+    @Test
+    public void testCopyCtor() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo1 = new Histogram<>();
+        for (final int i : is) histo1.increment(i);
+
+        final Histogram<Integer> histo2 = new Histogram<>(histo1);
+        Assert.assertEquals(histo1, histo2);
+        Assert.assertEquals(histo2, histo1);
+    }
+
+    @Test
+    public void testGet() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+
+        Assert.assertEquals(histo.get(4).getValue(), 2.0);
+        Assert.assertEquals(histo.get(5).getValue(), 3.0);
+        Assert.assertEquals(histo.get(6), null);
+    }
+
+    @Test
+    public void testAddHistogram() {
+        final int[] is1 = {4,4,5,5,5};
+        final Histogram<Integer> histo1 = new Histogram<>();
+        Assert.assertTrue(histo1.isEmpty());
+        for (final int i : is1) histo1.increment(i);
+
+        Assert.assertFalse(histo1.isEmpty());
+
+        final int[] is2 = {5,5, 6,6,6,6};
+        final Histogram<Integer> histo2 = new Histogram<>();
+        for (final int i : is2) histo2.increment(i);
+
+        Assert.assertEquals(histo1.get(4).getValue(), 2.0);
+        Assert.assertEquals(histo1.get(5).getValue(), 3.0);
+        Assert.assertEquals(histo1.get(6), null);
+
+        histo1.addHistogram(histo2);
+
+        Assert.assertEquals(histo1.get(4).getValue(), 2.0);
+        Assert.assertEquals(histo1.get(5).getValue(), 5.0);
+        Assert.assertEquals(histo1.get(6).getValue(), 4.0);
+    }
+
+    @Test
+    public void testGetCumulativeProbability() {
+        final int[] is = {4,4,5,5,5,6,6,6,6};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getCumulativeProbability(2.0), 0.0);
+        Assert.assertEquals(histo.getCumulativeProbability(4.0), 2.0/9);
+        Assert.assertEquals(histo.getCumulativeProbability(5.0), 5.0/9);
+        Assert.assertEquals(histo.getCumulativeProbability(6.0), 9.0/9);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testGetCumulativeProbabilityBlowup() {
+        final String[] is = {"foo"};
+        final Histogram<String> histo = new Histogram<>();
+        for (final String i : is) histo.increment(i);
+        histo.getCumulativeProbability(2.0);
+    }
+
+    @Test
+    public void testPercentile() {
+        final int[] is = {4,4,5,5,5,6,6,6,6};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getPercentile(0.01), 4.0);
+        Assert.assertEquals(histo.getPercentile(2.0/9), 4.0);
+        Assert.assertEquals(histo.getPercentile(5.0/9), 5.0);
+        Assert.assertEquals(histo.getPercentile(0.99999), 6.0);
+    }
+
+    @Test
+    public void testGetMinMax() {
+        final int[] is = {4,4,5,5,5,6,6,6,6};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getMin(), 4.0);
+        Assert.assertEquals(histo.getMax(), 6.0);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testGetMinBlowup() {
+        final String[] is = {"foo", "bar", "bar"};
+        final Histogram<String> histo = new Histogram<>();
+        for (final String i : is) histo.increment(i);
+        histo.getMin();//blow up
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testGetMaxBlowup() {
+        final String[] is = {"foo", "bar", "bar"};
+        final Histogram<String> histo = new Histogram<>();
+        for (final String i : is) histo.increment(i);
+        histo.getMax();//blow up
+    }
+
+    @Test
+    public void testGetMedianBinSize() {
+        final int[] is = {4,4,5,5,5,6,6,6,6};
+        final Histogram<Integer> histo = new Histogram<>();
+        Assert.assertEquals(histo.getMedianBinSize(), 0, 0.000001); //empty
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getMedianBinSize(), 3, 0.000001); //three fives
+    }
+
+    @Test
+    public void testGetMedianBinSize_Even() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        Assert.assertEquals(histo.getMedianBinSize(), 0, 0.000001); //empty
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getMedianBinSize(), (2+3)/2.0, 0.000001); //even split
+    }
+
+    @Test
+    public void testSize() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.size(), 2); //2 unique values
+    }
+
+
+    @Test
+    public void testMode() {
+        final int[] is = {4,4,5,5,5,6};
+        final Histogram<Integer> histo = new Histogram<>();
+        for (final int i : is) histo.increment(i);
+        Assert.assertEquals(histo.getMode(), 5.0);
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testModeBlowup() {
+        final String[] is = {"foo"};
+        final Histogram<String> histo = new Histogram<>();
+        for (final String i : is) histo.increment(i);
+        histo.getMode();//blowup
+    }
+
+    @Test
+    public void testComparator() {
+        final int[] is = {4,4,5,5,5};
+        final Histogram<Integer> histo1 = new Histogram<>();
+        for (final int i : is) histo1.increment(i);
+        Assert.assertNull(histo1.comparator());
+
+        final Histogram<Integer> histo2 = new Histogram<>(Comparator.comparingInt(Integer::intValue));
+        Comparator<Integer> comp = (Comparator<Integer>) histo2.comparator();
+        Assert.assertNotNull(comp);
+        Assert.assertEquals(comp.compare(4,5), -1);
+    }
+
+    @Test
+    public void testEquals() {
+        final int[] is = {4,4,4,4,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8};
+        final Histogram<Integer> histo1 = new Histogram<>();
+        final Histogram<Integer> histo2 = new Histogram<>();
+        for (final int i : is) histo1.increment(i);
+        for (final int i : is) histo2.increment(i);
+        Assert.assertEquals(histo1, histo1);
+        Assert.assertEquals(histo2, histo1);
+        Assert.assertEquals(histo1, histo2);
+
+        Assert.assertEquals(histo1.hashCode(), histo2.hashCode());
+
+        Assert.assertNotEquals(null, histo1);
+        Assert.assertNotEquals(histo1, null);
+
+        histo2.increment(4);//make them not equal
+        Assert.assertEquals(histo1, histo1);
+        Assert.assertNotEquals(histo2, histo1);
+        Assert.assertNotEquals(histo1, histo2);
+        Assert.assertNotEquals(histo1.hashCode(), histo2.hashCode());
+
+
+    }
+
     @Test(dataProvider = "medianTestData")
     public void testMedian(final int [] values, final double median) {
-        final Histogram<Integer> histo = new Histogram<Integer>();
+        final Histogram<Integer> histo = new Histogram<>();
         for (final int i : values) histo.increment(i);
         Assert.assertEquals(histo.getMedian(), median);
     }
@@ -68,8 +337,8 @@ public class HistogramTest {
 
     @Test
     public void testMad() {
-        final int[] is = new int[] {4,4,4,4,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8};
-        final Histogram<Integer> histo = new Histogram<Integer>();
+        final int[] is = {4,4,4,4,5,5,5,5,6,6,6,6,6,6,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8};
+        final Histogram<Integer> histo = new Histogram<>();
         for (final int i : is) histo.increment(i);
 
         Assert.assertEquals(7d, histo.getMedian());
@@ -80,7 +349,7 @@ public class HistogramTest {
 
     @Test(dataProvider = "histogramData") //this data provider has several extra variables that we don't make use of here
     public void testSerializeHistogram(final int[] values, final double mean, final double stdev, final Integer trimByWidth) throws IOException, ClassNotFoundException {
-        final Histogram<Integer> histo = new Histogram<Integer>();
+        final Histogram<Integer> histo = new Histogram<>();
         for (int value : values) {
             histo.increment(value);
         }


### PR DESCRIPTION
### Description
Fixes #630. Fixes to Histogram - made it not extend TreeSet but use a TreeSet, made Bin static, add many tests, cleanup generics use.

Not backward compatible because Histogram does not extend TreeSet anymore and Bin is a static class. Some changes in clients look like this `Histogram<Integer>.Bin` -> `Histogram.Bin<Integer>`


### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [X] Is not backward compatible (breaks binary or source compatibility)


