### PR TITLE
More getters for VariantContext

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.variantcontext;
 
 
+import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.vcf.VCFConstants;
 
 import java.io.Serializable;
@@ -37,6 +38,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /**
@@ -253,6 +256,40 @@ public final class CommonInfo implements Serializable {
         if ( o instanceof List ) return (List<Object>)o;
         if ( o.getClass().isArray() ) return Arrays.asList((Object[])o);
         return Collections.singletonList(o);
+    }
+
+    private <T> List<T> getAttributeAsList(String key, Function<Object, T> transformer) {
+        return getAttributeAsList(key).stream().map(transformer).collect(Collectors.toList());
+    }
+
+    public List<String> getAttributeAsStringList(String key, String defaultValue) {
+        return getAttributeAsList(key, x -> (x == null) ? defaultValue : String.valueOf(x));
+    }
+
+    public List<Integer> getAttributeAsIntList(String key, int defaultValue) {
+        return getAttributeAsList(key, x -> {
+                            if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
+                                return defaultValue;
+                            } else if (x instanceof Integer) {
+                                return (Integer) x;
+                            } else {
+                                return Integer.valueOf((String)x); // throws an exception if this isn't a string
+                            }
+                        }
+                );
+    }
+
+    public List<Double> getAttributeAsDoubleList(String key, Double defaultValue) {
+        return getAttributeAsList(key, x -> {
+                    if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
+                        return defaultValue;
+                    } else if (x instanceof Double) {
+                        return (Double) x;
+                    } else {
+                        return Double.valueOf((String)x); // throws an exception if this isn't a string
+                    }
+                }
+        );
     }
 
     public String getAttributeAsString(String key, String defaultValue) {

--- a/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -26,7 +26,6 @@
 package htsjdk.variant.variantcontext;
 
 
-
 import htsjdk.variant.vcf.VCFConstants;
 
 import java.io.Serializable;
@@ -40,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -254,7 +254,14 @@ public final class CommonInfo implements Serializable {
         Object o = getAttribute(key);
         if ( o == null ) return Collections.emptyList();
         if ( o instanceof List ) return (List<Object>)o;
-        if ( o.getClass().isArray() ) return Arrays.asList((Object[])o);
+        if ( o.getClass().isArray() ) {
+            if (o instanceof int[]) {
+                return Arrays.stream((int[])o).boxed().collect(Collectors.toList());
+            } else if (o instanceof double[]) {
+                return Arrays.stream((double[])o).boxed().collect(Collectors.toList());
+            }
+            return Arrays.asList((Object[])o);
+        }
         return Collections.singletonList(o);
     }
 
@@ -266,12 +273,12 @@ public final class CommonInfo implements Serializable {
         return getAttributeAsList(key, x -> (x == null) ? defaultValue : String.valueOf(x));
     }
 
-    public List<Integer> getAttributeAsIntList(String key, int defaultValue) {
+    public List<Integer> getAttributeAsIntList(String key, Integer defaultValue) {
         return getAttributeAsList(key, x -> {
                             if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
                                 return defaultValue;
-                            } else if (x instanceof Integer) {
-                                return (Integer) x;
+                            } else if (x instanceof Number) {
+                                return ((Number) x).intValue();
                             } else {
                                 return Integer.valueOf((String)x); // throws an exception if this isn't a string
                             }
@@ -283,8 +290,8 @@ public final class CommonInfo implements Serializable {
         return getAttributeAsList(key, x -> {
                     if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
                         return defaultValue;
-                    } else if (x instanceof Double) {
-                        return (Double) x;
+                    } else if (x instanceof Number) {
+                        return ((Number) x).doubleValue();
                     } else {
                         return Double.valueOf((String)x); // throws an exception if this isn't a string
                     }

--- a/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -26,7 +26,7 @@
 package htsjdk.variant.variantcontext;
 
 
-import htsjdk.tribble.util.ParsingUtils;
+
 import htsjdk.variant.vcf.VCFConstants;
 
 import java.io.Serializable;

--- a/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -244,7 +244,7 @@ public final class CommonInfo implements Serializable {
         else
             return defaultValue;
     }
-    
+
     /**
      * Gets the attributes from a key as a list.
      *
@@ -291,15 +291,14 @@ public final class CommonInfo implements Serializable {
 
     public List<Double> getAttributeAsDoubleList(String key, Double defaultValue) {
         return getAttributeAsList(key, x -> {
-                    if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
-                        return defaultValue;
-                    } else if (x instanceof Number) {
-                        return ((Number) x).doubleValue();
-                    } else {
-                        return Double.valueOf((String)x); // throws an exception if this isn't a string
-                    }
-                }
-        );
+            if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
+                return defaultValue;
+            } else if (x instanceof Number) {
+                return ((Number) x).doubleValue();
+            } else {
+                return Double.valueOf((String)x); // throws an exception if this isn't a string
+            }
+        });
     }
 
     public String getAttributeAsString(String key, String defaultValue) {

--- a/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 
 /**
@@ -248,7 +249,16 @@ public final class CommonInfo implements Serializable {
 
     /** returns the value as an empty list if the key was not found,
         as a java.util.List if the value is a List or an Array,
-        as a Collections.singletonList if there is only one value */
+        as a Collections.singletonList if there is only one value
+     */
+    /**
+     * Gets the attributes from a key as a list.
+     *
+     * Note: int[] and double[] arrays are boxed.
+     *
+     * @return empty list if the key was not found; {@link Collections#singletonList(Object)} if
+     * there is only one value; a list containing the values if the value is a {@link List} or array.
+     */
     @SuppressWarnings("unchecked")
     public List<Object> getAttributeAsList(String key) {
         Object o = getAttribute(key);

--- a/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -39,8 +39,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 
 /**
@@ -246,11 +244,7 @@ public final class CommonInfo implements Serializable {
         else
             return defaultValue;
     }
-
-    /** returns the value as an empty list if the key was not found,
-        as a java.util.List if the value is a List or an Array,
-        as a Collections.singletonList if there is only one value
-     */
+    
     /**
      * Gets the attributes from a key as a list.
      *
@@ -285,15 +279,14 @@ public final class CommonInfo implements Serializable {
 
     public List<Integer> getAttributeAsIntList(String key, Integer defaultValue) {
         return getAttributeAsList(key, x -> {
-                            if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
-                                return defaultValue;
-                            } else if (x instanceof Number) {
-                                return ((Number) x).intValue();
-                            } else {
-                                return Integer.valueOf((String)x); // throws an exception if this isn't a string
-                            }
-                        }
-                );
+            if (x == null || x == VCFConstants.MISSING_VALUE_v4) {
+                return defaultValue;
+            } else if (x instanceof Number) {
+                return ((Number) x).intValue();
+            } else {
+                return Integer.valueOf((String)x); // throws an exception if this isn't a string
+            }
+        });
     }
 
     public List<Double> getAttributeAsDoubleList(String key, Double defaultValue) {

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -747,7 +747,9 @@ public class VariantContext implements Feature, Serializable {
         as a java.util.List if the value is a List or an Array,
         as a Collections.singletonList if there is only one value */
     public List<Object> getAttributeAsList(String key)  { return commonInfo.getAttributeAsList(key); }
-
+    public List<String> getAttributeAsStringList(String key, String defaultValue) { return commonInfo.getAttributeAsStringList(key, defaultValue); }
+    public List<Integer> getAttributeAsIntList(String key, int defaultValue) { return commonInfo.getAttributeAsIntList(key, defaultValue); }
+    public List<Double> getAttributeAsDoubleList(String key, double defaultValue) { return commonInfo.getAttributeAsDoubleList(key, defaultValue); }
     public CommonInfo getCommonInfo() {
         return commonInfo;
     }

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -38,7 +38,6 @@ import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.tribble.TribbleException;
-import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.vcf.VCFConstants;
 import htsjdk.variant.vcf.VCFFileReader;
 
@@ -1477,5 +1476,72 @@ public class VariantContextUnitTest extends VariantBaseTest {
             CloserUtil.close(iter);
             CloserUtil.close(reader);
         }
+    }
+
+    @Test
+    public void testGetAttributeAsIntList() {
+        final VariantContext context = basicBuilder
+                .attribute("DefaultIntegerList", new int[5])
+                .attribute("ListWithMissing", new Object[]{1, null, null})
+                .attribute("IntegerList", new int[]{0, 1, 2, 3})
+                .attribute("DoubleList", new double[]{1.8, 1.6, 2.1})
+                .attribute("StringList", new String[]{"1", "2"})
+                .attribute("NotNumeric", new String[]{"A", "B"})
+                .make();
+        // test as integer
+        Assert.assertEquals(context.getAttributeAsIntList("DefaultIntegerList", 5), Arrays.asList(0, 0, 0, 0, 0));
+        Assert.assertEquals(context.getAttributeAsIntList("ListWithMissing", 5), Arrays.asList(1, 5, 5));
+        Assert.assertEquals(context.getAttributeAsIntList("IntegerList", 5), Arrays.asList(0, 1, 2, 3));
+        Assert.assertEquals(context.getAttributeAsIntList("DoubleList", 5), Arrays.asList(1, 1, 2));
+        Assert.assertEquals(context.getAttributeAsIntList("StringList", 5), Arrays.asList(1, 2));
+        try {
+            context.getAttributeAsIntList("NotNumeric", 5);
+            Assert.fail();
+        } catch (Exception e) {
+
+        }
+    }
+
+    @Test
+    public void testGetAttributeAsDoubleList() {
+        final VariantContext context = basicBuilder
+                .attribute("DefaultIntegerList", new int[5])
+                .attribute("ListWithMissing", new Object[]{1, null, null})
+                .attribute("IntegerList", new int[]{0, 1, 2, 3})
+                .attribute("DoubleList", new double[]{1.8, 1.6, 2.1})
+                .attribute("StringList", new String[]{"1", "2"})
+                .attribute("NotNumeric", new String[]{"A", "B"})
+                .make();
+        // test as integer
+        Assert.assertEquals(context.getAttributeAsDoubleList("DefaultIntegerList", 5), Arrays.asList(0d, 0d, 0d, 0d, 0d));
+        Assert.assertEquals(context.getAttributeAsDoubleList("ListWithMissing", 5), Arrays.asList(1d, 5d, 5d));
+        Assert.assertEquals(context.getAttributeAsDoubleList("IntegerList", 5), Arrays.asList(0d, 1d, 2d, 3d));
+        Assert.assertEquals(context.getAttributeAsDoubleList("DoubleList", 5), Arrays.asList(1.8, 1.6, 2.1));
+        Assert.assertEquals(context.getAttributeAsDoubleList("StringList", 5), Arrays.asList(1d, 2d));
+        try {
+            context.getAttributeAsIntList("NotNumeric", 5);
+            Assert.fail();
+        } catch (Exception e) {
+
+        }
+    }
+
+    @Test
+    public void testGetAttributeAsStringList() {
+        final VariantContext context = basicBuilder
+                .attribute("DefaultIntegerList", new int[5])
+                .attribute("ListWithMissing", new Object[]{1, null, null})
+                .attribute("IntegerList", new int[]{0, 1, 2, 3})
+                .attribute("DoubleList", new double[]{1.8, 1.6, 2.1})
+                .attribute("StringList", new String[]{"1", "2"})
+                .attribute("NotNumeric", new String[]{"A", "B"})
+                .make();
+        // test as integer
+        Assert.assertEquals(context.getAttributeAsStringList("DefaultIntegerList", "empty"), Arrays.asList("0", "0", "0", "0", "0"));
+        Assert.assertEquals(context.getAttributeAsStringList("ListWithMissing", "empty"), Arrays.asList("1", "empty", "empty"));
+        Assert.assertEquals(context.getAttributeAsStringList("IntegerList", "empty"), Arrays.asList("0", "1", "2", "3"));
+        Assert.assertEquals(context.getAttributeAsStringList("DoubleList", "empty"), Arrays.asList("1.8", "1.6", "2.1"));
+        Assert.assertEquals(context.getAttributeAsStringList("StringList", "empty"), Arrays.asList("1", "2"));
+        Assert.assertEquals(context.getAttributeAsStringList("NotNumeric", "empty"), Arrays.asList("A", "B"));
     }
 }

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1481,6 +1481,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
     @Test
     public void testGetAttributeAsIntList() {
         final VariantContext context = basicBuilder
+                .attribute("Empty", new int[0])
                 .attribute("DefaultIntegerList", new int[5])
                 .attribute("ListWithMissing", new Object[]{1, null, null})
                 .attribute("IntegerList", new int[]{0, 1, 2, 3})
@@ -1488,23 +1489,23 @@ public class VariantContextUnitTest extends VariantBaseTest {
                 .attribute("StringList", new String[]{"1", "2"})
                 .attribute("NotNumeric", new String[]{"A", "B"})
                 .make();
+        // test an empty value
+        Assert.assertTrue(context.getAttributeAsIntList("Empty", 5).isEmpty());
         // test as integer
         Assert.assertEquals(context.getAttributeAsIntList("DefaultIntegerList", 5), Arrays.asList(0, 0, 0, 0, 0));
         Assert.assertEquals(context.getAttributeAsIntList("ListWithMissing", 5), Arrays.asList(1, 5, 5));
         Assert.assertEquals(context.getAttributeAsIntList("IntegerList", 5), Arrays.asList(0, 1, 2, 3));
         Assert.assertEquals(context.getAttributeAsIntList("DoubleList", 5), Arrays.asList(1, 1, 2));
         Assert.assertEquals(context.getAttributeAsIntList("StringList", 5), Arrays.asList(1, 2));
-        try {
-            context.getAttributeAsIntList("NotNumeric", 5);
-            Assert.fail();
-        } catch (Exception e) {
-
-        }
+        Assert.assertThrows(() -> context.getAttributeAsIntList("NotNumeric", 5));
+        // test the case of a missing key
+        Assert.assertTrue(context.getAttributeAsIntList("MissingList", 5).isEmpty());
     }
 
     @Test
     public void testGetAttributeAsDoubleList() {
         final VariantContext context = basicBuilder
+                .attribute("Empty", new int[0])
                 .attribute("DefaultIntegerList", new int[5])
                 .attribute("ListWithMissing", new Object[]{1, null, null})
                 .attribute("IntegerList", new int[]{0, 1, 2, 3})
@@ -1512,23 +1513,23 @@ public class VariantContextUnitTest extends VariantBaseTest {
                 .attribute("StringList", new String[]{"1", "2"})
                 .attribute("NotNumeric", new String[]{"A", "B"})
                 .make();
-        // test as integer
+        // test an empty value
+        Assert.assertTrue(context.getAttributeAsDoubleList("Empty", 5).isEmpty());
+        // test as double
         Assert.assertEquals(context.getAttributeAsDoubleList("DefaultIntegerList", 5), Arrays.asList(0d, 0d, 0d, 0d, 0d));
         Assert.assertEquals(context.getAttributeAsDoubleList("ListWithMissing", 5), Arrays.asList(1d, 5d, 5d));
         Assert.assertEquals(context.getAttributeAsDoubleList("IntegerList", 5), Arrays.asList(0d, 1d, 2d, 3d));
         Assert.assertEquals(context.getAttributeAsDoubleList("DoubleList", 5), Arrays.asList(1.8, 1.6, 2.1));
         Assert.assertEquals(context.getAttributeAsDoubleList("StringList", 5), Arrays.asList(1d, 2d));
-        try {
-            context.getAttributeAsIntList("NotNumeric", 5);
-            Assert.fail();
-        } catch (Exception e) {
-
-        }
+        Assert.assertThrows(() -> context.getAttributeAsDoubleList("NotNumeric", 5));
+        // test the case of a missing key
+        Assert.assertTrue(context.getAttributeAsDoubleList("MissingList", 5).isEmpty());
     }
 
     @Test
     public void testGetAttributeAsStringList() {
         final VariantContext context = basicBuilder
+                .attribute("Empty", new int[0])
                 .attribute("DefaultIntegerList", new int[5])
                 .attribute("ListWithMissing", new Object[]{1, null, null})
                 .attribute("IntegerList", new int[]{0, 1, 2, 3})
@@ -1536,12 +1537,16 @@ public class VariantContextUnitTest extends VariantBaseTest {
                 .attribute("StringList", new String[]{"1", "2"})
                 .attribute("NotNumeric", new String[]{"A", "B"})
                 .make();
-        // test as integer
+        // test an empty value
+        Assert.assertTrue(context.getAttributeAsStringList("Empty", "empty").isEmpty());
+        // test as string
         Assert.assertEquals(context.getAttributeAsStringList("DefaultIntegerList", "empty"), Arrays.asList("0", "0", "0", "0", "0"));
         Assert.assertEquals(context.getAttributeAsStringList("ListWithMissing", "empty"), Arrays.asList("1", "empty", "empty"));
         Assert.assertEquals(context.getAttributeAsStringList("IntegerList", "empty"), Arrays.asList("0", "1", "2", "3"));
         Assert.assertEquals(context.getAttributeAsStringList("DoubleList", "empty"), Arrays.asList("1.8", "1.6", "2.1"));
         Assert.assertEquals(context.getAttributeAsStringList("StringList", "empty"), Arrays.asList("1", "2"));
         Assert.assertEquals(context.getAttributeAsStringList("NotNumeric", "empty"), Arrays.asList("A", "B"));
+        // test the case of a missing key
+        Assert.assertTrue(context.getAttributeAsStringList("MissingList", "empy").isEmpty());
     }
 }

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1547,6 +1547,6 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Assert.assertEquals(context.getAttributeAsStringList("StringList", "empty"), Arrays.asList("1", "2"));
         Assert.assertEquals(context.getAttributeAsStringList("NotNumeric", "empty"), Arrays.asList("A", "B"));
         // test the case of a missing key
-        Assert.assertTrue(context.getAttributeAsStringList("MissingList", "empy").isEmpty());
+        Assert.assertTrue(context.getAttributeAsStringList("MissingList", "empty").isEmpty());
     }
 }


### PR DESCRIPTION
### Description
- Fixes #371 including list getters as String, Integer and Double.
### Checklist
- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
