### PR TITLE
Fixed bug where SamPairUtil.setMateInfo() would omit the MQ tag if on…

### DIFF
--- a/src/main/java/htsjdk/samtools/SamPairUtil.java
+++ b/src/main/java/htsjdk/samtools/SamPairUtil.java
@@ -244,7 +244,7 @@ public class SamPairUtil {
             mapped.setMateAlignmentStart(unmapped.getAlignmentStart());
             mapped.setMateNegativeStrandFlag(unmapped.getReadNegativeStrandFlag());
             mapped.setMateUnmappedFlag(true);
-            // For the mapped read, set it's mateCigar to null, since the other read must be unmapped
+            mapped.setAttribute(SAMTag.MQ.name(), null);
             mapped.setAttribute(SAMTag.MC.name(), null);
             mapped.setInferredInsertSize(0);
 
@@ -252,7 +252,8 @@ public class SamPairUtil {
             unmapped.setMateAlignmentStart(mapped.getAlignmentStart());
             unmapped.setMateNegativeStrandFlag(mapped.getReadNegativeStrandFlag());
             unmapped.setMateUnmappedFlag(false);
-            // For the unmapped read, set it's mateCigar to the mate's Cigar, since the mate must be mapped
+            unmapped.setAttribute(SAMTag.MQ.name(), mapped.getMappingQuality());
+            // For the unmapped read, set mateCigar to the mate's Cigar, since the mate must be mapped
             if (setMateCigar) unmapped.setAttribute(SAMTag.MC.name(), mapped.getCigarString());
             else unmapped.setAttribute(SAMTag.MC.name(), null);
             unmapped.setInferredInsertSize(0);


### PR DESCRIPTION
### Description

Fix a small but annoying bug that was causing unmapped reads with mapped mates to get most mate information set _except_ `MQ` which is set in all other cases.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


…e read was mapped and the other unmapped.