### PR TITLE
updating urls in tests to point to new locations

### DIFF
--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -29,6 +29,11 @@ import java.io.*;
 
 public class TestUtil {
 
+    /**
+     * Base url where all test files for http tests are found
+     */
+    public static final String BASE_URL_FOR_HTTP_TESTS = "https://personal.broadinstitute.org/picard/testdata/";
+
     public static File getTempDirectory(final String prefix, final String suffix) {
         final File tempDirectory;
         try {

--- a/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
+++ b/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
@@ -24,6 +24,7 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.TestUtil;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -42,7 +43,7 @@ import static org.testng.Assert.*;
 public class BAMRemoteFileTest {
     private final File BAM_INDEX_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai");
     private final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
-    private final String BAM_URL_STRING = "http://www.broadinstitute.org/~picard/testdata/index_test.bam";
+    private final String BAM_URL_STRING = TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam";
     private final URL bamURL;
 
     private final boolean mVerbose = false;

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -5,12 +5,7 @@ import htsjdk.samtools.seekablestream.ISeekableStreamFactory;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableHTTPStream;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
-import htsjdk.samtools.util.Iterables;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.RuntimeIOException;
-import htsjdk.samtools.util.StopWatch;
-
-import java.nio.file.Path;
+import htsjdk.samtools.util.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -21,9 +16,9 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -159,8 +154,8 @@ public class SamReaderFactoryTest {
 
     {
         try {
-            bamUrl = new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam");
-            bamIndexUrl = new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam.bai");
+            bamUrl = new URL(TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam");
+            bamIndexUrl = new URL(TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam.bai");
         } catch (final MalformedURLException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamFactoryTest.java
@@ -1,5 +1,6 @@
 package htsjdk.samtools.seekablestream;
 
+import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,10 +30,10 @@ public class SeekableStreamFactoryTest {
                         new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath() },
                 { new URL("file://" + new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath()).toExternalForm(),
                         new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath() },
-                { new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam").toExternalForm(),
-                        new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam").toExternalForm() },
-                { new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam.bai").toExternalForm(),
-                       new URL("http://www.broadinstitute.org/~picard/testdata/index_test.bam.bai").toExternalForm() }
+                { new URL(TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam").toExternalForm(),
+                        new URL(TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam").toExternalForm() },
+                { new URL(TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam.bai").toExternalForm(),
+                       new URL(TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam.bai").toExternalForm() }
         };
     }
 

--- a/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
@@ -1,5 +1,6 @@
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.TestUtil;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.readers.LineIterator;
@@ -23,7 +24,7 @@ import static org.testng.Assert.*;
  */
 public class AbstractFeatureReaderTest {
 
-    final static String HTTP_INDEXED_VCF_PATH = "http://www.broadinstitute.org/~picard/testdata/ex2.vcf";
+    final static String HTTP_INDEXED_VCF_PATH = TestUtil.BASE_URL_FOR_HTTP_TESTS + "ex2.vcf";
     final static String LOCAL_MIRROR_HTTP_INDEXED_VCF_PATH = VariantBaseTest.variantTestDataRoot + "ex2.vcf";
 
     /**

--- a/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
@@ -1,6 +1,7 @@
 package htsjdk.tribble.readers;
 
 
+import htsjdk.samtools.util.TestUtil;
 import htsjdk.tribble.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -142,7 +143,7 @@ public class TabixReaderTest {
      */
     @Test
     public void testRemoteQuery() throws IOException {
-        String tabixFile = "http://www.broadinstitute.org/~picard/testdata/igvdata/tabix/trioDup.vcf.gz";
+        String tabixFile = TestUtil.BASE_URL_FOR_HTTP_TESTS +"igvdata/tabix/trioDup.vcf.gz";
 
         TabixReader tabixReader = new TabixReader(tabixFile);
 


### PR DESCRIPTION
### Description
Tests are breaking on master because of changed broad made to our webhosting
### Checklist

- [x] Code compiles correctly  
~~- [ ] New tests covering changes and new functionality~~  
- [x] All tests passing  
~~- [ ] Extended the README / documentation, if necessary~~  
~~- [ ] Is not backward compatible (breaks binary or source compatibility)~~  


broad changed its website's urls from http://www.broadinstitute.org/~picard -> https://personal.broadinstitute.org/picard
there are redirects in place that work in most browsers, but our implementation of http can't follow the redirects