### PR TITLE
Make unzipBlock in BlockGunzipper public.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/BlockGunzipper.java
+++ b/src/main/java/htsjdk/samtools/util/BlockGunzipper.java
@@ -58,7 +58,7 @@ public class BlockGunzipper {
      * @param compressedBlock compressed data starting at offset 0
      * @param compressedLength size of compressed data, possibly less than the size of the buffer.
      */
-    void unzipBlock(byte[] uncompressedBlock, byte[] compressedBlock, int compressedLength) {
+    public void unzipBlock(byte[] uncompressedBlock, byte[] compressedBlock, int compressedLength) {
         try {
             ByteBuffer byteBuffer = ByteBuffer.wrap(compressedBlock, 0, compressedLength);
             byteBuffer.order(ByteOrder.LITTLE_ENDIAN);


### PR DESCRIPTION
This is a simple change to expose the `unzipBlock` method, and is useful for folks that are de-compressing gzip blocks, for example specialty tools built for BAM files.

@tfenne @akiezun care to take a look?