### PR TITLE
Removed PollableTreeSet in SortingCollection as it was no longer necessary.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -393,10 +393,10 @@ public class SortingCollection<T> implements Iterable<T> {
      * location in the PriorityQueue
      */
     class MergingIterator implements CloseableIterator<T> {
-        private final PollableTreeSet<PeekFileRecordIterator> queue;
+        private final TreeSet<PeekFileRecordIterator> queue;
 
         MergingIterator() {
-            this.queue = new PollableTreeSet<PeekFileRecordIterator>(new PeekFileRecordIteratorComparator());
+            this.queue = new TreeSet<PeekFileRecordIterator>(new PeekFileRecordIteratorComparator());
             int n = 0;
             for (final File f : SortingCollection.this.files) {
                 final FileRecordIterator it = new FileRecordIterator(f);
@@ -418,7 +418,7 @@ public class SortingCollection<T> implements Iterable<T> {
                 throw new NoSuchElementException();
             }
 
-            final PeekFileRecordIterator fileIterator = queue.poll();
+            final PeekFileRecordIterator fileIterator = queue.pollFirst();
             final T ret = fileIterator.next();
             if (fileIterator.hasNext()) {
                 this.queue.add(fileIterator);
@@ -436,7 +436,7 @@ public class SortingCollection<T> implements Iterable<T> {
 
         public void close() {
             while (!this.queue.isEmpty()) {
-                final PeekFileRecordIterator it = this.queue.poll();
+                final PeekFileRecordIterator it = this.queue.pollFirst();
                 ((CloseableIterator<T>)it.getUnderlyingIterator()).close();
             }
         }
@@ -509,24 +509,6 @@ public class SortingCollection<T> implements Iterable<T> {
             final int result = comparator.compare(lhs.peek(), rhs.peek());
             if (result == 0) return lhs.n - rhs.n;
             else return result;
-        }
-    }
-
-    /** Little class that provides the Java 1.5 TreeSet with a poll() method */
-    static class PollableTreeSet<T> extends TreeSet<T> {
-        PollableTreeSet(final Comparator<? super T> comparator) {
-            super(comparator);
-        }
-
-        public T poll() {
-            if (isEmpty()) {
-                return null;
-            }
-            else {
-                final T t = first();
-                remove(t);
-                return t;
-            }
         }
     }
 }


### PR DESCRIPTION
### Description

Replaced with direct usage of TreeSet.pollFirst(). One advantage (other than removing unneeded code) is that this now only has to search the tree once, instead of twice for poll() then remove().

This also resolved a bug I was experiencing where the `remove()` call was getting a NoSuchElementException that I couldn't figure out.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
