### PR TITLE
Changes made to upgrade HTSJDK to VCFv4.3 complience --- DO NOT MERGE---INCOMPLETE

### DIFF
--- a/src/main/java/htsjdk/tribble/TribbleException.java
+++ b/src/main/java/htsjdk/tribble/TribbleException.java
@@ -136,4 +136,10 @@ public class TribbleException extends RuntimeException {
             setSource(f);
         }
     }
+
+    public static class VCFException extends TribbleException {
+        public VCFException(String message) {
+            super(message);
+        }
+    }
 }

--- a/src/main/java/htsjdk/variant/variantcontext/GenotypeBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/GenotypeBuilder.java
@@ -28,12 +28,7 @@ package htsjdk.variant.variantcontext;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.vcf.VCFConstants;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * A builder class for genotypes
@@ -379,6 +374,15 @@ public final class GenotypeBuilder {
             return filter(filters.get(0));
         else
             return filter(ParsingUtils.join(";", ParsingUtils.sortList(filters)));
+    }
+
+    public GenotypeBuilder filters(final Set<String> filters) {
+        if ( filters.isEmpty() )
+            return filter(null);
+        else if ( filters.size() == 1 )
+            return filter((String)filters.toArray()[0]);
+        else
+            return filters(new ArrayList<String>(filters));
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -30,11 +30,7 @@ import htsjdk.tribble.Feature;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.utils.GeneralUtils;
-import htsjdk.variant.vcf.VCFCompoundHeaderLine;
-import htsjdk.variant.vcf.VCFConstants;
-import htsjdk.variant.vcf.VCFHeader;
-import htsjdk.variant.vcf.VCFHeaderLineCount;
-import htsjdk.variant.vcf.VCFHeaderLineType;
+import htsjdk.variant.vcf.*;
 
 import java.io.Serializable;
 import java.util.AbstractMap;
@@ -269,6 +265,9 @@ public class VariantContext implements Feature, Serializable {
     /* cached monomorphic value: null -> not yet computed, False, True */
     private Boolean monomorphic = null;
 
+    // The VCF fileformat version the read originated from: null -> artificial
+    private VCFHeaderVersion oldVersion;
+
     /*
 * Determine which genotype fields are in use in the genotypes in VC
 * @return an ordered list of genotype fields in use in VC.  If vc has genotypes this will always include GT first
@@ -346,7 +345,7 @@ public class VariantContext implements Feature, Serializable {
                 other.getAlleles(), other.getGenotypes(), other.getLog10PError(),
                 other.getFiltersMaybeNull(),
                 other.getAttributes(),
-                other.fullyDecoded, NO_VALIDATION);
+                other.fullyDecoded, NO_VALIDATION, other.oldVersion);
     }
 
     /**
@@ -375,10 +374,28 @@ public class VariantContext implements Feature, Serializable {
                              final Map<String, Object> attributes,
                              final boolean fullyDecoded,
                              final EnumSet<Validation> validationToPerform ) {
+        this(source, ID, contig, start, stop, alleles, genotypes, log10PError, filters, attributes, fullyDecoded, validationToPerform, VCFHeaderVersion.mostRecentHeaderVersion());
+    }
+
+    protected VariantContext(final String source,
+                             final String ID,
+                             final String contig,
+                             final long start,
+                             final long stop,
+                             final Collection<Allele> alleles,
+                             final GenotypesContext genotypes,
+                             final double log10PError,
+                             final Set<String> filters,
+                             final Map<String, Object> attributes,
+                             final boolean fullyDecoded,
+                             final EnumSet<Validation> validationToPerform,
+                             final VCFHeaderVersion oldVersion
+    ){
         if ( contig == null ) { throw new IllegalArgumentException("Contig cannot be null"); }
         this.contig = contig;
         this.start = start;
         this.stop = stop;
+        this.oldVersion = oldVersion;
 
         // intern for efficiency.  equals calls will generate NPE if ID is inappropriately passed in as null
         if ( ID == null || ID.equals("") ) throw new IllegalArgumentException("ID field cannot be the null or the empty string");
@@ -1731,5 +1748,10 @@ public class VariantContext implements Feature, Serializable {
         final int index = getAlleleIndex(targetAllele);
         if ( index == -1 ) throw new IllegalArgumentException("Allele " + targetAllele + " not in this VariantContex " + this);
         return GenotypeLikelihoods.getPLIndecesOfAlleles(0, index);
+    }
+
+    public VCFHeaderVersion getOldVersion() {
+        if (this.oldVersion != null) return this.oldVersion;
+        return VCFHeaderVersion.mostRecentHeaderVersion();
     }
 }

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextBuilder.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.variantcontext;
 
 import htsjdk.variant.vcf.VCFConstants;
+import htsjdk.variant.vcf.VCFHeaderVersion;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -71,6 +72,7 @@ public class VariantContextBuilder {
     private long start = -1;
     private long stop = -1;
     private Collection<Allele> alleles = null;
+    private VCFHeaderVersion oldVersion; //TODO add a way to set this
 
     // optional -> these are set to the appropriate default value
     private String ID = VCFConstants.EMPTY_ID_FIELD;
@@ -124,6 +126,7 @@ public class VariantContextBuilder {
         this.start = parent.getStart();
         this.stop = parent.getEnd();
         this.fullyDecoded = parent.isFullyDecoded();
+        this.oldVersion = parent.getOldVersion();
     }
 
     public VariantContextBuilder(final VariantContextBuilder parent) {
@@ -138,6 +141,7 @@ public class VariantContextBuilder {
         this.start = parent.start;
         this.stop = parent.stop;
         this.fullyDecoded = parent.fullyDecoded;
+        this.oldVersion = parent.oldVersion;
 
         this.attributes(parent.attributes);
         this.filters(parent.filters);
@@ -436,6 +440,16 @@ public class VariantContextBuilder {
     }
 
     /**
+     * sets the source version that the variant context file originated from
+     * @param version
+     * @return
+     */
+    public VariantContextBuilder sourceVersion(VCFHeaderVersion version) {
+        this.oldVersion = version;
+        return this;
+    }
+
+    /**
      * Compute the end position for this VariantContext from the alleles themselves
      *
      * assigns this builder the stop position computed.
@@ -493,6 +507,6 @@ public class VariantContextBuilder {
 
         return new VariantContext(source, ID, contig, start, stop, alleles,
                 genotypes, log10PError, filters, attributes,
-                fullyDecoded, toValidate);
+                fullyDecoded, toValidate, oldVersion);
     }
 }

--- a/src/main/java/htsjdk/variant/vcf/VCF3Codec.java
+++ b/src/main/java/htsjdk/variant/vcf/VCF3Codec.java
@@ -30,6 +30,7 @@ import htsjdk.tribble.readers.LineIterator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 
@@ -97,24 +98,24 @@ public class VCF3Codec extends AbstractVCFCodec {
      * @param filterString the string to parse
      * @return a set of the filters applied
      */
-    protected List<String> parseFilters(String filterString) {
+    protected HashSet<String> parseFilters(String filterString) {
 
         // null for unfiltered
         if ( filterString.equals(VCFConstants.UNFILTERED) )
             return null;
 
         // empty set for passes filters
-        List<String> fFields = new ArrayList<String>();
+        HashSet<String> fFields = new HashSet<String>();
 
         if ( filterString.equals(VCFConstants.PASSES_FILTERS_v3) )
-            return new ArrayList<String>(fFields);
+            return new HashSet<String>(fFields);
 
         if (filterString.isEmpty())
             generateException("The VCF specification requires a valid filter status");
 
         // do we have the filter string cached?
         if ( filterHash.containsKey(filterString) )
-            return new ArrayList<String>(filterHash.get(filterString));
+            return new HashSet<String>(filterHash.get(filterString));
 
         // otherwise we have to parse and cache the value
         if ( filterString.indexOf(VCFConstants.FILTER_CODE_SEPARATOR) == -1 )

--- a/src/main/java/htsjdk/variant/vcf/VCFAltHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFAltHeaderLine.java
@@ -1,0 +1,12 @@
+package htsjdk.variant.vcf;
+
+import java.util.List;
+
+public class VCFAltHeaderLine extends VCFSimpleHeaderLine implements VCFIDHeaderLine {
+
+    public VCFAltHeaderLine(final String line, final VCFHeaderVersion version, final String key, final List<String> expectedTagOrdering) {
+        super(key, VCFHeaderLineTranslator.parseLine(version, line, expectedTagOrdering));
+    }
+
+    public String getID() {return name;}
+}

--- a/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
@@ -34,11 +34,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
- * a base class for compound header lines, which include info lines and format lines (so far)
+ * a base class for compound header lines, which include info lines, format lines, and pedigree lines (so far)
  */
 public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCFIDHeaderLine {
+
+    // regex pattern corresponding to legal info/format field keys
+    public final static Pattern LEGAL_HEADER_ID_KEYS = Pattern.compile("^[A-Za-z_][0-9A-Za-z_.]*$");
 
     public enum SupportedHeaderLineType {
         INFO(true), FORMAT(false);
@@ -126,6 +130,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
         this.description = description;
         this.lineType = lineType;
         validate();
+        validateIDStrict();
     }
 
     /**
@@ -145,6 +150,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
         this.description = description;
         this.lineType = lineType;
         validate();
+        validateIDStrict();
     }
 
     /**
@@ -198,6 +204,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
         this.lineType = lineType;
 
         validate();
+        if (version.isAtLeastAsRecentAs(VCFHeaderVersion.VCF4_3)) validateIDStrict();
     }
 
     private void validate() {
@@ -297,5 +304,11 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
      * @return true if we do, false otherwise
      */
     abstract boolean allowFlagValues();
+
+    protected void validateIDStrict() {
+        if (!VCFCompoundHeaderLine.LEGAL_HEADER_ID_KEYS.matcher(getID()).matches() ) {
+            throw new TribbleException.InvalidHeader(String.format("The %s header line ID value \"%s\" is invalid", getKey(), getID()));
+        }
+    }
 
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFConstants.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFConstants.java
@@ -45,7 +45,7 @@ public final class VCFConstants {
     public static final String GENOTYPE_KEY = "GT";
     public static final String GENOTYPE_POSTERIORS_KEY = "GP";
     public static final String GENOTYPE_QUALITY_KEY = "GQ";
-    public static final String GENOTYPE_ALLELE_DEPTHS = "AD"; //AD isn't reserved, but is specifically handled by VariantContext
+    public static final String GENOTYPE_ALLELE_DEPTHS = "AD"; //AD is now reserved
     public static final String GENOTYPE_PL_KEY = "PL";   // phred-scaled genotype likelihoods
     public static final String EXPECTED_ALLELE_COUNT_KEY = "EC";
     @Deprecated public static final String GENOTYPE_LIKELIHOODS_KEY = "GL";         // log10 scaled genotype likelihoods
@@ -87,6 +87,7 @@ public final class VCFConstants {
     public static final String FORMAT_HEADER_START = "##FORMAT";
     public static final String INFO_HEADER_START = "##INFO";
     public static final String ALT_HEADER_START = "##ALT";
+    public static final String PEDIGREE_HEADER_START = "##PEDIGREE";
     public static final String CONTIG_HEADER_KEY = "contig";
     public static final String CONTIG_HEADER_START = "##" + CONTIG_HEADER_KEY;
 

--- a/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
@@ -30,6 +30,7 @@ import htsjdk.tribble.TribbleException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * A special class representing a contig VCF header line.  Knows the true contig order and sorts on that
@@ -38,8 +39,9 @@ import java.util.Map;
  *
  * @author mdepristo
  */
-public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
+public class VCFContigHeaderLine extends VCFSimpleHeaderLine implements VCFIDHeaderLine {
     final Integer contigIndex;
+    final static Pattern VALID_ID_TAG_EXPRESSION = Pattern.compile("");//TODO figure out this regex
 
     /**
      * create a VCF contig header line
@@ -52,12 +54,14 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
         super(line, version, key, null);
 	    if (contigIndex < 0) throw new TribbleException("The contig index is less than zero.");
         this.contigIndex = contigIndex;
+        assertValidID();
     }
 
     public VCFContigHeaderLine(final Map<String, String> mapping, final int contigIndex) {
         super(VCFHeader.CONTIG_KEY, mapping);
 	    if (contigIndex < 0) throw new TribbleException("The contig index is less than zero.");
         this.contigIndex = contigIndex;
+        assertValidID();
     }
 
 	VCFContigHeaderLine(final SAMSequenceRecord sequenceRecord, final String assembly) {
@@ -69,6 +73,7 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
 			if ( assembly != null ) this.put("assembly", assembly);
 		}});
 		this.contigIndex = sequenceRecord.getSequenceIndex();
+        assertValidID();
 	}
 
     public Integer getContigIndex() {
@@ -113,6 +118,16 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
             return contigIndex.compareTo(((VCFContigHeaderLine) other).contigIndex);
         else {
             return super.compareTo(other);
+        }
+    }
+
+    public String getID() {
+        return name;
+    }
+
+    private void assertValidID() {
+        if (VALID_ID_TAG_EXPRESSION.matcher(getID()).matches()) {
+            throw new TribbleException.InvalidHeader("Illegal characters contig header ID field \""+getID()+"\"");
         }
     }
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFFilterHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFilterHeaderLine.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
  * 
  * A class representing a key=value entry for FILTER fields in the VCF header
  */
-public class VCFFilterHeaderLine extends VCFSimpleHeaderLine  {
+public class VCFFilterHeaderLine extends VCFSimpleHeaderLine implements VCFIDHeaderLine {
 
     /**
      * create a VCF filter header line
@@ -65,5 +65,9 @@ public class VCFFilterHeaderLine extends VCFSimpleHeaderLine  {
     @Override
     public boolean shouldBeAddedToDictionary() {
         return true;
+    }
+
+    public String getID() {
+        return name;
     }
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
@@ -26,6 +26,8 @@
 package htsjdk.variant.vcf;
 
 
+import htsjdk.tribble.TribbleException;
+
 /**
  * @author ebanks
  *         <p>

--- a/src/main/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeader.java
@@ -98,6 +98,8 @@ public class VCFHeader implements Serializable {
     private boolean writeEngineHeaders = true;
     private boolean writeCommandLine = true;
 
+    private VCFHeaderVersion oldVersion;
+
     /**
      * Create an empty VCF header with no header lines and no samples
      */
@@ -355,6 +357,7 @@ public class VCFHeader implements Serializable {
             if ( GeneralUtils.DEBUG_MODE_ENABLED ) {
                 System.err.println("Found duplicate VCF header lines for " + key + "; keeping the first only" );
             }
+            //TODO check if there is anything to be doing right here
             return false;
         }
 
@@ -403,7 +406,7 @@ public class VCFHeader implements Serializable {
 
     private static Set<VCFHeaderLine> makeGetMetaDataSet(final Set<VCFHeaderLine> headerLinesInSomeOrder) {
         final Set<VCFHeaderLine> lines = new LinkedHashSet<VCFHeaderLine>();
-        lines.add(new VCFHeaderLine(VCFHeaderVersion.VCF4_2.getFormatString(), VCFHeaderVersion.VCF4_2.getVersionString()));
+        lines.add(new VCFHeaderLine(VCFHeaderVersion.VCF4_3.getFormatString(), VCFHeaderVersion.VCF4_3.getVersionString()));
         lines.addAll(headerLinesInSomeOrder);
         return Collections.unmodifiableSet(lines);
     }

--- a/src/main/java/htsjdk/variant/vcf/VCFHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeaderLine.java
@@ -62,6 +62,7 @@ public class VCFHeaderLine implements Comparable, Serializable {
             throw new IllegalArgumentException("VCFHeaderLine: key cannot contain angle brackets");
         if ( key.contains("=") )
             throw new IllegalArgumentException("VCFHeaderLine: key cannot contain an equals sign");
+        //TODO this is where a change to the typing happens
         mKey = key;
         mValue = value;
     }
@@ -157,7 +158,7 @@ public class VCFHeaderLine implements Comparable, Serializable {
             builder.append(entry.getKey());
             builder.append('=');
             builder.append(entry.getValue().toString().contains(",") ||
-                           entry.getValue().toString().contains(" ") ||
+                           entry.getValue().toString().contains(" ") || //TODO what exactly does this affect?
                            entry.getKey().equals("Description") ? "\""+ escapeQuotes(entry.getValue().toString()) + "\"" : entry.getValue());
         }
         builder.append('>');

--- a/src/main/java/htsjdk/variant/vcf/VCFHeaderLineTranslator.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeaderLineTranslator.java
@@ -43,6 +43,7 @@ public class VCFHeaderLineTranslator {
         mapping.put(VCFHeaderVersion.VCF4_0,new VCF4Parser());
         mapping.put(VCFHeaderVersion.VCF4_1,new VCF4Parser());
         mapping.put(VCFHeaderVersion.VCF4_2,new VCF4Parser());
+        mapping.put(VCFHeaderVersion.VCF4_3,new VCF4Parser());
         mapping.put(VCFHeaderVersion.VCF3_3,new VCF3Parser());
         mapping.put(VCFHeaderVersion.VCF3_2,new VCF3Parser());
     }

--- a/src/main/java/htsjdk/variant/vcf/VCFHeaderVersion.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeaderVersion.java
@@ -35,7 +35,8 @@ public enum VCFHeaderVersion {
     VCF3_3("VCFv3.3","fileformat"),
     VCF4_0("VCFv4.0","fileformat"),
     VCF4_1("VCFv4.1","fileformat"),
-    VCF4_2("VCFv4.2","fileformat");
+    VCF4_2("VCFv4.2","fileformat"),
+    VCF4_3("VCFv4.3","fileformat");
 
     private final String versionString;
     private final String formatString;
@@ -114,10 +115,12 @@ public enum VCFHeaderVersion {
      */
     public boolean isAtLeastAsRecentAs(final VCFHeaderVersion target) {
         switch (target) {
+            case VCF4_3:
+                return this ==VCF4_3;
             case VCF4_2:
-                return this == VCF4_2;
+                return this == VCF4_2 || this == VCF4_3;
             case VCF4_1:
-                return this == VCF4_1 || this == VCF4_2;
+                return this == VCF4_1 || this == VCF4_2 || this == VCF4_3;
             case VCF4_0:
                 return this != VCF3_2 && this != VCF3_3;
             case VCF3_3:
@@ -134,5 +137,9 @@ public enum VCFHeaderVersion {
 
     public String getFormatString() {
         return formatString;
+    }
+
+    public static VCFHeaderVersion mostRecentHeaderVersion() {
+        return VCF4_3;
     }
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFPedigreeHeaderLIne.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFPedigreeHeaderLIne.java
@@ -1,0 +1,16 @@
+package htsjdk.variant.vcf;
+
+
+import htsjdk.tribble.TribbleException;
+
+public class VCFPedigreeHeaderLine extends VCFSimpleHeaderLine implements VCFIDHeaderLine{
+
+    public VCFPedigreeHeaderLine(String line, VCFHeaderVersion version) {
+        super(line, version, "PEDIGREE", null);
+        if (getID() == null) {throw new TribbleException.InvalidHeader("Invalid ##PEDIGREE line, requires an 'ID' field");}
+    }
+
+    public String getID() {
+        return this.name;
+    }
+}

--- a/src/main/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
@@ -35,9 +35,9 @@ import java.util.Map;
  * 
  * A class representing a key=value entry for simple VCF header types
  */
-public class VCFSimpleHeaderLine extends VCFHeaderLine implements VCFIDHeaderLine {
+public class VCFSimpleHeaderLine extends VCFHeaderLine {
 
-    private String name;
+    protected String name;
     private Map<String, String> genericFields = new LinkedHashMap<String, String>();
 
     /**
@@ -119,9 +119,5 @@ public class VCFSimpleHeaderLine extends VCFHeaderLine implements VCFIDHeaderLin
         result = 31 * result + name.hashCode();
         result = 31 * result + genericFields.hashCode();
         return result;
-    }
-
-    public String getID() {
-        return name;
     }
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFUtils.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFUtils.java
@@ -27,12 +27,12 @@ package htsjdk.variant.vcf;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.tribble.TribbleException;
 import htsjdk.variant.utils.GeneralUtils;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -43,6 +43,8 @@ import java.util.TreeMap;
 
 public class VCFUtils {
 
+    public static final char[] DANGEROUS_VCF_CHARACTERS = {'%', ';', ':', '=', ',', '\n', '\r', '\t'};
+
     public static Set<VCFHeaderLine> smartMergeHeaders(final Collection<VCFHeader> headers, final boolean emitWarnings) throws IllegalStateException {
         // We need to maintain the order of the VCFHeaderLines, otherwise they will be scrambled in the returned Set.
         // This will cause problems for VCFHeader.getSequenceDictionary and anything else that implicitly relies on the line ordering.
@@ -50,32 +52,32 @@ public class VCFUtils {
         final HeaderConflictWarner conflictWarner = new HeaderConflictWarner(emitWarnings);
 
         // todo -- needs to remove all version headers from sources and add its own VCF version line
-        for ( final VCFHeader source : headers ) {
+        for (final VCFHeader source : headers) {
             //System.out.printf("Merging in header %s%n", source);
-            for ( final VCFHeaderLine line : source.getMetaDataInSortedOrder()) {
+            for (final VCFHeaderLine line : source.getMetaDataInSortedOrder()) {
 
                 String key = line.getKey();
-                if ( line instanceof VCFIDHeaderLine )
-                    key = key + "-" + ((VCFIDHeaderLine)line).getID();
+                if (line instanceof VCFIDHeaderLine)
+                    key = key + "-" + ((VCFIDHeaderLine) line).getID();
 
-                if ( map.containsKey(key) ) {
+                if (map.containsKey(key)) {
                     final VCFHeaderLine other = map.get(key);
-                    if ( line.equals(other) ) {
+                    if (line.equals(other)) {
                         // continue;
-                    } else if ( ! line.getClass().equals(other.getClass()) ) {
-                        throw new IllegalStateException("Incompatible header types: " + line + " " + other );
-                    } else if ( line instanceof VCFFilterHeaderLine ) {
+                    } else if (!line.getClass().equals(other.getClass())) {
+                        throw new IllegalStateException("Incompatible header types: " + line + " " + other);
+                    } else if (line instanceof VCFFilterHeaderLine) {
                         final String lineName = ((VCFFilterHeaderLine) line).getID();
                         final String otherName = ((VCFFilterHeaderLine) other).getID();
-                        if ( ! lineName.equals(otherName) )
-                            throw new IllegalStateException("Incompatible header types: " + line + " " + other );
-                    } else if ( line instanceof VCFCompoundHeaderLine ) {
-                        final VCFCompoundHeaderLine compLine = (VCFCompoundHeaderLine)line;
-                        final VCFCompoundHeaderLine compOther = (VCFCompoundHeaderLine)other;
+                        if (!lineName.equals(otherName))
+                            throw new IllegalStateException("Incompatible header types: " + line + " " + other);
+                    } else if (line instanceof VCFCompoundHeaderLine) {
+                        final VCFCompoundHeaderLine compLine = (VCFCompoundHeaderLine) line;
+                        final VCFCompoundHeaderLine compOther = (VCFCompoundHeaderLine) other;
 
                         // if the names are the same, but the values are different, we need to quit
-                        if (! (compLine).equalsExcludingDescription(compOther) ) {
-                            if ( compLine.getType().equals(compOther.getType()) ) {
+                        if (!(compLine).equalsExcludingDescription(compOther)) {
+                            if (compLine.getType().equals(compOther.getType())) {
                                 // The Number entry is an Integer that describes the number of values that can be
                                 // included with the INFO field. For example, if the INFO field contains a single
                                 // number, then this value should be 1. However, if the INFO field describes a pair
@@ -83,18 +85,18 @@ public class VCFUtils {
                                 // values varies, is unknown, or is unbounded, then this value should be '.'.
                                 conflictWarner.warn(line, "Promoting header field Number to . due to number differences in header lines: " + line + " " + other);
                                 compOther.setNumberToUnbounded();
-                            } else if ( compLine.getType() == VCFHeaderLineType.Integer && compOther.getType() == VCFHeaderLineType.Float ) {
+                            } else if (compLine.getType() == VCFHeaderLineType.Integer && compOther.getType() == VCFHeaderLineType.Float) {
                                 // promote key to Float
                                 conflictWarner.warn(line, "Promoting Integer to Float in header: " + compOther);
                                 map.put(key, compOther);
-                            } else if ( compLine.getType() == VCFHeaderLineType.Float && compOther.getType() == VCFHeaderLineType.Integer ) {
+                            } else if (compLine.getType() == VCFHeaderLineType.Float && compOther.getType() == VCFHeaderLineType.Integer) {
                                 // promote key to Float
                                 conflictWarner.warn(line, "Promoting Integer to Float in header: " + compOther);
                             } else {
-                                throw new IllegalStateException("Incompatible header types, collision between these two types: " + line + " " + other );
+                                throw new IllegalStateException("Incompatible header types, collision between these two types: " + line + " " + other);
                             }
                         }
-                        if ( ! compLine.getDescription().equals(compOther.getDescription()) )
+                        if (!compLine.getDescription().equals(compOther.getDescription()))
                             conflictWarner.warn(line, "Allowing unequal description fields through: keeping " + compOther + " excluding " + compLine);
                     } else {
                         // we are not equal, but we're not anything special either
@@ -113,9 +115,9 @@ public class VCFUtils {
     /**
      * Add / replace the contig header lines in the VCFHeader with the in the reference file and master reference dictionary
      *
-     * @param oldHeader the header to update
+     * @param oldHeader     the header to update
      * @param referenceFile the file path to the reference sequence used to generate this vcf
-     * @param refDict the SAM formatted reference sequence dictionary
+     * @param refDict       the SAM formatted reference sequence dictionary
      */
     public static VCFHeader withUpdatedContigs(final VCFHeader oldHeader, final File referenceFile, final SAMSequenceDictionary refDict) {
         return new VCFHeader(withUpdatedContigsAsLines(oldHeader.getMetaDataInInputOrder(), referenceFile, refDict), oldHeader.getGenotypeSamples());
@@ -128,15 +130,15 @@ public class VCFUtils {
     public static Set<VCFHeaderLine> withUpdatedContigsAsLines(final Set<VCFHeaderLine> oldLines, final File referenceFile, final SAMSequenceDictionary refDict, final boolean referenceNameOnly) {
         final Set<VCFHeaderLine> lines = new LinkedHashSet<VCFHeaderLine>(oldLines.size());
 
-        for ( final VCFHeaderLine line : oldLines ) {
-            if ( line instanceof VCFContigHeaderLine )
+        for (final VCFHeaderLine line : oldLines) {
+            if (line instanceof VCFContigHeaderLine)
                 continue; // skip old contig lines
-            if ( line.getKey().equals(VCFHeader.REFERENCE_KEY) )
+            if (line.getKey().equals(VCFHeader.REFERENCE_KEY))
                 continue; // skip the old reference key
             lines.add(line);
         }
 
-        for ( final VCFHeaderLine contigLine : makeContigHeaderLines(refDict, referenceFile) )
+        for (final VCFHeaderLine contigLine : makeContigHeaderLines(refDict, referenceFile))
             lines.add(contigLine);
 
         final String referenceValue;
@@ -144,8 +146,7 @@ public class VCFUtils {
             if (referenceNameOnly) {
                 final int extensionStart = referenceFile.getName().lastIndexOf('.');
                 referenceValue = extensionStart == -1 ? referenceFile.getName() : referenceFile.getName().substring(0, extensionStart);
-            }
-            else {
+            } else {
                 referenceValue = "file://" + referenceFile.getAbsolutePath();
             }
             lines.add(new VCFHeaderLine(VCFHeader.REFERENCE_KEY, referenceValue));
@@ -155,7 +156,8 @@ public class VCFUtils {
 
     /**
      * Create VCFHeaderLines for each refDict entry, and optionally the assembly if referenceFile != null
-     * @param refDict reference dictionary
+     *
+     * @param refDict       reference dictionary
      * @param referenceFile for assembly name.  May be null
      * @return list of vcf contig header lines
      */
@@ -163,7 +165,7 @@ public class VCFUtils {
                                                                   final File referenceFile) {
         final List<VCFContigHeaderLine> lines = new ArrayList<VCFContigHeaderLine>();
         final String assembly = referenceFile != null ? getReferenceAssembly(referenceFile.getName()) : null;
-        for ( final SAMSequenceRecord contig : refDict.getSequences() )
+        for (final SAMSequenceRecord contig : refDict.getSequences())
             lines.add(makeContigHeaderLine(contig, assembly));
         return lines;
     }
@@ -172,7 +174,7 @@ public class VCFUtils {
         final Map<String, String> map = new LinkedHashMap<String, String>(3);
         map.put("ID", contig.getSequenceName());
         map.put("length", String.valueOf(contig.getSequenceLength()));
-        if ( assembly != null ) map.put("assembly", assembly);
+        if (assembly != null) map.put("assembly", assembly);
         return new VCFContigHeaderLine(map, contig.getSequenceIndex());
     }
 
@@ -190,20 +192,125 @@ public class VCFUtils {
         return assembly;
     }
 
-    /** Only displays a warning if warnings are enabled and an identical warning hasn't been already issued */
+    /**
+     * Only displays a warning if warnings are enabled and an identical warning hasn't been already issued
+     */
     private static final class HeaderConflictWarner {
         boolean emitWarnings;
         Set<String> alreadyIssued = new HashSet<String>();
 
-        private HeaderConflictWarner( final boolean emitWarnings ) {
+        private HeaderConflictWarner(final boolean emitWarnings) {
             this.emitWarnings = emitWarnings;
         }
 
         public void warn(final VCFHeaderLine line, final String msg) {
-            if ( GeneralUtils.DEBUG_MODE_ENABLED && emitWarnings && ! alreadyIssued.contains(line.getKey()) ) {
+            if (GeneralUtils.DEBUG_MODE_ENABLED && emitWarnings && !alreadyIssued.contains(line.getKey())) {
                 alreadyIssued.add(line.getKey());
                 System.err.println(msg);
             }
         }
     }
+
+    /**
+     * A utility that decodes percent encoded strings found in VCF files. For example, when given the string '%3D%41'
+     * will return the string '=A'. Throws an exception if the the encoding is uninterpretable.
+     * NOTE: Decoding only functions for the first 127 Unicode Codepoints, and interprets
+     *
+     * @param input string to be decoded
+     * @return a string (possibly the input string) that has interpreted every example of percent encoding
+     *         into the corresponding character
+     */
+    public static String decodePercentEncodedChars(String input) {
+        if (input.contains("%")) {
+            StringBuilder builder = new StringBuilder(input.length() - 2);
+            for (int i = 0; i < input.length(); i++) {
+                char c = input.charAt(i);
+                if (c == '%') {
+                    // Checking for characters at the back of the sequence
+                    if (i + 2 >= input.length()) {
+                        throw new TribbleException.VCFException("Improperly formatted '%' escape sequence");
+                    }
+                    char[] trans;
+                    try {
+                        trans = Character.toChars(Integer.parseInt(input.substring(i + 1, i + 3), 16));
+                    } catch (NumberFormatException e) {
+                        throw new TribbleException.VCFException(String.format("'%%s' is not a valid percent encoded character"));
+                    }
+                    if (trans.length != 1) {
+                        throw new TribbleException.VCFException("'%' escape sequence corresponded to an invalid codepoint");
+                    }
+                    builder.append(trans[0]);
+                    i = i + 2;
+                } else {
+                    builder.append(c);
+                }
+            }
+            return builder.toString();
+        }
+        return input;
+    }
+
+    /**
+     * Method that returns a string corresponding to the input string where all instances of the '%' character have
+     * been replaced with its percent encoded equivalent, "%25." This method is intended to be used for efficiently
+     * converting pre-VCFv4.3 files to the new encoding standard.
+     *
+     * @param input the string to be encoded
+     * @return a string (may be the input string) corresponding to every existing '%' as "%25"
+     */
+    public static String toPercentEncodingFast(String input) {
+        if (input.indexOf('%') > -1) {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < input.length(); i++) {
+                if (input.charAt(i) == '%') {
+                    builder.append("%25");
+                } else {
+                    builder.append(input.charAt(i));
+                }
+            }
+            return builder.toString();
+        }
+        return input;
+    }
+
+    /**
+     * Method that returns a string corresponding to the input string where all instances of the of dangerous characters
+     * that will break the parsing of VCF files if found in the info field have been replaced with their capitalized
+     * percent-encoded equivalent according to the VCFv4.3 spec. For example: the string "abc,def" -> "abc%2Cdef"
+     *
+     * @param input the string to be encoded
+     * @return a string (may be the input string) corresponding to every existing '%' as "%25"
+     */
+    public static String toPercentEncodingSlow(String input) {
+        if (containsDangerousCharacter(input)) {
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < input.length(); i++) {
+                char c = input.charAt(i);
+                boolean encoded = false;
+                for (char danger : DANGEROUS_VCF_CHARACTERS) {
+                    if (danger == c) {
+                        builder.append("%"+(c > 16? "" : "0")+Integer.toHexString((int)c).toUpperCase());
+                        encoded = true;
+                        break;
+                    }
+                }
+                if (!encoded ) builder.append(c);
+            }
+            return builder.toString();
+        }
+        return input;
+    }
+
+    private static boolean containsDangerousCharacter(String s) {
+        for (int i = 0; i < 1000; i++) {
+            int l = VCFUtils.DANGEROUS_VCF_CHARACTERS.length;
+            for (int c = 0; c < l; c++) {
+                if (s.indexOf(VCFUtils.DANGEROUS_VCF_CHARACTERS[c]) > -1) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/test/java/htsjdk/variant/bcf2/BCF2UtilsUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2UtilsUnitTest.java
@@ -79,13 +79,13 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
         inputLines.add(new VCFFilterHeaderLine(String.valueOf(counter++)));
         inputLines.add(new VCFContigHeaderLine(Collections.singletonMap("ID", String.valueOf(counter++)), counter));
         inputLines.add(new VCFContigHeaderLine(Collections.singletonMap("ID", String.valueOf(counter++)), counter));
-        inputLines.add(new VCFInfoHeaderLine(String.valueOf(counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
-        inputLines.add(new VCFInfoHeaderLine(String.valueOf(counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
+        inputLines.add(new VCFInfoHeaderLine(String.valueOf("A"+counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
+        inputLines.add(new VCFInfoHeaderLine(String.valueOf("A"+counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
         inputLines.add(new VCFHeaderLine("x", "misc"));
         inputLines.add(new VCFHeaderLine("y", "misc"));
         inputLines.add(new VCFSimpleHeaderLine("GATKCommandLine","z","misc"));
-        inputLines.add(new VCFFormatHeaderLine(String.valueOf(counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
-        inputLines.add(new VCFFormatHeaderLine(String.valueOf(counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
+        inputLines.add(new VCFFormatHeaderLine(String.valueOf("A"+counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
+        inputLines.add(new VCFFormatHeaderLine(String.valueOf("A"+counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
         final int inputLineCounter = counter;
         final VCFHeader inputHeader = new VCFHeader(new LinkedHashSet<VCFHeaderLine>(inputLines));
         final ArrayList<String> dict = BCF2Utils.makeDictionary(inputHeader);

--- a/src/test/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
+++ b/src/test/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
@@ -57,4 +57,28 @@ public class AbstractVCFCodecTest extends VariantBaseTest {
 		Assert.assertEquals(new VCFCodec().getTabixFormat(), TabixFormat.VCF);
 		Assert.assertEquals(new VCF3Codec().getTabixFormat(), TabixFormat.VCF);
 	}
+
+	@Test (expectedExceptions = TribbleException.MalformedFeatureFile.class)
+	public void testDuplicatedHeaderFieldCrash() {
+		final File originalVCF = new File("src/test/resources/htsjdk/variant/HiSeq.10000.duplicatedField.vcf");
+		final VCFFileReader reader = new VCFFileReader(originalVCF, false);
+		final VCFHeader header = reader.getFileHeader();
+		reader.close();
+	}
+
+	@Test (expectedExceptions = TribbleException.class)
+	public void testDuplicatedInfoFieldCrash() {
+		final File originalVCF = new File("src/test/resources/htsjdk/variant/ex2.duplicatedInfo.vcf");
+		final VCFFileReader reader = new VCFFileReader(originalVCF, false);
+		final VCFHeader header = reader.getFileHeader();
+		reader.iterator().next(); // This should crash due to duplicated DB info tag
+	}
+
+	@Test
+	public void testSpacesInInfoField() {
+		final File originalVCF = new File("src/test/resources/htsjdk/variant/ex2.spacesInfoField.vcf");
+		final VCFFileReader reader = new VCFFileReader(originalVCF, false);
+		final VCFHeader header = reader.getFileHeader();
+		reader.iterator().next(); // This should not crash despite having a space in the info field
+	}
 }

--- a/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
@@ -25,8 +25,10 @@
 
 package htsjdk.variant.vcf;
 
+import htsjdk.tribble.TribbleException;
 import htsjdk.variant.VariantBaseTest;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -42,5 +44,30 @@ public class VCFCompoundHeaderLineUnitTest extends VariantBaseTest {
 	final VCFCompoundHeaderLine headerline = new VCFInfoHeaderLine(line, VCFHeaderVersion.VCF4_2);
 	// if we don't support version fields then we should fail before we ever get here
 	Assert.assertTrue(true);
+    }
+
+    @Test (dataProvider = "BadIDFieldValues")
+    public void testMalformedIDFieldValue(String badID) {
+        // Should pass with old version specified
+        new VCFInfoHeaderLine(String.format("<ID=%s,Number=1,Type=Float,Description=\"foo\",Version=3>", badID), VCFHeaderVersion.VCF4_2);
+
+        // Should fail with new version specified
+        boolean hasCrashed = false;
+        try {
+            new VCFInfoHeaderLine(String.format("<ID=%s,Number=1,Type=Float,Description=\"foo\",Version=3>", badID), VCFHeaderVersion.VCF4_3);
+        } catch (TribbleException.InvalidHeader e) {
+            hasCrashed = true;
+        }
+        Assert.assertTrue(hasCrashed);
+    }
+
+    @DataProvider (name = "BadIDFieldValues")
+    public Object[][] getBadIDFieldValues() {
+        return new Object[][] {
+                {"3abcz"},
+                {"?ABC"},
+                {"AB;"},
+                {"AB\n9"},
+        };
     }
 }

--- a/src/test/java/htsjdk/variant/vcf/VCFUtilsUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFUtilsUnitTest.java
@@ -1,0 +1,89 @@
+package htsjdk.variant.vcf;
+
+import htsjdk.tribble.TribbleException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class VCFUtilsUnitTest {
+
+    @Test (dataProvider = "percentEncodedCharsDecodeTest")
+    public static void decodePercentEncodedCharsTest(String original, String expected) {
+        String actual = VCFUtils.decodePercentEncodedChars(original);
+        Assert.assertEquals(actual, expected,
+                String.format("decodePercentEncodedChars produced invalid result decoding string '%s', expected string '%s' and received '%s'",original, expected, actual));
+    }
+
+    @Test (dataProvider = "percentEncodedCharsDecodeTestBadInput", expectedExceptions = TribbleException.VCFException.class )
+    public static void decodePercentEncodedCharsTestBadInput(String original) {
+        VCFUtils.decodePercentEncodedChars(original);
+    }
+
+    @Test (dataProvider = "toPercentEncodingFastTest")
+    public static void toPercentEncodingFastTest(String original, String expected) {
+        String actual = VCFUtils.toPercentEncodingFast(original);
+        Assert.assertEquals(actual, expected,
+                String.format("toPercentEncodingFast produced invalid result encoding string '%s', expected string '%s' and received '%s'",original, expected, actual));
+    }
+
+    @Test (dataProvider = "toPercentEncodingTest")
+    public static void toPercentEncodingSlowTest(String original, String expected) {
+        String actual = VCFUtils.toPercentEncodingSlow(original);
+        Assert.assertEquals(actual, expected,
+                String.format("toPercentEncodingFast produced invalid result encoding string '%s', expected string '%s' and received '%s'",original, expected, actual));
+    }
+
+    @DataProvider(name = "percentEncodedCharsDecodeTest")
+    public Object[][] makePercentEncodedCharsDecodeTest() {
+        final Object[][] tests = new Object[][] {
+                {"ab cde","ab cde"},
+                {"%41bcde","Abcde"},
+                {"%2c%2524",",%24"},
+                {"%41%42%43%44","ABCD"},
+                {"%3B",";"},
+                {"%3b",";"},
+                {"",""}
+        };
+        return tests;
+    }
+
+    @DataProvider(name = "percentEncodedCharsDecodeTestBadInput")
+    public Object[][] makePercentEncodedCharsDecodeTestBadInput() {
+        final Object[][] tests = new Object[][] {
+                {"%4"},//Test for incomplete end
+                {"%%%%%"},//Test for non-single charater encoded stirng
+                {"%GF"},//Test for codepoint >127
+                {"40% of"},
+        };
+        return tests;
+    }
+
+    @DataProvider(name = "toPercentEncodingTest")
+    public Object[][] makeToPercentEncodingTest() {
+        final Object[][] tests = new Object[][] {
+                {"",""},//Test for empty strings behaving
+                {"abcd","abcd"},//Test for simple strings
+                {", %24","%2C %2524"},//Test for mix of encoded and unencoded characters
+                {"a,;:=%\n","a%2C%3B%3A%3D%25%0A"}, //test of most disalowed characters
+                {"eéeü","eéeü"}//Test for >127 unicode codepoints
+        };
+        return tests;
+    }
+
+    @DataProvider(name = "toPercentEncodingFastTest")
+    public Object[][] makeToPercentEncodingFastTest() {
+        final Object[][] tests = new Object[][] {
+                {"",""},//Test for empty strings behaving
+                {"abcd","abcd"},//Test for simple strings
+                {",\n ,%",",\n ,%25"},//Test that ONLY the percent character is being encoded
+                {", ;,",", ;,"},
+                {"%","%25"},
+                {"abc%abc%cdb%","abc%25abc%25cdb%25"}
+        };
+        return tests;
+    }
+}

--- a/src/test/resources/htsjdk/variant/HiSeq.10000.duplicatedField.vcf
+++ b/src/test/resources/htsjdk/variant/HiSeq.10000.duplicatedField.vcf
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.0
+##fileformat=VCFv4.3
 ##FILTER=<ID=ABFilter,Description="AB  0.75 && DP  40">
 ##FILTER=<ID=DPFilter,Description="DP  120 || SB  -0.10">
 ##FILTER=<ID=FDRtranche0.00to0.10,Description="FDR tranche level at qual 0.06">
@@ -9,6 +9,7 @@
 ##FILTER=<ID=HARD_TO_VALIDATE,Description="MQ0 = 4 && ((MQ0 / (1.0 * DP))  0.1)">
 ##FILTER=<ID=Indel,Description="Overlaps a user-input mask">
 ##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=LowQual,Description="QUAL  50.0">
 ##FILTER=<ID=SnpCluster,Description="SNPs found in clusters">
 ##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth (only filtered reads used for calling)">

--- a/src/test/resources/htsjdk/variant/VCF4HeaderTest.vcf
+++ b/src/test/resources/htsjdk/variant/VCF4HeaderTest.vcf
@@ -9,7 +9,6 @@
 ##FILTER=<ID=HARD_TO_VALIDATE,Description="MQ0 = 4 && ((MQ0 / (1.0 * DP))  0.1)">
 ##FILTER=<ID=Indel,Description="Overlaps a user-input mask">
 ##FILTER=<ID=LowQual,Description="Low quality">
-##FILTER=<ID=LowQual,Description="QUAL  50.0">
 ##FILTER=<ID=ANNOTATION,Description="ANNOTATION != \"NA\" || ANNOTATION <= 0.01">
 ##FILTER=<ID=ANNOTATION2,Description="ANNOTATION with quote \" that is unmatched but escaped">
 ##FILTER=<ID=SnpCluster,Description="SNPs found in clusters">


### PR DESCRIPTION
### Description

Here are most of the upgrades required for VCF4.3 compliance in the HTSJDK. Big lingering issues are:
-No BCF 2.2 support features in this branch
-No support for new integer restrictions
-No validation of the contig name is being done, it is waiting on this hts-specs issue to be resolved: https://github.com/samtools/hts-specs/issues/167
-No testing for newline/utf-8 support
-4 tests fail, 2 of which are md5 tests and 2 of which involve a testing suit trying to write spaces into a format ID field
### Checklist
- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
