### PR TITLE
split async flags for read and write

### DIFF
--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -22,25 +22,20 @@ public class Defaults {
     /** Should MD5 files be created when writing out SAM and BAM files?  Default = false. */
     public static final boolean CREATE_MD5;
 
-    /** Should asynchronous I/O be used where supported throughout all of htsjdk (one thread per file).
-     *  Note: this option takes precedence over {@link #USE_ASYNC_IO_FOR_SAMTOOLS} and {@link #USE_ASYNC_IO_FOR_TRIBBLE}.
+    /** Should asynchronous read I/O be used where supported by the samtools package (one thread per file).
      *  Default = false.
      */
-    public static final boolean USE_ASYNC_IO;
+    public static final boolean USE_ASYNC_IO_READ_FOR_SAMTOOLS;
 
-    /** Should asynchronous I/O be used where supported by the samtools package (one thread per file).
-     *  Note: The {@link #USE_ASYNC_IO} option takes precedence over this option.
+    /** Should asynchronous write I/O be used where supported by the samtools package (one thread per file).
      *  Default = false.
      */
-    public static final boolean USE_ASYNC_IO_FOR_SAMTOOLS;
+    public static final boolean USE_ASYNC_IO_WRITE_FOR_SAMTOOLS;
 
-    /** Should asynchronous I/O be used where supported by the tribble package (one thread per file).
-     *  Note: performance may depend on the characteristics of the input file (eg number of samples in the VCF) and should be tested on a case-by-case basis.
-     *  In particular, asynchronous reading of VCF files with few samples is known to perform worse than synchronous reading.
-     *  Note: The {@link #USE_ASYNC_IO} option takes precedence over this option.
+    /** Should asynchronous write I/O be used where supported by the tribble package (one thread per file).
      *  Default = false.
      */
-    public static final boolean USE_ASYNC_IO_FOR_TRIBBLE;
+    public static final boolean USE_ASYNC_IO_WRITE_FOR_TRIBBLE;
 
     /** Compresion level to be used for writing BAM and other block-compressed outputs.  Default = 5. */
     public static final int COMPRESSION_LEVEL;
@@ -93,15 +88,9 @@ public class Defaults {
     static {
         CREATE_INDEX = getBooleanProperty("create_index", false);
         CREATE_MD5 = getBooleanProperty("create_md5", false);
-        if (hasProperty("use_async_io")){
-            USE_ASYNC_IO = getBooleanProperty("use_async_io", false);
-            USE_ASYNC_IO_FOR_SAMTOOLS = USE_ASYNC_IO;
-            USE_ASYNC_IO_FOR_TRIBBLE = USE_ASYNC_IO;
-        } else {
-            USE_ASYNC_IO = false;
-            USE_ASYNC_IO_FOR_SAMTOOLS = getBooleanProperty("use_async_io_samtools", false);
-            USE_ASYNC_IO_FOR_TRIBBLE = getBooleanProperty("use_async_io_tribble", false);
-        }
+        USE_ASYNC_IO_READ_FOR_SAMTOOLS = getBooleanProperty("use_async_io_read_samtools", false);
+        USE_ASYNC_IO_WRITE_FOR_SAMTOOLS = getBooleanProperty("use_async_io_write_samtools", false);
+        USE_ASYNC_IO_WRITE_FOR_TRIBBLE = getBooleanProperty("use_async_io_write_tribble", false);
         COMPRESSION_LEVEL = getIntProperty("compression_level", 5);
         BUFFER_SIZE = getIntProperty("buffer_size", 1024 * 128);
         if (BUFFER_SIZE == 0) {
@@ -126,9 +115,9 @@ public class Defaults {
         final SortedMap<String, Object> result = new TreeMap<>();
         result.put("CREATE_INDEX", CREATE_INDEX);
         result.put("CREATE_MD5", CREATE_MD5);
-        result.put("USE_ASYNC_IO", USE_ASYNC_IO);
-        result.put("USE_ASYNC_IO_FOR_SAMTOOLS", USE_ASYNC_IO_FOR_SAMTOOLS);
-        result.put("USE_ASYNC_IO_FOR_TRIBBLE", USE_ASYNC_IO_FOR_TRIBBLE);
+        result.put("USE_ASYNC_IO_READ_FOR_SAMTOOLS", USE_ASYNC_IO_READ_FOR_SAMTOOLS);
+        result.put("USE_ASYNC_IO_WRITE_FOR_SAMTOOLS", USE_ASYNC_IO_WRITE_FOR_SAMTOOLS);
+        result.put("USE_ASYNC_IO_WRITE_FOR_TRIBBLE", USE_ASYNC_IO_WRITE_FOR_TRIBBLE);
         result.put("COMPRESSION_LEVEL", COMPRESSION_LEVEL);
         result.put("BUFFER_SIZE", BUFFER_SIZE);
         result.put("NON_ZERO_BUFFER_SIZE", NON_ZERO_BUFFER_SIZE);
@@ -176,7 +165,7 @@ public class Defaults {
         return Integer.parseInt(value);
     }
 
-    /** Gets a File system property, prefixed with "samdjk." using the default if the property does not exist. */
+    /** Gets a File system property, prefixed with "samjdk." using the default if the property does not exist. */
     private static File getFileProperty(final String name, final String def) {
         final String value = getStringProperty(name, def);
         // TODO: assert that it is readable

--- a/src/main/java/htsjdk/samtools/SAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileReader.java
@@ -74,7 +74,7 @@ public class SAMFileReader implements SamReader, SamReader.Indexing {
     private BAMIndex mIndex = null;
     private SAMRecordFactory samRecordFactory = new DefaultSAMRecordFactory();
     private ReaderImplementation mReader = null;
-    private boolean useAsyncIO = Defaults.USE_ASYNC_IO_FOR_SAMTOOLS;
+    private boolean useAsyncIO = Defaults.USE_ASYNC_IO_READ_FOR_SAMTOOLS;
 
     private File samFile = null;
 

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -46,7 +46,7 @@ public class SAMFileWriterFactory implements Cloneable {
     private boolean createIndex = defaultCreateIndexWhileWriting;
     private static boolean defaultCreateMd5File = Defaults.CREATE_MD5;
     private boolean createMd5File = defaultCreateMd5File;
-    private boolean useAsyncIo = Defaults.USE_ASYNC_IO_FOR_SAMTOOLS;
+    private boolean useAsyncIo = Defaults.USE_ASYNC_IO_WRITE_FOR_SAMTOOLS;
     private int asyncOutputBufferSize = AsyncSAMFileWriter.DEFAULT_QUEUE_SIZE;
     private int bufferSize = Defaults.BUFFER_SIZE;
     private File tmpDir;

--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -125,7 +125,7 @@ public abstract class SamReaderFactory {
         private final static Log LOG = Log.getInstance(SamReaderFactory.class);
         private final EnumSet<Option> enabledOptions;
         private ValidationStringency validationStringency;
-        private boolean asynchronousIO = Defaults.USE_ASYNC_IO_FOR_SAMTOOLS;
+        private boolean asynchronousIO = Defaults.USE_ASYNC_IO_READ_FOR_SAMTOOLS;
         private SAMRecordFactory samRecordFactory;
         private CustomReaderFactory customReaderFactory;
         private CRAMReferenceSource referenceSource;

--- a/src/main/java/htsjdk/samtools/fastq/FastqWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqWriterFactory.java
@@ -10,7 +10,7 @@ import java.io.File;
  * @author Tim Fennell
  */
 public class FastqWriterFactory {
-    boolean useAsyncIo = Defaults.USE_ASYNC_IO_FOR_SAMTOOLS;
+    boolean useAsyncIo = Defaults.USE_ASYNC_IO_WRITE_FOR_SAMTOOLS;
     boolean createMd5  = Defaults.CREATE_MD5;
 
     /** Sets whether or not to use async io (i.e. a dedicated thread per writer. */

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -131,7 +131,7 @@ public class VariantContextWriterBuilder {
      * Default constructor.  Adds <code>USE_ASYNC_IO</code> to the Options if it is present in Defaults.
      */
     public VariantContextWriterBuilder() {
-        if (Defaults.USE_ASYNC_IO_FOR_TRIBBLE) {
+        if (Defaults.USE_ASYNC_IO_WRITE_FOR_TRIBBLE) {
             options.add(Options.USE_ASYNC_IO);
         }
     }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterFactory.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterFactory.java
@@ -56,7 +56,7 @@ public class VariantContextWriterFactory {
     public static final EnumSet<Options> NO_OPTIONS = EnumSet.noneOf(Options.class);
 
     static {
-        if (Defaults.USE_ASYNC_IO_FOR_TRIBBLE) {
+        if (Defaults.USE_ASYNC_IO_WRITE_FOR_TRIBBLE) {
             DEFAULT_OPTIONS.add(Options.USE_ASYNC_IO);
         }
     }

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -26,21 +26,11 @@ package htsjdk.samtools;
 import htsjdk.samtools.cram.build.CramIO;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.util.IOUtil;
-import htsjdk.variant.variantcontext.writer.AsyncVariantContextWriter;
-import htsjdk.variant.variantcontext.writer.Options;
-import htsjdk.variant.variantcontext.writer.VariantContextWriter;
-import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 
 public class SAMFileWriterFactoryTest {
 
@@ -306,7 +296,7 @@ public class SAMFileWriterFactoryTest {
         final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
 
         SAMFileWriter writer = builder.makeWriter(header, false, outputFile, referenceFile);
-        Assert.assertEquals(writer instanceof AsyncSAMFileWriter, Defaults.USE_ASYNC_IO_FOR_SAMTOOLS, "testAsync default");
+        Assert.assertEquals(writer instanceof AsyncSAMFileWriter, Defaults.USE_ASYNC_IO_WRITE_FOR_SAMTOOLS, "testAsync default");
 
         writer = builder.setUseAsyncIo(true).makeWriter(header, false, outputFile, referenceFile);
         Assert.assertTrue(writer instanceof AsyncSAMFileWriter, "testAsync option=set");

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -209,7 +209,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
                 .setOutputFile(vcf);
 
         VariantContextWriter writer = builder.build();
-        Assert.assertEquals(writer instanceof AsyncVariantContextWriter, Defaults.USE_ASYNC_IO_FOR_TRIBBLE, "testAsync default");
+        Assert.assertEquals(writer instanceof AsyncVariantContextWriter, Defaults.USE_ASYNC_IO_WRITE_FOR_TRIBBLE, "testAsync default");
 
         writer = builder.setOption(Options.USE_ASYNC_IO).build();
         Assert.assertTrue(writer instanceof AsyncVariantContextWriter, "testAsync option=set");


### PR DESCRIPTION
### Description

This PR splits the flags that control the async behavior to read/write to give more fine-grained control to clients. This will be important when hooking up #576 and make multi-threaded reading an opt-in option.

Not backward compatible because I removed the master option `USE_ASYNC_IO` - having that option conflicts with the opt-in requirement. I think an uber  `USE_ASYNC_IO` is just too broad. Note that there's no `USE_ASYNC_IO_READ_FOR_TRIBBLE` because we have no asynch tribble readers right now.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

@droazen can you review?
