### PR TITLE
Throw exception on MD5 mismatch when constructing SAMRecords from CRA…

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -177,10 +177,12 @@ public class CRAMIterator implements SAMRecordIterator {
             final Slice slice = container.slices[i];
             if (slice.sequenceId < 0)
                 continue;
-            if (validationStringency != ValidationStringency.SILENT && !slice.validateRefMD5(refs)) {
-                log.error(String
+            if (!slice.validateRefMD5(refs)) {
+                final String msg = String
                         .format("Reference sequence MD5 mismatch for slice: seq id %d, start %d, span %d, expected MD5 %s", slice.sequenceId,
-                                slice.alignmentStart, slice.alignmentSpan, String.format("%032x", new BigInteger(1, slice.refMD5))));
+                                slice.alignmentStart, slice.alignmentSpan, String.format("%032x", new BigInteger(1, slice.refMD5)));
+                log.error(msg);
+                throw new CRAMException(msg);
             }
         }
 

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -181,7 +181,6 @@ public class CRAMIterator implements SAMRecordIterator {
                 final String msg = String
                         .format("Reference sequence MD5 mismatch for slice: seq id %d, start %d, span %d, expected MD5 %s", slice.sequenceId,
                                 slice.alignmentStart, slice.alignmentSpan, String.format("%032x", new BigInteger(1, slice.refMD5)));
-                log.error(msg);
                 throw new CRAMException(msg);
             }
         }


### PR DESCRIPTION
### Description

 If the sequences don't match there is a 100% certainty the reconstructed records will have an incorrect read sequence.   This is a very serious error, qualitatively a different level  than the typical "validation" errors that ValidationStringency settings control.