### PR TITLE
Public CustomGzipOutputStream

### DIFF
--- a/src/main/java/htsjdk/samtools/util/CustomGzipOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/CustomGzipOutputStream.java
@@ -1,0 +1,24 @@
+package htsjdk.samtools.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Hacky little class used to allow us to set the compression level on a GZIP output stream which, for some
+ * bizarre reason, is not exposed in the standard API.
+ *
+ * @author Tim Fennell
+ */
+public class CustomGzipOutputStream extends GZIPOutputStream {
+    CustomGzipOutputStream(final OutputStream outputStream, final int bufferSize, final int compressionLevel) throws
+            IOException {
+        super(outputStream, bufferSize);
+        this.def.setLevel(compressionLevel);
+    }
+
+    CustomGzipOutputStream(final OutputStream outputStream, final int compressionLevel) throws IOException {
+        super(outputStream);
+        this.def.setLevel(compressionLevel);
+    }
+}

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -944,22 +944,3 @@ public class IOUtil {
         return output;
     }
 }
-
-
-/**
- * Hacky little class used to allow us to set the compression level on a GZIP output stream which, for some
- * bizarre reason, is not exposed in the standard API.
- *
- * @author Tim Fennell
- */
-class CustomGzipOutputStream extends GZIPOutputStream {
-    CustomGzipOutputStream(final OutputStream outputStream, final int bufferSize, final int compressionLevel) throws IOException {
-        super(outputStream, bufferSize);
-        this.def.setLevel(compressionLevel);
-    }
-
-    CustomGzipOutputStream(final OutputStream outputStream, final int compressionLevel) throws IOException {
-        super(outputStream);
-        this.def.setLevel(compressionLevel);
-    }
-}


### PR DESCRIPTION
### Description

There is a `CustomGzipOutputStream` in HTSJDK for setting the compression level at construction, which is used in `IOUtils.openGzipFileForWriting(File file, boolean append)`. But if you want to wrap an `OutputStream` from other sources (like a `Path`) using the `Defaults.COMPRESSION_LEVEL` or other compression, it is impossible to set unless this class is coded again.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


