### PR TITLE
Discounts reads that are non-filter-passing in DuplicateScoringStrategy 

### DIFF
--- a/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
+++ b/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
@@ -111,11 +111,6 @@ public class DuplicateScoringStrategy {
     public static int compare(final SAMRecord rec1, final SAMRecord rec2, final ScoringStrategy scoringStrategy, final boolean assumeMateCigar) {
         int cmp;
 
-        // always prefer passing filter over non-passing filter
-        if (rec1.getReadFailsVendorQualityCheckFlag() != rec2.getReadFailsVendorQualityCheckFlag()) {
-            return rec1.getReadFailsVendorQualityCheckFlag() ? 1 : -1;
-        }
-
         // always prefer paired over non-paired
         if (rec1.getReadPairedFlag() != rec2.getReadPairedFlag()) return rec1.getReadPairedFlag() ? 1 : -1;
 


### PR DESCRIPTION
### Description

DuplicateScoringStrategy is a class used by Picard's MarkDuplicates for the purpose of choosing the "best" read/read-pair from a duplicate set. It has multiple strategies, but they all ignore the filter-flag. This means (as mentioned in https://github.com/broadinstitute/picard/issues/690) that in some cases a duplicate-set will end up being represented by a filter-failing read, which will then be ignored by most downstream tools. 

To fix this problem, this PR discounts the score of reads if they are failing the vendor flag. The other scores are capped to guarantee that the discount is large enough. 

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

