### PR TITLE
Fix for issue #432 in Picard Tools. CreateSequenceDictionary stalls indefinitely with large genomes 

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -1,17 +1,19 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.LineReader;
+import htsjdk.samtools.util.RuntimeIOException;
 
 import java.io.BufferedWriter;
+import java.io.IOException;
 import java.io.Writer;
 
 public class SAMSequenceDictionaryCodec {
 
     private final SAMTextHeaderCodec codec;
 
-    public SAMSequenceDictionaryCodec(final Writer writer) {
+    public SAMSequenceDictionaryCodec(final BufferedWriter writer) {
         codec = new SAMTextHeaderCodec();
-        codec.setWriter(new BufferedWriter(writer));
+        codec.setWriter(writer);
     }
 
     public void encodeSQLine(final SAMSequenceRecord sequenceRecord) {
@@ -24,6 +26,7 @@ public class SAMSequenceDictionaryCodec {
 
     public void encode(final SAMSequenceDictionary dictionary) {
         dictionary.getSequences().forEach(this::encodeSQLine);
+
     }
 
     public void setValidationStringency(final ValidationStringency validationStringency) {

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -55,8 +55,7 @@ import java.io.BufferedWriter;
  * try(BufferedWriter writer = new BufferedWriter(new FileWriter("path/to/file"))) {
  *      SAMSequenceDictionaryCodec codec = new SAMSequenceDictionaryCodec(writer);
  *
- *      //we have complete SAMSequenceDictionary, so encode header line and {@link SAMSequenceDictionary}.
- *      codec.encodeHeaderLine(false);
+ *      //we have complete {@link SAMSequenceDictionary}, so just encode it.
  *      codec.encode(dict);
  *}
  *
@@ -105,6 +104,7 @@ public class SAMSequenceDictionaryCodec {
      * @param dictionary object to be converted to text.
      */
     public void encode(final SAMSequenceDictionary dictionary) {
+        codec.encodeHeaderLine(false);
         dictionary.getSequences().forEach(this::encodeSequenceRecord);
     }
 

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -31,14 +31,45 @@ import java.io.BufferedWriter;
  * "On the fly" codec SAMSequenceDictionaryCodec.
  * Encodes each sequence and directly writes it to the Dictionary file.
  *
+ * To use this class you should provide BufferedWriter to it, and so you should close it as you stop using this class.
+ * You can work with this class as shown below.
+ *
+ * Example of using this class:
+ *
+ * List<SAMSequenceRecord> dict = ...;
+ *
+ * //open BufferedReader and close in try-with-resources
+ * try(BufferedWriter writer = new BufferedWriter(new FileWriter("path/to/file"))) {
+ *      SAMSequenceDictionaryCodec codec = new SAMSequenceDictionaryCodec(writer);
+ *
+ *      //we have list of sequences, so encode header line and after that encode each sequence
+ *      codec.encodeHeaderLine(false);
+ *      dict.forEach(codec::encodeSequenceRecord);
+ *}
+ *
+ * or
+ *
+ * SAMSequenceDictionary dict = ...;
+ *
+ * //open BufferedReader and close in try-with-resources
+ * try(BufferedWriter writer = new BufferedWriter(new FileWriter("path/to/file"))) {
+ *      SAMSequenceDictionaryCodec codec = new SAMSequenceDictionaryCodec(writer);
+ *
+ *      //we have complete SAMSequenceDictionary, so just encode it.
+ *      codec.encode(dict);
+ *}
+ *
  * @author Pavel_Silin@epam.com, EPAM Systems, Inc. <www.epam.com>
  */
 public class SAMSequenceDictionaryCodec {
+
+    private static final SAMFileHeader EMPTY_HEADER = new SAMFileHeader();
 
     private final SAMTextHeaderCodec codec;
 
     public SAMSequenceDictionaryCodec(final BufferedWriter writer) {
         codec = new SAMTextHeaderCodec();
+        codec.setmFileHeader(EMPTY_HEADER);
         codec.setWriter(writer);
     }
 
@@ -55,7 +86,6 @@ public class SAMSequenceDictionaryCodec {
      * @param keepExistingVersionNumber boolean flag to keep existing version number.
      */
     public void encodeHeaderLine(final boolean keepExistingVersionNumber) {
-        codec.setmFileHeader(new SAMFileHeader());
         codec.encodeHeaderLine(keepExistingVersionNumber);
     }
 

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -55,7 +55,8 @@ import java.io.BufferedWriter;
  * try(BufferedWriter writer = new BufferedWriter(new FileWriter("path/to/file"))) {
  *      SAMSequenceDictionaryCodec codec = new SAMSequenceDictionaryCodec(writer);
  *
- *      //we have complete SAMSequenceDictionary, so just encode it.
+ *      //we have complete SAMSequenceDictionary, so encode header line and {@link SAMSequenceDictionary}.
+ *      codec.encodeHeaderLine(false);
  *      codec.encode(dict);
  *}
  *
@@ -104,7 +105,6 @@ public class SAMSequenceDictionaryCodec {
      * @param dictionary object to be converted to text.
      */
     public void encode(final SAMSequenceDictionary dictionary) {
-        encodeHeaderLine(false);
         dictionary.getSequences().forEach(this::encodeSequenceRecord);
     }
 

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -1,0 +1,32 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.util.LineReader;
+
+import java.io.BufferedWriter;
+import java.io.Writer;
+
+public class SAMSequenceDictionaryCodec {
+
+    private final SAMTextHeaderCodec codec;
+
+    public SAMSequenceDictionaryCodec(final Writer writer) {
+        codec = new SAMTextHeaderCodec();
+        codec.setWriter(new BufferedWriter(writer));
+    }
+
+    public void encodeSQLine(final SAMSequenceRecord sequenceRecord) {
+        codec.writeSQLine(sequenceRecord);
+    }
+
+    public SAMSequenceDictionary decode(final LineReader reader, final String source) {
+       return codec.decode(reader, source).getSequenceDictionary();
+    }
+
+    public void encode(final SAMSequenceDictionary dictionary) {
+        dictionary.getSequences().forEach(this::encodeSQLine);
+    }
+
+    public void setValidationStringency(final ValidationStringency validationStringency) {
+        codec.setValidationStringency(validationStringency);
+    }
+}

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -25,14 +25,10 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.LineReader;
-import htsjdk.samtools.util.RuntimeIOException;
-
 import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
 
 /**
- * "On fly" codec SAMSequenceDictionaryCodec.
+ * "On the fly" codec SAMSequenceDictionaryCodec.
  * Encodes each sequence and directly writes it to the Dictionary file.
  *
  * @author Pavel_Silin@epam.com, EPAM Systems, Inc. <www.epam.com>
@@ -50,8 +46,17 @@ public class SAMSequenceDictionaryCodec {
      * Write {@link SAMSequenceRecord}.
      * @param sequenceRecord object to be converted to text.
      */
-    public void encodeSQLine(final SAMSequenceRecord sequenceRecord) {
-        codec.writeSQLine(sequenceRecord);
+    public void encodeSequenceRecord(final SAMSequenceRecord sequenceRecord) {
+        codec.encodeSequenceRecord(sequenceRecord);
+    }
+
+    /**
+     * Write Header line.
+     * @param keepExistingVersionNumber boolean flag to keep existing version number.
+     */
+    public void encodeHeaderLine(final boolean keepExistingVersionNumber) {
+        codec.setmFileHeader(new SAMFileHeader());
+        codec.encodeHeaderLine(keepExistingVersionNumber);
     }
 
     /**
@@ -69,8 +74,8 @@ public class SAMSequenceDictionaryCodec {
      * @param dictionary object to be converted to text.
      */
     public void encode(final SAMSequenceDictionary dictionary) {
-        dictionary.getSequences().forEach(this::encodeSQLine);
-
+        encodeHeaderLine(false);
+        dictionary.getSequences().forEach(this::encodeSequenceRecord);
     }
 
     public void setValidationStringency(final ValidationStringency validationStringency) {

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.LineReader;
@@ -7,6 +31,12 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
 
+/**
+ * "On fly" codec SAMSequenceDictionaryCodec.
+ * Encodes each sequence and directly writes it to the Dictionary file.
+ *
+ * @author Pavel_Silin@epam.com, EPAM Systems, Inc. <www.epam.com>
+ */
 public class SAMSequenceDictionaryCodec {
 
     private final SAMTextHeaderCodec codec;
@@ -16,14 +46,28 @@ public class SAMSequenceDictionaryCodec {
         codec.setWriter(writer);
     }
 
+    /**
+     * Write {@link SAMSequenceRecord}.
+     * @param sequenceRecord object to be converted to text.
+     */
     public void encodeSQLine(final SAMSequenceRecord sequenceRecord) {
         codec.writeSQLine(sequenceRecord);
     }
 
+    /**
+     * Reads text SAM header and converts to a SAMSequenceDictionary object.
+     * @param reader Where to get header text from.
+     * @param source Name of the input file, for error messages.  May be null.
+     * @return complete SAMSequenceDictionary object.
+     */
     public SAMSequenceDictionary decode(final LineReader reader, final String source) {
        return codec.decode(reader, source).getSequenceDictionary();
     }
 
+    /**
+     * Convert {@link SAMSequenceDictionary} from in-memory representation to text representation.
+     * @param dictionary object to be converted to text.
+     */
     public void encode(final SAMSequenceDictionary dictionary) {
         dictionary.getSequences().forEach(this::encodeSQLine);
 

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -70,8 +70,12 @@ public class SAMTextHeaderCodec {
 
     public static final String COMMENT_PREFIX = HEADER_LINE_START + HeaderRecordType.CO.name() + FIELD_SEPARATOR;
 
-    void setWriter(BufferedWriter writer) {
+    void setWriter(final BufferedWriter writer) {
         this.writer = writer;
+    }
+
+    void setmFileHeader(final SAMFileHeader header) {
+        this.mFileHeader = header;
     }
 
     /**
@@ -391,6 +395,30 @@ public class SAMTextHeaderCodec {
         }
     }
 
+    /**
+     * Encode {@link SAMSequenceRecord}.
+     * Designed for using in {@link SAMSequenceDictionaryCodec}, allows you to implement recording on the fly.
+     * @throws IllegalStateException, if writer is null.
+     */
+    void encodeSequenceRecord(final SAMSequenceRecord sequenceRecord) {
+        if (writer == null) {
+            throw new IllegalStateException("writer couldn't be null");
+        }
+        writeSQLine(sequenceRecord);
+    }
+
+    /**
+     * Encode HD line.
+     * Designed for using in {@link SAMSequenceDictionaryCodec}, allows you to implement recording on the fly.
+     * @throws IllegalStateException, if writer is null.
+     */
+    void encodeHeaderLine(final boolean keepExistingVersionNumber) {
+        if (writer == null) {
+            throw new IllegalStateException("writer couldn't be null");
+        }
+        writeHDLine(keepExistingVersionNumber);
+    }
+
     private void println(final String s) {
         try {
             writer.append(s);
@@ -441,7 +469,7 @@ public class SAMTextHeaderCodec {
         println(StringUtil.join(FIELD_SEPARATOR, fields));
     }
 
-    void writeSQLine(final SAMSequenceRecord sequenceRecord) {
+    private void writeSQLine(final SAMSequenceRecord sequenceRecord) {
         final int numAttributes = sequenceRecord.getAttributes() != null ? sequenceRecord.getAttributes().size() : 0;
         final String[] fields = new String[3 + numAttributes];
         fields[0] = HEADER_LINE_START + HeaderRecordType.SQ;

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -397,7 +397,7 @@ public class SAMTextHeaderCodec {
 
     /**
      * Encode {@link SAMSequenceRecord}.
-     * Designed for using in {@link SAMSequenceDictionaryCodec}, allows you to implement recording on the fly.
+     * Designed for using in {@link SAMSequenceDictionaryCodec}, allows to implement recording on the fly.
      * @throws IllegalStateException, if writer is null.
      */
     void encodeSequenceRecord(final SAMSequenceRecord sequenceRecord) {
@@ -409,7 +409,7 @@ public class SAMTextHeaderCodec {
 
     /**
      * Encode HD line.
-     * Designed for using in {@link SAMSequenceDictionaryCodec}, allows you to implement recording on the fly.
+     * Designed for using in {@link SAMSequenceDictionaryCodec}, allows to implement recording on the fly.
      * @throws IllegalStateException, if writer is null.
      */
     void encodeHeaderLine(final boolean keepExistingVersionNumber) {

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -70,6 +70,10 @@ public class SAMTextHeaderCodec {
 
     public static final String COMMENT_PREFIX = HEADER_LINE_START + HeaderRecordType.CO.name() + FIELD_SEPARATOR;
 
+    void setWriter(BufferedWriter writer) {
+        this.writer = writer;
+    }
+
     /**
      * Reads text SAM header and converts to a SAMFileHeader object.
      * @param reader Where to get header text from.
@@ -80,8 +84,8 @@ public class SAMTextHeaderCodec {
         mFileHeader = new SAMFileHeader();
         mReader = reader;
         mSource = source;
-        sequences = new ArrayList<SAMSequenceRecord>();
-        readGroups = new ArrayList<SAMReadGroupRecord>();
+        sequences = new ArrayList<>();
+        readGroups = new ArrayList<>();
 
         while (advanceLine() != null) {
             final ParsedHeaderLine parsedHeaderLine = new ParsedHeaderLine(mCurrentLine);
@@ -437,8 +441,8 @@ public class SAMTextHeaderCodec {
         println(StringUtil.join(FIELD_SEPARATOR, fields));
     }
 
-    private void writeSQLine(final SAMSequenceRecord sequenceRecord) {
-        final int numAttributes =sequenceRecord.getAttributes() != null ? sequenceRecord.getAttributes().size() : 0;
+    void writeSQLine(final SAMSequenceRecord sequenceRecord) {
+        final int numAttributes = sequenceRecord.getAttributes() != null ? sequenceRecord.getAttributes().size() : 0;
         final String[] fields = new String[3 + numAttributes];
         fields[0] = HEADER_LINE_START + HeaderRecordType.SQ;
         fields[1] = SAMSequenceRecord.SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + sequenceRecord.getSequenceName();

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
@@ -65,7 +65,6 @@ public class SAMSequenceDictionaryCodecTest {
         LineReader readerOne = null;
         LineReader readerTwo = null;
         try {
-            codec.encodeHeaderLine(false);
             codec.encode(dictionary);
             bufferedWriter.close();
             readerOne = new StringLineReader(writer.toString());

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
@@ -62,15 +62,15 @@ public class SAMSequenceDictionaryCodecTest {
     public void testEncodeDecode() throws Exception {
         LineReader reader = null;
         try {
+            codec.encodeHeaderLine(false);
             codec.encode(dictionary);
             bufferedWriter.close();
             reader = new StringLineReader(writer.toString());
             SAMSequenceDictionary actual = codec.decode(reader, null);
             assertEquals(actual, dictionary);
-        }finally {
+        } finally {
             assert reader != null;
             reader.close();
         }
     }
-
 }

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
@@ -1,0 +1,49 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.util.LineReader;
+import htsjdk.samtools.util.StringLineReader;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.BufferedWriter;
+import java.io.StringWriter;
+import java.util.Random;
+
+import static org.testng.Assert.*;
+
+public class SAMSequenceDictionaryCodecTest {
+
+    private static final Random RANDOM = new Random();
+    private SAMSequenceDictionary dictionary;
+    private StringWriter writer;
+    private SAMSequenceDictionaryCodec codec;
+    private BufferedWriter bufferedWriter;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        String[] seqs = new String[]{"chr1", "chr2", "chr12", "chr16", "chrX"};
+        dictionary = new SAMSequenceDictionary();
+        for (String seq : seqs) {
+            dictionary.addSequence(new SAMSequenceRecord(seq, RANDOM.nextInt(10_000_000)));
+        }
+        writer = new StringWriter(10);
+        bufferedWriter = new BufferedWriter(writer);
+        codec = new SAMSequenceDictionaryCodec(bufferedWriter);
+    }
+
+    @Test
+    public void testEncodeDecode() throws Exception {
+        LineReader reader = null;
+        try {
+            codec.encode(dictionary);
+            bufferedWriter.close();
+            reader = new StringLineReader(writer.toString());
+            SAMSequenceDictionary actual = codec.decode(reader, null);
+            assertEquals(actual, dictionary);
+        }finally {
+            assert reader != null;
+            reader.close();
+        }
+    }
+
+}

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
@@ -40,7 +40,7 @@ import static org.testng.Assert.*;
  */
 public class SAMSequenceDictionaryCodecTest {
 
-    private static final Random RANDOM = new Random();
+    private static final Random random = new Random();
     private SAMSequenceDictionary dictionary;
     private StringWriter writer;
     private SAMSequenceDictionaryCodec codec;
@@ -51,7 +51,7 @@ public class SAMSequenceDictionaryCodecTest {
         String[] seqs = new String[]{"chr1", "chr2", "chr12", "chr16", "chrX"};
         dictionary = new SAMSequenceDictionary();
         for (String seq : seqs) {
-            dictionary.addSequence(new SAMSequenceRecord(seq, RANDOM.nextInt(10_000_000)));
+            dictionary.addSequence(new SAMSequenceRecord(seq, random.nextInt(10_000_000)));
         }
         writer = new StringWriter(10);
         bufferedWriter = new BufferedWriter(writer);

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 20016 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.LineReader;
@@ -11,6 +35,9 @@ import java.util.Random;
 
 import static org.testng.Assert.*;
 
+/**
+ * @author Pavel_Silin@epam.com, EPAM Systems, Inc. <www.epam.com>
+ */
 public class SAMSequenceDictionaryCodecTest {
 
     private static final Random RANDOM = new Random();


### PR DESCRIPTION
We introduce two pull requests to Htsjdk and Picard Tools(https://github.com/broadinstitute/picard/pull/687) to resolve the issue https://github.com/broadinstitute/picard/issues/432 .

Original version of CreateSequenceDictionary creates and stores all reference sequences entirely in memory in a SAMHeader object and then writes it to a file.

In order to check sequence's names for uniqueness, they are added to a HashSet. This might lead to "Out of memory" exceptions for files with a large number of sequences .


**Changes in Htsjdk:**

In our implementation we introduce a new "on fly" codec SAMSequenceDictionaryCodec, which encodes each sequence and directly writes it to the Dictionary file. This allows us not to store sequences in memory.


**Changes in Picard Tools:**

CreateSequenceDictionary now uses new SAMSequenceDictionaryCodec to write dictionary file.

SortingCollection is used instead of a HashSet to verify the sequences names uniqueness , this allows us not to keep all the names in memory since identical names will be stored in the collection one after another and we can find duplicates in one pass. 

Please pay attention, that now CreateSequenceDictionary doesn't write HD line, since we think that it is not required, SequenceDictionary must contain only SQ line, not HD. If our assumption is wrong, correct us, please.

 

 

So, if we look at the plot "GC Times" from JMC: FlightRecorder, we will see that standard version of CreateSequenceDictionary have a big trouble with a large amount of records (several millions):

**The plot "GC Times" for a  Standard version:**
 
![selection_041](https://cloud.githubusercontent.com/assets/11179595/20395648/16c18ec0-acfd-11e6-8576-bf4c52013e4f.png)
![selection_043](https://cloud.githubusercontent.com/assets/11179595/20395649/16c275a6-acfd-11e6-9d54-63f1f20c50a4.png)


**The plot "GC Times" for a fixed version:**
![selection_040](https://cloud.githubusercontent.com/assets/11179595/20395646/16990892-acfd-11e6-829a-832b63679b73.png)
![selection_042](https://cloud.githubusercontent.com/assets/11179595/20395647/16be48c8-acfd-11e6-8eac-2982b09fe183.png)

How we can see, now CreateSequenceDictionary processes a big reference without troubles, for example time of execution for file from issue https://github.com/broadinstitute/picard/issues/432 is:

```
real 762.83
user 626.94
sys 67.02
```

Full GC reports (jmc flight recorder):
[JMC FR logs.zip](https://github.com/broadinstitute/picard/files/597773/JMC.FR.logs.zip)


### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing


