### PR TITLE
Adding delta for getTime assert to fix #578

### DIFF
--- a/src/test/java/htsjdk/samtools/util/RelativeIso8601DateTest.java
+++ b/src/test/java/htsjdk/samtools/util/RelativeIso8601DateTest.java
@@ -10,13 +10,17 @@ import java.util.List;
 /** @author mccowan */
 
 public class RelativeIso8601DateTest {
+
+    // 1 second resolution is ISO date
+    private final static double DELTA_FOR_TIME = 1000;
+
     @Test
     public void testLazyInstance() {
         final RelativeIso8601Date lazy = RelativeIso8601Date.generateLazyNowInstance();
         Assert.assertEquals(lazy.toString(), RelativeIso8601Date.LAZY_NOW_LABEL);
         Assert.assertEquals(lazy.toString(), RelativeIso8601Date.LAZY_NOW_LABEL);
         Assert.assertEquals(lazy.toString(), RelativeIso8601Date.LAZY_NOW_LABEL);
-        Assert.assertEquals(lazy.getTime(), new Iso8601Date(new Date(System.currentTimeMillis())).getTime(), 1000); // 1 second resolution is ISO date
+        Assert.assertEquals(lazy.getTime(), new Iso8601Date(new Date(System.currentTimeMillis())).getTime(), DELTA_FOR_TIME);
         // Assert no exception thrown; this should be valid, because toString should now return an iso-looking date.
         new Iso8601Date(lazy.toString());
     }
@@ -33,7 +37,7 @@ public class RelativeIso8601DateTest {
 
         for (final RelativeIso8601Date nonLazy : testDates) {
             Assert.assertFalse(nonLazy.toString().equals(RelativeIso8601Date.LAZY_NOW_LABEL));
-            Assert.assertEquals((double) nonLazy.getTime(), (double) time);
+            Assert.assertEquals((double) nonLazy.getTime(), (double) time, DELTA_FOR_TIME);
             // Assert no exception thrown; this should be valid, because toString return an iso-looking date.
             new RelativeIso8601Date(nonLazy.toString());
         }
@@ -44,6 +48,6 @@ public class RelativeIso8601DateTest {
         final String s = new Iso8601Date(new Date(12345)).toString();
         final Iso8601Date iso8601Date = new Iso8601Date(s);
         final RelativeIso8601Date relativeIso8601Date = new RelativeIso8601Date(s);
-        Assert.assertEquals(relativeIso8601Date.getTime(), iso8601Date.getTime());
+        Assert.assertEquals(relativeIso8601Date.getTime(), iso8601Date.getTime(), DELTA_FOR_TIME);
     }
 }


### PR DESCRIPTION
### Description

After overhaul the tests in `RelativeIso8601DateTest` because of test failures due to #578, I found that some of the `getTime()` asserts does not contain a delta value when one of them does. Thus, I added a delta value for all the tests to try to solve this issue.

Because the test failure is not deterministic, I don't know how to tests this. But at least it is a good practice to test always with the same delta value. This is a very simple patch that does not change anything important in the code.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


