### PR TITLE
Added a secondary constructor to IntervalList that takes a dict.

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -120,6 +120,12 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         setAttribute(VERSION_TAG, CURRENT_VERSION);
     }
 
+    /** Constructor that initializes the sequence dictionary with the provided one. */
+    public SAMFileHeader(final SAMSequenceDictionary dict) {
+        this();
+        setSequenceDictionary(dict);
+    }
+
     public String getVersion() {
         return (String) getAttribute("VN");
     }

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -71,10 +71,13 @@ public class IntervalList implements Iterable<Interval> {
 
     /** Constructs a new interval list using the supplied header information. */
     public IntervalList(final SAMFileHeader header) {
-        if (header == null) {
-            throw new IllegalArgumentException("SAMFileHeader must be supplied.");
-        }
+        if (header == null) throw new IllegalArgumentException("SAMFileHeader must be supplied.");
         this.header = header;
+    }
+
+    /** Constructs a new interval list using the supplied header information. */
+    public IntervalList(final SAMSequenceDictionary dict) {
+        this(new SAMFileHeader(dict));
     }
 
     /** Gets the header (if there is one) for the interval list. */


### PR DESCRIPTION
### Description

I find myself writing these three lines of code again and again and again to initialize an IntervalList since it requires a `SAMFileHeader` with a useful `SAMSequenceDictionary` and there's no way to create a header from a dictionary as an expression.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


