### PR TITLE
Yf add tag aware merge samdictionary

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
@@ -270,7 +270,6 @@ public class SAMSequenceDictionary implements Serializable {
     }
 
     public static final List<String> DEFAULT_DICTIONARY_EQUAL_TAG = Arrays.asList(
-            SAMSequenceRecord.URI_TAG,
             SAMSequenceRecord.MD5_TAG,
             SAMSequenceRecord.SEQUENCE_LENGTH_TAG);
 
@@ -308,18 +307,11 @@ public class SAMSequenceDictionary implements Serializable {
                         "the dictionaries.",
                         sequence.getSequenceName(), dict2.getSequence(sequenceIndex).getSequenceName(), sequenceIndex));
             }
-            final Set<String> allTags = new HashSet<>();
 
-            for (SAMSequenceRecord seq : Arrays.asList(
-                    dict1.getSequence(sequenceIndex),
-                    dict2.getSequence(sequenceIndex))) {
-
-                final Set<String> dictTags = seq
-                        .getAttributes().parallelStream()
-                        .map(Map.Entry::getKey)
-                        .collect(Collectors.toSet());
-                allTags.addAll(dictTags);
-            }
+            final Set<String> allTags = new HashSet<>(dict1.getSequence(sequenceIndex).getAttributes()
+                    .stream().map(Map.Entry::getKey).collect(Collectors.toSet()));
+            allTags.addAll(dict2.getSequence(sequenceIndex).getAttributes()
+                    .stream().map(Map.Entry::getKey).collect(Collectors.toSet()));
 
             for (final String tag : allTags) {
                 final String value1 = dict1.getSequence(sequenceIndex).getAttribute(tag);

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
@@ -32,8 +32,10 @@ import org.testng.annotations.Test;
 
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -130,10 +132,10 @@ public class SAMSequenceDictionaryTest {
         try {
             SAMSequenceDictionary.mergeDictionaries(dict1, dict2, SAMSequenceDictionary.DEFAULT_DICTIONARY_EQUAL_TAG);
         } catch (final IllegalArgumentException e) {
-            if (!canMerge){
+            if (canMerge) {
+                throw new Exception("Expected to be able to merge dictionaries, but wasn't:" , e);
+            } else {
                 throw e;
-            } else{
-                throw new Exception("Expected to be able to merge dictionaries, but wasn't");
             }
         }
         if (canMerge){

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
@@ -92,9 +92,9 @@ public class SAMSequenceDictionaryTest {
     }
 
     @DataProvider(name="testMergeDictionariesData")
-    Object[][] testMergeDictionariesData(){
+    public Object[][] testMergeDictionariesData(){
 
-        final SAMSequenceRecord rec1, rec2, rec3, rec4;
+        final SAMSequenceRecord rec1, rec2, rec3, rec4, rec5;
         rec1 = new SAMSequenceRecord("chr1", 100);
         rec2 = new SAMSequenceRecord("chr1", 101);
         rec2.setMd5("dummy");
@@ -104,14 +104,26 @@ public class SAMSequenceDictionaryTest {
         rec4 = new SAMSequenceRecord("chr1", 100);
         rec4.setAttribute(SAMSequenceRecord.URI_TAG,"file://some/file/name.ok");
 
+        rec5 = new SAMSequenceRecord("chr2", 200);
+        rec4.setAttribute(SAMSequenceRecord.URI_TAG,"file://some/file/name.ok");
 
         return new Object[][]{
-                new Object[]{rec1,rec2,false}
+                new Object[]{rec1, rec1, true},
+                new Object[]{rec2, rec2, true},
+                new Object[]{rec3, rec3, true},
+                new Object[]{rec4, rec4, true},
+                new Object[]{rec1, rec2, false},//since 100 != 101 in Length
+                new Object[]{rec1, rec3, true},
+                new Object[]{rec1, rec4, true},
+                new Object[]{rec2, rec3, false}, // since MD5 is not equal
+                new Object[]{rec2, rec4, false}, //length differs
+                new Object[]{rec3, rec4, true},
+                new Object[]{rec4, rec5, false}, // different name
         };
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testMergeDictionaries(final SAMSequenceRecord rec1 ,final SAMSequenceRecord rec2, boolean canMerge) throws Exception {
+    @Test(dataProvider = "testMergeDictionariesData", expectedExceptions = IllegalArgumentException.class)
+    public void testMergeDictionaries(final SAMSequenceRecord rec1, final SAMSequenceRecord rec2, boolean canMerge) throws Exception {
         final SAMSequenceDictionary dict1 = new SAMSequenceDictionary(Collections.singletonList(rec1));
         final SAMSequenceDictionary dict2 = new SAMSequenceDictionary(Collections.singletonList(rec2));
 
@@ -125,7 +137,7 @@ public class SAMSequenceDictionaryTest {
             }
         }
         if (canMerge){
-            throw new Exception("Expected to be able to merge dictionaries, but wasn't");
+            throw new IllegalArgumentException("Expected to be able to merge dictionaries, and was indeed able to do so.");
         } else {
             throw new Exception("Expected to not be able to merge dictionaries, but was able");
         }

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
@@ -27,11 +27,13 @@
 package htsjdk.samtools;
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Collections;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -89,4 +91,43 @@ public class SAMSequenceDictionaryTest {
         Assert.assertEquals(dict1, dict2);
     }
 
+    @DataProvider(name="testMergeDictionariesData")
+    Object[][] testMergeDictionariesData(){
+
+        final SAMSequenceRecord rec1, rec2, rec3, rec4;
+        rec1 = new SAMSequenceRecord("chr1", 100);
+        rec2 = new SAMSequenceRecord("chr1", 101);
+        rec2.setMd5("dummy");
+        rec3 = new SAMSequenceRecord("chr1", SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH);
+        rec3.setMd5("dummy2");
+
+        rec4 = new SAMSequenceRecord("chr1", 100);
+        rec4.setAttribute(SAMSequenceRecord.URI_TAG,"file://some/file/name.ok");
+
+
+        return new Object[][]{
+                new Object[]{rec1,rec2,false}
+        };
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMergeDictionaries(final SAMSequenceRecord rec1 ,final SAMSequenceRecord rec2, boolean canMerge) throws Exception {
+        final SAMSequenceDictionary dict1 = new SAMSequenceDictionary(Collections.singletonList(rec1));
+        final SAMSequenceDictionary dict2 = new SAMSequenceDictionary(Collections.singletonList(rec2));
+
+        try {
+            SAMSequenceDictionary.mergeDictionaries(dict1, dict2, SAMSequenceDictionary.DEFAULT_DICTIONARY_EQUAL_TAG);
+        } catch (final IllegalArgumentException e) {
+            if (!canMerge){
+                throw e;
+            } else{
+                throw new Exception("Expected to be able to merge dictionaries, but wasn't");
+            }
+        }
+        if (canMerge){
+            throw new Exception("Expected to be able to merge dictionaries, but wasn't");
+        } else {
+            throw new Exception("Expected to not be able to merge dictionaries, but was able");
+        }
+    }
 }


### PR DESCRIPTION
### Description

This adds a static function that can merge two SamSequenceDictionaries into one. The problem it's solving is that in MergeBamAlignment the reference dictionary and the aligned Bam dictionary, while having the same sequences, may have different tags. In particular, the reference dictionary has lots of interesting tags like MD, SP, UR etc. and the (bwa) dictionary in the aligned bam may contain AH which informs us that the sequence is an Alternative Haplotype. 

This PR enables MergeBamAlignment to merge the two dictionaries rather than only use the reference one (as it currently does)

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

