### PR TITLE
Removed artificial cap of 99 on GQ from older VCF versions.

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/writer/IntGenotypeFieldAccessors.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/IntGenotypeFieldAccessors.java
@@ -80,7 +80,7 @@ public class IntGenotypeFieldAccessors {
     }
 
     public static class GQAccessor extends AtomicAccessor {
-        @Override public int getValue(final Genotype g) { return Math.min(g.getGQ(), VCFConstants.MAX_GENOTYPE_QUAL); }
+        @Override public int getValue(final Genotype g) { return g.getGQ(); }
     }
 
     public static class DPAccessor extends AtomicAccessor {


### PR DESCRIPTION
### Description

Removes the GQ limit of 99 for VCF files. This was a limitation posed by older standards, which is no longer the case (page 6, <a href="http://samtools.github.io/hts-specs/VCFv4.2.pdf">VCF Spec</a>).

This fixes the problem where importing then exporting a VCF with GQ values greater than 99 results in a different VCF file.
### Checklist
- [X] Code compiles correctly
- [X] New tests covering changes and new functionality (<b>no new tests</b>)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
