### PR TITLE
made LazyInitializer a @FunctionalIterface to enable java8 sugar.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/Lazy.java
+++ b/src/main/java/htsjdk/samtools/util/Lazy.java
@@ -28,6 +28,7 @@ public class Lazy<T> {
     }
 
     /** Describes how to build the instance of the lazy object. */
+    @FunctionalInterface
     public interface LazyInitializer<T> {
         /** Returns the desired object instance. */
         T make();


### PR DESCRIPTION
### Description
The LazyInitilizer class can use java8 sugar but only if it's annotated correctly. This one-line PR makes that change.
### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


