### PR TITLE
Support use of Path in ParsingUtils, SeekableStreamFactory, AbstractVCFCodec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     compile "gov.nih.nlm.ncbi:ngs-java:1.2.4"
 
     testCompile "org.testng:testng:6.9.9"
+    testCompile "com.google.jimfs:jimfs:1.1"
 }
 
 sourceCompatibility = 1.8

--- a/src/main/java/htsjdk/samtools/SamInputResource.java
+++ b/src/main/java/htsjdk/samtools/SamInputResource.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.sra.SRAAccession;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Lazy;
 import htsjdk.samtools.util.RuntimeIOException;
 
@@ -366,8 +367,8 @@ class UrlInputResource extends InputResource {
     @Override
     public Path asPath() {
         try {
-            return Paths.get(urlResource.toURI());
-        } catch (URISyntaxException | IllegalArgumentException |
+            return IOUtil.getPath(urlResource.toExternalForm());
+        } catch (IOException | IllegalArgumentException |
             FileSystemNotFoundException | SecurityException e) {
             return null;
         }

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableStreamFactory.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableStreamFactory.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools.seekablestream;
 
+import htsjdk.samtools.util.IOUtil;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -78,6 +79,8 @@ public class SeekableStreamFactory{
                 return new SeekableFTPStream(new URL(path));
             } else if (path.startsWith("file:")) {
                 return new SeekableFileStream(new File(new URL(path).getPath()));
+            } else if (IOUtil.hasScheme(path)) {
+                return new SeekablePathStream(IOUtil.getPath(path));
             } else {
                 return new SeekableFileStream(new File(path));
             }

--- a/src/main/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/main/java/htsjdk/tribble/util/ParsingUtils.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.tribble.util;
 
+import htsjdk.samtools.util.IOUtil;
 import java.awt.Color;
 import java.io.File;
 import java.io.FileInputStream;
@@ -31,6 +32,7 @@ import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -83,6 +85,8 @@ public class ParsingUtils {
 
         if (path.startsWith("http:") || path.startsWith("https:") || path.startsWith("ftp:")) {
             inputStream = getURLHelper(new URL(path)).openInputStream();
+        } else if (IOUtil.hasScheme(path)) {
+            inputStream = Files.newInputStream(IOUtil.getPath(path));
         } else {
             File file = new File(path);
             inputStream = new FileInputStream(file);
@@ -400,6 +404,8 @@ public class ParsingUtils {
             }
             URLHelper helper = getURLHelper(url);
             return helper.exists();
+        } else if (IOUtil.hasScheme(resource)) {
+            return Files.exists(IOUtil.getPath(resource));
         } else {
             return (new File(resource)).exists();
         }

--- a/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.vcf;
 
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.NameAwareCodec;
@@ -45,6 +46,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -616,10 +619,11 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
 
     public static boolean canDecodeFile(final String potentialInput, final String MAGIC_HEADER_LINE) {
         try {
+            Path path = IOUtil.getPath(potentialInput);
             //isVCFStream closes the stream that's passed in
-            return isVCFStream(new FileInputStream(potentialInput), MAGIC_HEADER_LINE) ||
-                    isVCFStream(new GZIPInputStream(new FileInputStream(potentialInput)), MAGIC_HEADER_LINE) ||
-                    isVCFStream(new BlockCompressedInputStream(new FileInputStream(potentialInput)), MAGIC_HEADER_LINE);
+            return isVCFStream(Files.newInputStream(path), MAGIC_HEADER_LINE) ||
+                    isVCFStream(new GZIPInputStream(Files.newInputStream(path)), MAGIC_HEADER_LINE) ||
+                    isVCFStream(new BlockCompressedInputStream(Files.newInputStream(path)), MAGIC_HEADER_LINE);
         } catch ( FileNotFoundException e ) {
             return false;
         } catch ( IOException e ) {


### PR DESCRIPTION
### Description

Added support for java.util.nio.Path for some more code pathways.

This is to support loading of Features with Spark in GATK.
### Checklist
- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)
