### PR TITLE
Provided an option to disable auto-download of SRA native libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     compile "org.xerial.snappy:snappy-java:1.0.3-rc3"
     compile "org.apache.commons:commons-compress:1.4.1"
     compile "org.tukaani:xz:1.5"
-    compile "gov.nih.nlm.ncbi:ngs-java:1.2.2"
+    compile "gov.nih.nlm.ncbi:ngs-java:1.2.4"
 
     testCompile "org.testng:testng:6.9.9"
 }
@@ -125,6 +125,8 @@ test {
 }
 
 task testSRA(type: Test){
+    jvmArgs '-Dsamjdk.sra_libraries_download=true'
+
     description "Run the SRA tests"
     useTestNG{
         includeGroups "sra"

--- a/build.gradle
+++ b/build.gradle
@@ -124,11 +124,11 @@ test {
     }
 }
 
-task testSRA(type: Test){
+task testSRA(type: Test) {
     jvmArgs '-Dsamjdk.sra_libraries_download=true'
 
     description "Run the SRA tests"
-    useTestNG{
+    useTestNG {
         includeGroups "sra"
     }
 }

--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -83,6 +83,10 @@ public class Defaults {
      */
     public static final String EBI_REFERENCE_SERVICE_URL_MASK;
 
+    /**
+     * Boolean describing whether downloading of SRA native libraries is allowed,
+     * in case such native libraries are not found locally
+     */
     public static final boolean SRA_LIBRARIES_DOWNLOAD;
 
 

--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -83,6 +83,8 @@ public class Defaults {
      */
     public static final String EBI_REFERENCE_SERVICE_URL_MASK;
 
+    public static final boolean SRA_LIBRARIES_DOWNLOAD;
+
 
     static {
         CREATE_INDEX = getBooleanProperty("create_index", false);
@@ -108,6 +110,7 @@ public class Defaults {
         EBI_REFERENCE_SERVICE_URL_MASK = "http://www.ebi.ac.uk/ena/cram/md5/%s";
         CUSTOM_READER_FACTORY = getStringProperty("custom_reader", "");
         SAM_FLAG_FIELD_FORMAT = SamFlagField.valueOf(getStringProperty("sam_flag_field_format", SamFlagField.DECIMAL.name()));
+        SRA_LIBRARIES_DOWNLOAD = getBooleanProperty("sra_libraries_download", false);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SRAFileReader.java
+++ b/src/main/java/htsjdk/samtools/SRAFileReader.java
@@ -170,7 +170,9 @@ public class SRAFileReader extends SamReader.ReaderImplementation implements Sam
     }
 
     @Override
-    public void close() { }
+    public void close() {
+        run = null;
+    }
 
     @Override
     public ValidationStringency getValidationStringency() {

--- a/src/main/java/htsjdk/samtools/SRAIterator.java
+++ b/src/main/java/htsjdk/samtools/SRAIterator.java
@@ -197,6 +197,9 @@ public class SRAIterator implements SAMRecordIterator {
                 return true;
             }
 
+            if (alignmentIterator != null) {
+                alignmentIterator.close();
+            }
             alignmentIterator = null;
             unalignmentIterator = null;
             if (chunksIterator.hasNext()) {
@@ -230,7 +233,12 @@ public class SRAIterator implements SAMRecordIterator {
     public void remove() { throw new UnsupportedOperationException("Removal of records not implemented."); }
 
     @Override
-    public void close() { }
+    public void close() {
+        if (alignmentIterator != null) {
+            alignmentIterator.close();
+            alignmentIterator = null;
+        }
+    }
 
     @Override
     public SAMRecordIterator assertSorted(final SortOrder sortOrder) { throw new UnsupportedOperationException("assertSorted is not implemented."); }

--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -337,6 +337,10 @@ public abstract class SamReaderFactory {
         /** Attempts to detect whether the file is an SRA accessioned file. If SRA support is not available, returns false. */
         private boolean isSra(final File sourceFile) {
             try {
+                // if SRA fails to initialize (the most common reason is a failure to find/load native libraries),
+                // it will throw a subclass of java.lang.Error and here we only catch subclasses of java.lang.Exception
+                //
+                // Note: SRA initialization errors should not be ignored, but rather shown to user
                 return SRAAccession.isValid(sourceFile.getPath());
             } catch (final Exception e) {
                 return false;

--- a/src/main/java/htsjdk/samtools/sra/SRAAccession.java
+++ b/src/main/java/htsjdk/samtools/sra/SRAAccession.java
@@ -50,7 +50,6 @@ public class SRAAccession implements Serializable {
 
     private static boolean noLibraryDownload;
     private static boolean initTried = false;
-    private static ExceptionInInitializerError ngsInitError;
     private static String appVersionString = null;
     private final static String defaultAppVersionString = "[unknown software]";
     private final static String htsJdkVersionString = "HTSJDK-NGS";
@@ -88,6 +87,7 @@ public class SRAAccession implements Serializable {
      * @return ExceptionInInitializerError if initialization failed, null if initialization was successful
      */
     public static ExceptionInInitializerError checkIfInitialized() {
+        final ExceptionInInitializerError ngsInitError;
         if (!initTried) {
             log.debug("Initializing SRA module");
             ngsInitError = NGS.getInitializationError();
@@ -97,6 +97,8 @@ public class SRAAccession implements Serializable {
                 NGS.setAppVersionString(getFullVersionString());
             }
             initTried = true;
+        } else {
+            ngsInitError = NGS.getInitializationError();
         }
         return ngsInitError;
     }
@@ -130,12 +132,12 @@ public class SRAAccession implements Serializable {
 
         if (!looksLikeSRA) return false;
 
-        ExceptionInInitializerError initError = checkIfInitialized();
+        final ExceptionInInitializerError initError = checkIfInitialized();
         if (initError != null) {
             if (noLibraryDownload && initError instanceof LibraryLoadError) {
                 throw new LinkageError(
                         "Failed to load SRA native libraries and auto-download is disabled. " +
-                        "Please set property samjdk.sra_libraries_download=true to enable auto-download of native libraries",
+                        "Please re-run with JVM argument -Dsamjdk.sra_libraries_download=true to enable auto-download of native libraries",
                         initError
                 );
             } else {

--- a/src/test/java/htsjdk/samtools/sra/SRAReferenceTest.java
+++ b/src/test/java/htsjdk/samtools/sra/SRAReferenceTest.java
@@ -6,6 +6,13 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class SRAReferenceTest extends AbstractSRATest {
     @DataProvider(name = "testReference")
     private Object[][] createDataForReference() {
@@ -19,5 +26,70 @@ public class SRAReferenceTest extends AbstractSRATest {
         final ReferenceSequenceFile refSeqFile = new SRAIndexedSequenceFile(new SRAAccession(acc));
         final ReferenceSequence refSeq = refSeqFile.getSubsequenceAt(refContig, refStart, refStop);
         Assert.assertEquals(new String(refSeq.getBases()), refBases);
+    }
+
+    class TestReferenceMtData {
+        String refContig;
+        int refStart;
+        int refStop;
+        String refBases;
+
+        TestReferenceMtData(String refContig, int refStart, int refStop, String refBases) {
+            this.refContig = refContig;
+            this.refStart = refStart;
+            this.refStop = refStop;
+            this.refBases = refBases;
+        }
+
+        @Override
+        public String toString() {
+            return refContig + ":" + refStart + "-" + refStop + " = " + refBases;
+        }
+    }
+
+    @DataProvider(name = "testReferenceMt")
+    private Object[][] createDataForReferenceMt() {
+        return new Object[][] {
+                {
+                    "SRR353866", Arrays.asList(
+                        new TestReferenceMtData("AAAB01001871.1", 1, 50, "TGACGCGCATGAATGGATTAACGAGATTCCCTCTGTCCCTATCTACTATC"),
+                        new TestReferenceMtData("AAAB01001871.1", 901, 950, "ACCAAGCGTACGATTGTTCACCCTTTCAAGGGAACGTGAGCTGGGTTTAG"),
+                        new TestReferenceMtData("AAAB01008987.1", 1, 50, "TTTTGGACGATGTTTTTGGTGAACAGAAAACGAGCTCAATCATCCAGAGC"),
+                        new TestReferenceMtData("AAAB01008859.1", 1, 50, "CAAAACGATGCCACAGATCAGAAGTTAATTAACGCACATTCTCCACCCAC")
+                    )
+                },
+        };
+    }
+
+    @Test(dataProvider = "testReferenceMt")
+    public void testReferenceMt(String acc, List<TestReferenceMtData> parallelTests) throws Exception {
+        final ReferenceSequenceFile refSeqFile = new SRAIndexedSequenceFile(new SRAAccession(acc));
+        final long timeout = 1000L * 5; // just in case
+        final List<Thread> threads = new ArrayList<Thread>(parallelTests.size());
+        final Map<TestReferenceMtData, Exception> runErrors = Collections.synchronizedMap(new HashMap<TestReferenceMtData, Exception>());
+        for (final TestReferenceMtData testData: parallelTests) {
+            threads.add(new Thread() {
+                @Override
+                public void run() {
+                    try {
+                        final ReferenceSequence refSeq = refSeqFile.getSubsequenceAt(testData.refContig,
+                                testData.refStart, testData.refStop);
+                        Assert.assertEquals(new String(refSeq.getBases()), testData.refBases);
+                    } catch (final Exception e) {
+                        Assert.assertNull(runErrors.put(testData, e));
+                    }
+                }
+            });
+        }
+        for (final Thread thread: threads) {
+            thread.start();
+        }
+        for (final Thread thread: threads) {
+            thread.join(timeout);
+        }
+        for (final Map.Entry<TestReferenceMtData, Exception> result: runErrors.entrySet()) {
+            // Will fail only on the first, but a debugger will be able to see all the results.
+            Assert.fail("failed: " + result.getKey(), result.getValue());
+        }
     }
 }

--- a/src/test/java/htsjdk/samtools/sra/SRATest.java
+++ b/src/test/java/htsjdk/samtools/sra/SRATest.java
@@ -60,7 +60,8 @@ public class SRATest extends AbstractSRATest {
     @DataProvider(name = "testCounts")
     private Object[][] createDataForCounts() {
         return new Object[][] {
-            {"SRR2096940", 10591, 498}
+            {"SRR2096940", 10591, 498},
+            {"SRR000123", 0, 4583}
         };
     }
 


### PR DESCRIPTION
### Description

This PR implements optional SRA native libraries auto-download, as requested in #414
In case, when ngs-java fails to locate/load native libraries, we throw a subclass of java.lang.Error with details of what went wrong and a recommendation on how to fix the problem.

In ngs-java 1.2.4 we also improved version checking of native libraries before loading them and addressed issue #462 

We also fixed an issue with keeping references to SRA objects forever, which prevented them from being garbage collected and sometimes produced issues with reaching a limit of opened file handlers.

