### PR TITLE
Genotype attributes

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Genotype.java
@@ -528,7 +528,7 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
     }
 
     /**
-     * A totally generic getter, that allows you to specific keys that correspond
+     * A totally generic getter, that allows you to get specific keys that correspond
      * to even inline values (GQ, for example).  Can be very expensive.  Additionally,
      * all <code>int[]</code> are converted inline into <code>List&lt;Integer&gt;</code> for convenience.
      *
@@ -556,6 +556,8 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
             return Collections.EMPTY_LIST;
         } else if (key.equals(VCFConstants.DEPTH_KEY)) {
             return getDP();
+        } else if (key.equals(VCFConstants.GENOTYPE_FILTER_KEY)) {
+            return getFilters();
         } else {
             return getExtendedAttribute(key);
         }
@@ -572,6 +574,8 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
             return hasPL();
         } else if (key.equals(VCFConstants.DEPTH_KEY)) {
             return hasDP();
+        } else if (key.equals(VCFConstants.GENOTYPE_FILTER_KEY)) {
+            return true;  //always available
         } else {
             return hasExtendedAttribute(key);
         }

--- a/src/test/java/htsjdk/variant/variantcontext/GenotypeUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/GenotypeUnitTest.java
@@ -30,6 +30,7 @@ package htsjdk.variant.variantcontext;
 
 
 import htsjdk.variant.VariantBaseTest;
+import htsjdk.variant.vcf.VCFConstants;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -63,6 +64,9 @@ public class GenotypeUnitTest extends VariantBaseTest {
         Assert.assertEquals(makeGB().filters("x", "y", "z").make().getFilters(), "x;y;z", "Multiple filter field values should be joined with ;");
         Assert.assertTrue(makeGB().filters("x", "y", "z").make().isFiltered(), "Multiple filter values should be filtered");
         Assert.assertEquals(makeGB().filter("x;y;z").make().getFilters(), "x;y;z", "Multiple filter field values should be joined with ;");
+        Assert.assertEquals(makeGB().filter("x;y;z").make().getAnyAttribute(VCFConstants.GENOTYPE_FILTER_KEY), "x;y;z", "getAnyAttribute(GENOTYPE_FILTER_KEY) should return the filter");
+        Assert.assertTrue(makeGB().filter("x;y;z").make().hasAnyAttribute(VCFConstants.GENOTYPE_FILTER_KEY), "hasAnyAttribute(GENOTYPE_FILTER_KEY) should return true");
+        Assert.assertTrue(makeGB().make().hasAnyAttribute(VCFConstants.GENOTYPE_FILTER_KEY), "hasAnyAttribute(GENOTYPE_FILTER_KEY) should return true");
         Assert.assertFalse(makeGB().filter("").make().isFiltered(), "empty filters should count as unfiltered");
         Assert.assertEquals(makeGB().filter("").make().getFilters(), null, "empty filter string should result in null filters");
     }


### PR DESCRIPTION
### Description

A Genotype always has filters. If there are no non-PASS filters, it's PASS. Genotype.getAnyAttribute() currently will never return a value for "FT", which I dont think is the right behavior.  This also means you cant use GATK's JEXL select/filtering based on the genotype's filters. This is a minor change to Genotype to support this.  It includes a simple unit test.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


…ibute