### PR TITLE
Removing TribbleIndexedFeatureReader.isGZIPPath deprecated method

### DIFF
--- a/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -276,31 +276,6 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
     }
 
     /**
-     * @deprecated use {@link #hasBlockCompressedExtension(String)} instead
-     */
-    //Visible for testing
-    @Deprecated
-    static boolean isGZIPPath(final String path) {
-        if (path.toLowerCase().endsWith(".gz")) {
-            return true;
-        }
-        else {
-            String uriPath = null;
-            try {
-                URI uri = new URI(path);
-                if (uri != null) {
-                    uriPath = uri.getPath();
-                    return uriPath != null && uriPath.toLowerCase().endsWith(".gz");
-                }
-                return false;
-            }
-            catch (URISyntaxException e) {
-                return false;
-            }
-        }
-    }
-
-    /**
      * Class to iterator over an entire file.
      */
     class WFIterator implements CloseableTribbleIterator<T> {

--- a/src/test/java/htsjdk/tribble/TribbleIndexFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/TribbleIndexFeatureReaderTest.java
@@ -16,50 +16,6 @@ import static org.testng.Assert.assertEquals;
 
 public class TribbleIndexFeatureReaderTest {
 
-    @DataProvider(name = "extensionURIStrings")
-    public Object[][] createBlockCompressedExtensionURIs() {
-        return new Object[][]{
-                {"testzip.gz", true},
-                {"testzip.GZ", true},
-                {"testzip.gZ", true},
-                {"testzip.Gz", true},
-
-                {"test", false},
-                {"test.gzip", false},
-                {"test.bgz", false},
-                {"test.bgzf", false},
-                {"test.bzip2", false},
-
-                {"file://testzip.gz", true},
-                {"file://apath/testzip.gz", true},
-
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gz", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.GZ", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gzip", false},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgz", false},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgzf", false},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bzip2", false},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877", false},
-
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gz?alt=media", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.GZ?alt=media", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gzip?alt=media", false},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgz?alt=media", false},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgzf?alt=media", false},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bzip2?alt=media", false},
-
-                {"ftp://ftp.broadinstitute.org/distribution/igv/TEST/cpgIslands.hg18.gz", true},
-                {"ftp://ftp.broadinstitute.org/distribution/igv/TEST/cpgIslands.hg18.bed", false},
-
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gz", true},
-        };
-    }
-
-    @Test(enabled = true, dataProvider = "extensionURIStrings")
-    public void testGZExtension(final String testString, final boolean expected) throws URISyntaxException {
-        Assert.assertEquals(TribbleIndexedFeatureReader.isGZIPPath(testString), expected);
-    }
-
     @DataProvider(name = "featureFileStrings")
     public Object[][] createFeatureFileStrings() {
         return new Object[][]{


### PR DESCRIPTION
### Description

Removed unused package-specific (visible for testing) deprecated method. Found in #707.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


