### PR TITLE
SAMUtils:getOtherCanonicalAlignments extract 'SA' tag  and return a list of supplementary alignments

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -1102,7 +1102,7 @@ public final class SAMUtils {
      * Extract a List of 'other canonical alignments' from a SAM record. Those alignments are stored as a string in the 'SA' tag as defined
      * in the SAM specification.
      * Each record in the List is a non-paired read.
-     * The name, sequence and qualities are copied from the original recordabsent.
+     * The name, sequence and qualities are copied from the original record.
      * The SAM flag is set to <code>SUPPLEMENTARY_ALIGNMENT (+ READ_REVERSE_STRAND )</code>
      * @param record must be non null and must have a non-null associated header.
      * @return a list of 'other canonical alignments' SAMRecords. The list is empty if the 'SA' attribute is missing.
@@ -1123,7 +1123,7 @@ public final class SAMUtils {
         /* the spec says: "Other canonical alignments in a chimeric alignment, formatted as a 
          * semicolon-delimited list: (rname,pos,strand,CIGAR,mapQ,NM;)+. 
          * Each element in the list represents a part of the chimeric alignment.
-         * Conventionally, at a supplementary line, the  rst element points to the primary line.
+         * Conventionally, at a supplementary line, the  1rst element points to the primary line.
          */
         
         /* break string using semicolon */

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -1162,6 +1162,11 @@ public final class SAMUtils {
             otherRec.setMappingQuality( Integer.parseInt(commaStrs[4]) );
             otherRec.setAttribute( SAMTagUtil.getSingleton().NM , Integer.parseInt(commaStrs[5]) );                  
             
+            /* if strand is not the same: reverse-complement */
+            if( otherRec.getReadNegativeStrandFlag() != record.getReadNegativeStrandFlag() ) {
+                SAMRecordUtil.reverseComplement(otherRec);
+            }
+            
             /* add the alignment */
             alignments.add( otherRec );
         }

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -1118,7 +1118,7 @@ public final class SAMUtils {
         if( ! (saValue instanceof String) ) throw new SAMException(
                 "Expected a String for attribute 'SA' but got " + saValue.getClass() );
         
-        final SAMRecordFactory srf = new DefaultSAMRecordFactory();
+        final SAMRecordFactory samReaderFactory = new DefaultSAMRecordFactory();
         
         /* the spec says: "Other canonical alignments in a chimeric alignment, formatted as a 
          * semicolon-delimited list: (rname,pos,strand,CIGAR,mapQ,NM;)+. 
@@ -1138,10 +1138,10 @@ public final class SAMUtils {
             
             /* break string using comma */
             final String commaStrs[] = commaPattern.split(semiColonStr);
-            if( commaStrs.length < 5 )  throw new SAMException("Bad 'SA' attribute in " + semiColonStr);
+            if( commaStrs.length != 6 )  throw new SAMException("Bad 'SA' attribute in " + semiColonStr);
             
             /* create the new record */
-            final SAMRecord otherRec = srf.createSAMRecord( record.getHeader() );
+            final SAMRecord otherRec = samReaderFactory.createSAMRecord( record.getHeader() );
             
             /* copy fields from the original record */
             otherRec.setReadName( record.getReadName() );
@@ -1160,7 +1160,9 @@ public final class SAMUtils {
                 (commaStrs[2].equals("+") ? 0 : SAMFlag.READ_REVERSE_STRAND.flag) );
             otherRec.setCigar( TextCigarCodec.decode( commaStrs[3] ) );
             otherRec.setMappingQuality( Integer.parseInt(commaStrs[4]) );
-            otherRec.setAttribute(SAMTagUtil.getSingleton().NM, Integer.parseInt(commaStrs[5]) );                  
+            otherRec.setAttribute( SAMTagUtil.getSingleton().NM , Integer.parseInt(commaStrs[5]) );                  
+            
+            /* add the alignment */
             alignments.add( otherRec );
         }
         return alignments;

--- a/src/test/java/htsjdk/samtools/SAMUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/SAMUtilsTest.java
@@ -204,8 +204,10 @@ public class SAMUtilsTest {
             Assert.assertFalse(other.getReadPairedFlag());
             Assert.assertTrue(other.getSupplementaryAlignmentFlag());
             Assert.assertEquals(other.getReadName(),record.getReadName());
-            Assert.assertEquals(other.getReadString(),record.getReadString());
-            Assert.assertEquals(other.getBaseQualityString(),record.getBaseQualityString());
+            if( other.getReadNegativeStrandFlag()==record.getReadNegativeStrandFlag()) {
+                Assert.assertEquals(other.getReadString(),record.getReadString());
+                Assert.assertEquals(other.getBaseQualityString(),record.getBaseQualityString());
+                }
         }
         
         SAMRecord other = suppl.get(0);

--- a/src/test/java/htsjdk/samtools/SAMUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/SAMUtilsTest.java
@@ -26,7 +26,7 @@ package htsjdk.samtools;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
+import java.util.List;
 
 public class SAMUtilsTest {
     @Test
@@ -173,4 +173,57 @@ public class SAMUtilsTest {
         record.setSecondOfPairFlag(true);
         Assert.assertEquals(SAMUtils.getNumOverlappingAlignedBasesToClip(record), 10);
     }
+    
+    @Test
+    public void testOtherCanonicalAlignments() {
+        // setup the record
+        final SAMFileHeader header = new SAMFileHeader();
+        header.addSequence(new SAMSequenceRecord("1", 1000));
+        header.addSequence(new SAMSequenceRecord("2", 1000));
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadPairedFlag(true);
+        record.setFirstOfPairFlag(true);
+        record.setCigar(TextCigarCodec.decode("10M"));
+        record.setReferenceIndex(0);
+        record.setAlignmentStart(1);
+        record.setMateReferenceIndex(0);
+        record.setMateAlignmentStart(1);
+        record.setReadBases("AAAAAAAAAA".getBytes());
+        record.setBaseQualities("##########".getBytes());
+        record.setAttribute(SAMTagUtil.getSingleton().SA,
+                "2,500,+,3S2=1X2=2S,60,1;" + 
+                "1,191,-,8M2S,60,0;");
+        
+        // extract suppl alignments
+        final List<SAMRecord> suppl = SAMUtils.getOtherCanonicalAlignments(record);
+        Assert.assertNotNull(suppl);
+        Assert.assertEquals(suppl.size(), 2);
+    
+        for(final SAMRecord other: suppl) {
+            Assert.assertFalse(other.getReadUnmappedFlag());
+            Assert.assertFalse(other.getReadPairedFlag());
+            Assert.assertTrue(other.getSupplementaryAlignmentFlag());
+            Assert.assertEquals(other.getReadName(),record.getReadName());
+            Assert.assertEquals(other.getReadString(),record.getReadString());
+            Assert.assertEquals(other.getBaseQualityString(),record.getBaseQualityString());
+        }
+        
+        SAMRecord other = suppl.get(0);
+        Assert.assertEquals(other.getReferenceName(),"2");
+        Assert.assertEquals(other.getAlignmentStart(),500);
+        Assert.assertFalse(other.getReadNegativeStrandFlag());
+        Assert.assertEquals(other.getMappingQuality(), 60);
+        Assert.assertEquals(other.getAttribute(SAMTagUtil.getSingleton().NM),1);
+        Assert.assertEquals(other.getCigarString(),"3S2=1X2=2S");
+        
+        other = suppl.get(1);
+        Assert.assertEquals(other.getReferenceName(),"1");
+        Assert.assertEquals(other.getAlignmentStart(),191);
+        Assert.assertTrue(other.getReadNegativeStrandFlag());
+        Assert.assertEquals(other.getMappingQuality(), 60);
+        Assert.assertEquals(other.getAttribute(SAMTagUtil.getSingleton().NM),0);
+        Assert.assertEquals(other.getCigarString(),"8M2S");
+        
+    }
+    
 }


### PR DESCRIPTION
### Description

I've added a new function `getOtherCanonicalAlignments` in SAMUtils. This function is used to extract the 'SA' tag of a SAMRecord as a `List<SAMRecord>`of supplementary alignements. 

* 
```   
    /**
     * Extract a List of 'other canonical alignments' from a SAM record. Those alignments are stored as a string in the 'SA' tag as defined
     * in the SAM specification.
     * Each record in the List is a non-paired read.
     * The name, sequence and qualities are copied from the original record
     * The SAM flag is set to <code>SUPPLEMENTARY_ALIGNMENT (+ READ_REVERSE_STRAND )</code>
     * @param record must be non null and must have a non-null associated header.
     * @return a list of 'other canonical alignments' SAMRecords. The list is empty if the 'SA' attribute is missing.
     */
public static List<SAMRecord> getOtherCanonicalAlignments(final SAMRecord record)
```
* `testOtherCanonicalAlignments` was added to SAMUtilsTest ( create one read with SA flag, check the values of the supplementary alignments)

PS: The SA tag is defined in the spec as 

> Other canonical alignments in a chimeric alignment, formatted as a   semicolon-delimited list: (rname,pos,strand,CIGAR,mapQ,NM;)+.  Each element in the list represents a part of the chimeric alignment.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


