### PR TITLE
Added a "RANDOM" duplicate scoring strategy.

### DIFF
--- a/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
+++ b/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
@@ -24,6 +24,8 @@
 
 package htsjdk.samtools;
 
+import htsjdk.samtools.util.Murmur3;
+
 /**
  * This class helps us compute and compare duplicate scores, which are used for selecting the non-duplicate
  * during duplicate marking (see MarkDuplicates).
@@ -33,8 +35,12 @@ public class DuplicateScoringStrategy {
 
     public enum ScoringStrategy {
         SUM_OF_BASE_QUALITIES,
-        TOTAL_MAPPED_REFERENCE_LENGTH
+        TOTAL_MAPPED_REFERENCE_LENGTH,
+        RANDOM,
     }
+
+    /** Hash used for the RANDOM scoring strategy. */
+    private static final Murmur3 hasher = new Murmur3(1);
 
     /** An enum to use for storing temporary attributes on SAMRecords. */
     private static enum Attr { DuplicateScore }
@@ -80,6 +86,8 @@ public class DuplicateScoringStrategy {
                         score += SAMUtils.getMateCigar(record).getReferenceLength();
                     }
                     break;
+                case RANDOM:
+                    score += (short) (hasher.hashUnencodedChars(record.getReadName()) >> 16);
             }
 
             storedScore = score;


### PR DESCRIPTION
### Description

When evaluating error rates in data with UMIs and contrasting different approaches to duplicate marking, it is useful to have an unbiased read picked as the representative for a duplicate set instead of some heuristic for "best".

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


