### PR TITLE
Carried over "extends Comparable" from Histogram<K> to Bin<K>.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/Histogram.java
+++ b/src/main/java/htsjdk/samtools/util/Histogram.java
@@ -73,7 +73,7 @@ public final class Histogram<K extends Comparable> implements Serializable {
     }
 
     /** Represents a bin in the Histogram. */
-    public static class Bin<K> implements Serializable{
+    public static class Bin<K extends Comparable> implements Serializable {
         private static final long serialVersionUID = 1L;
         private final K id;
         private double value = 0;


### PR DESCRIPTION
### Description

Minor change to fix the fact that after making Bin a static inner class it's type parameter no longer had Comparable as a bound, which it did before because Histogram's type parameter was bounded.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)
