### PR TITLE
Fix for issue 563: make CRAMFileReader work with only one iterator simultaneously

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
@@ -20,8 +20,12 @@ public class CramContainerIterator implements Iterator<Container> {
     private long offset = 0;
 
     public CramContainerIterator(final InputStream inputStream) throws IOException {
-        cramHeader = CramIO.readCramHeader(inputStream);
+        this(inputStream, CramIO.readCramHeader(inputStream));
+    }
+
+    public CramContainerIterator(final InputStream inputStream, final CramHeader cramHeader) {
         this.inputStream = inputStream;
+        this.cramHeader = cramHeader;
     }
 
     void readNextContainer() {

--- a/src/test/java/htsjdk/samtools/CRAMCRAIIndexerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMCRAIIndexerTest.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.reference.FakeReferenceSequenceFile;
 import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
+import htsjdk.samtools.util.CloseableIterator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -138,17 +139,20 @@ public class CRAMCRAIIndexerTest extends HtsjdkTest {
         );
         Assert.assertTrue(cramReader.hasIndex());
 
-        Iterator<SAMRecord> it = cramReader.query(new QueryInterval[]{new QueryInterval(0, 0, 5)}, false);
+        CloseableIterator<SAMRecord> it = cramReader.query(new QueryInterval[]{new QueryInterval(0, 0, 5)}, false);
         long count = getIteratorCount(it);
         Assert.assertEquals(count, 1);
+        it.close();
 
         it = cramReader.query(new QueryInterval[]{new QueryInterval(1, 0, 5)}, false);
         count = getIteratorCount(it);
         Assert.assertEquals(count, 3);
+        it.close();
 
         it = cramReader.query(new QueryInterval[]{new QueryInterval(2, 0, 5)}, false);
         count = getIteratorCount(it);
         Assert.assertEquals(count, 2);
+        it.close();
     }
 
     private static SAMRecord createSAMRecord(SAMFileHeader header, int recordIndex, int seqId, int start) {

--- a/src/test/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
@@ -131,6 +131,7 @@ public class CRAMFileBAIIndexTest extends HtsjdkTest {
             Assert.assertEquals(samRecord.getReferenceName(), cramRecord.getReferenceName(), s1 + s2);
             // default 'overlap' is true, so test records intersect the query:
             Assert.assertTrue(CoordMath.overlaps(cramRecord.getAlignmentStart(), cramRecord.getAlignmentEnd(), samRecord.getAlignmentStart(), samRecord.getAlignmentEnd()), s1 + s2);
+            iterator.close();
         }
         samRecordIterator.close();
         reader.close();

--- a/src/test/java/htsjdk/samtools/CRAMFileCRAIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileCRAIIndexTest.java
@@ -163,6 +163,7 @@ public class CRAMFileCRAIIndexTest extends HtsjdkTest {
                         samRecord.getAlignmentStart(),
                         samRecord.getAlignmentEnd()),
                         sam1 + sam2);
+                iterator.close();
             }
             Assert.assertEquals(counter, nofMappedReads);
             cramReader.close();

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterWithIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterWithIndexTest.java
@@ -40,6 +40,7 @@ public class CRAMFileWriterWithIndexTest extends HtsjdkTest {
             SAMRecord record = iterator.next();
             Assert.assertEquals(record.getReferenceName(), sequenceRecord.getSequenceName());
             Assert.assertEquals(record.getAlignmentStart(), 1);
+            iterator.close();
         }
     }
 


### PR DESCRIPTION
### Fix for issue [#563](https://github.com/samtools/htsjdk/issues/563):

`CRAMFileReader`can keep several iterators opened and this may lead to inconsistent iterator's state if the source of the `CRAMFileReader`is a stream. @cmnbroad suggests to implement the same iterator handling for `CRAMFileReader`as in `BAMFileReader`.  `BAMFileReader` produces iterator as inner class `AbstractBAMIterator`  and iterator is set to reader's field `mCurrentIterator`. `mCurrentIterator` is set to null when `close()` method is called on the iterator and it allows us to check the state of the reader and iterator when creating a new one.

But there are several difficulties with implementing this approach in `CRAMFileReader` and it's iterators:
 - There are two types of iterators: `CRAMFileReader.CRAMIntervalIterator` (private inner) and `CRAMIterator` - public class, that doesn't have access to `CRAMFileReader` fields. `CRAMIterator`'s public access prevents us from implementing the desired approach, but making it private inner class of `CRAMFileReader` will cause lost of backward compatibility. So we suggest another solution: we introduce the new Interface `CloseCheckable` extends `SAMRecordIterator` for the inner `CRAMFileReader` iterator, which allows us to check the iterator's state from the `CRAMFileReader` and restrict simultaneous iterators creation.
 - Besides, there is no way to get several iterators from reader on a stream with a consistent state in the current implementation as `CRAMIterator` reads header by itself. But we need to read it by `CRAMFileReader` and pass to `CRAMIterator`, otherwise, we can open only a single `CRAMIterator` on a stream. We've made changes to the constructors to fix this issue.

We propose the following changes:
 - New constructors in `CRAMIterator` and `CramContainerIterator` that receive CRAM header as an argument. These changes were caused by re-instancing iterator in `CRAMFileReader`.
 - Mark `CRAMIterator` public constructors deprecated since new constructors with header and package access were  implemented. `CRAMIterator` should be instanced only in `CRAMFileReader`, so it is more appropriate not to make its constructors public. 
 - Create inner interface `CRAMFileReader.CloseCheckableSAMRecordIterator` that extends `SAMRecordIterator` by `isClose()` method to check if existing iterator is closed; `CRAMIterator` and `CRAMFileReader.CRAMIntervalIterator` implement this interface to allow `CRAMFileReader` check its state.
 - Throw `IllegalStateException` in `CRAMFileReader` if iterator isn't closed, but a new one is created.
 - Add new fields in `CRAMFileReader` (`cramFileHeader`, `firstContainerOffset`, `mReader`) to keep information about header, first container offset and source.
 - Do some refactoring for code readability: create `initHeaderAndFirstOffset(CRAMIterator)` and `initCRAMIterator()` methods in `CRAMFileReader` class.
 - Fix some tests (`CRAMCRAIIndexerTest`, `CRAMFileBAIIndexTest`, `CRAMFileCRAIIndexTest`, `CRAMFileWriterWithIndexTest`) since it should be impossible to hold several iterators opened at the same time.

Also, we updated license and added new tests in `CRAMFileReaderTest` to check code correctness.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing