### PR TITLE
Fix BEDCodec.canDecode() to handle block-compressed extensions

### DIFF
--- a/src/main/java/htsjdk/tribble/bed/BEDCodec.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDCodec.java
@@ -23,11 +23,15 @@
  */
 package htsjdk.tribble.bed;
 
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.tribble.util.ParsingUtils;
+import org.apache.commons.compress.compressors.FileNameUtil;
+import org.apache.commons.compress.utils.IOUtils;
 
 import java.util.regex.Pattern;
 
@@ -197,7 +201,13 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
 
     @Override
     public boolean canDecode(final String path) {
-        return path.toLowerCase().endsWith(".bed");
+        final String toDecode;
+        if (AbstractFeatureReader.hasBlockCompressedExtension(path)) {
+            toDecode = path.substring(0, path.lastIndexOf("."));
+        } else {
+            toDecode = path;
+        }
+        return toDecode.toLowerCase().endsWith(".bed");
     }
 
     public int getStartOffset() {

--- a/src/main/java/htsjdk/tribble/bed/BEDCodec.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDCodec.java
@@ -23,15 +23,12 @@
  */
 package htsjdk.tribble.bed;
 
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.tribble.util.ParsingUtils;
-import org.apache.commons.compress.compressors.FileNameUtil;
-import org.apache.commons.compress.utils.IOUtils;
 
 import java.util.regex.Pattern;
 
@@ -43,6 +40,9 @@ import java.util.regex.Pattern;
  *         Date: Dec 20, 2009
  */
 public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
+
+    /** Default extension for BED files. */
+    public static final String BED_EXTENSION = ".bed";
 
     private static final Pattern SPLIT_PATTERN = Pattern.compile("\\t|( +)");
     private final int startOffsetValue;
@@ -207,7 +207,7 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
         } else {
             toDecode = path;
         }
-        return toDecode.toLowerCase().endsWith(".bed");
+        return toDecode.toLowerCase().endsWith(BED_EXTENSION);
     }
 
     public int getStartOffset() {

--- a/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
@@ -226,4 +226,15 @@ public class BEDCodecTest {
     public void testGetTabixFormat() {
         Assert.assertEquals(new BEDCodec().getTabixFormat(), TabixFormat.BED);
     }
+
+    @Test
+    public void testCanDecode() {
+        final BEDCodec codec = new BEDCodec();
+        final String pattern = "filename.%s%s";
+        for(final String bcExt: AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS) {
+            Assert.assertTrue(codec.canDecode(String.format(pattern, "bed", bcExt)));
+            Assert.assertFalse(codec.canDecode(String.format(pattern, "vcf", bcExt)));
+            Assert.assertFalse(codec.canDecode(String.format(pattern, "bed.gzip", bcExt)));
+        }
+    }
 }


### PR DESCRIPTION
### Description

When using `canDecode("filename.bed.gz")` it will return false, but the `AbstractFeatureReader` could support block-compressed bed files. This could cause problems when trying to find the codec for a file (for instance, https://github.com/broadinstitute/gatk/pull/2131).

I added here a check for block-compression extensions and tests for them.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


