### PR TITLE
Removed unused deprecated URLHelper.openInputStreamForRange

### DIFF
--- a/src/main/java/htsjdk/tribble/util/FTPHelper.java
+++ b/src/main/java/htsjdk/tribble/util/FTPHelper.java
@@ -43,12 +43,6 @@ public class FTPHelper implements URLHelper {
     }
 
     @Override
-    @Deprecated
-    public InputStream openInputStreamForRange(long start, long end) throws IOException {
-        throw new UnsupportedOperationException("Cannot perform range operations over FTP");
-    }
-
-    @Override
     public boolean exists() throws IOException {
         return FTPUtils.resourceAvailable(this.url);
     }

--- a/src/main/java/htsjdk/tribble/util/HTTPHelper.java
+++ b/src/main/java/htsjdk/tribble/util/HTTPHelper.java
@@ -90,24 +90,6 @@ public class HTTPHelper implements URLHelper {
         return new WrapperInputStream(connection, connection.getInputStream());
     }
 
-
-    /**
-     * Open an input stream for the requested byte range.  Its the client's responsibility to close the stream.
-     *
-     * @param start start of range in bytes
-     * @param end   end of range ni bytes
-     * @return
-     * @throws IOException
-     */
-    @Deprecated
-    public InputStream openInputStreamForRange(long start, long end) throws IOException {
-
-        HttpURLConnection connection = openConnection();
-        String byteRange = "bytes=" + start + "-" + end;
-        connection.setRequestProperty("Range", byteRange);
-        return new WrapperInputStream(connection, connection.getInputStream());
-    }
-
     private HttpURLConnection openConnection() throws IOException {
         HttpURLConnection connection;
         if (proxy == null) {

--- a/src/main/java/htsjdk/tribble/util/RemoteURLHelper.java
+++ b/src/main/java/htsjdk/tribble/util/RemoteURLHelper.java
@@ -43,12 +43,6 @@ public class RemoteURLHelper implements URLHelper {
     }
 
     @Override
-    @Deprecated
-    public InputStream openInputStreamForRange(long start, long end) throws IOException {
-        return this.wrappedHelper.openInputStreamForRange(start, end);
-    }
-
-    @Override
     public boolean exists() throws IOException {
         return this.wrappedHelper.exists();
     }

--- a/src/main/java/htsjdk/tribble/util/URLHelper.java
+++ b/src/main/java/htsjdk/tribble/util/URLHelper.java
@@ -21,7 +21,6 @@ package htsjdk.tribble.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import javax.naming.OperationNotSupportedException;
 
 /**
  * Interface defining a helper class for dealing with URL resources.  Purpose of this class is to provide the

--- a/src/main/java/htsjdk/tribble/util/URLHelper.java
+++ b/src/main/java/htsjdk/tribble/util/URLHelper.java
@@ -21,6 +21,7 @@ package htsjdk.tribble.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import javax.naming.OperationNotSupportedException;
 
 /**
  * Interface defining a helper class for dealing with URL resources.  Purpose of this class is to provide the
@@ -38,18 +39,6 @@ public interface URLHelper {
     long getContentLength() throws IOException;
 
     InputStream openInputStream() throws IOException;
-
-    /**
-     * May throw an OperationUnsupportedException
-     * @deprecated Will be removed in a future release, as is somewhat fragile
-     * and not used.
-     * @param start
-     * @param end
-     * @return
-     * @throws IOException
-     */
-    @Deprecated
-    InputStream openInputStreamForRange(long start, long end) throws IOException;
 
     public boolean exists() throws IOException;
 


### PR DESCRIPTION
### Description

Removed unused and deprecated method in URLHelper. Found in #707.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


