### PR TITLE
FeatureCodec.getTabixFormat() to encapsulate tabix formatting

### DIFF
--- a/src/main/java/htsjdk/tribble/AbstractFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureCodec.java
@@ -23,6 +23,8 @@
  */
 package htsjdk.tribble;
 
+import htsjdk.tribble.index.tabix.TabixFormat;
+
 import java.io.IOException;
 
 /**
@@ -46,5 +48,12 @@ public abstract class AbstractFeatureCodec<FEATURE_TYPE extends Feature, SOURCE>
     @Override
     public Class<FEATURE_TYPE> getFeatureType() {
         return myClass;
+    }
+
+    /**
+     * Default implementation throws an exception
+     */
+    public TabixFormat getTabixFormat() {
+        throw new TribbleException(this.getClass().getSimpleName() + "does not have defined tabix format");
     }
 }

--- a/src/main/java/htsjdk/tribble/AbstractFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureCodec.java
@@ -50,10 +50,4 @@ public abstract class AbstractFeatureCodec<FEATURE_TYPE extends Feature, SOURCE>
         return myClass;
     }
 
-    /**
-     * Default implementation throws an exception
-     */
-    public TabixFormat getTabixFormat() {
-        throw new TribbleException(this.getClass().getSimpleName() + "does not have defined tabix format");
-    }
 }

--- a/src/main/java/htsjdk/tribble/AbstractFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureCodec.java
@@ -23,8 +23,6 @@
  */
 package htsjdk.tribble;
 
-import htsjdk.tribble.index.tabix.TabixFormat;
-
 import java.io.IOException;
 
 /**
@@ -49,5 +47,4 @@ public abstract class AbstractFeatureCodec<FEATURE_TYPE extends Feature, SOURCE>
     public Class<FEATURE_TYPE> getFeatureType() {
         return myClass;
     }
-
 }

--- a/src/main/java/htsjdk/tribble/BinaryFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/BinaryFeatureCodec.java
@@ -49,5 +49,4 @@ abstract public class BinaryFeatureCodec<T extends Feature> implements FeatureCo
     public final TabixFormat getTabixFormat() {
         throw new TribbleException("Binary codecs does not support tabix");
     }
-
 }

--- a/src/main/java/htsjdk/tribble/BinaryFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/BinaryFeatureCodec.java
@@ -3,6 +3,7 @@ package htsjdk.tribble;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.PositionalBufferedStream;
 
 import java.io.IOException;
@@ -40,4 +41,13 @@ abstract public class BinaryFeatureCodec<T extends Feature> implements FeatureCo
             throw new RuntimeIOException("Failure reading from stream.", e);
         }
     }
+
+    /**
+     * Marked as final because binary features could not be tabix indexed
+     */
+    @Override
+    public final TabixFormat getTabixFormat() {
+        throw new TribbleException("Binary codecs does not support tabix");
+    }
+
 }

--- a/src/main/java/htsjdk/tribble/FeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/FeatureCodec.java
@@ -122,7 +122,7 @@ public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
     public boolean canDecode(final String path);
 
     /**
-     * Define the tabix format for the feature, used for indexing.
+     * Define the tabix format for the feature, used for indexing. Default implementation throws an exception.
      *
      * Note that only {@link AsciiFeatureCodec} could read tabix files as defined in
      * {@link AbstractFeatureReader#getFeatureReader(String, String, FeatureCodec, boolean)}
@@ -130,5 +130,7 @@ public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
      * @return the format to use with tabix
      * @throws TribbleException if the format is not defined
      */
-    public TabixFormat getTabixFormat();
+    default public TabixFormat getTabixFormat() {
+        throw new TribbleException(this.getClass().getSimpleName() + "does not have defined tabix format");
+    }
 }

--- a/src/main/java/htsjdk/tribble/FeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/FeatureCodec.java
@@ -19,6 +19,7 @@
 package htsjdk.tribble;
 
 import htsjdk.samtools.util.LocationAware;
+import htsjdk.tribble.index.tabix.TabixFormat;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -119,4 +120,15 @@ public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
      * @return true if potentialInput can be parsed, false otherwise
      */
     public boolean canDecode(final String path);
+
+    /**
+     * Define the tabix format for the feature, used for indexing.
+     *
+     * Note that only {@link AsciiFeatureCodec} could read tabix files as defined in
+     * {@link AbstractFeatureReader#getFeatureReader(String, String, FeatureCodec, boolean)}
+     *
+     * @return the format to use with tabix
+     * @throws TribbleException if the format is not defined
+     */
+    public TabixFormat getTabixFormat();
 }

--- a/src/main/java/htsjdk/tribble/bed/BEDCodec.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDCodec.java
@@ -25,6 +25,7 @@ package htsjdk.tribble.bed;
 
 import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.annotation.Strand;
+import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.tribble.util.ParsingUtils;
 
@@ -222,6 +223,11 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
         public int value() {
             return this.start;
         }
+    }
+
+    @Override
+    public TabixFormat getTabixFormat() {
+        return TabixFormat.BED;
     }
 
 }

--- a/src/main/java/htsjdk/tribble/bed/BEDCodec.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDCodec.java
@@ -229,5 +229,4 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
     public TabixFormat getTabixFormat() {
         return TabixFormat.BED;
     }
-
 }

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -264,7 +264,7 @@ public class IndexFactory {
     }
 
     /**
-     * Create a index of the specified type with default binning parameters
+     * Create an index of the specified type with default binning parameters
      *
      * @param inputFile the input file to load features from
      * @param codec     the codec to use for decoding records
@@ -334,7 +334,7 @@ public class IndexFactory {
 
     /**
      * @param inputFile The file to be indexed.
-     * @param codec Mechanism for reading inputFile.
+     * @param codec the codec to use for decoding records
      * @param sequenceDictionary May be null, but if present may reduce memory footprint for index creation.  Features
      *                           in inputFile must be in the order defined by sequenceDictionary, if it is present.
      *

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -269,7 +269,7 @@ public class IndexFactory {
      * @param inputFile the input file to load features from
      * @param codec     the codec to use for decoding records
      * @param type      the type of index to create
-     * @param
+     * @param sequenceDictionary May be null, but if present may reduce memory footprint for tabix index creation
      */
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createIndex(final File inputFile,
                                                                                 final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,

--- a/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -30,6 +30,7 @@ import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.NameAwareCodec;
 import htsjdk.tribble.TribbleException;
+import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.utils.GeneralUtils;
 import htsjdk.variant.variantcontext.Allele;
@@ -781,5 +782,10 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
 
     protected static void generateException(String message, int lineNo) {
         throw new TribbleException(String.format("The provided VCF file is malformed at approximately line number %d: %s", lineNo, message));
+    }
+
+    @Override
+    public TabixFormat getTabixFormat() {
+        return TabixFormat.VCF;
     }
 }

--- a/src/test/java/htsjdk/tribble/BinaryFeaturesTest.java
+++ b/src/test/java/htsjdk/tribble/BinaryFeaturesTest.java
@@ -54,4 +54,9 @@ public class BinaryFeaturesTest {
         originalReader.close();
         binaryReader.close();
     }
+
+    @Test(expectedExceptions = TribbleException.class)
+    public void testGetTabixFormatThrowsException() {
+        new ExampleBinaryCodec().getTabixFormat();
+    }
 }

--- a/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
@@ -31,6 +31,7 @@ import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.bed.FullBEDFeature.Exon;
 import htsjdk.tribble.index.IndexFactory;
 import htsjdk.tribble.index.linear.LinearIndex;
+import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.util.LittleEndianOutputStream;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -220,5 +221,10 @@ public class BEDCodecTest {
             }
         }
 
+    }
+
+    @Test
+    public void testGetTabixFormat() {
+        Assert.assertEquals(new BEDCodec().getTabixFormat(), TabixFormat.BED);
     }
 }

--- a/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
@@ -220,7 +220,6 @@ public class BEDCodecTest {
                 stream.close();
             }
         }
-
     }
 
     @Test

--- a/src/test/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
+++ b/src/test/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
@@ -57,5 +57,4 @@ public class AbstractVCFCodecTest extends VariantBaseTest {
 		Assert.assertEquals(new VCFCodec().getTabixFormat(), TabixFormat.VCF);
 		Assert.assertEquals(new VCF3Codec().getTabixFormat(), TabixFormat.VCF);
 	}
-
 }

--- a/src/test/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
+++ b/src/test/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
@@ -1,6 +1,7 @@
 package htsjdk.variant.vcf;
 
 import htsjdk.tribble.TribbleException;
+import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -14,6 +15,7 @@ import java.util.List;
 
 
 public class AbstractVCFCodecTest extends VariantBaseTest {
+
 	@Test
 	public void shouldPreserveSymbolicAlleleCase() {
 		VCFFileReader reader = new VCFFileReader(new File(VariantBaseTest.variantTestDataRoot + "breakpoint.vcf"), false);
@@ -48,6 +50,12 @@ public class AbstractVCFCodecTest extends VariantBaseTest {
 	@Test(dataProvider = "thingsToTryToDecode")
 	public void testCanDecodeFile(String potentialInput, boolean canDecode) {
 		Assert.assertEquals(AbstractVCFCodec.canDecodeFile(potentialInput, VCFCodec.VCF4_MAGIC_HEADER), canDecode);
+	}
+
+	@Test
+	public void testGetTabixFormat() {
+		Assert.assertEquals(new VCFCodec().getTabixFormat(), TabixFormat.VCF);
+		Assert.assertEquals(new VCF3Codec().getTabixFormat(), TabixFormat.VCF);
 	}
 
 }


### PR DESCRIPTION
### Description

Current implementation of tabix indexing requires a `TabixFormat`, which should be defined by the API user outside the codecs except for the static instances inside the class (VCF and BED). Due to this, `IndexFactory` requires always to provide the `TabixFormat` when creating a new index, not allowing the creation of indexes with a common interface.

Nevertheless, when developers implements a new `FeatureCodec`, they know how the format for tabix is specified (if it is possible), and others could use it without the need to implement it by themselves.

Here I implemented a new default method for `FeatureCodec` for retrieve the `TabixFormat` associated, and added some static methods to `IndexFactory` to use it. This could be useful in GATK4 tool `IndexFeatureFile`, which only supports tabix indexing for VCF files.

It does not break compatibility because the new method have a default implementation, so other classes don't have to implement it.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
