### PR TITLE
Clean some deprecated classes/methods usages in htsjdk

### DIFF
--- a/src/main/java/htsjdk/samtools/SamPairUtil.java
+++ b/src/main/java/htsjdk/samtools/SamPairUtil.java
@@ -182,6 +182,15 @@ public class SamPairUtil {
     }
 
     /**
+     * Write the mate info for two SAMRecords.  This will always clear/remove any mate cigar tag that is present.
+     * @param rec1 the first SAM record
+     * @param rec2 the second SAM record
+     */
+    public static void setMateInfo(final SAMRecord rec1, final SAMRecord rec2) {
+        setMateInfo(rec1, rec2, false);
+    }
+
+    /**
      * Write the mate info for two SAMRecords
      * @param rec1 the first SAM record. Must have a non-null SAMFileHeader.
      * @param rec2 the second SAM record. Must have a non-null SAMFileHeader.
@@ -270,6 +279,7 @@ public class SamPairUtil {
      * @param rec2 the second SAM record
      * @param header the SAM file header
      * @param setMateCigar true if we are to update/create the Mate CIGAR (MC) optional tag, false if we are to clear any mate cigar tag that is present.
+     * @deprecated use {@link #setMateInfo(SAMRecord, SAMRecord, boolean)} instead
      */
     @Deprecated
     public static void setMateInfo(final SAMRecord rec1, final SAMRecord rec2, final SAMFileHeader header, final boolean setMateCigar) {
@@ -281,9 +291,11 @@ public class SamPairUtil {
      * @param rec1 the first SAM record
      * @param rec2 the second SAM record
      * @param header the SAM file header
+     * @deprecated use {@link #setMateInfo(SAMRecord, SAMRecord)} instead
      */
+    @Deprecated
     public static void setMateInfo(final SAMRecord rec1, final SAMRecord rec2, final SAMFileHeader header) {
-        setMateInfo(rec1, rec2, false);
+        setMateInfo(rec1, rec2);
     }
 
     /**
@@ -322,11 +334,13 @@ public class SamPairUtil {
 
     /**
      * This method will clear any mate cigar already present.
+     * @deprecated use {@link #setProperPairAndMateInfo(SAMRecord, SAMRecord, List)} instead
      */
+    @Deprecated
     public static void setProperPairAndMateInfo(final SAMRecord rec1, final SAMRecord rec2,
                                                 final SAMFileHeader header,
                                                 final List<PairOrientation> exepectedOrientations) {
-        setProperPairAndMateInfo(rec1, rec2, header, exepectedOrientations, false);
+        setProperPairAndMateInfo(rec1, rec2, exepectedOrientations, false);
     }
 
     /**
@@ -335,12 +349,34 @@ public class SamPairUtil {
      * @param header
      * @param exepectedOrientations
      * @param addMateCigar true if we are to update/create the Mate CIGAR (MC) optional tag, false if we are to clear any mate cigar tag that is present.
+     * @deprecated use {@link #setProperPairAndMateInfo(SAMRecord, SAMRecord, List, boolean)}
      */
+    @Deprecated
     public static void setProperPairAndMateInfo(final SAMRecord rec1, final SAMRecord rec2,
                                                 final SAMFileHeader header,
                                                 final List<PairOrientation> exepectedOrientations,
                                                 final boolean addMateCigar) {
-        setMateInfo(rec1, rec2, header, addMateCigar);
+        setProperPairAndMateInfo(rec1, rec2, exepectedOrientations, addMateCigar);
+    }
+
+    /**
+     * This method will clear any mate cigar already present.
+     */
+    public static void setProperPairAndMateInfo(final SAMRecord rec1, final SAMRecord rec2,
+                                                final List<PairOrientation> exepectedOrientations) {
+        setProperPairAndMateInfo(rec1, rec2, exepectedOrientations, false);
+    }
+
+    /**
+     * @param rec1
+     * @param rec2
+     * @param exepectedOrientations
+     * @param addMateCigar true if we are to update/create the Mate CIGAR (MC) optional tag, false if we are to clear any mate cigar tag that is present.
+     */
+    public static void setProperPairAndMateInfo(final SAMRecord rec1, final SAMRecord rec2,
+                                                final List<PairOrientation> exepectedOrientations,
+                                                final boolean addMateCigar) {
+        setMateInfo(rec1, rec2, addMateCigar);
         setProperPairFlags(rec1, rec2, exepectedOrientations);
     }
 

--- a/src/main/java/htsjdk/samtools/SamPairUtil.java
+++ b/src/main/java/htsjdk/samtools/SamPairUtil.java
@@ -339,45 +339,38 @@ public class SamPairUtil {
     @Deprecated
     public static void setProperPairAndMateInfo(final SAMRecord rec1, final SAMRecord rec2,
                                                 final SAMFileHeader header,
-                                                final List<PairOrientation> exepectedOrientations) {
-        setProperPairAndMateInfo(rec1, rec2, exepectedOrientations, false);
+                                                final List<PairOrientation> expectedOrientations) {
+        setProperPairAndMateInfo(rec1, rec2, expectedOrientations);
     }
 
     /**
-     * @param rec1
-     * @param rec2
-     * @param header
-     * @param exepectedOrientations
      * @param addMateCigar true if we are to update/create the Mate CIGAR (MC) optional tag, false if we are to clear any mate cigar tag that is present.
      * @deprecated use {@link #setProperPairAndMateInfo(SAMRecord, SAMRecord, List, boolean)}
      */
     @Deprecated
     public static void setProperPairAndMateInfo(final SAMRecord rec1, final SAMRecord rec2,
                                                 final SAMFileHeader header,
-                                                final List<PairOrientation> exepectedOrientations,
+                                                final List<PairOrientation> expectedOrientations,
                                                 final boolean addMateCigar) {
-        setProperPairAndMateInfo(rec1, rec2, exepectedOrientations, addMateCigar);
+        setProperPairAndMateInfo(rec1, rec2, expectedOrientations, addMateCigar);
     }
 
     /**
      * This method will clear any mate cigar already present.
      */
     public static void setProperPairAndMateInfo(final SAMRecord rec1, final SAMRecord rec2,
-                                                final List<PairOrientation> exepectedOrientations) {
-        setProperPairAndMateInfo(rec1, rec2, exepectedOrientations, false);
+                                                final List<PairOrientation> expectedOrientations) {
+        setProperPairAndMateInfo(rec1, rec2, expectedOrientations, false);
     }
 
     /**
-     * @param rec1
-     * @param rec2
-     * @param exepectedOrientations
      * @param addMateCigar true if we are to update/create the Mate CIGAR (MC) optional tag, false if we are to clear any mate cigar tag that is present.
      */
     public static void setProperPairAndMateInfo(final SAMRecord rec1, final SAMRecord rec2,
-                                                final List<PairOrientation> exepectedOrientations,
+                                                final List<PairOrientation> expectedOrientations,
                                                 final boolean addMateCigar) {
         setMateInfo(rec1, rec2, addMateCigar);
-        setProperPairFlags(rec1, rec2, exepectedOrientations);
+        setProperPairFlags(rec1, rec2, expectedOrientations);
     }
 
     public static void setProperPairFlags(final SAMRecord rec1, final SAMRecord rec2, final List<PairOrientation> expectedOrientations) {

--- a/src/main/java/htsjdk/samtools/util/CollectionUtil.java
+++ b/src/main/java/htsjdk/samtools/util/CollectionUtil.java
@@ -104,8 +104,10 @@ public class CollectionUtil {
     /**
      * Partitions a collection into groups based on a characteristics of that group.  Partitions are embodied in a map, whose keys are the
      * value of that characteristic, and the values are the partition of elements whose characteristic evaluate to that key.
+     *
+     * @deprecated use java8 .stream().collect(Collectors.groupingBy(()-> function)) instead
      */
-    @Deprecated //use java8 .stream().collect(Collectors.groupingBy(()-> function)) instead
+    @Deprecated
     public static <K, V> Map<K, Collection<V>> partition(final Collection<V> collection, final Partitioner<V, K> p) {
         final MultiMap<K, V> partitionToValues = new MultiMap<>();
         for (final V entry : collection) {
@@ -113,7 +115,11 @@ public class CollectionUtil {
         }
         return partitionToValues;
     }
-    @Deprecated //not needed, use Collectors.groupingBy instead
+
+    /**
+     * @deprecated use Collectors.groupingBy instead
+     */
+    @Deprecated
     public static abstract class Partitioner<V, K> {
         public abstract K getPartition(final V v);
     }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -71,7 +71,7 @@ import java.util.zip.GZIPOutputStream;
  */
 public class IOUtil {
     /**
-     * @deprecated Use Defaults.NON_ZERO_BUFFER_SIZE instead.
+     * @deprecated Use {@link Defaults#NON_ZERO_BUFFER_SIZE} instead.
      */
     @Deprecated
     public static final int STANDARD_BUFFER_SIZE = Defaults.NON_ZERO_BUFFER_SIZE;

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -102,9 +102,14 @@ public class IntervalList implements Iterable<Interval> {
         }
     }
 
-    /** Sorts the internal collection of intervals by coordinate. */
-    @Deprecated // Use sorted() instead of sort(). The sort() function modifies the object in-place and
-    // is therefore difficult to work with. sorted() returns a new IntervalList that is sorted
+    /**
+     * Sorts the internal collection of intervals by coordinate.
+     *
+     * Note: this function modifies the object in-place and is therefore difficult to work with.
+     *
+     * @deprecated use {@link #sorted()} instead.
+     */
+    @Deprecated
     public void sort() {
         Collections.sort(this.intervals, new IntervalCoordinateComparator(this.header));
         this.header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
@@ -154,19 +159,27 @@ public class IntervalList implements Iterable<Interval> {
         return value;
     }
 
-    /** Sorts and uniques the list of intervals held within this interval list. */
-    @Deprecated//use uniqued() instead. This function modifies the object in-place and
-    // is therefore difficult to work with.
+    /**
+     * Sorts and uniques the list of intervals held within this interval list.
+     *
+     * Note: this function modifies the object in-place and is therefore difficult to work with.
+     *
+     * @deprecated use {@link #uniqued()} instead.
+     */
+    @Deprecated
     public void unique() {
         unique(true);
     }
 
     /**
      * Sorts and uniques the list of intervals held within this interval list.
+     *
+     * Note: this function modifies the object in-place and is therefore difficult to work with.
+     *
      * @param concatenateNames If false, interval names are not concatenated when merging intervals to save space.
+     * @deprecated use {@link #uniqued(boolean)} instead.
      */
-    @Deprecated//use uniqued() instead. This function modifies the object in-place and
-    // is therefore difficult to work with
+    @Deprecated
     public void unique(final boolean concatenateNames) {
         sort();
         final List<Interval> tmp = getUniqueIntervals(concatenateNames);
@@ -186,10 +199,12 @@ public class IntervalList implements Iterable<Interval> {
      *
      * Note: has the side-effect of sorting the stored intervals in coordinate order if not already sorted.
      *
+     * Note: this function modifies the object in-place and is therefore difficult to work with.
+     *
      * @return the set of unique intervals condensed from the contained intervals
+     * @deprecated use {@link #uniqued()#getIntervals()} instead.
      */
-    @Deprecated//use uniqued().getIntervals() instead. This function modifies the object in-place and
-    // is therefore difficult to work with
+    @Deprecated
     public List<Interval> getUniqueIntervals() {
         return getUniqueIntervals(true);
     }
@@ -249,14 +264,14 @@ public class IntervalList implements Iterable<Interval> {
     }
 
     /**
-     * Merges list of intervals and reduces them like htsjdk.samtools.util.IntervalList#getUniqueIntervals()
-     * @param concatenateNames If false, the merged interval has the name of the earlier interval.  This keeps name shorter.
+     * Merges list of intervals and reduces them like {@link #getUniqueIntervals()}.
+     *
+     * Note: this function modifies the object in-place and is therefore difficult to work with.
+     *
+     * @param concatenateNames If false, the merged interval has the name of the earlier interval. This keeps name shorter.
+     * @deprecated use {@link #uniqued(boolean)#getIntervals()} or {@link #getUniqueIntervals(IntervalList, boolean)} instead.
      */
-    @Deprecated //use uniqued(concatenateNames).getIntervals() or the static version instead to avoid changing the underlying object.
-    /**
-     * Merges list of intervals and reduces them like htsjdk.samtools.util.IntervalList#getUniqueIntervals()
-     * @param concatenateNames If false, the merged interval has the name of the earlier interval.  This keeps name shorter.
-     */
+    @Deprecated
     public List<Interval> getUniqueIntervals(final boolean concatenateNames) {
         if (getHeader().getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
             sort();

--- a/src/main/java/htsjdk/tribble/Feature.java
+++ b/src/main/java/htsjdk/tribble/Feature.java
@@ -36,6 +36,8 @@ public interface Feature extends Locatable {
      * @deprecated use getContig() instead
      */
     @Deprecated
-    public String getChr();
+    default public String getChr() {
+        return getContig();
+    }
 
 }

--- a/src/main/java/htsjdk/tribble/SimpleFeature.java
+++ b/src/main/java/htsjdk/tribble/SimpleFeature.java
@@ -39,11 +39,6 @@ public class SimpleFeature implements Feature {
         this.end = end;
     }
 
-    @Deprecated
-    public String getChr() {
-        return contig;
-    }
-
     public String getContig() {
         return contig;
     }

--- a/src/main/java/htsjdk/tribble/bed/SimpleBEDFeature.java
+++ b/src/main/java/htsjdk/tribble/bed/SimpleBEDFeature.java
@@ -51,14 +51,6 @@ public class SimpleBEDFeature implements BEDFeature {
         this.chr = chr;
     }
 
-
-    @Deprecated
-    @Override
-    public String getChr() {
-        return getContig();
-    }
-
-
     @Override
     public String getContig() {
         return chr;

--- a/src/main/java/htsjdk/tribble/example/CountRecords.java
+++ b/src/main/java/htsjdk/tribble/example/CountRecords.java
@@ -193,12 +193,8 @@ public class CountRecords {
         //    return new VCFCodec();
         if (featureFile.getName().endsWith(".bed") || featureFile.getName().endsWith(".BED") )
             return new BEDCodec();
-        //if (featureFile.getName().endsWith(".snp") || featureFile.getName().endsWith(".rod") )
-        //    return new OldDbSNPCodec();
         if (featureFile.getName().endsWith(".geli.calls") || featureFile.getName().endsWith(".geli") )
             return new GeliTextCodec();
-        //if (featureFile.getName().endsWith(".txt") || featureFile.getName().endsWith(".TXT") )
-        //    return new SoapSNPCodec();
         throw new IllegalArgumentException("Unable to determine correct file type based on the file name, for file -> " + featureFile);
     }
 }

--- a/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
+++ b/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
@@ -118,7 +118,7 @@ public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
         Iterator<FEATURE_TYPE> it = reader.iterator();
         while ( it.hasNext() ) {
             final Feature f = it.next();
-            dos.writeUTF(f.getChr());
+            dos.writeUTF(f.getContig());
             dos.writeInt(f.getStart());
             dos.writeInt(f.getEnd());
         }

--- a/src/main/java/htsjdk/tribble/gelitext/GeliTextFeature.java
+++ b/src/main/java/htsjdk/tribble/gelitext/GeliTextFeature.java
@@ -83,12 +83,6 @@ public class GeliTextFeature implements Feature {
         this.likelihoods = likelihoods;
     }
 
-    /** Return the features reference sequence name, e.g chromosome or contig */
-    @Deprecated
-    public String getChr() {
-        return getContig();
-    }
-
     @Override
     public String getContig() {
         return this.contig;

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -345,8 +345,8 @@ public class IndexFactory {
 
             checkSorted(inputFile, lastFeature, currentFeature);
             //should only visit chromosomes once
-            final String curChr = currentFeature.getChr();
-            final String lastChr = lastFeature != null ? lastFeature.getChr() : null;
+            final String curChr = currentFeature.getContig();
+            final String lastChr = lastFeature != null ? lastFeature.getContig() : null;
             if(!curChr.equals(lastChr)){
                 if(visitedChromos.containsKey(curChr)){
                     String msg = "Input file must have contiguous chromosomes.";
@@ -369,15 +369,15 @@ public class IndexFactory {
     }
 
     private static String featToString(final Feature feature){
-        return feature.getChr() + ":" + feature.getStart() + "-" + feature.getEnd();
+        return feature.getContig() + ":" + feature.getStart() + "-" + feature.getEnd();
     }
 
     private static void checkSorted(final File inputFile, final Feature lastFeature, final Feature currentFeature){
         // if the last currentFeature is after the current currentFeature, exception out
-        if (lastFeature != null && currentFeature.getStart() < lastFeature.getStart() && lastFeature.getChr().equals(currentFeature.getChr()))
+        if (lastFeature != null && currentFeature.getStart() < lastFeature.getStart() && lastFeature.getContig().equals(currentFeature.getContig()))
             throw new TribbleException.MalformedFeatureFile("Input file is not sorted by start position. \n" +
-                    "We saw a record with a start of " + currentFeature.getChr() + ":" + currentFeature.getStart() +
-                    " after a record with a start of " + lastFeature.getChr() + ":" + lastFeature.getStart(), inputFile.getAbsolutePath());
+                    "We saw a record with a start of " + currentFeature.getContig() + ":" + currentFeature.getStart() +
+                    " after a record with a start of " + lastFeature.getContig() + ":" + lastFeature.getStart(), inputFile.getAbsolutePath());
     }
 
 

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
@@ -64,13 +64,13 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
 
     public void addFeature(final Feature feature, final long filePosition) {
         // if we don't have a chrIndex yet, or if the last one was for the previous contig, create a new one
-        if (chrList.isEmpty() || !chrList.getLast().getName().equals(feature.getChr())) {
+        if (chrList.isEmpty() || !chrList.getLast().getName().equals(feature.getContig())) {
             // if we're creating a new chrIndex (not the first), make sure to dump the intervals to the old chrIndex
             if (!chrList.isEmpty())
                 addIntervalsToLastChr(filePosition);
 
             // create a new chr index for the current contig
-            chrList.add(new ChrIndex(feature.getChr()));
+            chrList.add(new ChrIndex(feature.getContig()));
             intervals.clear();
         }
 

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
@@ -66,14 +66,14 @@ public class LinearIndexCreator  extends TribbleIndexCreator {
      */
     public void addFeature(final Feature feature, final long filePosition) {
         // fi we don't have a chrIndex yet, or if the last one was for the previous contig, create a new one
-        if (chrList.isEmpty() || !chrList.getLast().getName().equals(feature.getChr())) {
+        if (chrList.isEmpty() || !chrList.getLast().getName().equals(feature.getContig())) {
             // if we're creating a new chrIndex (not the first), make sure to dump the blocks to the old chrIndex
             if (!chrList.isEmpty())
                 for (int x = 0; x < blocks.size(); x++) {
                     blocks.get(x).setEndPosition((x + 1 == blocks.size()) ? filePosition : blocks.get(x + 1).getStartPosition());
                     chrList.getLast().addBlock(blocks.get(x));
                 }
-            chrList.add(new LinearIndex.ChrIndex(feature.getChr(),binWidth));
+            chrList.add(new LinearIndex.ChrIndex(feature.getContig(),binWidth));
             blocks.clear();
 
             // Add the first block

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndexCreator.java
@@ -73,7 +73,7 @@ public class TabixIndexCreator implements IndexCreator {
 
     @Override
     public void addFeature(final Feature feature, final long filePosition) {
-        final String sequenceName = feature.getChr();
+        final String sequenceName = feature.getContig();
         final int referenceIndex;
         if (sequenceName.equals(currentSequenceName)) {
             referenceIndex = sequenceNames.size() - 1;

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -342,7 +342,7 @@ public class VariantContext implements Feature, Serializable {
      * @param other the VariantContext to copy
      */
     protected VariantContext(VariantContext other) {
-        this(other.getSource(), other.getID(), other.getChr(), other.getStart(), other.getEnd(),
+        this(other.getSource(), other.getID(), other.getContig(), other.getStart(), other.getEnd(),
                 other.getAlleles(), other.getGenotypes(), other.getLog10PError(),
                 other.getFiltersMaybeNull(),
                 other.getAttributes(),
@@ -1653,10 +1653,6 @@ public class VariantContext implements Feature, Serializable {
     // tribble integration routines -- not for public consumption
     //
     // ---------------------------------------------------------------------------------------------------------
-    @Deprecated
-    public String getChr() {
-        return getContig();
-    }
 
     @Override
     public String getContig() {

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextComparator.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextComparator.java
@@ -84,7 +84,7 @@ public class VariantContextComparator implements Comparator<VariantContext>, Ser
 		// present. This error checking should already have been done in the constructor but it's left
 		// in as defence anyway.
 		final int contigCompare =
-				this.contigIndexLookup.get(firstVariantContext.getChr()) - this.contigIndexLookup.get(secondVariantContext.getChr());
+				this.contigIndexLookup.get(firstVariantContext.getContig()) - this.contigIndexLookup.get(secondVariantContext.getContig());
 		return contigCompare != 0
 				? contigCompare
 				: firstVariantContext.getStart() - secondVariantContext.getStart();

--- a/src/main/java/htsjdk/variant/variantcontext/VariantJEXLContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantJEXLContext.java
@@ -59,7 +59,7 @@ class VariantJEXLContext implements JexlContext {
 
     static {
         attributes.put("vc", (VariantContext vc) -> vc);
-        attributes.put("CHROM", VariantContext::getChr);
+        attributes.put("CHROM", VariantContext::getContig);
         attributes.put("POS", VariantContext::getStart);
         attributes.put("TYPE", (VariantContext vc) -> vc.getType().toString());
         attributes.put("QUAL", (VariantContext vc) -> -10 * vc.getLog10PError());

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2FieldWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2FieldWriter.java
@@ -255,7 +255,7 @@ public abstract class BCF2FieldWriter {
             if ( vc.getNAlleles() > BCF2Utils.MAX_ALLELES_IN_GENOTYPES )
                 throw new IllegalStateException("Current BCF2 encoder cannot handle sites " +
                         "with > " + BCF2Utils.MAX_ALLELES_IN_GENOTYPES + " alleles, but you have "
-                        + vc.getNAlleles() + " at " + vc.getChr() + ":" + vc.getStart());
+                        + vc.getNAlleles() + " at " + vc.getContig() + ":" + vc.getStart());
 
             encodingType = BCF2Type.INT8;
             buildAlleleMap(vc);

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -234,9 +234,9 @@ class BCF2Writer extends IndexingVariantContextWriter {
     //
     // --------------------------------------------------------------------------------
     private byte[] buildSitesData( VariantContext vc ) throws IOException {
-        final int contigIndex = contigDictionary.get(vc.getChr());
+        final int contigIndex = contigDictionary.get(vc.getContig());
         if ( contigIndex == -1 )
-            throw new IllegalStateException(String.format("Contig %s not found in sequence dictionary from reference", vc.getChr()));
+            throw new IllegalStateException(String.format("Contig %s not found in sequence dictionary from reference", vc.getContig()));
 
         // note use of encodeRawValue to not insert the typing byte
         encoder.encodeRawValue(contigIndex, BCF2Type.INT32);
@@ -391,7 +391,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
      */
     private void errorUnexpectedFieldToWrite(final VariantContext vc, final String field, final String fieldType) {
         throw new IllegalStateException("Found field " + field + " in the " + fieldType + " fields of VariantContext at " +
-                vc.getChr() + ":" + vc.getStart() + " from " + vc.getSource() + " but this hasn't been defined in the VCFHeader");
+                vc.getContig() + ":" + vc.getStart() + " from " + vc.getSource() + " but this hasn't been defined in the VCFHeader");
     }
 
     // --------------------------------------------------------------------------------

--- a/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
@@ -118,11 +118,11 @@ abstract class SortingVariantContextWriterBase implements VariantContextWriter {
            since there is no implicit ordering of chromosomes:
          */
         VCFRecord firstRec = queue.peek();
-        if (firstRec != null && !vc.getChr().equals(firstRec.vc.getChr())) { // if we hit a new contig, flush the queue
-            if (finishedChromosomes.contains(vc.getChr()))
-                throw new IllegalArgumentException("Added a record at " + vc.getChr() + ":" + vc.getStart() + ", but already finished with chromosome" + vc.getChr());
+        if (firstRec != null && !vc.getContig().equals(firstRec.vc.getContig())) { // if we hit a new contig, flush the queue
+            if (finishedChromosomes.contains(vc.getContig()))
+                throw new IllegalArgumentException("Added a record at " + vc.getContig() + ":" + vc.getStart() + ", but already finished with chromosome" + vc.getContig());
 
-            finishedChromosomes.add(firstRec.vc.getChr());
+            finishedChromosomes.add(firstRec.vc.getContig());
             stopWaitingToSort();
         }
 
@@ -159,7 +159,7 @@ abstract class SortingVariantContextWriterBase implements VariantContextWriter {
     protected void noteCurrentRecord(VariantContext vc) {
         // did the user break the contract by giving a record too late?
         if (mostUpstreamWritableLoc != null && vc.getStart() < mostUpstreamWritableLoc) // went too far back, since may have already written anything that is <= mostUpstreamWritableLoc
-            throw new IllegalArgumentException("Permitted to write any record upstream of position " + mostUpstreamWritableLoc + ", but a record at " + vc.getChr() + ":" + vc.getStart() + " was just added.");
+            throw new IllegalArgumentException("Permitted to write any record upstream of position " + mostUpstreamWritableLoc + ", but a record at " + vc.getContig() + ":" + vc.getStart() + " was just added.");
     }
 
     // --------------------------------------------------------------------------------

--- a/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
@@ -72,7 +72,7 @@ public class VCFEncoder {
 		final StringBuilder stringBuilder = new StringBuilder();
 
 		// CHROM
-		stringBuilder.append(context.getChr()).append(VCFConstants.FIELD_SEPARATOR)
+		stringBuilder.append(context.getContig()).append(VCFConstants.FIELD_SEPARATOR)
 				// POS
 				.append(String.valueOf(context.getStart())).append(VCFConstants.FIELD_SEPARATOR)
 				// ID
@@ -170,7 +170,7 @@ public class VCFEncoder {
 	private void fieldIsMissingFromHeaderError(final VariantContext vc, final String id, final String field) {
 		if ( ! allowMissingFieldsInHeader)
 			throw new IllegalStateException("Key " + id + " found in VariantContext field " + field
-					+ " at " + vc.getChr() + ":" + vc.getStart()
+					+ " at " + vc.getContig() + ":" + vc.getStart()
 					+ " but this key isn't defined in the VCFHeader.  We require all VCFs to have"
 					+ " complete VCF headers by default.");
 	}

--- a/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -116,7 +116,7 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
                 final Integer intervalEnd=vc.getCommonInfo().getAttributeAsInt("END",vc.getEnd());
                 if(".".equals(name) || name == null)
                     name = "interval-" + (++intervals);
-                list.add(new Interval(vc.getChr(), vc.getStart(), intervalEnd, false, name));
+                list.add(new Interval(vc.getContig(), vc.getStart(), intervalEnd, false, name));
             }
         }
 

--- a/src/test/java/htsjdk/samtools/sra/AbstractSRATest.java
+++ b/src/test/java/htsjdk/samtools/sra/AbstractSRATest.java
@@ -18,7 +18,7 @@ public abstract class AbstractSRATest {
 
     @BeforeGroups(groups = "sra")
     public final void checkIfCanResolve() {
-        if (!SRAAccession.isSupported()) {
+        if (SRAAccession.checkIfInitialized() != null) {
             return;
         }
         canResolveNetworkAccession = SRAAccession.isValid(checkAccession);
@@ -26,7 +26,7 @@ public abstract class AbstractSRATest {
 
     @BeforeMethod
     public final void assertSRAIsSupported() {
-        if(!SRAAccession.isSupported()){
+        if(SRAAccession.checkIfInitialized() != null){
             throw new SkipException("Skipping SRA Test because SRA native code is unavailable.");
         }
     }

--- a/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
@@ -52,17 +52,17 @@ public class BEDCodecTest {
         BEDFeature feature;
 
         feature = codec.decode("chr1 1");
-        Assert.assertEquals(feature.getChr(), "chr1");
+        Assert.assertEquals(feature.getContig(), "chr1");
         Assert.assertEquals(feature.getStart(), 2);
         Assert.assertEquals(feature.getEnd(), 2);
 
         feature = codec.decode("chr1 1 2");
-        Assert.assertEquals(feature.getChr(), "chr1");
+        Assert.assertEquals(feature.getContig(), "chr1");
         Assert.assertEquals(feature.getStart(), 2);
         Assert.assertEquals(feature.getEnd(), 2);
 
         feature = codec.decode("chr1 1 3");
-        Assert.assertEquals(feature.getChr(), "chr1");
+        Assert.assertEquals(feature.getContig(), "chr1");
         Assert.assertEquals(feature.getStart(), 2);
         Assert.assertEquals(feature.getEnd(), 3);
     }
@@ -77,7 +77,7 @@ public class BEDCodecTest {
         // Borrowed samples from Example: on http://genome.ucsc.edu/FAQ/FAQformat#format1
 
         feature = (FullBEDFeature) codec.decode("chr22 1000 5000 cloneA 960 + 1000 5000 0 2 567,488, 0,3512");
-        Assert.assertEquals(feature.getChr(), "chr22");
+        Assert.assertEquals(feature.getContig(), "chr22");
         Assert.assertEquals(feature.getStart(), 1001);
         Assert.assertEquals(feature.getEnd(), 5000);
         Assert.assertEquals(feature.getName(), "cloneA");
@@ -103,7 +103,7 @@ public class BEDCodecTest {
         Assert.assertEquals(exons.get(1).getCodingLength(), 488);
 
         feature = (FullBEDFeature) codec.decode("chr22 2000 6000 cloneB 900 - 2000 6000 0 2 433,399, 0,3601");
-        Assert.assertEquals(feature.getChr(), "chr22");
+        Assert.assertEquals(feature.getContig(), "chr22");
         Assert.assertEquals(feature.getStart(), 2001);
         Assert.assertEquals(feature.getEnd(), 6000);
         Assert.assertEquals(feature.getName(), "cloneB");
@@ -150,23 +150,23 @@ public class BEDCodecTest {
         Iterable<Feature> iter = reader.iterator();
         int count = 0;
         for (Feature feat : iter) {
-            Assert.assertTrue(feat.getChr().length() > 0);
+            Assert.assertTrue(feat.getContig().length() > 0);
             Assert.assertTrue(feat.getEnd() >= feat.getStart());
 
             if (count == 0) {
-                Assert.assertEquals("1", feat.getChr());
+                Assert.assertEquals("1", feat.getContig());
                 Assert.assertEquals(25592413 + 1, feat.getStart());
                 Assert.assertEquals(25657872, feat.getEnd());
             }
 
             if (count == 3) {
-                Assert.assertEquals("1", feat.getChr());
+                Assert.assertEquals("1", feat.getContig());
                 Assert.assertEquals(152555536 + 1, feat.getStart());
                 Assert.assertEquals(152587611, feat.getEnd());
             }
 
             if (count == 28) {
-                Assert.assertEquals("14", feat.getChr());
+                Assert.assertEquals("14", feat.getContig());
                 Assert.assertEquals(73996607 + 1, feat.getStart());
                 Assert.assertEquals(74025282, feat.getEnd());
             }

--- a/src/test/java/htsjdk/tribble/gelitext/GeliTextTest.java
+++ b/src/test/java/htsjdk/tribble/gelitext/GeliTextTest.java
@@ -77,7 +77,7 @@ public class GeliTextTest {
             GeliTextFeature feat = iter.next();
             // check the first records contents
             // 22 14438070 A   0 0     GG      33.2618 33.2618 0       0       0       0     0 0       0       33.2618 0       0
-            Assert.assertTrue("22".equals(feat.getChr()));
+            Assert.assertTrue("22".equals(feat.getContig()));
             Assert.assertEquals(feat.getStart(), 14438070);
             Assert.assertEquals('A', feat.getRefBase());
             Assert.assertEquals(feat.getDepthOfCoverage(), 0.0, 0.0001);

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
@@ -831,7 +831,7 @@ public class VariantContextTestProvider {
      */
     public static void assertEquals( final VariantContext actual, final VariantContext expected ) {
         Assert.assertNotNull(actual, "VariantContext expected not null");
-        Assert.assertEquals(actual.getChr(), expected.getChr(), "chr");
+        Assert.assertEquals(actual.getContig(), expected.getContig(), "chr");
         Assert.assertEquals(actual.getStart(), expected.getStart(), "start");
         Assert.assertEquals(actual.getEnd(), expected.getEnd(), "end");
         Assert.assertEquals(actual.getID(), expected.getID(), "id");

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -189,7 +189,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         List<Allele> alleles = Arrays.asList(Aref, T);
         VariantContext vc = snpBuilder.alleles(alleles).make();
 
-        Assert.assertEquals(vc.getChr(), snpLoc);
+        Assert.assertEquals(vc.getContig(), snpLoc);
         Assert.assertEquals(vc.getStart(), snpLocStart);
         Assert.assertEquals(vc.getEnd(), snpLocStop);
         Assert.assertEquals(vc.getType(), VariantContext.Type.SNP);
@@ -217,7 +217,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         List<Allele> alleles = Arrays.asList(Aref);
         VariantContext vc = snpBuilder.alleles(alleles).make();
 
-        Assert.assertEquals(vc.getChr(), snpLoc);
+        Assert.assertEquals(vc.getContig(), snpLoc);
         Assert.assertEquals(vc.getStart(), snpLocStart);
         Assert.assertEquals(vc.getEnd(), snpLocStop);
         Assert.assertEquals(VariantContext.Type.NO_VARIATION, vc.getType());
@@ -244,7 +244,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         List<Allele> alleles = Arrays.asList(ATCref, del);
         VariantContext vc = new VariantContextBuilder("test", delLoc, delLocStart, delLocStop, alleles).make();
 
-        Assert.assertEquals(vc.getChr(), delLoc);
+        Assert.assertEquals(vc.getContig(), delLoc);
         Assert.assertEquals(vc.getStart(), delLocStart);
         Assert.assertEquals(vc.getEnd(), delLocStop);
         Assert.assertEquals(vc.getType(), VariantContext.Type.INDEL);
@@ -272,7 +272,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         List<Allele> alleles = Arrays.asList(Tref, ATC);
         VariantContext vc = new VariantContextBuilder("test", insLoc, insLocStart, insLocStop, alleles).make();
 
-        Assert.assertEquals(vc.getChr(), insLoc);
+        Assert.assertEquals(vc.getContig(), insLoc);
         Assert.assertEquals(vc.getStart(), insLocStart);
         Assert.assertEquals(vc.getEnd(), insLocStop);
         Assert.assertEquals(vc.getType(), VariantContext.Type.INDEL);
@@ -310,7 +310,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         List<Allele> alleles = Arrays.asList(delRef, ATC);
         VariantContext vc = insBuilder.alleles(alleles).make();
 
-        Assert.assertEquals(vc.getChr(), insLoc);
+        Assert.assertEquals(vc.getContig(), insLoc);
         Assert.assertEquals(vc.getStart(), insLocStart);
         Assert.assertEquals(vc.getEnd(), insLocStop);
         Assert.assertEquals(vc.getType(), VariantContext.Type.INDEL);
@@ -737,7 +737,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
     @Test(dataProvider = "SitesAndGenotypesVC")
     public void runModifyVCTests(SitesAndGenotypesVC cfg) {
         VariantContext modified = new VariantContextBuilder(cfg.vc).loc("chr2", 123, 123).make();
-        Assert.assertEquals(modified.getChr(), "chr2");
+        Assert.assertEquals(modified.getContig(), "chr2");
         Assert.assertEquals(modified.getStart(), 123);
         Assert.assertEquals(modified.getEnd(), 123);
 
@@ -757,7 +757,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Assert.assertEquals(modified.getAttribute("AC"), 1);
 
         // test the behavior when the builder's attribute object is not initialized
-        modified = new VariantContextBuilder(modified.getSource(), modified.getChr(), modified.getStart(), modified.getEnd(), modified.getAlleles()).attribute("AC", 1).make();
+        modified = new VariantContextBuilder(modified.getSource(), modified.getContig(), modified.getStart(), modified.getEnd(), modified.getAlleles()).attribute("AC", 1).make();
 
         // test normal attribute modification
         modified = new VariantContextBuilder(cfg.vc).attribute("AC", 1).make();
@@ -775,7 +775,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Assert.assertTrue(modified.getGenotypes().isEmpty());
 
         // test that original hasn't changed
-        Assert.assertEquals(cfg.vc.getChr(), cfg.copy.getChr());
+        Assert.assertEquals(cfg.vc.getContig(), cfg.copy.getContig());
         Assert.assertEquals(cfg.vc.getStart(), cfg.copy.getStart());
         Assert.assertEquals(cfg.vc.getEnd(), cfg.copy.getEnd());
         Assert.assertEquals(cfg.vc.getAlleles(), cfg.copy.getAlleles());
@@ -837,7 +837,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         VariantContext sub = vc.subContextFromSamples(cfg.samples, cfg.updateAlleles);
 
         // unchanged attributes should be the same
-        Assert.assertEquals(sub.getChr(), vc.getChr());
+        Assert.assertEquals(sub.getContig(), vc.getContig());
         Assert.assertEquals(sub.getStart(), vc.getStart());
         Assert.assertEquals(sub.getEnd(), vc.getEnd());
         Assert.assertEquals(sub.getLog10PError(), vc.getLog10PError());


### PR DESCRIPTION
### Description

I explore some of the deprecated classes/methods when cleaning some of my own code, and I found that there are usages of some of this methods in other parts of htsjdk. This is a PR to clean the usages and to ask for removal of some deprecated classes/methods no longer used. This includes:
- ~~Fixes #330~~ Already fixed in other PR
- Changed all `Feature.getChr()` to `Feature.getContig()` usages in htsjdk.
- Remove `SRAAccession.isSupported()` usages in the tests and change for the recomended one.
- Annotating some deprecated methods with `@Deprecated` and `/** @deprecated */`
- Adding javadoc `{@link }` for pointing to new/correct usage.
- ~~Asking for removal of classes and methods for different packages, including gelitext support, `VariantContextWriterFactory` and others.~~ Edited: open a PR for removal and discussion.

I divided the PR in several commits according to common changes, to make it easier to review. I think that this will help in the maintenance of the htsjdk library. If the removal of some classes is made effective, this will break compatibility with previous versions.

### Checklist
- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
