### PR TITLE
Made SAMTextReader.RecordIterator close itself properly

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMTextReader.java
+++ b/src/main/java/htsjdk/samtools/SAMTextReader.java
@@ -221,10 +221,16 @@ class SAMTextReader extends SamReader.ReaderImplementation {
         }
 
         public void close() {
-            SAMTextReader.this.close();
+            if ( mReader != null) {
+                if (mIterator != null && this != mIterator) {
+                    throw new IllegalStateException("Attempt to close non-current iterator");
+                }
+                mIterator = null;
+            }
         }
 
         public boolean hasNext() {
+            if (mIterator == null) {throw new IllegalStateException("Iterator has been closed");}
             return mCurrentLine != null;
         }
 

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -434,4 +434,25 @@ public class SamReaderFactoryTest {
         countRecords(reader);
     }
 
+    @Test
+    public void testGettingNewIteratorFromSamTextFileAfterClosing() throws IOException {
+        final String samFilePath = new File(TEST_DATA_DIR, "unsorted.sam").getAbsolutePath();
+        final URL samURL = new URL("file://" + samFilePath);
+        final SamReaderFactory factory = SamReaderFactory.makeDefault()
+                .validationStringency(ValidationStringency.SILENT);
+        final SamReader reader = factory.open(SamInputResource.of(samURL));
+        CloseableIterator<SAMRecord> iterator = reader.iterator();
+        Assert.assertTrue(iterator.hasNext());
+        iterator.close();
+        //Testing that an empty iterator throws
+        boolean hasThrown = false;
+        try {
+            iterator.hasNext();
+        } catch (IllegalStateException e) {
+            hasThrown = true;
+        }
+        Assert.assertTrue(hasThrown);
+        iterator = reader.iterator();
+        Assert.assertTrue(iterator.hasNext());
+    }
 }


### PR DESCRIPTION
I fixed the bug that cause SAMTextReaders to fail to get a new iterator after closing one properly.

resolves #681 
