### PR TITLE
fix UnsupportedOperationException in VariantContextBuiilder and handl…

### DIFF
--- a/src/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/java/htsjdk/variant/variantcontext/Genotype.java
@@ -556,6 +556,8 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
             return Collections.EMPTY_LIST;
         } else if (key.equals(VCFConstants.DEPTH_KEY)) {
             return getDP();
+        } else if (key.equals(VCFConstants.GENOTYPE_FILTER_KEY)) {
+            return getFilters();
         } else {
             return getExtendedAttribute(key);
         }
@@ -572,6 +574,8 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
             return hasPL();
         } else if (key.equals(VCFConstants.DEPTH_KEY)) {
             return hasDP();
+        } else if (key.equals(VCFConstants.GENOTYPE_FILTER_KEY)) {
+            return true;  //always available
         } else {
             return hasExtendedAttribute(key);
         }

--- a/src/java/htsjdk/variant/variantcontext/VariantContextBuilder.java
+++ b/src/java/htsjdk/variant/variantcontext/VariantContextBuilder.java
@@ -191,10 +191,10 @@ public class VariantContextBuilder {
      */
     public VariantContextBuilder attributes(final Map<String, Object> attributes) {
         if (attributes != null) {
-            this.attributes = attributes;
+            this.attributes = new HashMap<>(attributes);
         }
         else {
-            this.attributes = new HashMap<String, Object>();
+            this.attributes = new HashMap<>();
         }
 
         this.attributesCanBeModified = true;


### PR DESCRIPTION
### Description

This PR has two fixes:

1) I found an issue when running picard tool's LiftoverVcf.  It can produce this stack:

Exception in thread "main" java.lang.UnsupportedOperationException
at java.util.Collections$UnmodifiableMap.put(Collections.java:1457)
at htsjdk.variant.variantcontext.VariantContextBuilder.attribute(VariantContextBuilder.java:212)
at picard.vcf.LiftoverVcf.doWork(LiftoverVcf.java:249)
at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:209)
at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:95)
at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:105)

Basically you have code that called VariantContextBuilder.attributes() and passed an unmodifiable map.  This map is stored directly into VariantContextBuilder.  Later code called VariantContextBuilder.attribute(), which tries to modify this map.  The proposed change is to clone the incoming map in VariantContextBuilder.attributes(), so we know it will be modifiable.

2) A Genotype always has filters.  If there is no non-PASS filters, it's PASS.  Genotype.getAnyAttribute() currently will never return a value for "FT", which I dont think is accurate.  This also means you cant ue GATK's JEXL select/filtering based on the genotype's filters.  There is a minor change to Genotype to support this.


### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


…e filters in Genotype.getAnyAttribute()