### PR TITLE
Fix setting null bases in SAMRecord

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -249,7 +249,11 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     public void setReadBases(final byte[] value) {
-        mReadBases = value;
+        if (value == null) {
+            mReadBases = NULL_SEQUENCE;
+        } else {
+            mReadBases = value;
+        }
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -334,8 +334,8 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
     /**
      * Adds an unmapped fragment read to the builder.
      */
-    public void addUnmappedFragment(final String name) {
-        addFrag(name, -1, -1, false, true, null, null, -1, false);
+    public SAMRecord addUnmappedFragment(final String name) {
+        return addFrag(name, -1, -1, false, true, null, null, -1, false);
     }
 
 

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -960,4 +960,15 @@ public class SAMRecordUnitTest {
         SAMRecord.resolveNameFromIndex(1, null);
     }
 
+    @Test
+    public void testNullBases() {
+        SAMRecord sam = new SAMRecordSetBuilder().addUnmappedFragment("nullRecord");
+        // set the bases to null
+        sam.setReadBases(null);
+        // the sequence should be byte[0]
+        Assert.assertEquals(sam.getReadBases(), SAMRecord.NULL_SEQUENCE);
+        // check that toString() is not blowing up
+        sam.toString();
+    }
+
 }


### PR DESCRIPTION
### Description

* Fixes #297
* `SAMRecordBuilder.addUnmappedFrag(String)` returns the created `SAMRecord`.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


