### PR TITLE
Add the ability to publish to local maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 plugins {
     id "java"
     id 'maven'
+    id 'maven-publish'
     id 'signing'
     id 'jacoco'
     id 'com.palantir.git-version' version '0.5.1'
@@ -22,6 +23,14 @@ repositories {
     //maven {
     //    url "https://artifactory.broadinstitute.org/artifactory/libs-snapshot/"
     //}
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
 }
 
 jacocoTestReport {


### PR DESCRIPTION
### Description

Added maven publish plugin. This allows us to use publishToLocalMaven which in turn will allow use to use mavenLocal() in Picard to pick up snapshot builds from the local repository.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


