### PR TITLE
Change default logging level to INFO

### DIFF
--- a/src/main/java/htsjdk/samtools/util/Log.java
+++ b/src/main/java/htsjdk/samtools/util/Log.java
@@ -43,7 +43,7 @@ public final class Log {
     /** Enumeration for setting log levels. */
     public static enum LogLevel { ERROR, WARNING, INFO, DEBUG }
 
-    private static LogLevel globalLogLevel = LogLevel.DEBUG;
+    private static LogLevel globalLogLevel = LogLevel.INFO;
 
     private final Class<?> clazz;
     private final String className;


### PR DESCRIPTION
### Description

Implements https://github.com/samtools/htsjdk/issues/739.
Do not want to get DEBUG messages by default.


### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


