### PR TITLE
Added getDescription() in VCFFilterHeaderLine

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFFilterHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFilterHeaderLine.java
@@ -27,12 +27,16 @@ package htsjdk.variant.vcf;
 
 import java.util.Arrays;
 
+import htsjdk.samtools.util.StringUtil;
+
 /**
  * @author ebanks
  * 
  * A class representing a key=value entry for FILTER fields in the VCF header
  */
 public class VCFFilterHeaderLine extends VCFSimpleHeaderLine  {
+    
+    private static final long serialVersionUID = 1L;
 
     /**
      * create a VCF filter header line
@@ -40,7 +44,7 @@ public class VCFFilterHeaderLine extends VCFSimpleHeaderLine  {
      * @param name         the name for this header line
      * @param description  the description for this header line
      */
-    public VCFFilterHeaderLine(String name, String description) {
+    public VCFFilterHeaderLine(final String name, final String description) {
         super("FILTER", name, description);
     }
 
@@ -48,7 +52,7 @@ public class VCFFilterHeaderLine extends VCFSimpleHeaderLine  {
      * Convenience constructor for FILTER whose description is the name
      * @param name
      */
-    public VCFFilterHeaderLine(String name) {
+    public VCFFilterHeaderLine(final String name) {
         super("FILTER", name, name);
     }
 
@@ -58,12 +62,21 @@ public class VCFFilterHeaderLine extends VCFSimpleHeaderLine  {
      * @param line      the header line
      * @param version   the vcf header version
      */
-    public VCFFilterHeaderLine(String line, VCFHeaderVersion version) {
+    public VCFFilterHeaderLine(final String line, final VCFHeaderVersion version) {
         super(line, version, "FILTER", Arrays.asList("ID", "Description"));
     }
 
     @Override
     public boolean shouldBeAddedToDictionary() {
         return true;
+    }
+    
+    /**
+     * get the "Description" field
+     * @return the "Description" or the Filter ID if the description is null or empty 
+     */
+    public String getDescription() {
+        final String desc = getGenericFieldValue("Description");
+        return ( StringUtil.isBlank(desc) ? getID() : desc );
     }
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFFilterHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFilterHeaderLine.java
@@ -27,8 +27,6 @@ package htsjdk.variant.vcf;
 
 import java.util.Arrays;
 
-import htsjdk.samtools.util.StringUtil;
-
 /**
  * @author ebanks
  * 
@@ -73,10 +71,9 @@ public class VCFFilterHeaderLine extends VCFSimpleHeaderLine  {
     
     /**
      * get the "Description" field
-     * @return the "Description" or the Filter ID if the description is null or empty 
+     * @return the "Description" field
      */
     public String getDescription() {
-        final String desc = getGenericFieldValue("Description");
-        return ( StringUtil.isBlank(desc) ? getID() : desc );
+        return getGenericFieldValue("Description");
     }
 }

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -196,7 +196,9 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     @Test
     public void testVCFHeaderAddFilterLine() {
         final VCFHeader header = getHiSeqVCFHeader();
-        final VCFFilterHeaderLine filterLine = new VCFFilterHeaderLine("TestFilterLine");
+        final String filterDesc = "TestFilterLine Description";
+        final VCFFilterHeaderLine filterLine = new VCFFilterHeaderLine("TestFilterLine",filterDesc);
+        Assert.assertEquals(filterDesc,filterLine.getDescription());
         header.addMetaDataLine(filterLine);
 
         Assert.assertTrue(header.getFilterLines().contains(filterLine), "TestFilterLine not found in filter header lines");
@@ -207,6 +209,10 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertFalse(header.getFormatHeaderLines().contains(filterLine), "TestFilterLine present in format header lines");
         Assert.assertFalse(header.getContigLines().contains(filterLine), "TestFilterLine present in contig header lines");
         Assert.assertFalse(header.getOtherHeaderLines().contains(filterLine), "TestFilterLine present in other header lines");
+    
+    
+        final VCFFilterHeaderLine filterLineNoDesc = new VCFFilterHeaderLine("TestFilterLine2","");
+        Assert.assertEquals(filterLineNoDesc.getID(),filterLineNoDesc.getDescription());
     }
 
     @Test

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -209,10 +209,6 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertFalse(header.getFormatHeaderLines().contains(filterLine), "TestFilterLine present in format header lines");
         Assert.assertFalse(header.getContigLines().contains(filterLine), "TestFilterLine present in contig header lines");
         Assert.assertFalse(header.getOtherHeaderLines().contains(filterLine), "TestFilterLine present in other header lines");
-    
-    
-        final VCFFilterHeaderLine filterLineNoDesc = new VCFFilterHeaderLine("TestFilterLine2","");
-        Assert.assertEquals(filterLineNoDesc.getID(),filterLineNoDesc.getDescription());
     }
 
     @Test


### PR DESCRIPTION
### Description

Using a VCFFilterHeaderLine as a java-bean, I was surprised to see that there is no (?) public/easy way to get the "Description" of a VCFFilterHeaderLine . This PR adds the method `getDescription()` ; It returns the ID if the description is empty. 
I've also added some `final` keywords and the `serialVersionUID`
### Checklist
- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [X] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
