### PR TITLE
Fix for issue #547

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013 EMBL-EBI
+ * Copyright 2013-2016 EMBL-EBI
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -466,9 +466,8 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
             iterator.setFileSource(enabled ? reader : null);
     }
 
-    private class CRAMIntervalIterator
-            extends BAMQueryMultipleIntervalsIteratorFilter
-            implements SAMRecordIterator {
+    private class CRAMIntervalIterator extends BAMQueryMultipleIntervalsIteratorFilter
+            implements CloseableIterator<SAMRecord> {
 
         // the granularity of this iterator is the container, so the records returned
         // by it must still be filtered to find those matching the filter criteria
@@ -504,11 +503,6 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
             }
 
             return BAMFileSpan.merge(spanArray).toCoordinateArray();
-        }
-
-        @Override
-        public SAMRecordIterator assertSorted(final SortOrder sortOrder) {
-            return null;
         }
 
         @Override

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2013 EMBL-EBI
+ * Copyright 2013-2016 EMBL-EBI
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -292,7 +292,7 @@ public class CRAMIterator implements SAMRecordIterator {
 
     @Override
     public SAMRecordIterator assertSorted(final SortOrder sortOrder) {
-        throw new RuntimeException("Not implemented.");
+        return SamReader.AssertingIterator.of(this).assertSorted(sortOrder);
     }
 
     public SamReader getFileSource() {

--- a/src/test/java/htsjdk/samtools/CRAMFileReaderTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileReaderTest.java
@@ -82,7 +82,7 @@ public class CRAMFileReaderTest {
     @Test(description = "Test CRAMReader 2 input required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader2_InputRequired() {
         File file = null;
-        InputStream bis =  null;
+        InputStream bis = null;
         new CRAMFileReader(file, bis, createReferenceSource());
     }
 


### PR DESCRIPTION
# Fix for issue [#547](https://github.com/samtools/htsjdk/issues/547):

Currently, SAMRecordIterator implementations in CRAMFileReader don't implement assertSorted method correctly. Firstly, in CRAMFileReader.CRAMIntervalIterator this method always returns null. Secondly, in CRAMIterator class this method just throws a runtime exception.
In case of CRAMIterator the solution is implementing this method using wrapping with SamReader.AssertingIterator class. The second class for CRAM iteration is inner private class CRAMFileReader.CRAMIntervalIterator. We changed its interface to CloseableIterator<SAMRecord>, since it allows us to keep all current functionality and this class is never used as SamRecordIterator, so assertSort method is useless for it. Also, we added new unit test to check code correctness.
### Checklist
- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
