### PR TITLE
code cleanup: using <> where possible

### DIFF
--- a/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
@@ -209,7 +209,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
     public BAMIndexMetaData getMetaData(final int reference) {
         seek(4);
 
-        final List<Chunk> metaDataChunks = new ArrayList<Chunk>();
+        final List<Chunk> metaDataChunks = new ArrayList<>();
 
         final int sequenceCount = readInteger();
 
@@ -258,7 +258,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
     protected BAMIndexContent query(final int referenceSequence, final int startPos, final int endPos) {
         seek(4);
 
-        final List<Chunk> metaDataChunks = new ArrayList<Chunk>();
+        final List<Chunk> metaDataChunks = new ArrayList<>();
 
         final int sequenceCount = readInteger();
 
@@ -283,7 +283,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
             // System.out.println("# bin[" + i + "] = " + indexBin + ", nChunks = " + nChunks);
             Chunk lastChunk = null;
             if (regionBins.get(indexBin)) {
-            	chunks = new ArrayList<Chunk>(nChunks);
+            	chunks = new ArrayList<>(nChunks);
                 for (int ci = 0; ci < nChunks; ci++) {
                     final long chunkBegin = readLong();
                     final long chunkEnd = readLong();

--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -38,7 +38,7 @@ import javax.xml.bind.annotation.XmlTransient;
 public abstract class AbstractSAMHeaderRecord implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    private final Map<String,String> mAttributes = new LinkedHashMap<String, String>();
+    private final Map<String,String> mAttributes = new LinkedHashMap<>();
 
     public String getAttribute(final String key) {
         return mAttributes.get(key);

--- a/src/main/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/BAMFileReader.java
@@ -546,7 +546,7 @@ class BAMFileReader extends SamReader.ReaderImplementation {
             }
         } else {
             // If only binary sequences are present, copy them into samFileHeader
-            final List<SAMSequenceRecord> sequences = new ArrayList<SAMSequenceRecord>(sequenceCount);
+            final List<SAMSequenceRecord> sequences = new ArrayList<>(sequenceCount);
             for (int i = 0; i < sequenceCount; i++) {
                 sequences.add(readSequenceRecord(stream, source));
             }

--- a/src/main/java/htsjdk/samtools/BAMFileSpan.java
+++ b/src/main/java/htsjdk/samtools/BAMFileSpan.java
@@ -53,7 +53,7 @@ public class BAMFileSpan implements SAMFileSpan, Serializable {
      * Create a new empty list of chunks.
      */
     public BAMFileSpan() {
-        this.chunks = new ArrayList<Chunk>();
+        this.chunks = new ArrayList<>();
     }
 
     /**
@@ -62,7 +62,7 @@ public class BAMFileSpan implements SAMFileSpan, Serializable {
      * @param chunk Chunk to use as the sole region in this span.
      */
     public BAMFileSpan(final Chunk chunk) {
-        this.chunks = new ArrayList<Chunk>();
+        this.chunks = new ArrayList<>();
         chunks.add(chunk);
     }
 
@@ -71,7 +71,7 @@ public class BAMFileSpan implements SAMFileSpan, Serializable {
      * @param chunks Constituent chunks.
      */
     public BAMFileSpan(final List<Chunk> chunks) {
-        this.chunks = new ArrayList<Chunk>(chunks);
+        this.chunks = new ArrayList<>(chunks);
     }
 
     /**
@@ -257,7 +257,7 @@ public class BAMFileSpan implements SAMFileSpan, Serializable {
      * and contained chunks are intelligently merged, and the chunks are sorted.
      */
     public static BAMFileSpan merge(final BAMFileSpan[] spans) {
-        final ArrayList<Chunk> inputChunks = new ArrayList<Chunk>();
+        final ArrayList<Chunk> inputChunks = new ArrayList<>();
         for (final BAMFileSpan span : spans) {
             if(span != null){
                 inputChunks.addAll(span.chunks);

--- a/src/main/java/htsjdk/samtools/Bin.java
+++ b/src/main/java/htsjdk/samtools/Bin.java
@@ -121,7 +121,7 @@ public class Bin implements Comparable<Bin> {
      * Adds the first chunk to the bin
      */
     public void addInitialChunk(final Chunk newChunk){
-        final List<Chunk> oldChunks = new ArrayList<Chunk>();
+        final List<Chunk> oldChunks = new ArrayList<>();
         setChunkList(oldChunks);
         setLastChunk(newChunk);
         oldChunks.add(newChunk);

--- a/src/main/java/htsjdk/samtools/BinningIndexContent.java
+++ b/src/main/java/htsjdk/samtools/BinningIndexContent.java
@@ -95,7 +95,7 @@ public class BinningIndexContent {
      * @return all chunks associated with all bins in this content
      */
     public List<Chunk> getAllChunks() {
-        final List<Chunk> allChunks = new ArrayList<Chunk>();
+        final List<Chunk> allChunks = new ArrayList<>();
         for (final Bin b : mBinList)
             if (b.getChunkList() != null) {
                 allChunks.addAll(b.getChunkList());
@@ -122,7 +122,7 @@ public class BinningIndexContent {
         if (overlappingBins == null) return null;
 
         // System.out.println("# Sequence target TID: " + referenceIndex);
-        final List<Chunk> chunkList = new ArrayList<Chunk>();
+        final List<Chunk> chunkList = new ArrayList<>();
 
         for (int index = overlappingBins.nextSetBit(0); index >= 0; index = overlappingBins.nextSetBit(index + 1)) {
             final Bin bin = getBins().getBin(index);

--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -45,7 +45,7 @@ public class CRAMContainerStreamWriter {
     private final OutputStream outputStream;
     private CRAMReferenceSource source;
 
-    private final List<SAMRecord> samRecords = new ArrayList<SAMRecord>();
+    private final List<SAMRecord> samRecords = new ArrayList<>();
     private ContainerFactory containerFactory;
     private int refSeqIndex = REF_SEQ_INDEX_NOT_INITIALIZED;
 
@@ -54,8 +54,8 @@ public class CRAMContainerStreamWriter {
     private boolean preserveReadNames = true;
     private QualityScorePreservation preservation = null;
     private boolean captureAllTags = true;
-    private Set<String> captureTags = new TreeSet<String>();
-    private Set<String> ignoreTags = new TreeSet<String>();
+    private Set<String> captureTags = new TreeSet<>();
+    private Set<String> ignoreTags = new TreeSet<>();
 
     private CRAMBAIIndexer indexer;
     private long offset;
@@ -306,7 +306,7 @@ public class CRAMContainerStreamWriter {
             updateTracks(samRecords, tracks);
         }
 
-        final List<CramCompressionRecord> cramRecords = new ArrayList<CramCompressionRecord>(samRecords.size());
+        final List<CramCompressionRecord> cramRecords = new ArrayList<>(samRecords.size());
 
         final Sam2CramRecordFactory sam2CramRecordFactory = new Sam2CramRecordFactory(refs, samFileHeader, cramVersion);
         sam2CramRecordFactory.preserveReadNames = preserveReadNames;
@@ -341,8 +341,8 @@ public class CRAMContainerStreamWriter {
         {
             if (samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.coordinate) {
                 // mating:
-                final Map<String, CramCompressionRecord> primaryMateMap = new TreeMap<String, CramCompressionRecord>();
-                final Map<String, CramCompressionRecord> secondaryMateMap = new TreeMap<String, CramCompressionRecord>();
+                final Map<String, CramCompressionRecord> primaryMateMap = new TreeMap<>();
+                final Map<String, CramCompressionRecord> secondaryMateMap = new TreeMap<>();
                 for (final CramCompressionRecord r : cramRecords) {
                     if (!r.isMultiFragment()) {
                         r.setDetached(true);

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -87,7 +87,7 @@ public class CRAMIterator implements SAMRecordIterator {
         this.containerIterator = containerIterator;
 
         firstContainerOffset = this.countingInputStream.getCount();
-        records = new ArrayList<SAMRecord>(10000);
+        records = new ArrayList<>(10000);
         normalizer = new CramNormalizer(cramHeader.getSamFileHeader(),
                 referenceSource);
         parser = new ContainerParser(cramHeader.getSamFileHeader());
@@ -106,7 +106,7 @@ public class CRAMIterator implements SAMRecordIterator {
         this.containerIterator = containerIterator;
 
         firstContainerOffset = containerIterator.getFirstContainerOffset();
-        records = new ArrayList<SAMRecord>(10000);
+        records = new ArrayList<>(10000);
         normalizer = new CramNormalizer(cramHeader.getSamFileHeader(),
                 referenceSource);
         parser = new ContainerParser(cramHeader.getSamFileHeader());
@@ -147,11 +147,11 @@ public class CRAMIterator implements SAMRecordIterator {
         }
 
         if (records == null)
-            records = new ArrayList<SAMRecord>(container.nofRecords);
+            records = new ArrayList<>(container.nofRecords);
         else
             records.clear();
         if (cramRecords == null)
-            cramRecords = new ArrayList<CramCompressionRecord>(container.nofRecords);
+            cramRecords = new ArrayList<>(container.nofRecords);
         else
             cramRecords.clear();
 

--- a/src/main/java/htsjdk/samtools/CachingBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/CachingBAMFileIndex.java
@@ -38,7 +38,7 @@ import java.util.WeakHashMap;
 class CachingBAMFileIndex extends AbstractBAMFileIndex implements BrowseableBAMIndex
 {
     private Integer mLastReferenceRetrieved = null;
-    private final WeakHashMap<Integer,BAMIndexContent> mQueriesByReference = new WeakHashMap<Integer,BAMIndexContent>();
+    private final WeakHashMap<Integer,BAMIndexContent> mQueriesByReference = new WeakHashMap<>();
 
     public CachingBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
         super(file, dictionary);
@@ -107,7 +107,7 @@ class CachingBAMFileIndex extends AbstractBAMFileIndex implements BrowseableBAMI
         final int firstLocusInBin = getFirstLocusInBin(bin);
 
         // Add the specified bin to the tree if it exists.
-        final List<Bin> binTree = new ArrayList<Bin>();
+        final List<Bin> binTree = new ArrayList<>();
         if(indexQuery.containsBin(bin))
             binTree.add(indexQuery.getBins().getBin(bin.getBinNumber()));
 
@@ -121,7 +121,7 @@ class CachingBAMFileIndex extends AbstractBAMFileIndex implements BrowseableBAMI
                 binTree.add(parentBin);
         }
 
-        List<Chunk> chunkList = new ArrayList<Chunk>();
+        List<Chunk> chunkList = new ArrayList<>();
         for(final Bin coveringBin: binTree) {
             for(final Chunk chunk: coveringBin.getChunkList())
                 chunkList.add(chunk.clone());

--- a/src/main/java/htsjdk/samtools/Chunk.java
+++ b/src/main/java/htsjdk/samtools/Chunk.java
@@ -143,7 +143,7 @@ public class Chunk implements Cloneable, Serializable,Comparable<Chunk> {
     public static List<Chunk> optimizeChunkList(final List<Chunk> chunks, final long minimumOffset) {
         Chunk lastChunk = null;
         Collections.sort(chunks);
-        final List<Chunk> result = new ArrayList<Chunk>();
+        final List<Chunk> result = new ArrayList<>();
         for (final Chunk chunk : chunks) {
             if (chunk.getChunkEnd() <= minimumOffset) {
                 continue;               // linear index optimization

--- a/src/main/java/htsjdk/samtools/Cigar.java
+++ b/src/main/java/htsjdk/samtools/Cigar.java
@@ -41,7 +41,7 @@ import java.util.List;
 public class Cigar implements Serializable, Iterable<CigarElement> {
     public static final long serialVersionUID = 1L;
 
-    private final List<CigarElement> cigarElements = new ArrayList<CigarElement>();
+    private final List<CigarElement> cigarElements = new ArrayList<>();
 
     public Cigar() {
     }
@@ -148,7 +148,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
         for (int i = 0; i < cigarElements.size(); ++i) {
             final CigarElement element = cigarElements.get(i);
             if (element.getLength() == 0) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR,
                         "CIGAR element with zero length", readName, recordNumber));
             }
@@ -157,7 +157,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
             if (isClippingOperator(op)) {
                 if (op == CigarOperator.H) {
                     if (i != 0 && i != cigarElements.size() - 1) {
-                        if (ret == null) ret = new ArrayList<SAMValidationError>();
+                        if (ret == null) ret = new ArrayList<>();
                         ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR,
                                 "Hard clipping operator not at start or end of CIGAR", readName, recordNumber));
                     }
@@ -170,20 +170,20 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
                             // Handle funky special case in which S operator is both one from the beginning and one
                             // from the end.
                         } else if (cigarElements.get(0).getOperator() != CigarOperator.H) {
-                            if (ret == null) ret = new ArrayList<SAMValidationError>();
+                            if (ret == null) ret = new ArrayList<>();
                             ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR,
                                 "Soft clipping CIGAR operator can only be inside of hard clipping operator",
                                     readName, recordNumber));
                         }
                     } else if (i == cigarElements.size() - 2) {
                         if (cigarElements.get(cigarElements.size() - 1).getOperator() != CigarOperator.H) {
-                            if (ret == null) ret = new ArrayList<SAMValidationError>();
+                            if (ret == null) ret = new ArrayList<>();
                             ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR,
                                 "Soft clipping CIGAR operator can only be inside of hard clipping operator",
                                     readName, recordNumber));
                         }
                     } else {
-                        if (ret == null) ret = new ArrayList<SAMValidationError>();
+                        if (ret == null) ret = new ArrayList<>();
                         ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR,
                             "Soft clipping CIGAR operator can at start or end of read, or be inside of hard clipping operator",
                                 readName, recordNumber));
@@ -202,7 +202,7 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
                             break;
                         }
                         if (isInDelOperator(nextOperator) && op == nextOperator) {
-                            if (ret == null) ret = new ArrayList<SAMValidationError>();
+                            if (ret == null) ret = new ArrayList<>();
                             ret.add(new SAMValidationError(SAMValidationError.Type.ADJACENT_INDEL_IN_CIGAR,
                                     "No M or N operator between pair of " + op.name() + " operators in CIGAR", readName, recordNumber));
                         }
@@ -216,19 +216,19 @@ public class Cigar implements Serializable, Iterable<CigarElement> {
                      * position on the unpadded reference.
                     */
                 } else if (i == cigarElements.size() - 1) {
-                    if (ret == null) ret = new ArrayList<SAMValidationError>();
+                    if (ret == null) ret = new ArrayList<>();
                     ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR,
                             "Padding operator not valid at end of CIGAR", readName, recordNumber));
                 } else if (!isRealOperator(cigarElements.get(i-1).getOperator()) ||
                         !isRealOperator(cigarElements.get(i+1).getOperator())) {
-                    if (ret == null) ret = new ArrayList<SAMValidationError>();
+                    if (ret == null) ret = new ArrayList<>();
                     ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR,
                             "Padding operator not between real operators in CIGAR", readName, recordNumber));
                 }
             }
         }
         if (!seenRealOperator) {
-            if (ret == null) ret = new ArrayList<SAMValidationError>();
+            if (ret == null) ret = new ArrayList<>();
             ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR,
                     "No real operator (M|I|D|N) in CIGAR", readName, recordNumber));
         }

--- a/src/main/java/htsjdk/samtools/ConstantMemoryDownsamplingIterator.java
+++ b/src/main/java/htsjdk/samtools/ConstantMemoryDownsamplingIterator.java
@@ -51,7 +51,7 @@ class ConstantMemoryDownsamplingIterator extends DownsamplingIterator {
     ConstantMemoryDownsamplingIterator(final Iterator<SAMRecord> iterator, final double proportion, final int seed) {
         super(proportion);
         this.hasher = new Murmur3(seed);
-        this.underlyingIterator = new PeekableIterator<SAMRecord>(iterator);
+        this.underlyingIterator = new PeekableIterator<>(iterator);
 
         final long range = (long) Integer.MAX_VALUE - (long) Integer.MIN_VALUE;
         this.maxHashValue = Integer.MIN_VALUE + (int) Math.round(range * proportion);

--- a/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
+++ b/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
@@ -63,7 +63,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
     private final Codec<KEY, REC> elementCodec;
     // Key is reference index (which is in the range [-1 .. max sequence index].
     // Value is the number of records on disk for this index.
-    private final Map<Integer, Integer> sizeOfMapOnDisk = new HashMap<Integer, Integer>();
+    private final Map<Integer, Integer> sizeOfMapOnDisk = new HashMap<>();
 
     // No other methods may be called when iteration is in progress, because iteration depends on and changes
     // internal state.
@@ -108,7 +108,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
                     mapInRam.clear();
                 }
             } else {
-                mapInRam = new HashMap<KEY, REC>();
+                mapInRam = new HashMap<>();
             }
 
             sequenceIndexOfMapInRam = sequenceIndex;
@@ -210,7 +210,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
 
     private class MapIterator implements CloseableIterator<Map.Entry<KEY, REC>> {
         private boolean closed = false;
-        private Set<Integer> referenceIndices = new HashSet<Integer>(sizeOfMapOnDisk.keySet());
+        private Set<Integer> referenceIndices = new HashSet<>(sizeOfMapOnDisk.keySet());
         private final Iterator<Integer> referenceIndexIterator;
         private Iterator<Map.Entry<KEY, REC>> currentReferenceIterator = null;
 

--- a/src/main/java/htsjdk/samtools/DiskBasedBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/DiskBasedBAMFileIndex.java
@@ -62,7 +62,7 @@ public class DiskBasedBAMFileIndex extends AbstractBAMFileIndex
         if(queryResults == null)
             return null;
 
-        List<Chunk> chunkList = new ArrayList<Chunk>();
+        List<Chunk> chunkList = new ArrayList<>();
         for(final Chunk chunk: queryResults.getAllChunks())
             chunkList.add(chunk.clone());
         chunkList = Chunk.optimizeChunkList(chunkList,queryResults.getLinearIndex().getMinimumOffset(startPos));

--- a/src/main/java/htsjdk/samtools/DuplicateSet.java
+++ b/src/main/java/htsjdk/samtools/DuplicateSet.java
@@ -65,7 +65,7 @@ public class DuplicateSet {
     }
 
     public DuplicateSet(final boolean setDuplicateFlag, final SAMRecordDuplicateComparator comparator) {
-        records = new ArrayList<SAMRecord>(10);
+        records = new ArrayList<>(10);
         this.setDuplicateFlag = setDuplicateFlag;
         this.comparator = comparator;
     }

--- a/src/main/java/htsjdk/samtools/HighAccuracyDownsamplingIterator.java
+++ b/src/main/java/htsjdk/samtools/HighAccuracyDownsamplingIterator.java
@@ -44,7 +44,7 @@ class HighAccuracyDownsamplingIterator extends DownsamplingIterator {
     private final Iterator<SAMRecord> underlyingIterator;
     private final Random random;
     private SAMRecord nextRecord;
-    private final Map<String, Boolean> decisions = new HashMap<String, Boolean>();
+    private final Map<String, Boolean> decisions = new HashMap<>();
 
     private double targetAccuracy = 0.0001;
     private long totalTemplates, keptTemplates;
@@ -143,8 +143,8 @@ class HighAccuracyDownsamplingIterator extends DownsamplingIterator {
      */
     protected boolean bufferNextChunkOfRecords(final double proportion, final double accuracy) {
         final int templatesToRead = (int) Math.ceil(1 / accuracy);
-        final Set<String> names = new HashSet<String>();
-        final List<SAMRecord> recs = new ArrayList<SAMRecord>(templatesToRead);
+        final Set<String> names = new HashSet<>();
+        final List<SAMRecord> recs = new ArrayList<>(templatesToRead);
 
         readFromUnderlyingIterator(recs, names, templatesToRead);
 
@@ -154,7 +154,7 @@ class HighAccuracyDownsamplingIterator extends DownsamplingIterator {
 
         // Randomly shuffle a list of all the template names, and then remove some from the set
         final int templatesToDiscard = templatesRead - templatesToKeep;
-        final List<String> tmp    = new ArrayList<String>(names);
+        final List<String> tmp    = new ArrayList<>(names);
         Collections.shuffle(tmp, this.random);
         for (int i = 0; i < templatesToDiscard; ++i) names.remove(tmp.get(i));
 

--- a/src/main/java/htsjdk/samtools/MergingSamRecordIterator.java
+++ b/src/main/java/htsjdk/samtools/MergingSamRecordIterator.java
@@ -70,7 +70,7 @@ public class MergingSamRecordIterator implements CloseableIterator<SAMRecord> {
         this.comparator = getComparator();
         this.readers = readers;
 
-        this.pq = new PriorityQueue<ComparableSamRecordIterator>(readers.size());
+        this.pq = new PriorityQueue<>(readers.size());
 
         for (final SamReader reader : readers) {
             if (!samHeaderMerger.getHeaders().contains(reader.getFileHeader()))

--- a/src/main/java/htsjdk/samtools/NotPrimarySkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/NotPrimarySkippingIterator.java
@@ -35,7 +35,7 @@ public class NotPrimarySkippingIterator {
     private final PeekIterator<SAMRecord> it;
 
     public NotPrimarySkippingIterator(final CloseableIterator<SAMRecord> underlyingIt) {
-        it = new PeekIterator<SAMRecord>(underlyingIt);
+        it = new PeekIterator<>(underlyingIt);
         skipAnyNotprimary();
     }
 

--- a/src/main/java/htsjdk/samtools/QueryInterval.java
+++ b/src/main/java/htsjdk/samtools/QueryInterval.java
@@ -74,7 +74,7 @@ public class QueryInterval implements Comparable<QueryInterval> {
         if (inputIntervals.length == 0) return EMPTY_QUERY_INTERVAL_ARRAY;
         Arrays.sort(inputIntervals);
 
-        final List<QueryInterval> unique = new ArrayList<QueryInterval>();
+        final List<QueryInterval> unique = new ArrayList<>();
         QueryInterval previous = inputIntervals[0];
 
 

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -48,13 +48,13 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     public static final String GROUP_ORDER_TAG = "GO";
     public static final String CURRENT_VERSION = "1.5";
     public static final Set<String> ACCEPTABLE_VERSIONS =
-            new HashSet<String>(Arrays.asList("1.0", "1.3", "1.4", "1.5"));
+            new HashSet<>(Arrays.asList("1.0", "1.3", "1.4", "1.5"));
 
     /**
      * These tags are of known type, so don't need a type field in the text representation.
      */
     public static final Set<String> STANDARD_TAGS =
-            new HashSet<String>(Arrays.asList(VERSION_TAG, SORT_ORDER_TAG, GROUP_ORDER_TAG));
+            new HashSet<>(Arrays.asList(VERSION_TAG, SORT_ORDER_TAG, GROUP_ORDER_TAG));
 
     Set<String> getStandardTags() {
         return STANDARD_TAGS;
@@ -106,15 +106,15 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     }
 
     private List<SAMReadGroupRecord> mReadGroups =
-        new ArrayList<SAMReadGroupRecord>();
-    private List<SAMProgramRecord> mProgramRecords = new ArrayList<SAMProgramRecord>();
+            new ArrayList<>();
+    private List<SAMProgramRecord> mProgramRecords = new ArrayList<>();
     private final Map<String, SAMReadGroupRecord> mReadGroupMap =
-        new HashMap<String, SAMReadGroupRecord>();
-    private final Map<String, SAMProgramRecord> mProgramRecordMap = new HashMap<String, SAMProgramRecord>();
+            new HashMap<>();
+    private final Map<String, SAMProgramRecord> mProgramRecordMap = new HashMap<>();
     private SAMSequenceDictionary mSequenceDictionary = new SAMSequenceDictionary();
-    final private List<String> mComments = new ArrayList<String>();
+    final private List<String> mComments = new ArrayList<>();
     private String textHeader;
-    private final List<SAMValidationError> mValidationErrors = new ArrayList<SAMValidationError>();
+    private final List<SAMValidationError> mValidationErrors = new ArrayList<>();
 
     public SAMFileHeader() {
         setAttribute(VERSION_TAG, CURRENT_VERSION);
@@ -365,7 +365,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     public static class PgIdGenerator {
         private int recordCounter;
 
-        private final Set<String> idsThatAreAlreadyTaken = new HashSet<String>();
+        private final Set<String> idsThatAreAlreadyTaken = new HashSet<>();
 
         public PgIdGenerator(final SAMFileHeader header) {
             for (final SAMProgramRecord pgRecord : header.getProgramRecords()) {

--- a/src/main/java/htsjdk/samtools/SAMFlag.java
+++ b/src/main/java/htsjdk/samtools/SAMFlag.java
@@ -100,7 +100,7 @@ public enum SAMFlag {
 
     /** @returns the java.util.Set of SAMFlag for 'flag' */
     public static Set<SAMFlag> getFlags(int flag) {
-        Set<SAMFlag> set = new HashSet<SAMFlag>();
+        Set<SAMFlag> set = new HashSet<>();
         for (SAMFlag f : values()) {
             if (f.isSet(flag))
                 set.add(f);

--- a/src/main/java/htsjdk/samtools/SAMProgramRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMProgramRecord.java
@@ -40,7 +40,7 @@ public class SAMProgramRecord extends AbstractSAMHeaderRecord {
     public static final String PREVIOUS_PROGRAM_GROUP_ID_TAG = "PP";
     private String mProgramGroupId;
     public static final Set<String> STANDARD_TAGS = Collections.unmodifiableSet(
-            new HashSet<String>(Arrays.asList(PROGRAM_GROUP_ID_TAG,
+            new HashSet<>(Arrays.asList(PROGRAM_GROUP_ID_TAG,
                     PROGRAM_NAME_TAG,
                     PROGRAM_VERSION_TAG,
                     COMMAND_LINE_TAG,

--- a/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
@@ -60,7 +60,7 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
     }
 
     public static final Set<String> STANDARD_TAGS =
-            new HashSet<String>(Arrays.asList(READ_GROUP_ID_TAG, SEQUENCING_CENTER_TAG, DESCRIPTION_TAG,
+            new HashSet<>(Arrays.asList(READ_GROUP_ID_TAG, SEQUENCING_CENTER_TAG, DESCRIPTION_TAG,
                     DATE_RUN_PRODUCED_TAG, FLOW_ORDER_TAG, KEY_SEQUENCE_TAG, LIBRARY_TAG,
                     PROGRAM_GROUP_TAG, PREDICTED_MEDIAN_INSERT_SIZE_TAG, PLATFORM_TAG, PLATFORM_MODEL_TAG,
                     PLATFORM_UNIT_TAG, READ_GROUP_SAMPLE_TAG));

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -1500,7 +1500,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      */
     public List<SAMTagAndValue> getAttributes() {
         SAMBinaryTagAndValue binaryAttributes = getBinaryAttributes();
-        final List<SAMTagAndValue> ret = new ArrayList<SAMTagAndValue>();
+        final List<SAMTagAndValue> ret = new ArrayList<>();
         while (binaryAttributes != null) {
             ret.add(new SAMTagAndValue(SAMTagUtil.getSingleton().makeStringTag(binaryAttributes.tag),
                     binaryAttributes.value));
@@ -1859,32 +1859,32 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         ArrayList<SAMValidationError> ret = null;
         if (!getReadPairedFlag()) {
             if (getProperPairFlagUnchecked()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_PROPER_PAIR, "Proper pair flag should not be set for unpaired read.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (getMateUnmappedFlagUnchecked()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_MATE_UNMAPPED, "Mate unmapped flag should not be set for unpaired read.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (getMateNegativeStrandFlagUnchecked()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_MATE_NEG_STRAND, "Mate negative strand flag should not be set for unpaired read.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (getFirstOfPairFlagUnchecked()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_FIRST_OF_PAIR, "First of pair flag should not be set for unpaired read.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (getSecondOfPairFlagUnchecked()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_SECOND_OF_PAIR, "Second of pair flag should not be set for unpaired read.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (null != getHeader() && getMateReferenceIndex() != NO_ALIGNMENT_REFERENCE_INDEX) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_MATE_REF_INDEX, "MRNM should not be set for unpaired read.", getReadName()));
                 if (firstOnly) return ret;
             }
@@ -1893,16 +1893,16 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
                     getMateAlignmentStart(), true, firstOnly);
             if (errors != null) {
                 if (firstOnly) return errors;
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.addAll(errors);
             }
             if (!hasMateReferenceName() && !getMateUnmappedFlag()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_MATE_UNMAPPED, "Mapped mate should have mate reference name", getReadName()));
                 if (firstOnly) return ret;
             }
             if (!getFirstOfPairFlagUnchecked() && !getSecondOfPairFlagUnchecked()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.PAIRED_READ_NOT_MARKED_AS_FIRST_OR_SECOND,
                         "Paired read should be marked as first of pair or second of pair.", getReadName()));
                 if (firstOnly) return ret;
@@ -1918,23 +1918,23 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 */
         }
         if (getInferredInsertSize() > MAX_INSERT_SIZE || getInferredInsertSize() < -MAX_INSERT_SIZE) {
-            if (ret == null) ret = new ArrayList<SAMValidationError>();
+            if (ret == null) ret = new ArrayList<>();
             ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_INSERT_SIZE, "Insert size out of range", getReadName()));
             if (firstOnly) return ret;
         }
         if (getReadUnmappedFlag()) {
             if (getNotPrimaryAlignmentFlag()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_NOT_PRIM_ALIGNMENT, "Not primary alignment flag should not be set for unmapped read.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (getSupplementaryAlignmentFlag()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_SUPPLEMENTARY_ALIGNMENT, "Supplementary alignment flag should not be set for unmapped read.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (getMappingQuality() != 0) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_MAPPING_QUALITY, "MAPQ should be 0 for unmapped read.", getReadName()));
                 if (firstOnly) return ret;
             }
@@ -1949,12 +1949,12 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 */
         } else {
             if (getMappingQuality() >= 256) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_MAPPING_QUALITY, "MAPQ should be < 256.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (getCigarLength() == 0) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_CIGAR, "CIGAR should have > zero elements for mapped read.", getReadName()));
             /* todo - will uncomment once unit tests are added
             } else if (getCigar().getReadLength() != getReadLength()) {
@@ -1964,12 +1964,12 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
                 if (firstOnly) return ret;
             }
             if (getHeader() != null && getHeader().getSequenceDictionary().isEmpty()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.MISSING_SEQUENCE_DICTIONARY, "Empty sequence dictionary.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (!hasReferenceName()) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_READ_UNMAPPED, "Mapped read should have valid reference name", getReadName()));
                 if (firstOnly) return ret;
             }
@@ -1987,14 +1987,14 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         // Validate the RG ID is found in header
         final String rgId = (String)getAttribute(SAMTagUtil.getSingleton().RG);
         if (rgId != null && getHeader() != null && getHeader().getReadGroup(rgId) == null) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.READ_GROUP_NOT_FOUND,
                         "RG ID on SAMRecord not found in header: " + rgId, getReadName()));
                 if (firstOnly) return ret;
         }
         final List<SAMValidationError> errors = isValidReferenceIndexAndPosition(mReferenceIndex, mReferenceName, getAlignmentStart(), false);
         if (errors != null) {
-            if (ret == null) ret = new ArrayList<SAMValidationError>();
+            if (ret == null) ret = new ArrayList<>();
             ret.addAll(errors);
             if (firstOnly) return ret;
         }
@@ -2005,7 +2005,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
                 final String cq = (String)getAttribute(SAMTagUtil.getSingleton().CQ);
                 final String cs = (String)getAttribute(SAMTagUtil.getSingleton().CS);
                 if (cq == null || cq.isEmpty() || cs == null || cs.isEmpty()) {
-                    if (ret == null) ret = new ArrayList<SAMValidationError>();
+                    if (ret == null) ret = new ArrayList<>();
                     ret.add(new SAMValidationError(SAMValidationError.Type.EMPTY_READ,
                             "Zero-length read without FZ, CS or CQ tag", getReadName()));
                     if (firstOnly) return ret;
@@ -2019,7 +2019,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
                         }
                     }
                     if (!hasIndel) {
-                        if (ret == null) ret = new ArrayList<SAMValidationError>();
+                        if (ret == null) ret = new ArrayList<>();
                         ret.add(new SAMValidationError(SAMValidationError.Type.EMPTY_READ,
                                 "Colorspace read with zero-length bases but no indel", getReadName()));
                         if (firstOnly) return ret;
@@ -2028,7 +2028,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             }
         }
         if (this.getReadLength() != getBaseQualities().length &&  !Arrays.equals(getBaseQualities(), NULL_QUALS)) {
-            if (ret == null) ret = new ArrayList<SAMValidationError>();
+            if (ret == null) ret = new ArrayList<>();
             ret.add(new SAMValidationError(SAMValidationError.Type.MISMATCH_READ_LENGTH_AND_QUALS_LENGTH,
                     "Read length does not match quals length", getReadName()));
             if (firstOnly) return ret;
@@ -2036,7 +2036,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 
         if (this.getAlignmentStart() != NO_ALIGNMENT_START && this.getIndexingBin() != null &&
                 this.computeIndexingBin() != this.getIndexingBin()) {
-            if (ret == null) ret = new ArrayList<SAMValidationError>();
+            if (ret == null) ret = new ArrayList<>();
             ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_INDEXING_BIN,
                     "bin field of BAM record does not equal value computed based on alignment start and end, and length of sequence to which read is aligned",
                     getReadName()));
@@ -2080,13 +2080,13 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         ArrayList<SAMValidationError> ret = null;
         if (!hasReference) {
             if (alignmentStart != 0) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_ALIGNMENT_START, buildMessage("Alignment start should be 0 because reference name = *.", isMate), getReadName()));
                 if (firstOnly) return ret;
             }
         } else {
             if (alignmentStart == 0) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_ALIGNMENT_START, buildMessage("Alignment start should != 0 because reference name != *.", isMate), getReadName()));
                 if (firstOnly) return ret;
             }
@@ -2094,12 +2094,12 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
                 final SAMSequenceRecord sequence =
                         (referenceIndex != null? getHeader().getSequence(referenceIndex): getHeader().getSequence(referenceName));
                 if (sequence == null) {
-                    if (ret == null) ret = new ArrayList<SAMValidationError>();
+                    if (ret == null) ret = new ArrayList<>();
                     ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_REFERENCE_INDEX, buildMessage("Reference sequence not found in sequence dictionary.", isMate), getReadName()));
                     if (firstOnly) return ret;
                 } else {
                     if (alignmentStart > sequence.getSequenceLength()) {
-                        if (ret == null) ret = new ArrayList<SAMValidationError>();
+                        if (ret == null) ret = new ArrayList<>();
                         ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_ALIGNMENT_START, buildMessage("Alignment start (" + alignmentStart + ") must be <= reference sequence length (" +
                                 sequence.getSequenceLength() + ") on reference " + sequence.getSequenceName(), isMate), getReadName()));
                         if (firstOnly) return ret;
@@ -2242,7 +2242,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * then stored as transient attributes to avoid frequent re-computation.
      */
     public final Object setTransientAttribute(final Object key, final Object value) {
-        if (this.transientAttributes == null) this.transientAttributes = new HashMap<Object,Object>();
+        if (this.transientAttributes == null) this.transientAttributes = new HashMap<>();
         return this.transientAttributes.put(key, value);
     }
 

--- a/src/main/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
@@ -50,7 +50,7 @@ public class SAMRecordDuplicateComparator implements SAMRecordComparator, Serial
 
     private static final byte FF = 0, FR = 1, F = 2, RF = 3, RR = 4, R = 5;
 
-    private final Map<String, Short> libraryIds = new HashMap<String, Short>(); // from library string to library id
+    private final Map<String, Short> libraryIds = new HashMap<>(); // from library string to library id
     private short nextLibraryId = 1;
     
     private ScoringStrategy scoringStrategy = ScoringStrategy.TOTAL_MAPPED_REFERENCE_LENGTH;

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -103,7 +103,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
 
     public SAMRecordSetBuilder(final boolean sortForMe, final SAMFileHeader.SortOrder sortOrder, final boolean addReadGroup,
                                final int defaultChromosomeLength, final ScoringStrategy duplicateScoringStrategy) {
-        final List<SAMSequenceRecord> sequences = new ArrayList<SAMSequenceRecord>();
+        final List<SAMSequenceRecord> sequences = new ArrayList<>();
         for (final String chrom : chroms) {
             final SAMSequenceRecord sequenceRecord = new SAMSequenceRecord(chrom, defaultChromosomeLength);
             sequences.add(sequenceRecord);
@@ -119,16 +119,16 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             } else {
                 comparator = new SAMRecordCoordinateComparator();
             }
-            this.records = new TreeSet<SAMRecord>(comparator);
+            this.records = new TreeSet<>(comparator);
         } else {
-            this.records = new ArrayList<SAMRecord>();
+            this.records = new ArrayList<>();
         }
 
         if (addReadGroup) {
             final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord(READ_GROUP_ID);
             readGroupRecord.setSample(SAMPLE);
             readGroupRecord.setPlatform("ILLUMINA");
-            final List<SAMReadGroupRecord> readGroups = new ArrayList<SAMReadGroupRecord>();
+            final List<SAMReadGroupRecord> readGroups = new ArrayList<>();
             readGroups.add(readGroupRecord);
             this.header.setReadGroups(readGroups);
         }
@@ -421,7 +421,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
                                    final boolean record1Unmapped, final boolean record2Unmapped, final String cigar1,
                                    final String cigar2, final boolean strand1, final boolean strand2, final boolean record1NonPrimary,
                                    final boolean record2NonPrimary, final int defaultQuality) {
-        final List<SAMRecord> recordsList = new LinkedList<SAMRecord>();
+        final List<SAMRecord> recordsList = new LinkedList<>();
 
         final SAMRecord end1 = createReadNoFlag(name, contig1, start1, strand1, record1Unmapped, cigar1, null, defaultQuality);
         final SAMRecord end2 = createReadNoFlag(name, contig2, start2, strand2, record2Unmapped, cigar2, null, defaultQuality);

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
@@ -50,8 +50,8 @@ public class SAMSequenceDictionary implements Serializable {
     getter because the later wraps the list into an unmodifiable List 
     see http://tech.joshuacummings.com/2010/10/problems-with-defensive-collection.html */
     @XmlElement(name="Reference")
-    private List<SAMSequenceRecord> mSequences = new ArrayList<SAMSequenceRecord>();
-    private final Map<String, SAMSequenceRecord> mSequenceMap = new HashMap<String, SAMSequenceRecord>();
+    private List<SAMSequenceRecord> mSequences = new ArrayList<>();
+    private final Map<String, SAMSequenceRecord> mSequenceMap = new HashMap<>();
 
     public SAMSequenceDictionary() {
     }

--- a/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -68,8 +68,8 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
      * The standard tags are stored in text header without type information, because the type of these tags is known.
      */
     public static final Set<String> STANDARD_TAGS =
-            new HashSet<String>(Arrays.asList(SEQUENCE_NAME_TAG, SEQUENCE_LENGTH_TAG, ASSEMBLY_TAG, MD5_TAG, URI_TAG,
-                                                SPECIES_TAG));
+            new HashSet<>(Arrays.asList(SEQUENCE_NAME_TAG, SEQUENCE_LENGTH_TAG, ASSEMBLY_TAG, MD5_TAG, URI_TAG,
+                    SPECIES_TAG));
 
     // Split on any whitespace
     private static Pattern SEQUENCE_NAME_SPLITTER = Pattern.compile("\\s");

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -258,7 +258,7 @@ public class SAMTextHeaderCodec {
      */
     private class ParsedHeaderLine {
         private HeaderRecordType mHeaderRecordType;
-        private final Map<String, String> mKeyValuePairs = new LinkedHashMap<String, String>();
+        private final Map<String, String> mKeyValuePairs = new LinkedHashMap<>();
         private boolean lineValid = false;
 
         ParsedHeaderLine(final String line) {

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -465,7 +465,7 @@ public final class SAMUtils {
     }
 
     private static final SAMHeaderRecordComparator<SAMReadGroupRecord> HEADER_RECORD_COMPARATOR =
-            new SAMHeaderRecordComparator<SAMReadGroupRecord>(
+            new SAMHeaderRecordComparator<>(
                     SAMReadGroupRecord.PLATFORM_UNIT_TAG,
                     SAMReadGroupRecord.LIBRARY_TAG,
                     SAMReadGroupRecord.DATE_RUN_PRODUCED_TAG,
@@ -494,11 +494,11 @@ public final class SAMUtils {
 
         // Sort the read group records by their first
         final SamReader reader = SamReaderFactory.makeDefault().referenceSequence(referenceFasta).open(input);
-        final List<SAMReadGroupRecord> sortedRecords = new ArrayList<SAMReadGroupRecord>(reader.getFileHeader().getReadGroups());
+        final List<SAMReadGroupRecord> sortedRecords = new ArrayList<>(reader.getFileHeader().getReadGroups());
         Collections.sort(sortedRecords, HEADER_RECORD_COMPARATOR);
 
         for (final SAMReadGroupRecord rgRecord : sortedRecords) {
-            final TreeMap<String, String> sortedAttributes = new TreeMap<String, String>();
+            final TreeMap<String, String> sortedAttributes = new TreeMap<>();
             for (final Map.Entry<String, String> attributeEntry : rgRecord.getAttributes()) {
                 sortedAttributes.put(attributeEntry.getKey(), attributeEntry.getValue());
             }
@@ -536,7 +536,7 @@ public final class SAMUtils {
 
         final List<SAMProgramRecord> pgs = header.getProgramRecords();
         if (!pgs.isEmpty()) {
-            final List<String> referencedIds = new ArrayList<String>();
+            final List<String> referencedIds = new ArrayList<>();
             for (final SAMProgramRecord pg : pgs) {
                 if (pg.getPreviousProgramGroupId() != null) {
                     referencedIds.add(pg.getPreviousProgramGroupId());
@@ -687,7 +687,7 @@ public final class SAMUtils {
     public static List<AlignmentBlock> getAlignmentBlocks(final Cigar cigar, final int alignmentStart, final String cigarTypeName) {
         if (cigar == null) return Collections.emptyList();
 
-        final List<AlignmentBlock> alignmentBlocks = new ArrayList<AlignmentBlock>();
+        final List<AlignmentBlock> alignmentBlocks = new ArrayList<>();
         int readBase = 1;
         int refBase = alignmentStart;
 
@@ -913,7 +913,7 @@ public final class SAMUtils {
         if (referenceIndex != SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
             SAMFileHeader samHeader = rec.getHeader();
             if (null == samHeader) {
-                if (ret == null) ret = new ArrayList<SAMValidationError>();
+                if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.MISSING_HEADER,
                         cigarTypeName + " A non-null SAMHeader is required to validate cigar elements for: ", rec.getReadName(), recordNumber));
             }
@@ -922,7 +922,7 @@ public final class SAMUtils {
                 final int referenceSequenceLength = sequence.getSequenceLength();
                 for (final AlignmentBlock alignmentBlock : alignmentBlocks) {
                     if (alignmentBlock.getReferenceStart() + alignmentBlock.getLength() - 1 > referenceSequenceLength) {
-                        if (ret == null) ret = new ArrayList<SAMValidationError>();
+                        if (ret == null) ret = new ArrayList<>();
                         ret.add(new SAMValidationError(SAMValidationError.Type.CIGAR_MAPS_OFF_REFERENCE,
                                 cigarTypeName + " M operator maps off end of reference", rec.getReadName(), recordNumber));
                         break;
@@ -951,7 +951,7 @@ public final class SAMUtils {
                 }
             } else {
                 if (getMateCigarString(rec) != null) {
-                    ret = new ArrayList<SAMValidationError>();
+                    ret = new ArrayList<>();
                     if (!rec.getReadPairedFlag()) {
                         // If the read is not paired, and the Mate Cigar String (MC Attribute) exists, that is a validation error
                         ret.add(new SAMValidationError(SAMValidationError.Type.MATE_CIGAR_STRING_INVALID_PRESENCE,

--- a/src/main/java/htsjdk/samtools/SRAIndex.java
+++ b/src/main/java/htsjdk/samtools/SRAIndex.java
@@ -193,7 +193,7 @@ public class SRAIndex implements BrowseableBAMIndex {
     public BAMFileSpan getSpanOverlapping(int referenceIndex, int startPos, int endPos) {
         BinList binList = getBinsOverlapping(referenceIndex, startPos, endPos);
         BAMFileSpan result = new BAMFileSpan();
-        Set<Chunk> savedChunks = new HashSet<Chunk>();
+        Set<Chunk> savedChunks = new HashSet<>();
         for (Bin bin : binList) {
             List<Chunk> chunks = getSpanOverlapping(bin).getChunks();
             for (Chunk chunk : chunks) {
@@ -247,7 +247,7 @@ public class SRAIndex implements BrowseableBAMIndex {
         long binGlobalOffset = binNumber * SRA_BIN_SIZE + refOffset;
         long firstChunkNumber = (binGlobalOffset + firstChunkCorrection) / SRA_CHUNK_SIZE;
         long lastChunkNumber = (binGlobalOffset + SRA_BIN_SIZE - 1) / SRA_CHUNK_SIZE;
-        List<Chunk> chunks = new ArrayList<Chunk>();
+        List<Chunk> chunks = new ArrayList<>();
         for (long chunkNumber = firstChunkNumber; chunkNumber <= lastChunkNumber; chunkNumber++) {
             chunks.add(new Chunk(chunkNumber * SRA_CHUNK_SIZE, (chunkNumber + 1) * SRA_CHUNK_SIZE));
         }

--- a/src/main/java/htsjdk/samtools/SRAIterator.java
+++ b/src/main/java/htsjdk/samtools/SRAIterator.java
@@ -82,7 +82,7 @@ public class SRAIterator implements SAMRecordIterator {
             this.numberOfReads = numberOfReads;
             this.referenceLengthsAligned = referenceLengthsAligned;
 
-            referenceOffsets = new ArrayList<Long>();
+            referenceOffsets = new ArrayList<>();
 
             totalReferencesLength = 0;
             for (Long refLen : referenceLengthsAligned) {

--- a/src/main/java/htsjdk/samtools/SamFileHeaderMerger.java
+++ b/src/main/java/htsjdk/samtools/SamFileHeaderMerger.java
@@ -74,7 +74,7 @@ public class SamFileHeaderMerger {
 
     //Translation of old group ids to new group ids
     private final Map<SAMFileHeader, Map<String, String>> samReadGroupIdTranslation =
-            new IdentityHashMap<SAMFileHeader, Map<String, String>>();
+            new IdentityHashMap<>();
 
     //the read groups from different files use the same group ids
     private boolean hasReadGroupCollisions = false;
@@ -84,7 +84,7 @@ public class SamFileHeaderMerger {
 
     //Translation of old program group ids to new program group ids
     private final Map<SAMFileHeader, Map<String, String>> samProgramGroupIdTranslation =
-            new IdentityHashMap<SAMFileHeader, Map<String, String>>();
+            new IdentityHashMap<>();
 
     private boolean hasMergedSequenceDictionary = false;
 
@@ -94,7 +94,7 @@ public class SamFileHeaderMerger {
     // the regular HashMap would fold them together, but the value stored in each of the two
     // Map entries will be the same, so it should not hurt anything.
     private final Map<SAMFileHeader, Map<Integer, Integer>> samSeqDictionaryIdTranslationViaHeader =
-            new IdentityHashMap<SAMFileHeader, Map<Integer, Integer>>();
+            new IdentityHashMap<>();
 
     //HeaderRecordFactory that creates SAMReadGroupRecord instances.
     private static final HeaderRecordFactory<SAMReadGroupRecord> READ_GROUP_RECORD_FACTORY = new HeaderRecordFactory<SAMReadGroupRecord>() {
@@ -153,7 +153,7 @@ public class SamFileHeaderMerger {
      *                          all input sequence dictionaries be identical.
      */
     public SamFileHeaderMerger(final SAMFileHeader.SortOrder sortOrder, final Collection<SAMFileHeader> headers, final boolean mergeDictionaries) {
-        this.headers = new LinkedHashSet<SAMFileHeader>(headers);
+        this.headers = new LinkedHashSet<>(headers);
         this.mergedHeader = new SAMFileHeader();
 
         SAMSequenceDictionary sequenceDictionary;
@@ -192,7 +192,7 @@ public class SamFileHeaderMerger {
 
     // Utility method to make use with old constructor
     private static List<SAMFileHeader> getHeadersFromReaders(final Collection<SamReader> readers) {
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>(readers.size());
+        final List<SAMFileHeader> headers = new ArrayList<>(readers.size());
         for (final SamReader reader : readers) {
             headers.add(reader.getFileHeader());
         }
@@ -209,21 +209,21 @@ public class SamFileHeaderMerger {
      */
     private List<SAMReadGroupRecord> mergeReadGroups(final Collection<SAMFileHeader> headers) {
         //prepare args for mergeHeaderRecords(..) call
-        final HashSet<String> idsThatAreAlreadyTaken = new HashSet<String>();
+        final HashSet<String> idsThatAreAlreadyTaken = new HashSet<>();
 
-        final List<HeaderRecordAndFileHeader<SAMReadGroupRecord>> readGroupsToProcess = new LinkedList<HeaderRecordAndFileHeader<SAMReadGroupRecord>>();
+        final List<HeaderRecordAndFileHeader<SAMReadGroupRecord>> readGroupsToProcess = new LinkedList<>();
         for (final SAMFileHeader header : headers) {
             for (final SAMReadGroupRecord readGroup : header.getReadGroups()) {
                 //verify that there are no existing id collisions in this input file
                 if (!idsThatAreAlreadyTaken.add(readGroup.getId()))
                     throw new SAMException("Input file: " + header + " contains more than one RG with the same id (" + readGroup.getId() + ")");
 
-                readGroupsToProcess.add(new HeaderRecordAndFileHeader<SAMReadGroupRecord>(readGroup, header));
+                readGroupsToProcess.add(new HeaderRecordAndFileHeader<>(readGroup, header));
             }
             idsThatAreAlreadyTaken.clear();
         }
 
-        final List<SAMReadGroupRecord> result = new LinkedList<SAMReadGroupRecord>();
+        final List<SAMReadGroupRecord> result = new LinkedList<>();
 
         recordCounter = 0;
         hasReadGroupCollisions = mergeHeaderRecords(readGroupsToProcess, READ_GROUP_RECORD_FACTORY, idsThatAreAlreadyTaken, samReadGroupIdTranslation, result);
@@ -244,20 +244,20 @@ public class SamFileHeaderMerger {
      */
     private List<SAMProgramRecord> mergeProgramGroups(final Collection<SAMFileHeader> headers) {
 
-        final List<SAMProgramRecord> overallResult = new LinkedList<SAMProgramRecord>();
+        final List<SAMProgramRecord> overallResult = new LinkedList<>();
 
         //this Set will accumulate all SAMProgramRecord ids that have been encountered so far.
-        final HashSet<String> idsThatAreAlreadyTaken = new HashSet<String>();
+        final HashSet<String> idsThatAreAlreadyTaken = new HashSet<>();
 
         //need to process all program groups
-        List<HeaderRecordAndFileHeader<SAMProgramRecord>> programGroupsLeftToProcess = new LinkedList<HeaderRecordAndFileHeader<SAMProgramRecord>>();
+        List<HeaderRecordAndFileHeader<SAMProgramRecord>> programGroupsLeftToProcess = new LinkedList<>();
         for (final SAMFileHeader header : headers) {
             for (final SAMProgramRecord programGroup : header.getProgramRecords()) {
                 //verify that there are no existing id collisions in this input file
                 if (!idsThatAreAlreadyTaken.add(programGroup.getId()))
                     throw new SAMException("Input file: " + header + " contains more than one PG with the same id (" + programGroup.getId() + ")");
 
-                programGroupsLeftToProcess.add(new HeaderRecordAndFileHeader<SAMProgramRecord>(programGroup, header));
+                programGroupsLeftToProcess.add(new HeaderRecordAndFileHeader<>(programGroup, header));
             }
             idsThatAreAlreadyTaken.clear();
         }
@@ -273,7 +273,7 @@ public class SamFileHeaderMerger {
         //and so on until all program group headers are processed.
 
         //currentProgramGroups is the list of records to merge next. Start by merging the programGroups that don't have a PP attribute (eg. the tree roots).
-        List<HeaderRecordAndFileHeader<SAMProgramRecord>> currentProgramGroups = new LinkedList<HeaderRecordAndFileHeader<SAMProgramRecord>>();
+        List<HeaderRecordAndFileHeader<SAMProgramRecord>> currentProgramGroups = new LinkedList<>();
         for (final Iterator<HeaderRecordAndFileHeader<SAMProgramRecord>> programGroupsLeftToProcessIterator = programGroupsLeftToProcess.iterator(); programGroupsLeftToProcessIterator.hasNext(); ) {
             final HeaderRecordAndFileHeader<SAMProgramRecord> pair = programGroupsLeftToProcessIterator.next();
             if (pair.getHeaderRecord().getAttribute(SAMProgramRecord.PREVIOUS_PROGRAM_GROUP_ID_TAG) == null) {
@@ -284,7 +284,7 @@ public class SamFileHeaderMerger {
 
         //merge currentProgramGroups
         while (!currentProgramGroups.isEmpty()) {
-            final List<SAMProgramRecord> currentResult = new LinkedList<SAMProgramRecord>();
+            final List<SAMProgramRecord> currentResult = new LinkedList<>();
 
             hasProgramGroupCollisions |= mergeHeaderRecords(currentProgramGroups, PROGRAM_RECORD_FACTORY, idsThatAreAlreadyTaken, samProgramGroupIdTranslation, currentResult);
 
@@ -297,7 +297,7 @@ public class SamFileHeaderMerger {
 
             //find all records in programGroupsLeftToProcess whose ppId points to a record that was just processed (eg. a record that's in currentProgramGroups),
             //and move them to the list of programGroupsToProcessNext.
-            final LinkedList<HeaderRecordAndFileHeader<SAMProgramRecord>> programGroupsToProcessNext = new LinkedList<HeaderRecordAndFileHeader<SAMProgramRecord>>();
+            final LinkedList<HeaderRecordAndFileHeader<SAMProgramRecord>> programGroupsToProcessNext = new LinkedList<>();
             for (final Iterator<HeaderRecordAndFileHeader<SAMProgramRecord>> programGroupsLeftToProcessIterator = programGroupsLeftToProcess.iterator(); programGroupsLeftToProcessIterator.hasNext(); ) {
                 final HeaderRecordAndFileHeader<SAMProgramRecord> pairLeftToProcess = programGroupsLeftToProcessIterator.next();
                 final Object ppIdOfRecordLeftToProcess = pairLeftToProcess.getHeaderRecord().getAttribute(SAMProgramRecord.PREVIOUS_PROGRAM_GROUP_ID_TAG);
@@ -350,7 +350,7 @@ public class SamFileHeaderMerger {
             final boolean translatePpIds) {
 
         //go through programGroups and translate any IDs and PPs based on the idTranslationTable.
-        final List<HeaderRecordAndFileHeader<SAMProgramRecord>> result = new LinkedList<HeaderRecordAndFileHeader<SAMProgramRecord>>();
+        final List<HeaderRecordAndFileHeader<SAMProgramRecord>> result = new LinkedList<>();
         for (final HeaderRecordAndFileHeader<SAMProgramRecord> pair : programGroups) {
             final SAMProgramRecord record = pair.getHeaderRecord();
             final String id = record.getProgramGroupId();
@@ -380,7 +380,7 @@ public class SamFileHeaderMerger {
             }
 
             if (translatedRecord != null) {
-                result.add(new HeaderRecordAndFileHeader<SAMProgramRecord>(translatedRecord, header));
+                result.add(new HeaderRecordAndFileHeader<>(translatedRecord, header));
             } else {
                 result.add(pair); //keep the original record
             }
@@ -418,7 +418,7 @@ public class SamFileHeaderMerger {
         //header records which have both identical ids and identical attributes. The List of
         //SAMFileHeaders keeps track of which readers these header record(s) came from.
         final Map<String, Map<RecordType, List<SAMFileHeader>>> idToRecord =
-                new LinkedHashMap<String, Map<RecordType, List<SAMFileHeader>>>();
+                new LinkedHashMap<>();
 
         //Populate the idToRecord and seenIds data structures
         for (final HeaderRecordAndFileHeader<RecordType> pair : headerRecords) {
@@ -427,13 +427,13 @@ public class SamFileHeaderMerger {
             final String recordId = record.getId();
             Map<RecordType, List<SAMFileHeader>> recordsWithSameId = idToRecord.get(recordId);
             if (recordsWithSameId == null) {
-                recordsWithSameId = new LinkedHashMap<RecordType, List<SAMFileHeader>>();
+                recordsWithSameId = new LinkedHashMap<>();
                 idToRecord.put(recordId, recordsWithSameId);
             }
 
             List<SAMFileHeader> fileHeaders = recordsWithSameId.get(record);
             if (fileHeaders == null) {
-                fileHeaders = new LinkedList<SAMFileHeader>();
+                fileHeaders = new LinkedList<>();
                 recordsWithSameId.put(record, fileHeaders);
             }
 
@@ -473,7 +473,7 @@ public class SamFileHeaderMerger {
                 for (final SAMFileHeader fileHeader : fileHeaders) {
                     Map<String, String> readerTranslationTable = idTranslationTable.get(fileHeader);
                     if (readerTranslationTable == null) {
-                        readerTranslationTable = new HashMap<String, String>();
+                        readerTranslationTable = new HashMap<>();
                         idTranslationTable.put(fileHeader, readerTranslationTable);
                     }
                     readerTranslationTable.put(recordId, newId);
@@ -558,10 +558,10 @@ public class SamFileHeaderMerger {
     private SAMSequenceDictionary mergeSequences(final SAMSequenceDictionary mergeIntoDict, final SAMSequenceDictionary mergeFromDict) {
 
         // a place to hold the sequences that we haven't found a home for, in the order the appear in mergeFromDict.
-        final LinkedList<SAMSequenceRecord> holder = new LinkedList<SAMSequenceRecord>();
+        final LinkedList<SAMSequenceRecord> holder = new LinkedList<>();
 
         // Return value will be created from this.
-        final LinkedList<SAMSequenceRecord> resultingDict = new LinkedList<SAMSequenceRecord>();
+        final LinkedList<SAMSequenceRecord> resultingDict = new LinkedList<>();
         for (final SAMSequenceRecord sequenceRecord : mergeIntoDict.getSequences()) {
             resultingDict.add(sequenceRecord);
         }

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -150,7 +150,7 @@ public class SamFileValidator {
             for (final Histogram.Bin<Type> bin : errorsByType.values()) {
                 errorsAndWarningsByType.increment(bin.getId().getHistogramString(), bin.getValue());
             }
-            final MetricsFile<ValidationMetrics, String> metricsFile = new MetricsFile<ValidationMetrics, String>();
+            final MetricsFile<ValidationMetrics, String> metricsFile = new MetricsFile<>();
             errorsByType.setBinLabel("Error Type");
             errorsByType.setValueLabel("Count");
             metricsFile.setHistogram(errorsAndWarningsByType);
@@ -537,7 +537,7 @@ public class SamFileValidator {
         }
 
         final List<SAMReadGroupRecord> rgs = fileHeader.getReadGroups();
-        final Set<String> readGroupIDs = new HashSet<String>();
+        final Set<String> readGroupIDs = new HashSet<>();
 
         for (final SAMReadGroupRecord record : rgs) {
             final String readGroupID = record.getReadGroupId();
@@ -679,7 +679,7 @@ public class SamFileValidator {
         }
 
         public List<SAMValidationError> validateMates(final PairEndInfo mate, final String readName) {
-            final List<SAMValidationError> errors = new ArrayList<SAMValidationError>();
+            final List<SAMValidationError> errors = new ArrayList<>();
             validateMateFields(this, mate, readName, errors);
             validateMateFields(mate, this, readName, errors);
             // Validations that should not be repeated on both ends
@@ -755,7 +755,7 @@ public class SamFileValidator {
 
     private class CoordinateSortedPairEndInfoMap implements PairEndInfoMap {
         private final CoordinateSortedPairInfoMap<String, PairEndInfo> onDiskMap =
-                new CoordinateSortedPairInfoMap<String, PairEndInfo>(maxTempFiles, new Codec());
+                new CoordinateSortedPairInfoMap<>(maxTempFiles, new Codec());
 
         public void put(int mateReferenceIndex, String key, PairEndInfo value) {
             onDiskMap.put(mateReferenceIndex, key, value);
@@ -836,7 +836,7 @@ public class SamFileValidator {
     }
 
     private static class InMemoryPairEndInfoMap implements PairEndInfoMap {
-        private final Map<String, PairEndInfo> map = new HashMap<String, PairEndInfo>();
+        private final Map<String, PairEndInfo> map = new HashMap<>();
 
         public void put(int mateReferenceIndex, String key, PairEndInfo value) {
             if (mateReferenceIndex != value.mateReferenceIndex)

--- a/src/main/java/htsjdk/samtools/SamInputResource.java
+++ b/src/main/java/htsjdk/samtools/SamInputResource.java
@@ -213,7 +213,7 @@ abstract class InputResource {
 class FileInputResource extends InputResource {
 
     final File fileResource;
-    final Lazy<SeekableStream> lazySeekableStream = new Lazy<SeekableStream>(new Lazy.LazyInitializer<SeekableStream>() {
+    final Lazy<SeekableStream> lazySeekableStream = new Lazy<>(new Lazy.LazyInitializer<SeekableStream>() {
         @Override
         public SeekableStream make() {
             try {
@@ -268,7 +268,7 @@ class FileInputResource extends InputResource {
 class PathInputResource extends InputResource {
 
     final Path pathResource;
-    final Lazy<SeekableStream> lazySeekableStream = new Lazy<SeekableStream>(new Lazy.LazyInitializer<SeekableStream>() {
+    final Lazy<SeekableStream> lazySeekableStream = new Lazy<>(new Lazy.LazyInitializer<SeekableStream>() {
         @Override
         public SeekableStream make() {
             try {
@@ -327,11 +327,14 @@ class PathInputResource extends InputResource {
 class UrlInputResource extends InputResource {
 
     final URL urlResource;
-    final Lazy<SeekableStream> lazySeekableStream = new Lazy<SeekableStream>(new Lazy.LazyInitializer<SeekableStream>() {
+    final Lazy<SeekableStream> lazySeekableStream = new Lazy<>(new Lazy.LazyInitializer<SeekableStream>() {
         @Override
         public SeekableStream make() {
-            try { return SeekableStreamFactory.getInstance().getStreamFor(urlResource); }
-            catch (final IOException ioe) { throw new RuntimeIOException(ioe); }
+            try {
+                return SeekableStreamFactory.getInstance().getStreamFor(urlResource);
+            } catch (final IOException ioe) {
+                throw new RuntimeIOException(ioe);
+            }
         }
     });
 

--- a/src/main/java/htsjdk/samtools/SamPairUtil.java
+++ b/src/main/java/htsjdk/samtools/SamPairUtil.java
@@ -358,7 +358,7 @@ public class SamPairUtil {
      */
     public static class SetMateInfoIterator extends PeekableIterator<SAMRecord> {
 
-        private final Queue<SAMRecord> records = new LinkedList<SAMRecord>();
+        private final Queue<SAMRecord> records = new LinkedList<>();
         private final boolean setMateCigar;
         private final boolean ignoreMissingMates;
         private long numMateCigarsAdded = 0;

--- a/src/main/java/htsjdk/samtools/SecondaryOrSupplementarySkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/SecondaryOrSupplementarySkippingIterator.java
@@ -13,7 +13,7 @@ public class SecondaryOrSupplementarySkippingIterator {
     private final PeekIterator<SAMRecord> it;
 
     public SecondaryOrSupplementarySkippingIterator(final CloseableIterator<SAMRecord> underlyingIt) {
-        it = new PeekIterator<SAMRecord>(underlyingIt);
+        it = new PeekIterator<>(underlyingIt);
         skipAnyNotprimary();
     }
 

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
@@ -69,7 +69,7 @@ public class ContainerFactory {
 
         header.readNamesIncluded = preserveReadNames;
 
-        final List<Slice> slices = new ArrayList<Slice>();
+        final List<Slice> slices = new ArrayList<>();
 
         final Container container = new Container();
         container.header = header;
@@ -126,7 +126,7 @@ public class ContainerFactory {
                                     final CompressionHeader header)
             throws IllegalArgumentException, IllegalAccessException,
             IOException {
-        final Map<Integer, ExposedByteArrayOutputStream> map = new HashMap<Integer, ExposedByteArrayOutputStream>();
+        final Map<Integer, ExposedByteArrayOutputStream> map = new HashMap<>();
         for (final int id : header.externalIds) {
             map.put(id, new ExposedByteArrayOutputStream());
         }
@@ -186,7 +186,7 @@ public class ContainerFactory {
         bitOutputStream.close();
         slice.coreBlock = Block.buildNewCore(bitBAOS.toByteArray());
 
-        slice.external = new HashMap<Integer, Block>();
+        slice.external = new HashMap<>();
         for (final Integer key : map.keySet()) {
             final ExposedByteArrayOutputStream os = map.get(key);
 

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
@@ -48,7 +48,7 @@ public class ContainerParser {
     private static final Log log = Log.getInstance(ContainerParser.class);
 
     private final SAMFileHeader samFileHeader;
-    private final Map<String, Long> nanosecondsMap = new TreeMap<String, Long>();
+    private final Map<String, Long> nanosecondsMap = new TreeMap<>();
 
     public ContainerParser(final SAMFileHeader samFileHeader) {
         this.samFileHeader = samFileHeader;
@@ -60,7 +60,7 @@ public class ContainerParser {
         if (container.isEOF()) return Collections.emptyList();
         final long time1 = System.nanoTime();
         if (records == null) {
-            records = new ArrayList<CramCompressionRecord>(container.nofRecords);
+            records = new ArrayList<>(container.nofRecords);
         }
 
         for (final Slice slice : container.slices) {
@@ -111,7 +111,7 @@ public class ContainerParser {
                 break;
             case Slice.MULTI_REFERENCE:
                 final DataReaderFactory dataReaderFactory = new DataReaderFactory();
-                final Map<Integer, InputStream> inputMap = new HashMap<Integer, InputStream>();
+                final Map<Integer, InputStream> inputMap = new HashMap<>();
                 for (final Integer exId : slice.external.keySet()) {
                     inputMap.put(exId, new ByteArrayInputStream(slice.external.get(exId)
                             .getRawContent()));
@@ -151,7 +151,7 @@ public class ContainerParser {
         }
 
         final DataReaderFactory dataReaderFactory = new DataReaderFactory();
-        final Map<Integer, InputStream> inputMap = new HashMap<Integer, InputStream>();
+        final Map<Integer, InputStream> inputMap = new HashMap<>();
         for (final Integer exId : slice.external.keySet()) {
             log.debug("Adding external data: " + exId);
             inputMap.put(exId, new ByteArrayInputStream(slice.external.get(exId)
@@ -165,7 +165,7 @@ public class ContainerParser {
                 inputMap, header, slice.sequenceId);
 
         if (records == null) {
-            records = new ArrayList<CramCompressionRecord>(slice.nofRecords);
+            records = new ArrayList<>(slice.nofRecords);
         }
 
         long readNanos = 0;

--- a/src/main/java/htsjdk/samtools/cram/build/Cram2SamRecordFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/Cram2SamRecordFactory.java
@@ -121,7 +121,7 @@ public class Cram2SamRecordFactory {
             return new Cigar(Collections.singletonList(cigarElement));
         }
 
-        final List<CigarElement> list = new ArrayList<CigarElement>();
+        final List<CigarElement> list = new ArrayList<>();
         int totalOpLen = 1;
         CigarElement cigarElement;
         CigarOperator lastOperator = CigarOperator.MATCH_OR_MISMATCH;

--- a/src/main/java/htsjdk/samtools/cram/build/CramSpanContainerIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramSpanContainerIterator.java
@@ -27,7 +27,7 @@ public class CramSpanContainerIterator implements Iterator<Container> {
         this.cramHeader = CramIO.readCramHeader(seekableStream);
         firstContainerOffset = seekableStream.position();
 
-        final List<Boundary> boundaries = new ArrayList<Boundary>();
+        final List<Boundary> boundaries = new ArrayList<>();
         for (int i = 0; i < coordinates.length; i += 2) {
             boundaries.add(new Boundary(coordinates[i], coordinates[i + 1]));
         }

--- a/src/main/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
@@ -66,21 +66,21 @@ public class Sam2CramRecordFactory {
 
     private static final Log log = Log.getInstance(Sam2CramRecordFactory.class);
 
-    private final Map<String, Integer> readGroupMap = new HashMap<String, Integer>();
+    private final Map<String, Integer> readGroupMap = new HashMap<>();
 
     private long landedRefMaskScores = 0;
     private long landedTotalScores = 0;
 
     public boolean captureAllTags = false;
     public boolean preserveReadNames = false;
-    public final Set<String> captureTags = new TreeSet<String>();
-    public final Set<String> ignoreTags = new TreeSet<String>();
+    public final Set<String> captureTags = new TreeSet<>();
+    public final Set<String> ignoreTags = new TreeSet<>();
 
     {
         ignoreTags.add(SAMTag.RG.name());
     }
 
-    private final List<ReadTag> readTagList = new ArrayList<ReadTag>();
+    private final List<ReadTag> readTagList = new ArrayList<>();
 
     private long baseCount = 0;
     private long featureCount = 0;
@@ -202,7 +202,7 @@ public class Sam2CramRecordFactory {
     }
 
     private List<ReadFeature> createVariations(final CramCompressionRecord cramRecord, final SAMRecord samRecord) {
-        final List<ReadFeature> features = new LinkedList<ReadFeature>();
+        final List<ReadFeature> features = new LinkedList<>();
         int zeroBasedPositionInRead = 0;
         int alignmentStartOffset = 0;
         int cigarElementLength;

--- a/src/main/java/htsjdk/samtools/cram/common/IntHashMap.java
+++ b/src/main/java/htsjdk/samtools/cram/common/IntHashMap.java
@@ -361,7 +361,7 @@ public class IntHashMap<T> {
         }
 
         // Creates the new entry.
-        final Entry<T> entry = new Entry<T>(key, key, value, tab[index]);
+        final Entry<T> entry = new Entry<>(key, key, value, tab[index]);
         tab[index] = entry;
         count++;
         return null;

--- a/src/main/java/htsjdk/samtools/cram/digest/ContentDigests.java
+++ b/src/main/java/htsjdk/samtools/cram/digest/ContentDigests.java
@@ -20,17 +20,17 @@ public class ContentDigests {
             KNOWN_DIGESTS.BD, KNOWN_DIGESTS.SD);
 
     private static final Log log = Log.getInstance(ContentDigests.class);
-    private List<Digester> digesters = new LinkedList<ContentDigests.Digester>();
+    private List<Digester> digesters = new LinkedList<>();
 
     public static ContentDigests create(final EnumSet<KNOWN_DIGESTS> requestedDigests) {
-        final List<Digester> digesters = new LinkedList<ContentDigests.Digester>();
+        final List<Digester> digesters = new LinkedList<>();
         for (final KNOWN_DIGESTS digest : requestedDigests)
             digesters.add(digest.createDigester());
         return new ContentDigests(digesters);
     }
 
     public static ContentDigests create(final SAMBinaryTagAndValue binaryTags) {
-        final List<Digester> digesters = new LinkedList<ContentDigests.Digester>();
+        final List<Digester> digesters = new LinkedList<>();
         SAMBinaryTagAndValue binaryTag = binaryTags;
         while (binaryTag != null) {
             final String tagID = SAMTagUtil.getSingleton().makeStringTag(

--- a/src/main/java/htsjdk/samtools/cram/encoding/EncodingFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/EncodingFactory.java
@@ -47,7 +47,7 @@ public class EncodingFactory {
                     case HUFFMAN:
                         return (Encoding<T>) new HuffmanByteEncoding();
                     case NULL:
-                        return new NullEncoding<T>();
+                        return new NullEncoding<>();
 
                     default:
                         break;
@@ -60,7 +60,7 @@ public class EncodingFactory {
                     case HUFFMAN:
                         return (Encoding<T>) new HuffmanIntegerEncoding();
                     case NULL:
-                        return new NullEncoding<T>();
+                        return new NullEncoding<>();
                     case EXTERNAL:
                         return (Encoding<T>) new ExternalIntegerEncoding();
                     case GOLOMB:
@@ -82,7 +82,7 @@ public class EncodingFactory {
             case LONG:
                 switch (id) {
                     case NULL:
-                        return new NullEncoding<T>();
+                        return new NullEncoding<>();
                     case GOLOMB:
                         return (Encoding<T>) new GolombLongEncoding();
                     case EXTERNAL:
@@ -96,7 +96,7 @@ public class EncodingFactory {
             case BYTE_ARRAY:
                 switch (id) {
                     case NULL:
-                        return new NullEncoding<T>();
+                        return new NullEncoding<>();
                     case BYTE_ARRAY_LEN:
                         return (Encoding<T>) new ByteArrayLenEncoding();
                     case BYTE_ARRAY_STOP:

--- a/src/main/java/htsjdk/samtools/cram/encoding/NullEncoding.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/NullEncoding.java
@@ -51,7 +51,7 @@ public class NullEncoding<T> implements Encoding<T> {
     @Override
     public BitCodec<T> buildCodec(final Map<Integer, InputStream> inputMap,
                                   final Map<Integer, ExposedByteArrayOutputStream> outputMap) {
-        return new NullCodec<T>();
+        return new NullCodec<>();
     }
 
 }

--- a/src/main/java/htsjdk/samtools/cram/encoding/huffman/HuffmanCode.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/huffman/HuffmanCode.java
@@ -27,10 +27,10 @@ import java.util.TreeMap;
 public class HuffmanCode {
 
     public static <T> HuffmanTree<T> buildTree(final int[] charFrequencies, final T[] values) {
-        final LinkedList<HuffmanTree<T>> list = new LinkedList<HuffmanTree<T>>();
+        final LinkedList<HuffmanTree<T>> list = new LinkedList<>();
         for (int i = 0; i < charFrequencies.length; i++)
             if (charFrequencies[i] > 0)
-                list.add(new HuffmanLeaf<T>(charFrequencies[i], values[i]));
+                list.add(new HuffmanLeaf<>(charFrequencies[i], values[i]));
 
         final Comparator<HuffmanTree<T>> comparator = new Comparator<HuffmanTree<T>>() {
 
@@ -45,15 +45,15 @@ public class HuffmanCode {
             // dumpList(list) ;
             final HuffmanTree<T> left = list.remove();
             final HuffmanTree<T> right = list.remove();
-            list.add(new HuffmanNode<T>(left, right));
+            list.add(new HuffmanNode<>(left, right));
         }
         return list.isEmpty() ? null : list.remove();
     }
 
     public static <T> void getValuesAndBitLengths(final List<T> values,
                                                   final List<Integer> lens, final HuffmanTree<T> tree) {
-        final TreeMap<T, HuffmanBitCode<T>> codes = new TreeMap<T, HuffmanBitCode<T>>();
-        getBitCode(tree, new HuffmanBitCode<T>(), codes);
+        final TreeMap<T, HuffmanBitCode<T>> codes = new TreeMap<>();
+        getBitCode(tree, new HuffmanBitCode<>(), codes);
 
         for (final T value : codes.keySet()) {
             final HuffmanBitCode<T> code = codes.get(value);
@@ -71,7 +71,7 @@ public class HuffmanCode {
                                        final HuffmanBitCode<T> code, final Map<T, HuffmanBitCode<T>> codes) {
         if (tree instanceof HuffmanLeaf) {
             final HuffmanLeaf<T> leaf = (HuffmanLeaf<T>) tree;
-            final HuffmanBitCode<T> readyCode = new HuffmanBitCode<T>();
+            final HuffmanBitCode<T> readyCode = new HuffmanBitCode<>();
             readyCode.bitCode = code.bitCode;
             readyCode.bitLength = code.bitLength;
             codes.put(leaf.value, readyCode);

--- a/src/main/java/htsjdk/samtools/cram/encoding/huffman/codec/HuffmanByteHelper.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/huffman/codec/HuffmanByteHelper.java
@@ -52,7 +52,7 @@ class HuffmanByteHelper {
         buildCodeBook();
         buildCodes();
 
-        final ArrayList<HuffmanBitCode> list = new ArrayList<HuffmanBitCode>(
+        final ArrayList<HuffmanBitCode> list = new ArrayList<>(
                 codes.size());
         list.addAll(codes.values());
         Collections.sort(list, bitCodeComparator);
@@ -86,12 +86,12 @@ class HuffmanByteHelper {
     }
 
     private void buildCodeBook() {
-        codeBook = new TreeMap<Integer, SortedSet<Integer>>();
+        codeBook = new TreeMap<>();
         for (int i = 0; i < values.length; i++) {
             if (codeBook.containsKey(bitLengths[i]))
                 codeBook.get(bitLengths[i]).add(values[i]);
             else {
-                final TreeSet<Integer> entry = new TreeSet<Integer>();
+                final TreeSet<Integer> entry = new TreeSet<>();
                 entry.add(values[i]);
                 codeBook.put(bitLengths[i], entry);
             }
@@ -99,7 +99,7 @@ class HuffmanByteHelper {
     }
 
     private void buildCodes() {
-        codes = new TreeMap<Integer, HuffmanBitCode>();
+        codes = new TreeMap<>();
         int codeLength = 0, codeValue = -1;
         for (final Object key : codeBook.keySet()) { // Iterate over code lengths
 

--- a/src/main/java/htsjdk/samtools/cram/encoding/huffman/codec/HuffmanIntHelper.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/huffman/codec/HuffmanIntHelper.java
@@ -50,7 +50,7 @@ class HuffmanIntHelper {
         buildCodeBook();
         buildCodes();
 
-        final ArrayList<HuffmanBitCode> list = new ArrayList<HuffmanBitCode>(
+        final ArrayList<HuffmanBitCode> list = new ArrayList<>(
                 codes.size());
         list.addAll(codes.values());
         Collections.sort(list, bitCodeComparator);
@@ -86,12 +86,12 @@ class HuffmanIntHelper {
     }
 
     private void buildCodeBook() {
-        codeBook = new TreeMap<Integer, SortedSet<Integer>>();
+        codeBook = new TreeMap<>();
         for (int i = 0; i < values.length; i++) {
             if (codeBook.containsKey(bitLengths[i]))
                 codeBook.get(bitLengths[i]).add(values[i]);
             else {
-                final TreeSet<Integer> entry = new TreeSet<Integer>();
+                final TreeSet<Integer> entry = new TreeSet<>();
                 entry.add(values[i]);
                 codeBook.put(bitLengths[i], entry);
             }
@@ -99,7 +99,7 @@ class HuffmanIntHelper {
     }
 
     private void buildCodes() {
-        codes = new TreeMap<Integer, HuffmanBitCode>();
+        codes = new TreeMap<>();
         int codeLength = 0, codeValue = -1;
         for (final Object key : codeBook.keySet()) { // Iterate over code lengths
 

--- a/src/main/java/htsjdk/samtools/cram/encoding/huffman/codec/HuffmanParamsCalculator.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/huffman/codec/HuffmanParamsCalculator.java
@@ -86,8 +86,8 @@ class HuffmanParamsCalculator {
             tree = HuffmanCode.buildTree(frequencies, autobox(values));
         }
 
-        final List<Integer> valueList = new ArrayList<Integer>();
-        final List<Integer> lens = new ArrayList<Integer>();
+        final List<Integer> valueList = new ArrayList<>();
+        final List<Integer> lens = new ArrayList<>();
         HuffmanCode.getValuesAndBitLengths(valueList, lens, tree);
 
         // the following sorting is not really required, but whatever:

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/CramRecordReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/CramRecordReader.java
@@ -103,7 +103,7 @@ public class CramRecordReader extends AbstractReader {
                 // reading read features:
                 final int size = numberOfReadFeaturesCodec.readData();
                 int prevPos = 0;
-                final java.util.List<ReadFeature> readFeatures = new LinkedList<ReadFeature>();
+                final java.util.List<ReadFeature> readFeatures = new LinkedList<>();
                 cramRecord.readFeatures = readFeatures;
                 for (int i = 0; i < size; i++) {
                     final Byte operator = readFeatureCodeCodec.readData();

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/DataReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/DataReaderFactory.java
@@ -107,23 +107,23 @@ public class DataReaderFactory {
         encoding.fromByteArray(params.params);
 
         //noinspection ConstantConditions
-        return collectStats ? new DataReaderWithStats(new DefaultDataReader<T>(
+        return collectStats ? new DataReaderWithStats(new DefaultDataReader<>(
                 encoding.buildCodec(inputMap, null), bitInputStream))
-                : new DefaultDataReader<T>(encoding.buildCodec(inputMap, null),
+                : new DefaultDataReader<>(encoding.buildCodec(inputMap, null),
                 bitInputStream);
     }
 
     private static <T> DataReader<T> buildNullReader(final DataSeriesType valueType) {
         switch (valueType) {
             case BYTE:
-                return (DataReader<T>) new SingleValueReader<Byte>((byte) 0);
+                return (DataReader<T>) new SingleValueReader<>((byte) 0);
             case INT:
-                return (DataReader<T>) new SingleValueReader<Integer>(
+                return (DataReader<T>) new SingleValueReader<>(
                         0);
             case LONG:
-                return (DataReader<T>) new SingleValueReader<Long>((long) 0);
+                return (DataReader<T>) new SingleValueReader<>((long) 0);
             case BYTE_ARRAY:
-                return (DataReader<T>) new SingleValueReader<byte[]>(new byte[]{});
+                return (DataReader<T>) new SingleValueReader<>(new byte[]{});
 
             default:
                 throw new RuntimeException("Unknown data type: " + valueType.name());
@@ -196,7 +196,7 @@ public class DataReaderFactory {
 
     public Map<String, DataReaderWithStats> getStats(final CramRecordReader reader)
             throws IllegalArgumentException, IllegalAccessException {
-        final Map<String, DataReaderWithStats> map = new TreeMap<String, DataReaderFactory.DataReaderWithStats>();
+        final Map<String, DataReaderWithStats> map = new TreeMap<>();
         //noinspection ConstantConditions,PointlessBooleanExpression
         if (!collectStats)
             return map;

--- a/src/main/java/htsjdk/samtools/cram/encoding/writer/DataWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/writer/DataWriterFactory.java
@@ -60,7 +60,7 @@ public class DataWriterFactory {
                 final DataSeriesMap dsm = f.getAnnotation(DataSeriesMap.class);
                 final String name = dsm.name();
                 if ("TAG".equals(name)) {
-                    final Map<Integer, DataWriter<byte[]>> map = new HashMap<Integer, DataWriter<byte[]>>();
+                    final Map<Integer, DataWriter<byte[]>> map = new HashMap<>();
                     for (final Integer key : h.tMap.keySet()) {
                         final EncodingParams params = h.tMap.get(key);
                         final DataWriter<byte[]> tagWriter = createWriter(
@@ -87,7 +87,7 @@ public class DataWriterFactory {
 
         encoding.fromByteArray(params.params);
 
-        return new DefaultDataWriter<T>(encoding.buildCodec(null, outputMap),
+        return new DefaultDataWriter<>(encoding.buildCodec(null, outputMap),
                 bitOutputStream);
     }
 

--- a/src/main/java/htsjdk/samtools/cram/lossy/PreservationPolicy.java
+++ b/src/main/java/htsjdk/samtools/cram/lossy/PreservationPolicy.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class PreservationPolicy {
     public ReadCategory readCategory;
-    public final List<BaseCategory> baseCategories = new ArrayList<BaseCategory>();
+    public final List<BaseCategory> baseCategories = new ArrayList<>();
 
     public QualityScoreTreatment treatment;
 

--- a/src/main/java/htsjdk/samtools/cram/lossy/QualityScorePreservation.java
+++ b/src/main/java/htsjdk/samtools/cram/lossy/QualityScorePreservation.java
@@ -73,7 +73,7 @@ public class QualityScorePreservation {
     }
 
     private static List<PreservationPolicy> parsePolicies(final String spec) {
-        final List<PreservationPolicy> policyList = new ArrayList<PreservationPolicy>();
+        final List<PreservationPolicy> policyList = new ArrayList<>();
         for (final String string : spec.split("-")) {
             if (string.isEmpty())
                 continue;
@@ -100,7 +100,7 @@ public class QualityScorePreservation {
 
     private static PreservationPolicy parseSinglePolicy(final String spec) {
         final PreservationPolicy preservationPolicy = new PreservationPolicy();
-        final LinkedList<Character> list = new LinkedList<Character>();
+        final LinkedList<Character> list = new LinkedList<>();
         for (final char character : spec.toCharArray())
             list.add(character);
 
@@ -201,7 +201,7 @@ public class QualityScorePreservation {
             for (int i = 0; i < scores.length; i++) {
                 if (scores[i] > -1) {
                     if (cramRecord.readFeatures == null)
-                        cramRecord.readFeatures = new LinkedList<ReadFeature>();
+                        cramRecord.readFeatures = new LinkedList<>();
                     cramRecord.readFeatures.add(new BaseQualityScore(i + 1, scores[i]));
                 }
             }

--- a/src/main/java/htsjdk/samtools/cram/ref/InMemoryReferenceSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/InMemoryReferenceSequenceFile.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 class InMemoryReferenceSequenceFile implements ReferenceSequenceFile {
-    private Map<Integer, byte[]> sequences = new HashMap<Integer, byte[]>();
+    private Map<Integer, byte[]> sequences = new HashMap<>();
     private SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
     private int currentIndex = 0;
 

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -55,7 +55,7 @@ public class ReferenceSource implements CRAMReferenceSource {
     private ReferenceSequenceFile rsFile;
     private int downloadTriesBeforeFailing = 2;
 
-    private final Map<String, WeakReference<byte[]>> cacheW = new HashMap<String, WeakReference<byte[]>>();
+    private final Map<String, WeakReference<byte[]>> cacheW = new HashMap<>();
 
     private ReferenceSource() {
     }
@@ -129,7 +129,7 @@ public class ReferenceSource implements CRAMReferenceSource {
         for (int i = 0; i < bases.length; i++) {
             bases[i] = Utils.normalizeBase(bases[i]);
         }
-        cacheW.put(sequenceName, new WeakReference<byte[]>(bases));
+        cacheW.put(sequenceName, new WeakReference<>(bases));
         return bases;
     }
 
@@ -249,7 +249,7 @@ public class ReferenceSource implements CRAMReferenceSource {
             Pattern.CASE_INSENSITIVE);
 
     List<String> getVariants(final String name) {
-        final List<String> variants = new ArrayList<String>();
+        final List<String> variants = new ArrayList<>();
 
         if (name.equals("M"))
             variants.add("MT");

--- a/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
@@ -52,7 +52,7 @@ public class CompressionHeader {
 
     public Map<EncodingKey, EncodingParams> encodingMap;
     public Map<Integer, EncodingParams> tMap;
-    public final Map<Integer, ExternalCompressor> externalCompressors = new HashMap<Integer, ExternalCompressor>();
+    public final Map<Integer, ExternalCompressor> externalCompressors = new HashMap<>();
 
     public SubstitutionMatrix substitutionMatrix;
 
@@ -68,11 +68,11 @@ public class CompressionHeader {
     }
 
     private byte[][][] parseDictionary(final byte[] bytes) {
-        final List<List<byte[]>> dictionary = new ArrayList<List<byte[]>>();
+        final List<List<byte[]>> dictionary = new ArrayList<>();
         {
             int i = 0;
             while (i < bytes.length) {
-                final List<byte[]> list = new ArrayList<byte[]>();
+                final List<byte[]> list = new ArrayList<>();
                 while (bytes[i] != 0) {
                     list.add(Arrays.copyOfRange(bytes, i, i + 3));
                     i += 3;
@@ -163,7 +163,7 @@ public class CompressionHeader {
             final ByteBuffer buffer = ByteBuffer.wrap(bytes);
 
             final int mapSize = ITF8.readUnsignedITF8(buffer);
-            encodingMap = new TreeMap<EncodingKey, EncodingParams>();
+            encodingMap = new TreeMap<>();
             for (final EncodingKey encodingKey : EncodingKey.values())
                 encodingMap.put(encodingKey, NullEncoding.toParam());
 
@@ -194,7 +194,7 @@ public class CompressionHeader {
             final ByteBuffer buf = ByteBuffer.wrap(bytes);
 
             final int mapSize = ITF8.readUnsignedITF8(buf);
-            tMap = new TreeMap<Integer, EncodingParams>();
+            tMap = new TreeMap<>();
             for (int i = 0; i < mapSize; i++) {
                 final int key = ITF8.readUnsignedITF8(buf);
 

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
@@ -88,7 +88,7 @@ public class ContainerIO {
         if (fromSlice > 0) //noinspection ResultOfMethodCallIgnored
             inputStream.skip(container.landmarks[fromSlice]);
 
-        final List<Slice> slices = new ArrayList<Slice>();
+        final List<Slice> slices = new ArrayList<>();
         for (int sliceCount = fromSlice; sliceCount < howManySlices - fromSlice; sliceCount++) {
             final Slice slice = new Slice();
             SliceIO.read(major, slice, inputStream);
@@ -182,7 +182,7 @@ public class ContainerIO {
         block.write(version.major, byteArrayOutputStream);
         container.blockCount = 1;
 
-        final List<Integer> landmarks = new ArrayList<Integer>();
+        final List<Integer> landmarks = new ArrayList<>();
         for (int i = 0; i < container.slices.length; i++) {
             final Slice slice = container.slices[i];
             landmarks.add(byteArrayOutputStream.size());

--- a/src/main/java/htsjdk/samtools/cram/structure/SliceIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/SliceIO.java
@@ -108,7 +108,7 @@ class SliceIO {
     }
 
     private static void readSliceBlocks(final int major, final Slice slice, final InputStream inputStream) throws IOException {
-        slice.external = new HashMap<Integer, Block>();
+        slice.external = new HashMap<>();
         for (int i = 0; i < slice.nofBlocks; i++) {
             final Block block = Block.readFromInputStream(major, inputStream);
 

--- a/src/main/java/htsjdk/samtools/filter/FilteringSamIterator.java
+++ b/src/main/java/htsjdk/samtools/filter/FilteringSamIterator.java
@@ -64,7 +64,7 @@ public class FilteringSamIterator implements CloseableIterator<SAMRecord> {
             ((SAMRecordIterator)iterator).assertSorted(SAMFileHeader.SortOrder.queryname);
         }
 
-        this.iterator = new PeekableIterator<SAMRecord>(iterator);
+        this.iterator = new PeekableIterator<>(iterator);
         this.filter = filter;
         this.filterReadPairs = filterByPair;
         next = getNextRecord();
@@ -77,7 +77,7 @@ public class FilteringSamIterator implements CloseableIterator<SAMRecord> {
      * @param filter   the filter (which may be a FilterAggregator)
      */
     public FilteringSamIterator(final Iterator<SAMRecord> iterator, final SamRecordFilter filter) {
-        this.iterator = new PeekableIterator<SAMRecord>(iterator);
+        this.iterator = new PeekableIterator<>(iterator);
         this.filter = filter;
         next = getNextRecord();
     }

--- a/src/main/java/htsjdk/samtools/filter/ReadNameFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/ReadNameFilter.java
@@ -41,7 +41,7 @@ import java.util.Set;
 public class ReadNameFilter implements SamRecordFilter {
 
     private boolean includeReads = false;
-    private Set<String> readNameFilterSet = new HashSet<String>();
+    private Set<String> readNameFilterSet = new HashSet<>();
 
     public ReadNameFilter(final File readNameFilterFile, final boolean includeReads) {
 

--- a/src/main/java/htsjdk/samtools/liftover/Chain.java
+++ b/src/main/java/htsjdk/samtools/liftover/Chain.java
@@ -87,7 +87,7 @@ class Chain {
     final int toChainEnd;
     /** ID of chain in file.  */
     final int id;
-    private final List<ContinuousBlock> blockList = new ArrayList<ContinuousBlock>();
+    private final List<ContinuousBlock> blockList = new ArrayList<>();
 
     /**
      * Construct a Chain from the parsed header fields.
@@ -313,7 +313,7 @@ class Chain {
      */
     static OverlapDetector<Chain> loadChains(final File chainFile) {
         final BufferedLineReader reader = new BufferedLineReader(IOUtil.openFileForReading(chainFile));
-        final OverlapDetector<Chain> ret = new OverlapDetector<Chain>(0, 0);
+        final OverlapDetector<Chain> ret = new OverlapDetector<>(0, 0);
         Chain chain;
         while ((chain = Chain.loadChain(reader, chainFile.toString())) != null) {
             ret.addLhs(chain, chain.interval);

--- a/src/main/java/htsjdk/samtools/liftover/LiftOver.java
+++ b/src/main/java/htsjdk/samtools/liftover/LiftOver.java
@@ -140,7 +140,7 @@ public class LiftOver {
     }
 
     public List<PartialLiftover> diagnosticLiftover(final Interval interval) {
-        final List<PartialLiftover> ret = new ArrayList<PartialLiftover>();
+        final List<PartialLiftover> ret = new ArrayList<>();
         if (interval.length() == 0) {
             throw new IllegalArgumentException("Zero-length interval cannot be lifted over.  Interval: " +
                     interval.getName());

--- a/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
+++ b/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
@@ -115,7 +115,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
     
     /** Returns the list of headers with the specified type. */
     public List<Header> getHeaders(final Class<? extends Header> type) {
-        List<Header> tmp = new ArrayList<Header>();
+        List<Header> tmp = new ArrayList<>();
         for (final Header h : this.headers) {
             if (h.getClass().equals(type)) {
                 tmp.add(h);
@@ -238,7 +238,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
 
     /** Prints the histogram if one is present. */
     private void printHistogram(final BufferedWriter out, final FormatUtil formatter) throws IOException {
-        final List<Histogram<HKEY>> nonEmptyHistograms = new ArrayList<Histogram<HKEY>>();
+        final List<Histogram<HKEY>> nonEmptyHistograms = new ArrayList<>();
         for (final Histogram<HKEY> histo : this.histograms) {
             if (!histo.isEmpty()) nonEmptyHistograms.add(histo);
         }
@@ -248,7 +248,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
         }
 
         // Build a combined key set.  Assume comparator is the same for all Histograms
-        final java.util.Set<HKEY> keys = new TreeSet<HKEY>(nonEmptyHistograms.get(0).comparator());
+        final java.util.Set<HKEY> keys = new TreeSet<>(nonEmptyHistograms.get(0).comparator());
         for (final Histogram<HKEY> histo : nonEmptyHistograms) {
             if (histo != null) keys.addAll(histo.keySet());
         }
@@ -421,7 +421,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
                     // Read the next line with the bin and value labels
                     final String[] labels = in.readLine().split(SEPARATOR);
                     for (int i=1; i<labels.length; ++i) {
-                        this.histograms.add(new Histogram<HKEY>(labels[0], labels[i]));
+                        this.histograms.add(new Histogram<>(labels[0], labels[i]));
                     }
 
                     // Read the entries in the histograms

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
@@ -45,7 +45,7 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
     /**
      * Store the entries.  Use a LinkedHashMap for consistent iteration in insertion order.
      */
-    private final Map<String,FastaSequenceIndexEntry> sequenceEntries = new LinkedHashMap<String,FastaSequenceIndexEntry>();
+    private final Map<String,FastaSequenceIndexEntry> sequenceEntries = new LinkedHashMap<>();
 
     /**
      * Build a sequence index from the specified file.

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableFileStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableFileStream.java
@@ -113,7 +113,7 @@ public class SeekableFileStream extends SeekableStream {
     }
 
     public static synchronized void closeAllInstances() {
-        Collection<SeekableFileStream> clonedInstances = new HashSet<SeekableFileStream>();
+        Collection<SeekableFileStream> clonedInstances = new HashSet<>();
         clonedInstances.addAll(allInstances);
         for (SeekableFileStream sfs : clonedInstances) {
             try {

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekablePathStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekablePathStream.java
@@ -107,7 +107,7 @@ public class SeekablePathStream extends SeekableStream {
     }
 
     public static synchronized void closeAllInstances() {
-        Collection<SeekablePathStream> clonedInstances = new HashSet<SeekablePathStream>();
+        Collection<SeekablePathStream> clonedInstances = new HashSet<>();
         clonedInstances.addAll(ALL_INSTANCES);
         for (SeekablePathStream sfs : clonedInstances) {
             try {

--- a/src/main/java/htsjdk/samtools/sra/SRAAlignmentIterator.java
+++ b/src/main/java/htsjdk/samtools/sra/SRAAlignmentIterator.java
@@ -180,7 +180,7 @@ public class SRAAlignmentIterator implements CloseableIterator<SAMRecord> {
     }
 
     private List<Chunk> getReferenceChunks(final Chunk chunk) {
-        List<Chunk> referencesChunks = new ArrayList<Chunk>();
+        List<Chunk> referencesChunks = new ArrayList<>();
         long refOffset = 0;
         for (Long refLen : referencesLengths) {
             if (chunk.getChunkStart() - refOffset >= refLen || chunk.getChunkEnd() - refOffset <= 0) {

--- a/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
+++ b/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
@@ -213,7 +213,7 @@ public class SRALazyRecord extends SAMRecord {
     private static Map<Short, LazyAttribute> lazyAttributeTags;
     static
     {
-        lazyAttributeTags = new HashMap<Short, LazyAttribute>();
+        lazyAttributeTags = new HashMap<>();
         lazyAttributeTags.put(SAMTagUtil.getSingleton().RG, LazyAttribute.RG);
     }
 

--- a/src/main/java/htsjdk/samtools/sra/SRAUtils.java
+++ b/src/main/java/htsjdk/samtools/sra/SRAUtils.java
@@ -69,7 +69,7 @@ public class SRAUtils {
      */
     public static List<Long> getReferencesLengthsAligned(ReadCollection run) throws ErrorMsg {
         ReferenceIterator refIt = run.getReferences();
-        List<Long> lengths = new ArrayList<Long>();
+        List<Long> lengths = new ArrayList<>();
         while (refIt.nextReference()) {
             long refLen = refIt.getLength();
             // lets optimize references so they always align in 5000 bases positions

--- a/src/main/java/htsjdk/samtools/util/AbstractAsyncWriter.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractAsyncWriter.java
@@ -28,7 +28,7 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
     private final BlockingQueue<T> queue;
     private final Thread writer;
     private final WriterRunnable writerRunnable;
-    private final AtomicReference<Throwable> ex = new AtomicReference<Throwable>(null);
+    private final AtomicReference<Throwable> ex = new AtomicReference<>(null);
 
     /** Returns the prefix to use when naming threads. */
     protected abstract String getThreadNamePrefix();
@@ -42,7 +42,7 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
      * internal queue and write records into the synchronous writer.
      */
     protected AbstractAsyncWriter(final int queueSize) {
-        this.queue = new ArrayBlockingQueue<T>(queueSize);
+        this.queue = new ArrayBlockingQueue<>(queueSize);
         this.writerRunnable = new WriterRunnable();
         this.writer = new Thread(writerRunnable, getThreadNamePrefix() + threadsCreated++);
         this.writer.setDaemon(true);

--- a/src/main/java/htsjdk/samtools/util/CigarUtil.java
+++ b/src/main/java/htsjdk/samtools/util/CigarUtil.java
@@ -52,7 +52,7 @@ public class CigarUtil {
     // package visible so can be unit-tested
     public static List<CigarElement> softClipEndOfRead(final int clipFrom, final List<CigarElement> oldCigar) {
         final int clippedBases = (int)CoordMath.getLength(clipFrom, Cigar.getReadLength(oldCigar));
-        List<CigarElement> newCigar = new LinkedList<CigarElement>();
+        List<CigarElement> newCigar = new LinkedList<>();
         int pos = 1;
 
         for (CigarElement c : oldCigar) {
@@ -117,7 +117,7 @@ public class CigarUtil {
         }
         if (negativeStrand){
             // Can't just use Collections.reverse() here because oldCigar is unmodifiable
-            oldCigar = new ArrayList<CigarElement>(oldCigar);
+            oldCigar = new ArrayList<>(oldCigar);
             Collections.reverse(oldCigar);
         }
         List<CigarElement> newCigarElems = CigarUtil.softClipEndOfRead(clipFrom, oldCigar);
@@ -217,7 +217,7 @@ public class CigarUtil {
     public static Cigar addSoftClippedBasesToEndsOfCigar(Cigar cigar, boolean negativeStrand,
                                                          final int threePrimeEnd, final int fivePrimeEnd) {
 
-        List<CigarElement> newCigar = new ArrayList<CigarElement>(cigar.getCigarElements());
+        List<CigarElement> newCigar = new ArrayList<>(cigar.getCigarElements());
         if (negativeStrand) {
             Collections.reverse(newCigar);
         }

--- a/src/main/java/htsjdk/samtools/util/CoordSpanInputSteam.java
+++ b/src/main/java/htsjdk/samtools/util/CoordSpanInputSteam.java
@@ -28,7 +28,7 @@ public class CoordSpanInputSteam extends InputStream {
     public CoordSpanInputSteam(SeekableStream delegate, long[] coords) throws IOException {
         this.delegate = delegate;
 
-        List<Chunk> chunks = new ArrayList<Chunk>();
+        List<Chunk> chunks = new ArrayList<>();
         for (int i = 0; i < coords.length; i += 2) {
             if (coords[i] > delegate.length()) throw new RuntimeException("Chunk start is passed EOF: " + coords[i]);
             Chunk chunk = new Chunk(coords[i], coords[i + 1] > delegate.length() ? delegate.length() : coords[i + 1]);

--- a/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
+++ b/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
@@ -94,7 +94,7 @@ public class DiskBackedQueue<E> implements Queue<E> {
         this.tmpDirs = tmpDirs;
         this.codec = codec;
         this.maxRecordsInRamQueue = (maxRecordsInRam == 0) ? 0 : maxRecordsInRam - 1; // the first of our ram records is stored as headRecord
-        this.ramRecords = new ArrayDeque<E>(this.maxRecordsInRamQueue);
+        this.ramRecords = new ArrayDeque<>(this.maxRecordsInRamQueue);
     }
 
     /**
@@ -107,7 +107,7 @@ public class DiskBackedQueue<E> implements Queue<E> {
     public static <T> DiskBackedQueue<T> newInstance(final SortingCollection.Codec<T> codec,
                                                      final int maxRecordsInRam,
                                                      final List<File> tmpDir) {
-        return new DiskBackedQueue<T>(codec, maxRecordsInRam, tmpDir);
+        return new DiskBackedQueue<>(codec, maxRecordsInRam, tmpDir);
     }
 
     public boolean canAdd() {

--- a/src/main/java/htsjdk/samtools/util/Histogram.java
+++ b/src/main/java/htsjdk/samtools/util/Histogram.java
@@ -524,7 +524,7 @@ public final class Histogram<K extends Comparable> implements Serializable {
      * @throws IllegalArgumentException if the keySet of this histogram is not equal to the keySet of the given divisorHistogram
      */
     public Histogram<K> divideByHistogram(final Histogram<K> divisorHistogram) {
-        final Histogram<K> output = new Histogram<K>();
+        final Histogram<K> output = new Histogram<>();
         if (!this.keySet().equals(divisorHistogram.keySet())) throw new IllegalArgumentException("Attempting to divide Histograms with non-identical bins");
         for (final K key : this.keySet()){
             final Bin<K> dividend = this.get(key);

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -895,7 +895,7 @@ public class IOUtil {
     private static List<String> tokenSlurp(final InputStream is, final Charset charSet, final String delimiterPattern) {
         try {
             final Scanner s = new Scanner(is, charSet.toString()).useDelimiter(delimiterPattern);
-            final LinkedList<String> tokens = new LinkedList<String>();
+            final LinkedList<String> tokens = new LinkedList<>();
             while (s.hasNext()) {
                 tokens.add(s.next());
             }
@@ -912,8 +912,8 @@ public class IOUtil {
     public static List<File> unrollFiles(final Collection<File> inputs, final String... extensions) {
         if (extensions.length < 1) throw new IllegalArgumentException("Must provide at least one extension.");
 
-        final Stack<File> stack = new Stack<File>();
-        final List<File> output = new ArrayList<File>();
+        final Stack<File> stack = new Stack<>();
+        final List<File> output = new ArrayList<>();
         stack.addAll(inputs);
 
         while (!stack.empty()) {

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -65,7 +65,7 @@ public class IntervalList implements Iterable<Interval> {
     public static final String INTERVAL_LIST_FILE_EXTENSION = ".interval_list";
 
     private final SAMFileHeader header;
-    private final List<Interval> intervals = new ArrayList<Interval>();
+    private final List<Interval> intervals = new ArrayList<>();
 
     private static final Log log = Log.getInstance(IntervalList.class);
 
@@ -219,8 +219,8 @@ public class IntervalList implements Iterable<Interval> {
             intervals = list.intervals;
         }
 
-        final List<Interval> unique = new ArrayList<Interval>();
-        final TreeSet<Interval> toBeMerged = new TreeSet<Interval>();
+        final List<Interval> unique = new ArrayList<>();
+        final TreeSet<Interval> toBeMerged = new TreeSet<>();
         Interval current = null;
 
         for (final Interval next : intervals) {
@@ -276,7 +276,7 @@ public class IntervalList implements Iterable<Interval> {
      * @return list of intervals that are broken up
      */
     public static List<Interval> breakIntervalsAtBandMultiples(final List<Interval> intervals, final int bandMultiple) {
-        final List<Interval> brokenUpIntervals = new ArrayList<Interval>();
+        final List<Interval> brokenUpIntervals = new ArrayList<>();
         for (final Interval interval : intervals) {
             if (interval.getEnd() >= interval.getStart()) {       // Normal, non-empty intervals
                 final int startIndex = interval.getStart() / bandMultiple;
@@ -305,7 +305,7 @@ public class IntervalList implements Iterable<Interval> {
      * @return list of intervals that are broken up
      */
     private static List<Interval> breakIntervalAtBandMultiples(final Interval interval, final int bandMultiple) {
-        final List<Interval> brokenUpIntervals = new ArrayList<Interval>();
+        final List<Interval> brokenUpIntervals = new ArrayList<>();
 
         int startPos = interval.getStart();
         final int startOfIntervalIndex = startPos / bandMultiple;
@@ -331,7 +331,7 @@ public class IntervalList implements Iterable<Interval> {
         int start = intervals.first().getStart();
         int end   = intervals.last().getEnd();
         final boolean neg  = intervals.first().isNegativeStrand();
-        final LinkedHashSet<String> names = new LinkedHashSet<String>();
+        final LinkedHashSet<String> names = new LinkedHashSet<>();
         final String name;
 
         for (final Interval i : intervals) {
@@ -409,7 +409,7 @@ public class IntervalList implements Iterable<Interval> {
      * Calls {@link #fromFile(java.io.File)} on the provided files, and returns their {@link #union(java.util.Collection)}.
      */
     public static IntervalList fromFiles(final Collection<File> intervalListFiles) {
-        final Collection<IntervalList> intervalLists = new ArrayList<IntervalList>();
+        final Collection<IntervalList> intervalLists = new ArrayList<>();
         for (final File file : intervalListFiles) {
             intervalLists.add(IntervalList.fromFile(file));
         }
@@ -551,7 +551,7 @@ public class IntervalList implements Iterable<Interval> {
 
         result = new IntervalList(list1.getHeader().clone());
 
-        final OverlapDetector<Interval> detector = new OverlapDetector<Interval>(0, 0);
+        final OverlapDetector<Interval> detector = new OverlapDetector<>(0, 0);
 
         detector.addAll(list1.getIntervals(), list1.getIntervals());
 
@@ -642,7 +642,7 @@ public class IntervalList implements Iterable<Interval> {
     public static IntervalList invert(final IntervalList list) {
         final IntervalList inverse = new IntervalList(list.header.clone());
 
-        final ListMap<Integer,Interval> map = new ListMap<Integer,Interval>();
+        final ListMap<Integer,Interval> map = new ListMap<>();
 
         //add all the intervals (uniqued and therefore also sorted) to a ListMap from sequenceIndex to a list of Intervals
         for(final Interval i : list.uniqued().getIntervals()){

--- a/src/main/java/htsjdk/samtools/util/IntervalListReferenceSequenceMask.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalListReferenceSequenceMask.java
@@ -58,7 +58,7 @@ public class IntervalListReferenceSequenceMask implements ReferenceSequenceMask 
             lastSequenceIndex = header.getSequenceIndex((lastInterval.getContig()));
             lastPosition = lastInterval.getEnd();
         }
-        intervalIterator = new PeekableIterator<Interval>(uniqueIntervals.iterator());
+        intervalIterator = new PeekableIterator<>(uniqueIntervals.iterator());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/IntervalTree.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalTree.java
@@ -74,7 +74,7 @@ public class IntervalTree<V> implements Iterable<IntervalTree.Node<V>>
 
         if ( mRoot == null )
         {
-            mRoot = new Node<V>(start,end,value);
+            mRoot = new Node<>(start, end, value);
         }
         else
         {
@@ -531,7 +531,7 @@ public class IntervalTree<V> implements Iterable<IntervalTree.Node<V>>
 
         Node<V1> insertLeft( final int start, final int end, final V1 value, final Node<V1> root )
         {
-            mLeft = new Node<V1>(this,start,end,value);
+            mLeft = new Node<>(this, start, end, value);
             return insertFixup(mLeft,root);
         }
 
@@ -542,7 +542,7 @@ public class IntervalTree<V> implements Iterable<IntervalTree.Node<V>>
 
         Node<V1> insertRight( final int start, final int end, final V1 value, final Node<V1> root )
         {
-            mRight = new Node<V1>(this,start,end,value);
+            mRight = new Node<>(this, start, end, value);
             return insertFixup(mRight,root);
         }
 

--- a/src/main/java/htsjdk/samtools/util/IntervalTreeMap.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalTreeMap.java
@@ -44,7 +44,7 @@ import java.util.Set;
 public class IntervalTreeMap<T>
     extends AbstractMap<Interval, T>
 {
-    private final Map<String, IntervalTree<T>> mSequenceMap = new HashMap<String, IntervalTree<T>>();
+    private final Map<String, IntervalTree<T>> mSequenceMap = new HashMap<>();
     private final EntrySet mEntrySet = new EntrySet();
 
     public IntervalTree<T> debugGetTree(final String sequence) {
@@ -126,7 +126,7 @@ public class IntervalTreeMap<T>
     public T put(final Interval key, final T value) {
         IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree == null) {
-            tree = new IntervalTree<T>();
+            tree = new IntervalTree<>();
             mSequenceMap.put(key.getContig(), tree);
         }
         return tree.put(key.getStart(), key.getEnd(), value);
@@ -167,7 +167,7 @@ public class IntervalTreeMap<T>
     
     
     public Collection<T> getOverlapping(final Interval key) {
-        final List<T> result = new ArrayList<T>();
+        final List<T> result = new ArrayList<>();
         final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree != null) {
             final Iterator<IntervalTree.Node<T>> iterator = tree.overlappers(key.getStart(), key.getEnd());
@@ -197,7 +197,7 @@ public class IntervalTreeMap<T>
     
     
     public Collection<T> getContained(final Interval key) {
-        final List<T> result = new ArrayList<T>();
+        final List<T> result = new ArrayList<>();
         final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree != null) {
             final Iterator<IntervalTree.Node<T>> iterator = tree.overlappers(key.getStart(), key.getEnd());

--- a/src/main/java/htsjdk/samtools/util/Iterables.java
+++ b/src/main/java/htsjdk/samtools/util/Iterables.java
@@ -13,7 +13,7 @@ public class Iterables {
     }
 
     public static <T> List<T> slurp(final Iterator<T> iterator) {
-        final List<T> ts = new ArrayList<T>();
+        final List<T> ts = new ArrayList<>();
         while (iterator.hasNext()) ts.add(iterator.next());
         return ts;
     }

--- a/src/main/java/htsjdk/samtools/util/ListMap.java
+++ b/src/main/java/htsjdk/samtools/util/ListMap.java
@@ -39,7 +39,7 @@ public class ListMap<K,V> extends HashMap<K, List<V>> {
     public void add(K key, V value) {
         List<V> values = get(key);
         if (values == null) {
-            values = new ArrayList<V>();
+            values = new ArrayList<>();
             put(key, values);
         }
 

--- a/src/main/java/htsjdk/samtools/util/MergingIterator.java
+++ b/src/main/java/htsjdk/samtools/util/MergingIterator.java
@@ -78,7 +78,7 @@ public class MergingIterator<T> implements CloseableIterator<T> {
 
 		this.comparator = comparator;
 
-		this.queue = new PriorityQueue<ComparableIterator>();
+		this.queue = new PriorityQueue<>();
 		for (final CloseableIterator<T> iterator : iterators) {
 			this.addIfNotEmpty(new ComparableIterator(iterator));
 		}

--- a/src/main/java/htsjdk/samtools/util/QualityEncodingDetector.java
+++ b/src/main/java/htsjdk/samtools/util/QualityEncodingDetector.java
@@ -99,7 +99,7 @@ public class QualityEncodingDetector {
      * "raw-est", read unmodified from the file.
      */
     private static class QualityRecordAggregator {
-        private Set<Integer> observedAsciiQualities = new HashSet<Integer>();
+        private Set<Integer> observedAsciiQualities = new HashSet<>();
 
         public Set<Integer> getObservedAsciiQualities() {
             return Collections.unmodifiableSet(observedAsciiQualities);
@@ -229,7 +229,7 @@ public class QualityEncodingDetector {
 
         for (final QualityScheme scheme : QualityScheme.values()) {
             final Iterator<Integer> qualityBinIterator = observedAsciiQualities.iterator();
-            final Collection<Range> remainingExpectedValueRanges = new ArrayList<Range>(scheme.expectedAsciiRanges);
+            final Collection<Range> remainingExpectedValueRanges = new ArrayList<>(scheme.expectedAsciiRanges);
             while (qualityBinIterator.hasNext()) {
                 final int quality = qualityBinIterator.next();
                 if (!scheme.asciiRange.contains(quality)) {
@@ -262,7 +262,7 @@ public class QualityEncodingDetector {
      */
     private static Iterator<FastqRecord> generateInterleavedFastqIterator(final FastqReader... readers) {
         return new Iterator<FastqRecord>() {
-            private Queue<Iterator<FastqRecord>> queue = new LinkedList<Iterator<FastqRecord>>();
+            private Queue<Iterator<FastqRecord>> queue = new LinkedList<>();
 
             {
                 for (final FastqReader reader : readers) {

--- a/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
@@ -69,7 +69,7 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
     public static final class LocusInfo implements Locus {
         private final SAMSequenceRecord referenceSequence;
         private final int position;
-        private final List<RecordAndOffset> recordAndOffsets = new ArrayList<RecordAndOffset>(100);
+        private final List<RecordAndOffset> recordAndOffsets = new ArrayList<>(100);
         private List<RecordAndOffset> deletedInRecord = null;
         private List<RecordAndOffset> insertedInRecord = null;
 
@@ -143,7 +143,7 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
      * LocusInfos on this list are ready to be returned by iterator.  All reads that overlap
      * the locus have been accumulated before the LocusInfo is moved into this list.
      */
-    private final ArrayList<LocusInfo> complete = new ArrayList<LocusInfo>(100);
+    private final ArrayList<LocusInfo> complete = new ArrayList<>(100);
 
     /**
      * LocusInfos for which accumulation is in progress.  When {@link #accumulateSamRecord(SAMRecord)} is called
@@ -157,7 +157,7 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
      *   ii) any uncovered positions between the last LocusInfo and the first aligned base of the new read
      *       have LocusInfos created and added to {@link #complete} if we are emitting uncovered loci
      */
-    private final ArrayList<LocusInfo> accumulator = new ArrayList<LocusInfo>(100);
+    private final ArrayList<LocusInfo> accumulator = new ArrayList<>(100);
 
     private int qualityScoreCutoff = Integer.MIN_VALUE;
     private int mappingQualityScoreCutoff = Integer.MIN_VALUE;
@@ -197,7 +197,7 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
     // Set to true when past all aligned reads in input SAM file
     private boolean finishedAlignedReads = false;
 
-    private final LocusComparator<Locus> locusComparator = new LocusComparator<Locus>();
+    private final LocusComparator<Locus> locusComparator = new LocusComparator<>();
 
 
     /**
@@ -260,7 +260,7 @@ public class SamLocusIterator implements Iterable<SamLocusIterator.LocusInfo>, C
         if (samFilters != null) {
             tempIterator = new FilteringSamIterator(tempIterator, new AggregateFilter(samFilters));
         }
-        samIterator = new PeekableIterator<SAMRecord>(tempIterator);
+        samIterator = new PeekableIterator<>(tempIterator);
         return this;
     }
 

--- a/src/main/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
+++ b/src/main/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
@@ -78,7 +78,7 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
         this.tmpDirs = tmpDirs;
         this.queueHeadRecordIndex = -1;
         this.queueTailRecordIndex = -1;
-        this.blocks = new ArrayDeque<BufferBlock>();
+        this.blocks = new ArrayDeque<>();
         this.header = header;
         this.clazz = clazz;
     }

--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -124,7 +124,7 @@ public class SortingCollection<T> implements Iterable<T> {
     /**
      * List of files in tmpDir containing sorted records
      */
-    private final List<File> files = new ArrayList<File>();
+    private final List<File> files = new ArrayList<>();
 
     private boolean destructiveIteration = true;
 
@@ -297,7 +297,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM,
                                                        final File... tmpDir) {
-        return new SortingCollection<T>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
 
     }
 
@@ -315,11 +315,11 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM,
                                                        final Collection<File> tmpDirs) {
-        return new SortingCollection<T>(componentType,
-                                        codec,
-                                        comparator,
-                                        maxRecordsInRAM,
-                                        tmpDirs.toArray(new File[tmpDirs.size()]));
+        return new SortingCollection<>(componentType,
+                codec,
+                comparator,
+                maxRecordsInRAM,
+                tmpDirs.toArray(new File[tmpDirs.size()]));
 
     }
 
@@ -338,7 +338,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final int maxRecordsInRAM) {
 
         final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
-        return new SortingCollection<T>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
     }
 
     /**
@@ -396,7 +396,7 @@ public class SortingCollection<T> implements Iterable<T> {
         private final TreeSet<PeekFileRecordIterator> queue;
 
         MergingIterator() {
-            this.queue = new TreeSet<PeekFileRecordIterator>(new PeekFileRecordIteratorComparator());
+            this.queue = new TreeSet<>(new PeekFileRecordIteratorComparator());
             int n = 0;
             for (final File f : SortingCollection.this.files) {
                 final FileRecordIterator it = new FileRecordIterator(f);

--- a/src/main/java/htsjdk/samtools/util/SortingLongCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingLongCollection.java
@@ -89,7 +89,7 @@ public class SortingLongCollection {
     /**
      * List of files in tmpDir containing sorted values
      */
-    private final List<File> files = new ArrayList<File>();
+    private final List<File> files = new ArrayList<>();
 
     // for in-memory iteration
     private int iterationIndex = 0;
@@ -145,7 +145,7 @@ public class SortingLongCollection {
             spillToDisk();
         }
 
-        this.priorityQueue = new PriorityQueue<PeekFileValueIterator>(files.size(),
+        this.priorityQueue = new PriorityQueue<>(files.size(),
                 new PeekFileValueIteratorComparator());
         for (final File f : files) {
             final FileValueIterator it = new FileValueIterator(f);

--- a/src/main/java/htsjdk/samtools/util/ftp/FTPUtils.java
+++ b/src/main/java/htsjdk/samtools/util/ftp/FTPUtils.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class FTPUtils {
 
-    static Map<String, String> userCredentials = new HashMap<String, String>();
+    static Map<String, String> userCredentials = new HashMap<>();
 
     static int TIMEOUT = 10000;
 

--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -50,7 +50,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
 
     private static ComponentMethods methods = new ComponentMethods();
 
-    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
+    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
 
     /**
      * Calls {@link #getFeatureReader(String, FeatureCodec, boolean)} with {@code requireIndex} = true
@@ -83,11 +83,11 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
             if (methods.isTabix(featureResource, indexResource)) {
                 if ( ! (codec instanceof AsciiFeatureCodec) )
                     throw new TribbleException("Tabix indexed files only work with ASCII codecs, but received non-Ascii codec " + codec.getClass().getSimpleName());
-                return new TabixFeatureReader<FEATURE, SOURCE>(featureResource, indexResource, (AsciiFeatureCodec) codec);
+                return new TabixFeatureReader<>(featureResource, indexResource, (AsciiFeatureCodec) codec);
             }
             // Not tabix => tribble index file (might be gzipped, but not block gzipped)
             else {
-                return new TribbleIndexedFeatureReader<FEATURE, SOURCE>(featureResource, indexResource, codec, requireIndex);
+                return new TribbleIndexedFeatureReader<>(featureResource, indexResource, codec, requireIndex);
             }
         } catch (IOException e) {
             throw new TribbleException.MalformedFeatureFile("Unable to create BasicFeatureReader using feature file ", featureResource, e);
@@ -108,7 +108,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      */
     public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, final FeatureCodec<FEATURE, SOURCE>  codec, final Index index) throws TribbleException {
         try {
-            return new TribbleIndexedFeatureReader<FEATURE, SOURCE>(featureResource, codec, index);
+            return new TribbleIndexedFeatureReader<>(featureResource, codec, index);
         } catch (IOException e) {
             throw new TribbleException.MalformedFeatureFile("Unable to create AbstractFeatureReader using feature file ", featureResource, e);
         }

--- a/src/main/java/htsjdk/tribble/TabixFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TabixFeatureReader.java
@@ -52,7 +52,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
     public TabixFeatureReader(final String featureFile, final AsciiFeatureCodec codec) throws IOException {
         super(featureFile, codec);
         tabixReader = new TabixReader(featureFile);
-        sequenceNames = new ArrayList<String>(tabixReader.getChromosomes());
+        sequenceNames = new ArrayList<>(tabixReader.getChromosomes());
         readHeader();
     }
 
@@ -66,7 +66,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
     public TabixFeatureReader(final String featureFile, final String indexFile, final AsciiFeatureCodec codec) throws IOException {
         super(featureFile, codec);
         tabixReader = new TabixReader(featureFile, indexFile);
-        sequenceNames = new ArrayList<String>(tabixReader.getChromosomes());
+        sequenceNames = new ArrayList<>(tabixReader.getChromosomes());
         readHeader();
     }
 
@@ -115,17 +115,17 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
         if (mp == null) throw new TribbleException.TabixReaderFailure("Unable to find sequence named " + chr +
                 " in the tabix index. ", path);
         if (!mp.contains(chr)) {
-            return new EmptyIterator<T>();
+            return new EmptyIterator<>();
         }
         final TabixIteratorLineReader lineReader = new TabixIteratorLineReader(tabixReader.query(tabixReader.chr2tid(chr), start - 1, end));
-        return new FeatureIterator<T>(lineReader, start - 1, end);
+        return new FeatureIterator<>(lineReader, start - 1, end);
     }
 
     public CloseableTribbleIterator<T> iterator() throws IOException {
         final InputStream is = new BlockCompressedInputStream(ParsingUtils.openInputStream(path));
         final PositionalBufferedStream stream = new PositionalBufferedStream(is);
         final LineReader reader = new SynchronousLineReader(stream);
-        return new FeatureIterator<T>(reader, 0, Integer.MAX_VALUE);
+        return new FeatureIterator<>(reader, 0, Integer.MAX_VALUE);
     }
 
     public void close() throws IOException {

--- a/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -194,7 +194,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
      * @return list of strings of the contig names
      */
     public List<String> getSequenceNames() {
-        return !this.hasIndex() ? new ArrayList<String>() : new ArrayList<String>(index.getSequenceNames());
+        return !this.hasIndex() ? new ArrayList<>() : new ArrayList<>(index.getSequenceNames());
     }
 
     @Override
@@ -262,7 +262,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
             final List<Block> blocks = index.getBlocks(chr, start - 1, end);
             return new QueryIterator(chr, start, end, blocks);
         } else {
-            return new EmptyIterator<T>();
+            return new EmptyIterator<>();
         }
     }
 

--- a/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
+++ b/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
@@ -70,7 +70,7 @@ public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
     public FeatureCodecHeader readHeader(final PositionalBufferedStream stream) throws IOException {
         // Construct a reader that does not read ahead (because we don't want to consume data from the stream that is not the header)
         final AsciiLineReader nonReadAheadLineReader = new AsciiLineReader(stream);
-        final List<String> headerLines = new ArrayList<String>();
+        final List<String> headerLines = new ArrayList<>();
         long headerLengthInBytes = 0;
         while (stream.peek() == ('#' & 0xff)) { // Look for header lines, which are prefixed by '#'.
             headerLines.add(nonReadAheadLineReader.readLine());

--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -148,8 +148,8 @@ public abstract class AbstractIndex implements MutableIndex {
      */
     public AbstractIndex() {
         this.version = VERSION; // <= is overriden when file is read
-        this.properties = new LinkedHashMap<String, String>();
-        chrIndices = new LinkedHashMap<String, ChrIndex>();
+        this.properties = new LinkedHashMap<>();
+        chrIndices = new LinkedHashMap<>();
     }
 
     /**
@@ -307,7 +307,7 @@ public abstract class AbstractIndex implements MutableIndex {
     }
 
     public List<String> getSequenceNames() {
-        return new ArrayList<String>(chrIndices.keySet());
+        return new ArrayList<>(chrIndices.keySet());
     }
 
     public List<Block> getBlocks(final String chr, final int start, final int end) {
@@ -360,7 +360,7 @@ public abstract class AbstractIndex implements MutableIndex {
             readHeader(dis);
 
             int nChromosomes = dis.readInt();
-            chrIndices = new LinkedHashMap<String, ChrIndex>(nChromosomes);
+            chrIndices = new LinkedHashMap<>(nChromosomes);
 
             while (nChromosomes-- > 0) {
                 final ChrIndex chrIdx = (ChrIndex) getChrIndexClass().newInstance();

--- a/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
@@ -93,7 +93,7 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
      * @return a map of index type to the best index for that balancing approach
      */
     private Map<IndexFactory.IndexType,TribbleIndexCreator> getIndexCreators(final File inputFile, final IndexFactory.IndexBalanceApproach iba) {
-        final Map<IndexFactory.IndexType,TribbleIndexCreator> creators = new HashMap<IndexFactory.IndexType,TribbleIndexCreator>();
+        final Map<IndexFactory.IndexType,TribbleIndexCreator> creators = new HashMap<>();
 
         if (iba == IndexFactory.IndexBalanceApproach.FOR_SIZE) {
             // add a linear index with the default bin size
@@ -170,7 +170,7 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
     protected static LinkedHashMap<Double,TribbleIndexCreator> scoreIndexes(final double densityOfFeatures, final Map<IndexFactory.IndexType,TribbleIndexCreator> indexes, final int longestFeature, final IndexFactory.IndexBalanceApproach iba) {
         if (indexes.size() < 1) throw new IllegalArgumentException("Please specify at least one index to evaluate");
 
-        final LinkedHashMap<Double,TribbleIndexCreator> scores = new LinkedHashMap<Double,TribbleIndexCreator>();
+        final LinkedHashMap<Double,TribbleIndexCreator> scores = new LinkedHashMap<>();
 
         for (final Map.Entry<IndexFactory.IndexType,TribbleIndexCreator> entry : indexes.entrySet()) {
             // we have different scoring
@@ -192,7 +192,7 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
      * @return the best score <b>index value</b>
      */
     private TribbleIndexCreator getMinIndex(final Map<Double,TribbleIndexCreator> scores, final IndexFactory.IndexBalanceApproach iba) {
-        final TreeMap<Double,TribbleIndexCreator> map = new TreeMap<Double,TribbleIndexCreator>();
+        final TreeMap<Double,TribbleIndexCreator> map = new TreeMap<>();
         map.putAll(scores);
         
         // if we are optimizing for seek time, choose the lowest score (adjusted features/bin value), if for storage size, choose the opposite

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -208,7 +208,7 @@ public class IndexFactory {
                                                                                       final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,
                                                                                       final int binSize) {
         final LinearIndexCreator indexCreator = new LinearIndexCreator(inputFile, binSize);
-        return (LinearIndex)createIndex(inputFile, new FeatureIterator<FEATURE_TYPE, SOURCE_TYPE>(inputFile, codec), indexCreator);
+        return (LinearIndex)createIndex(inputFile, new FeatureIterator<>(inputFile, codec), indexCreator);
     }
 
     /**
@@ -234,7 +234,7 @@ public class IndexFactory {
                                                                                         final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,
                                                                                         final int featuresPerInterval) {
         final IntervalIndexCreator indexCreator = new IntervalIndexCreator(inputFile, featuresPerInterval);
-        return (IntervalTreeIndex)createIndex(inputFile, new FeatureIterator<FEATURE_TYPE, SOURCE_TYPE>(inputFile, codec), indexCreator);
+        return (IntervalTreeIndex)createIndex(inputFile, new FeatureIterator<>(inputFile, codec), indexCreator);
     }
 
     /**
@@ -304,7 +304,7 @@ public class IndexFactory {
                                                                                        final IndexBalanceApproach iba) {
         // get a list of index creators
         final DynamicIndexCreator indexCreator = new DynamicIndexCreator(inputFile, iba);
-        return createIndex(inputFile, new FeatureIterator<FEATURE_TYPE, SOURCE_TYPE>(inputFile, codec), indexCreator);
+        return createIndex(inputFile, new FeatureIterator<>(inputFile, codec), indexCreator);
     }
 
     /**
@@ -319,7 +319,7 @@ public class IndexFactory {
                                                                                      final TabixFormat tabixFormat,
                                                                                      final SAMSequenceDictionary sequenceDictionary) {
         final TabixIndexCreator indexCreator = new TabixIndexCreator(sequenceDictionary, tabixFormat);
-        return (TabixIndex)createIndex(inputFile, new FeatureIterator<FEATURE_TYPE, SOURCE_TYPE>(inputFile, codec), indexCreator);
+        return (TabixIndex)createIndex(inputFile, new FeatureIterator<>(inputFile, codec), indexCreator);
     }
 
     /**
@@ -338,7 +338,7 @@ public class IndexFactory {
     private static Index createIndex(final File inputFile, final FeatureIterator iterator, final IndexCreator creator) {
         Feature lastFeature = null;
         Feature currentFeature;
-        final Map<String, Feature> visitedChromos = new HashMap<String, Feature>(40);
+        final Map<String, Feature> visitedChromos = new HashMap<>(40);
         while (iterator.hasNext()) {
             final long position = iterator.getPosition();
             currentFeature = iterator.next();

--- a/src/main/java/htsjdk/tribble/index/TribbleIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/TribbleIndexCreator.java
@@ -35,7 +35,7 @@ public abstract class TribbleIndexCreator implements IndexCreator {
     // a constant we use for marking sequence dictionary entries in the Tribble index property list
     private static final String SEQUENCE_DICTIONARY_PROPERTY_PREDICATE = "DICT:";
 
-    protected LinkedHashMap<String, String> properties = new LinkedHashMap<String, String>();
+    protected LinkedHashMap<String, String> properties = new LinkedHashMap<>();
 
     public void addProperty(final String key, final String value) {
         properties.put(key, value);

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
@@ -42,14 +42,14 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
      */
     private int featuresPerInterval = DEFAULT_FEATURE_COUNT;
 
-    private final LinkedList<ChrIndex> chrList = new LinkedList<ChrIndex>();
+    private final LinkedList<ChrIndex> chrList = new LinkedList<>();
 
     /**
      * Instance variable for the number of features we currently are storing in the interval
      */
     private int featureCount = 0;
 
-    private final ArrayList<MutableInterval> intervals = new ArrayList<MutableInterval>();
+    private final ArrayList<MutableInterval> intervals = new ArrayList<>();
 
     File inputFile;
 

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalTree.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalTree.java
@@ -80,7 +80,7 @@ public class IntervalTree {
             return Collections.emptyList();
         }
 
-        List<Interval> results = new ArrayList<Interval>();
+        List<Interval> results = new ArrayList<>();
         searchAll(interval, root(), results);
         return results;
     }
@@ -112,7 +112,7 @@ public class IntervalTree {
         if (root().isNull()) {
             return Collections.emptyList();
         }
-        List<Interval> results = new ArrayList<Interval>(size);
+        List<Interval> results = new ArrayList<>(size);
         getAll(root(), results);
         return results;
     }
@@ -499,7 +499,7 @@ public class IntervalTree {
         public String toString() {
 
             // Make some shorthand for the nodes
-            Map<Interval, Integer> keys = new LinkedHashMap<Interval, Integer>();
+            Map<Interval, Integer> keys = new LinkedHashMap<>();
 
             if (this == NIL) {
                 return "nil";

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalTreeIndex.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalTreeIndex.java
@@ -138,7 +138,7 @@ public class IntervalTreeIndex extends AbstractIndex {
             final List<Interval> intervals = tree.findOverlapping(new Interval(start, end));
 
             // save time (and save throwing an exception) if the blocks are empty, return now
-            if (intervals == null || intervals.isEmpty()) return new ArrayList<Block>();
+            if (intervals == null || intervals.isEmpty()) return new ArrayList<>();
 
             final Block[] blocks = new Block[intervals.size()];
             int idx = 0;
@@ -155,7 +155,7 @@ public class IntervalTreeIndex extends AbstractIndex {
             });
 
             // Consolidate blocks  that are close together
-            final List<Block> consolidatedBlocks = new ArrayList<Block>(blocks.length);
+            final List<Block> consolidatedBlocks = new ArrayList<>(blocks.length);
             Block lastBlock = blocks[0];
             consolidatedBlocks.add(lastBlock);
             for (int i = 1; i < blocks.length; i++) {

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -119,7 +119,7 @@ public class LinearIndex extends AbstractIndex {
 
     public List<String> getSequenceNames() {
         return (chrIndices == null ? Collections.EMPTY_LIST :
-                Collections.unmodifiableList(new ArrayList<String>(chrIndices.keySet())));
+                Collections.unmodifiableList(new ArrayList<>(chrIndices.keySet())));
     }
 
     @Override
@@ -167,7 +167,7 @@ public class LinearIndex extends AbstractIndex {
         ChrIndex(final String name, final int binWidth) {
             this.name = name;
             this.binWidth = binWidth;
-            this.blocks = new ArrayList<Block>(100);
+            this.blocks = new ArrayList<>(100);
             this.longestFeature = 0;
             //this.largestBlockSize = 0;
             this.nFeatures = 0;
@@ -265,7 +265,7 @@ public class LinearIndex extends AbstractIndex {
             nFeatures = dis.readInt();
 
             // note the code below accounts for > 60% of the total time to read an index
-            blocks = new ArrayList<Block>(nBins);
+            blocks = new ArrayList<>(nBins);
             long pos = dis.readLong();
             for (int binNumber = 0; binNumber < nBins; binNumber++) {
                 final long nextPos = dis.readLong();
@@ -393,7 +393,7 @@ public class LinearIndex extends AbstractIndex {
     public Index optimize(final double threshold) {
         if (enableAdaptiveIndexing) {
 
-            final List<ChrIndex> newIndices = new ArrayList<ChrIndex>(this.chrIndices.size());
+            final List<ChrIndex> newIndices = new ArrayList<>(this.chrIndices.size());
             for (final String name : chrIndices.keySet()) {
                 final LinearIndex.ChrIndex oldIdx = (LinearIndex.ChrIndex) chrIndices.get(name);
                 final LinearIndex.ChrIndex newIdx = oldIdx.optimize(threshold);

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
@@ -45,10 +45,10 @@ public class LinearIndexCreator  extends TribbleIndexCreator {
     // the input file
     private final File inputFile;
 
-    private final LinkedList<LinearIndex.ChrIndex> chrList = new LinkedList<LinearIndex.ChrIndex>();
+    private final LinkedList<LinearIndex.ChrIndex> chrList = new LinkedList<>();
     private int longestFeature= 0;
 
-    private final ArrayList<Block> blocks = new ArrayList<Block>();
+    private final ArrayList<Block> blocks = new ArrayList<>();
 
     public LinearIndexCreator(final File inputFile, final int binSize) {
         this.inputFile = inputFile;

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -76,7 +76,7 @@ public class TabixIndex implements Index {
             throw new IllegalArgumentException("sequenceNames.size() != indices.length");
         }
         this.formatSpec = formatSpec.clone();
-        this.sequenceNames = Collections.unmodifiableList(new ArrayList<String>(sequenceNames));
+        this.sequenceNames = Collections.unmodifiableList(new ArrayList<>(sequenceNames));
         this.indices = indices;
     }
 
@@ -112,7 +112,7 @@ public class TabixIndex implements Index {
         final int nameBlockSize = dis.readInt();
         final byte[] nameBlock = new byte[nameBlockSize];
         if (dis.read(nameBlock) != nameBlockSize) throw new EOFException("Premature end of file reading Tabix header");
-        final List<String> sequenceNames = new ArrayList<String>(numSequences);
+        final List<String> sequenceNames = new ArrayList<>(numSequences);
         int startPos = 0;
         for (int i = 0; i < numSequences; ++i) {
             int endPos = startPos;
@@ -290,7 +290,7 @@ public class TabixIndex implements Index {
         final int numBins = dis.readInt();
         if (numBins == 0) return null;
         int nonNullBins = 0;
-        final ArrayList<Bin> bins = new ArrayList<Bin>();
+        final ArrayList<Bin> bins = new ArrayList<>();
         for (int i = 0; i < numBins; ++i) {
             final Bin bin = loadBin(referenceSequenceIndex, dis);
             if (bin != null) {
@@ -328,7 +328,7 @@ public class TabixIndex implements Index {
         final int binNumber = dis.readInt();
         final Bin ret = new Bin(referenceSequenceIndex, binNumber);
         final int numChunks = dis.readInt();
-        final List<Chunk> chunkList = new ArrayList<Chunk>(numChunks);
+        final List<Chunk> chunkList = new ArrayList<>(numChunks);
         for (int i = 0; i < numChunks; ++i) {
             chunkList.add(loadChunk(dis));
         }

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndexCreator.java
@@ -42,10 +42,10 @@ import java.util.Set;
  */
 public class TabixIndexCreator implements IndexCreator {
     private final TabixFormat formatSpec;
-    private final List<BinningIndexContent> indexContents = new ArrayList<BinningIndexContent>();
-    private final List<String> sequenceNames = new ArrayList<String>();
+    private final List<BinningIndexContent> indexContents = new ArrayList<>();
+    private final List<String> sequenceNames = new ArrayList<>();
     // Merely a faster way to ensure that features are added in a specific sequence name order
-    private final Set<String> sequenceNamesSeen = new HashSet<String>();
+    private final Set<String> sequenceNamesSeen = new HashSet<>();
     // A sequence dictionary is not required, but if it is provided all sequences names must be present in it.
     // It is used to determine the length of a sequence in order to optimize index memory allocation.
     private final SAMSequenceDictionary sequenceDictionary;

--- a/src/main/java/htsjdk/tribble/readers/AsciiLineReaderIterator.java
+++ b/src/main/java/htsjdk/tribble/readers/AsciiLineReaderIterator.java
@@ -87,7 +87,7 @@ public class AsciiLineReaderIterator implements LocationAware, LineIterator, Clo
             } catch (IOException e) {
                 throw new RuntimeIOException(e);
             }
-            return line == null ? null : new Tuple<String, Long>(line, position);
+            return line == null ? null : new Tuple<>(line, position);
         }
 
         /** Returns the byte position at the beginning of the next line. */

--- a/src/main/java/htsjdk/tribble/readers/TabixReader.java
+++ b/src/main/java/htsjdk/tribble/readers/TabixReader.java
@@ -187,7 +187,7 @@ public class TabixReader {
 
         is.read(buf, 0, 4); // read "TBI\1"
         mSeq = new String[readInt(is)]; // # sequences
-        mChr2tid = new HashMap<String, Integer>();
+        mChr2tid = new HashMap<>();
         mPreset = readInt(is);
         mSc = readInt(is);
         mBc = readInt(is);
@@ -214,7 +214,7 @@ public class TabixReader {
             // the binning index
             int n_bin = readInt(is);
             mIndex[i] = new TIndex();
-            mIndex[i].b = new HashMap<Integer, TPair64[]>(n_bin);
+            mIndex[i].b = new HashMap<>(n_bin);
             for (j = 0; j < n_bin; ++j) {
                 int bin = readInt(is);
                 TPair64[] chunks = new TPair64[readInt(is)];

--- a/src/main/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/main/java/htsjdk/tribble/util/ParsingUtils.java
@@ -46,7 +46,7 @@ import java.util.WeakHashMap;
  */
 public class ParsingUtils {
 
-    public static Map<Object, Color> colorCache = new WeakHashMap<Object, Color>(100);
+    public static Map<Object, Color> colorCache = new WeakHashMap<>(100);
 
     // HTML 4.1 color table,  + orange and magenta
     static Map<String, String> colorSymbols = new HashMap();
@@ -117,17 +117,17 @@ public class ParsingUtils {
      * @return
      */
     public static <T extends Comparable> List<T> sortList(Collection<T> list) {
-        ArrayList<T> ret = new ArrayList<T>();
+        ArrayList<T> ret = new ArrayList<>();
         ret.addAll(list);
         Collections.sort(ret);
         return ret;
     }
 
     public static <T extends Comparable<T>, V> String sortedString(Map<T, V> c) {
-        List<T> t = new ArrayList<T>(c.keySet());
+        List<T> t = new ArrayList<>(c.keySet());
         Collections.sort(t);
 
-        List<String> pairs = new ArrayList<String>();
+        List<String> pairs = new ArrayList<>();
         for (T k : t) {
             pairs.add(k + "=" + c.get(k));
         }
@@ -182,7 +182,7 @@ public class ParsingUtils {
      */
     public static List<String> split(String input, char delim) {
         if (input.isEmpty()) return Arrays.asList("");
-        final ArrayList<String> output = new ArrayList<String>(1+input.length()/2);
+        final ArrayList<String> output = new ArrayList<>(1 + input.length() / 2);
         int from = -1, to;
         for (to = input.indexOf(delim);
              to >= 0;

--- a/src/main/java/htsjdk/tribble/util/TabixUtils.java
+++ b/src/main/java/htsjdk/tribble/util/TabixUtils.java
@@ -96,7 +96,7 @@ public class TabixUtils {
             buf = new byte[len];
             is.read(buf);
 
-            final List<SAMSequenceRecord> sequences = new ArrayList<SAMSequenceRecord>();
+            final List<SAMSequenceRecord> sequences = new ArrayList<>();
             for (i = j = 0; i < buf.length; ++i) {
                 if (buf[i] == 0) {
                     byte[] b = new byte[i - j];

--- a/src/main/java/htsjdk/variant/bcf2/BCF2Codec.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2Codec.java
@@ -67,7 +67,7 @@ public final class BCF2Codec extends BinaryFeatureCodec<VariantContext> {
     /**
      * Maps offsets (encoded in BCF) into contig names (from header) for the CHROM field
      */
-    private final ArrayList<String> contigNames = new ArrayList<String>();
+    private final ArrayList<String> contigNames = new ArrayList<>();
 
     /**
      * Maps header string names (encoded in VCF) into strings found in the BCF header
@@ -335,7 +335,7 @@ public final class BCF2Codec extends BinaryFeatureCodec<VariantContext> {
      */
     private List<Allele> decodeAlleles( final VariantContextBuilder builder, final int pos, final int nAlleles ) throws IOException {
         // TODO -- probably need inline decoder for efficiency here (no sense in going bytes -> string -> vector -> bytes
-        List<Allele> alleles = new ArrayList<Allele>(nAlleles);
+        List<Allele> alleles = new ArrayList<>(nAlleles);
         String ref = null;
 
         for ( int i = 0; i < nAlleles; i++ ) {
@@ -391,7 +391,7 @@ public final class BCF2Codec extends BinaryFeatureCodec<VariantContext> {
             // fast path, don't bother doing any work if there are no fields
             return;
 
-        final Map<String, Object> infoFieldEntries = new HashMap<String, Object>(numInfoFields);
+        final Map<String, Object> infoFieldEntries = new HashMap<>(numInfoFields);
         for ( int i = 0; i < numInfoFields; i++ ) {
             final String key = getDictionaryString();
             Object value = decoder.decodeTypedValue();

--- a/src/main/java/htsjdk/variant/bcf2/BCF2Decoder.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2Decoder.java
@@ -141,7 +141,7 @@ public final class BCF2Decoder {
             } else if ( size == 1 ) {
                 return decodeSingleValue(type);
             } else {
-                final ArrayList<Object> ints = new ArrayList<Object>(size);
+                final ArrayList<Object> ints = new ArrayList<>(size);
                 for ( int i = 0; i < size; i++ ) {
                     final Object val = decodeSingleValue(type);
                     if ( val == null ) continue; // auto-pruning.  We remove trailing nulls

--- a/src/main/java/htsjdk/variant/bcf2/BCF2GenotypeFieldDecoders.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2GenotypeFieldDecoders.java
@@ -50,7 +50,7 @@ public class BCF2GenotypeFieldDecoders {
     private final static int MIN_SAMPLES_FOR_FASTPATH_GENOTYPES = 0; // TODO -- update to reasonable number
 
     // initialized once per writer to allow parallel writers to work
-    private final HashMap<String, Decoder> genotypeFieldDecoder = new HashMap<String, Decoder>();
+    private final HashMap<String, Decoder> genotypeFieldDecoder = new HashMap<>();
     private final Decoder defaultDecoder = new GenericDecoder();
 
     public BCF2GenotypeFieldDecoders(final VCFHeader header) {
@@ -188,7 +188,7 @@ public class BCF2GenotypeFieldDecoders {
                     assert encoded.length > 0;
 
                     // we have at least some alleles to decode
-                    final List<Allele> gt = new ArrayList<Allele>(encoded.length);
+                    final List<Allele> gt = new ArrayList<>(encoded.length);
 
                     // note that the auto-pruning of fields magically handles different
                     // ploidy per sample at a site

--- a/src/main/java/htsjdk/variant/bcf2/BCF2LazyGenotypesDecoder.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2LazyGenotypesDecoder.java
@@ -87,7 +87,7 @@ public class BCF2LazyGenotypesDecoder implements LazyGenotypesContext.LazyParser
                 }
             }
 
-            final ArrayList<Genotype> genotypes = new ArrayList<Genotype>(nSamples);
+            final ArrayList<Genotype> genotypes = new ArrayList<>(nSamples);
             for ( final GenotypeBuilder gb : builders )
                 genotypes.add(gb.make());
 

--- a/src/main/java/htsjdk/variant/bcf2/BCF2Utils.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2Utils.java
@@ -85,8 +85,8 @@ public final class BCF2Utils {
      * @return a non-null dictionary of elements, may be empty
      */
     public static ArrayList<String> makeDictionary(final VCFHeader header) {
-        final Set<String> seen = new HashSet<String>();
-        final ArrayList<String> dict = new ArrayList<String>();
+        final Set<String> seen = new HashSet<>();
+        final ArrayList<String> dict = new ArrayList<>();
 
         // special case the special PASS field which doesn't show up in the FILTER field definitions
         seen.add(VCFConstants.PASSES_FILTERS_v4);
@@ -281,7 +281,7 @@ public final class BCF2Utils {
         else if ( o instanceof List ) return (List<T>)o;
         else if ( o.getClass().isArray() ) {
             final int arraySize = Array.getLength(o);
-            final List<T> list = new ArrayList<T>(arraySize);
+            final List<T> list = new ArrayList<>(arraySize);
             for (int i=0; i<arraySize; i++)
                 list.add((T)Array.get(o, i));
             return list;

--- a/src/main/java/htsjdk/variant/utils/GeneralUtils.java
+++ b/src/main/java/htsjdk/variant/utils/GeneralUtils.java
@@ -167,7 +167,7 @@ public class GeneralUtils {
     }
 
     public static <T> List<T> cons(final T elt, final List<T> l) {
-        List<T> l2 = new ArrayList<T>();
+        List<T> l2 = new ArrayList<>();
         l2.add(elt);
         if (l != null) l2.addAll(l);
         return l2;
@@ -187,7 +187,7 @@ public class GeneralUtils {
      * @return
      */
     public static <T> List<List<T>> makePermutations(final List<T> objects, final int n, final boolean withReplacement) {
-        final List<List<T>> combinations = new ArrayList<List<T>>();
+        final List<List<T>> combinations = new ArrayList<>();
 
         if ( n <= 0 )
             ;
@@ -237,7 +237,7 @@ public class GeneralUtils {
     }
 
     static public final <T> List<T> reverse(final List<T> l) {
-        final List<T> newL = new ArrayList<T>(l);
+        final List<T> newL = new ArrayList<>(l);
         Collections.reverse(newL);
         return newL;
     }

--- a/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -114,7 +114,7 @@ public final class CommonInfo implements Serializable {
 
     public void addFilter(String filter) {
         if ( filters == null ) // immutable -> mutable
-            filters = new HashSet<String>();
+            filters = new HashSet<>();
 
         if ( filter == null ) throw new IllegalArgumentException("BUG: Attempting to add null filter " + this);
         if ( getFilters().contains(filter) ) throw new IllegalArgumentException("BUG: Attempting to add duplicate filter " + filter + " at " + this);
@@ -169,7 +169,7 @@ public final class CommonInfo implements Serializable {
     //
     // ---------------------------------------------------------------------------------------------------------
     public void clearAttributes() {
-        attributes = new HashMap<String, Object>();
+        attributes = new HashMap<>();
     }
 
     /**
@@ -195,14 +195,14 @@ public final class CommonInfo implements Serializable {
             throw new IllegalStateException("Attempting to overwrite key->value binding: key = " + key + " this = " + this);
 
         if ( attributes == NO_ATTRIBUTES ) // immutable -> mutable
-            attributes = new HashMap<String, Object>();
+            attributes = new HashMap<>();
 
         attributes.put(key, value);
     }
 
     public void removeAttribute(String key) {
         if ( attributes == NO_ATTRIBUTES ) // immutable -> mutable
-            attributes = new HashMap<String, Object>();
+            attributes = new HashMap<>();
         attributes.remove(key);
     }
 
@@ -211,7 +211,7 @@ public final class CommonInfo implements Serializable {
             // for efficiency, we can skip the validation if the map is empty
             if (attributes.isEmpty()) {
                 if ( attributes == NO_ATTRIBUTES ) // immutable -> mutable
-                    attributes = new HashMap<String, Object>();
+                    attributes = new HashMap<>();
                 attributes.putAll(map);
             } else {
                 for ( Map.Entry<String, ?> elt : map.entrySet() ) {

--- a/src/main/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Genotype.java
@@ -374,7 +374,7 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
      * @return
      */
     protected List<String> getAlleleStrings() {
-        final List<String> al = new ArrayList<String>(getPloidy());
+        final List<String> al = new ArrayList<>(getPloidy());
         for ( Allele a : getAlleles() )
             al.add(a.getBaseString());
 
@@ -426,8 +426,8 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
         Collection<Allele> otherAlleles = other.getAlleles();
 
         if (ignorePhase) { // do not care about order, only identity of Alleles
-            thisAlleles = new TreeSet<Allele>(thisAlleles);   //implemented Allele.compareTo()
-            otherAlleles = new TreeSet<Allele>(otherAlleles);
+            thisAlleles = new TreeSet<>(thisAlleles);   //implemented Allele.compareTo()
+            otherAlleles = new TreeSet<>(otherAlleles);
         }
 
         return thisAlleles.equals(otherAlleles);
@@ -542,14 +542,14 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
             return getGQ();
         } else if (key.equals(VCFConstants.GENOTYPE_ALLELE_DEPTHS)) {
             if (hasAD()) {
-                final List<Integer> intList = new ArrayList<Integer>(getAD().length);
+                final List<Integer> intList = new ArrayList<>(getAD().length);
                 for(int i : getAD()) intList.add(i);
                 return intList;
             }
             return Collections.EMPTY_LIST;
         } else if (key.equals(VCFConstants.GENOTYPE_PL_KEY)) {
             if (hasPL()) {
-                final List<Integer> intList = new ArrayList<Integer>(getPL().length);
+                final List<Integer> intList = new ArrayList<>(getPL().length);
                 for(int i : getPL()) intList.add(i);
                 return intList;
             }
@@ -599,10 +599,10 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
     protected static <T extends Comparable<T>, V> String sortedString(Map<T, V> c) {
 
         // NOTE -- THIS IS COPIED FROM GATK UTILS TO ALLOW US TO KEEP A SEPARATION BETWEEN THE GATK AND VCF CODECS
-        final List<T> t = new ArrayList<T>(c.keySet());
+        final List<T> t = new ArrayList<>(c.keySet());
         Collections.sort(t);
 
-        final List<String> pairs = new ArrayList<String>();
+        final List<String> pairs = new ArrayList<>();
         for (final T k : t) {
             pairs.add(k + "=" + c.get(k));
         }

--- a/src/main/java/htsjdk/variant/variantcontext/GenotypeBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/GenotypeBuilder.java
@@ -359,7 +359,7 @@ public final class GenotypeBuilder {
      */
     public GenotypeBuilder attribute(final String key, final Object value) {
         if ( extendedAttributes == null )
-            extendedAttributes = new HashMap<String, Object>(initialAttributeMapSize);
+            extendedAttributes = new HashMap<>(initialAttributeMapSize);
         extendedAttributes.put(key, value);
         return this;
     }

--- a/src/main/java/htsjdk/variant/variantcontext/GenotypeJEXLContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/GenotypeJEXLContext.java
@@ -20,7 +20,7 @@ public class GenotypeJEXLContext extends VariantJEXLContext {
         public Object get(Genotype g);
     }
 
-    private static Map<String, AttributeGetter> attributes = new HashMap<String, AttributeGetter>();
+    private static Map<String, AttributeGetter> attributes = new HashMap<>();
 
     static {
         attributes.put("g", (Genotype g) -> g);

--- a/src/main/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
+++ b/src/main/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
@@ -79,7 +79,7 @@ public class GenotypeLikelihoods {
      * For example, for a ploidy of 3, the allele lists for each PL index is:
      * {0,0,0}, {0,0,1}, {0,1,1}, {1,1,1}, {0,0,2}, {0,1,2}, {1,1,2}, {0,2,2}, {1,2,2}, {2,2,2}
      */
-    protected final static Map<Integer, List<List<Integer>>> anyploidPloidyToPLIndexToAlleleIndices = new HashMap<Integer, List<List<Integer>>>();
+    protected final static Map<Integer, List<List<Integer>>> anyploidPloidyToPLIndexToAlleleIndices = new HashMap<>();
 
     public final static GenotypeLikelihoods fromPLField(String PLs) {
         return new GenotypeLikelihoods(PLs);
@@ -165,7 +165,7 @@ public class GenotypeLikelihoods {
         double[] likelihoods = normalizeFromLog10 ? GeneralUtils.normalizeFromLog10(getAsVector()) : getAsVector();
         if(likelihoods == null)
             return null;
-        EnumMap<GenotypeType,Double> likelihoodsMap = new EnumMap<GenotypeType, Double>(GenotypeType.class);
+        EnumMap<GenotypeType,Double> likelihoodsMap = new EnumMap<>(GenotypeType.class);
         likelihoodsMap.put(GenotypeType.HOM_REF,likelihoods[GenotypeType.HOM_REF.ordinal()-1]);
         likelihoodsMap.put(GenotypeType.HET,likelihoods[GenotypeType.HET.ordinal()-1]);
         likelihoodsMap.put(GenotypeType.HOM_VAR, likelihoods[GenotypeType.HOM_VAR.ordinal() - 1]);
@@ -382,7 +382,7 @@ public class GenotypeLikelihoods {
     private static void calculatePLIndexToAlleleIndices(final int altAlleles, final int ploidy, final List<List<Integer>> anyploidPLIndexToAlleleIndices,
                                                    final List<Integer> genotype) {
         for (int a=0; a <= altAlleles; a++) {
-            final List<Integer> gt = new ArrayList<Integer>(Arrays.asList(a));
+            final List<Integer> gt = new ArrayList<>(Arrays.asList(a));
             gt.addAll(genotype);
             if ( ploidy == 1 ) {// have all ploidy alleles for a PL index
                 anyploidPLIndexToAlleleIndices.add(gt);
@@ -402,8 +402,8 @@ public class GenotypeLikelihoods {
      * @return The alleles for each PL index for a ploidy
      */
     protected static List<List<Integer>> calculateAnyploidPLcache(final int altAlleles, final int ploidy) {
-        List<List<Integer>> anyploidPLIndexToAlleleIndices = new ArrayList<List<Integer>>();
-        calculatePLIndexToAlleleIndices(altAlleles, ploidy, anyploidPLIndexToAlleleIndices, new ArrayList<Integer>());
+        List<List<Integer>> anyploidPLIndexToAlleleIndices = new ArrayList<>();
+        calculatePLIndexToAlleleIndices(altAlleles, ploidy, anyploidPLIndexToAlleleIndices, new ArrayList<>());
         return anyploidPLIndexToAlleleIndices;
     }
 

--- a/src/main/java/htsjdk/variant/variantcontext/GenotypesContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/GenotypesContext.java
@@ -50,7 +50,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
      * static constant value for an empty GenotypesContext.  Useful since so many VariantContexts have no genotypes
      */
     public final static GenotypesContext NO_GENOTYPES =
-            new GenotypesContext(new ArrayList<Genotype>(0), new HashMap<String, Integer>(0), Collections.<String>emptyList()).immutable();
+            new GenotypesContext(new ArrayList<>(0), new HashMap<>(0), Collections.<String>emptyList()).immutable();
 
     /**
      *sampleNamesInOrder a list of sample names, one for each genotype in genotypes, sorted in alphabetical order
@@ -118,7 +118,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
      * Create an empty GenotypeContext, with initial capacity for n elements
      */
     protected GenotypesContext(final int n) {
-        this(new ArrayList<Genotype>(n));
+        this(new ArrayList<>(n));
     }
 
     /**
@@ -205,7 +205,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
      * @return an mutable GenotypeContext containing genotypes
      */
     public static final GenotypesContext create(final Genotype... genotypes) {
-        return create(new ArrayList<Genotype>(Arrays.asList(genotypes)));
+        return create(new ArrayList<>(Arrays.asList(genotypes)));
     }
 
     /**
@@ -215,7 +215,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
      * @return an mutable GenotypeContext containing genotypes
      */
     public static final GenotypesContext copy(final GenotypesContext toCopy) {
-        return create(new ArrayList<Genotype>(toCopy.getGenotypes()));
+        return create(new ArrayList<>(toCopy.getGenotypes()));
     }
 
     /**
@@ -226,7 +226,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
      * @return an mutable GenotypeContext containing genotypes
      */
     public static final GenotypesContext copy(final Collection<Genotype> toCopy) {
-        return toCopy == null ? NO_GENOTYPES : create(new ArrayList<Genotype>(toCopy));
+        return toCopy == null ? NO_GENOTYPES : create(new ArrayList<>(toCopy));
     }
 
     // ---------------------------------------------------------------------------
@@ -265,7 +265,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
 
     protected void ensureSampleOrdering() {
         if ( sampleNamesInOrder == null ) {
-            sampleNamesInOrder = new ArrayList<String>(size());
+            sampleNamesInOrder = new ArrayList<>(size());
 
             for ( int i = 0; i < size(); i++ ) {
                 sampleNamesInOrder.add(getGenotypes().get(i).getSampleName());
@@ -276,7 +276,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
 
     protected void ensureSampleNameMap() {
         if ( sampleNameToOffset == null ) {
-            sampleNameToOffset = new HashMap<String, Integer>(size());
+            sampleNameToOffset = new HashMap<>(size());
 
             for ( int i = 0; i < size(); i++ ) {
                 sampleNameToOffset.put(getGenotypes().get(i).getSampleName(), i);
@@ -690,7 +690,7 @@ public class GenotypesContext implements List<Genotype>, Serializable {
 
     @Override
     public String toString() {
-        final List<String> gS = new ArrayList<String>();
+        final List<String> gS = new ArrayList<>();
         for ( final Genotype g : this.iterateInSampleNameOrder() )
             gS.add(g.toString());
         return "[" + join(",", gS) + "]";

--- a/src/main/java/htsjdk/variant/variantcontext/LazyGenotypesContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/LazyGenotypesContext.java
@@ -88,7 +88,7 @@ public class LazyGenotypesContext extends GenotypesContext {
         }
     }
 
-    private final static ArrayList<Genotype> EMPTY = new ArrayList<Genotype>(0);
+    private final static ArrayList<Genotype> EMPTY = new ArrayList<>(0);
 
     /**
      * Simple lazy parser interface.  Provide an object implementing this

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -263,7 +263,7 @@ public class VariantContext implements Feature, Serializable {
 * @return an ordered list of genotype fields in use in VC.  If vc has genotypes this will always include GT first
 */
     public List<String> calcVCFGenotypeKeys(final VCFHeader header) {
-        final Set<String> keys = new HashSet<String>();
+        final Set<String> keys = new HashSet<>();
 
         boolean sawGoodGT = false;
         boolean sawGoodQual = false;
@@ -287,11 +287,11 @@ public class VariantContext implements Feature, Serializable {
         if ( sawPL ) keys.add(VCFConstants.GENOTYPE_PL_KEY);
         if ( sawGenotypeFilter ) keys.add(VCFConstants.GENOTYPE_FILTER_KEY);
 
-        List<String> sortedList = ParsingUtils.sortList(new ArrayList<String>(keys));
+        List<String> sortedList = ParsingUtils.sortList(new ArrayList<>(keys));
 
         // make sure the GT is first
         if (sawGoodGT) {
-            final List<String> newList = new ArrayList<String>(sortedList.size()+1);
+            final List<String> newList = new ArrayList<>(sortedList.size() + 1);
             newList.add(VCFConstants.GENOTYPE_KEY);
             newList.addAll(sortedList);
             sortedList = newList;
@@ -434,7 +434,7 @@ public class VariantContext implements Feature, Serializable {
                 Set<Allele> allelesFromGenotypes = allelesOfGenotypes(newGenotypes);
 
                 // ensure original order of genotypes
-                List<Allele> rederivedAlleles = new ArrayList<Allele>(allelesFromGenotypes.size());
+                List<Allele> rederivedAlleles = new ArrayList<>(allelesFromGenotypes.size());
                 for (Allele allele : alleles)
                     if (allelesFromGenotypes.contains(allele))
                         rederivedAlleles.add(allele);
@@ -469,7 +469,7 @@ public class VariantContext implements Feature, Serializable {
      * @return allele set
      */
     private final Set<Allele> allelesOfGenotypes(Collection<Genotype> genotypes) {
-        final Set<Allele> alleles = new HashSet<Allele>();
+        final Set<Allele> alleles = new HashSet<>();
 
         boolean addedref = false;
         for ( final Genotype g : genotypes ) {
@@ -863,7 +863,7 @@ public class VariantContext implements Feature, Serializable {
             return null;
         }
 
-        List<Integer> lengths = new ArrayList<Integer>();
+        List<Integer> lengths = new ArrayList<>();
         for ( Allele a : getAlternateAlleles() ) {
             lengths.add(a.length() - getReference().length());
         }
@@ -973,7 +973,7 @@ public class VariantContext implements Feature, Serializable {
      * @throws IllegalArgumentException if sampleName isn't bound to a genotype
      */
     protected GenotypesContext getGenotypes(Collection<String> sampleNames) {
-        return getGenotypes().subsetToSamples(new HashSet<String>(sampleNames));
+        return getGenotypes().subsetToSamples(new HashSet<>(sampleNames));
     }
 
     public GenotypesContext getGenotypes(Set<String> sampleNames) {
@@ -1049,7 +1049,7 @@ public class VariantContext implements Feature, Serializable {
      * @return chromosome count
      */
     public int getCalledChrCount(Allele a) {
-        return getCalledChrCount(a,new HashSet<String>(0));
+        return getCalledChrCount(a, new HashSet<>(0));
     }
 
     /**
@@ -1203,14 +1203,14 @@ public class VariantContext implements Feature, Serializable {
 
         // maintain a list of non-symbolic alleles reported in the REF and ALT fields of the record
         // (we exclude symbolic alleles because it's commonly expected that they don't show up in the genotypes, e.g. with GATK gVCFs)
-        final List<Allele> reportedAlleles = new ArrayList<Allele>();
+        final List<Allele> reportedAlleles = new ArrayList<>();
         for ( final Allele allele : getAlleles() ) {
             if ( !allele.isSymbolic() )
                 reportedAlleles.add(allele);
         }
 
         // maintain a list of non-symbolic alleles observed in the genotypes
-        final Set<Allele> observedAlleles = new HashSet<Allele>();
+        final Set<Allele> observedAlleles = new HashSet<>();
         observedAlleles.add(getReference());
         for ( final Genotype g : getGenotypes() ) {
             if ( g.isCalled() ) {
@@ -1247,7 +1247,7 @@ public class VariantContext implements Feature, Serializable {
 
         // AC
         if ( hasAttribute(VCFConstants.ALLELE_COUNT_KEY) ) {
-            ArrayList<Integer> observedACs = new ArrayList<Integer>();
+            ArrayList<Integer> observedACs = new ArrayList<>();
 
             // if there are alternate alleles, record the relevant tags
             if (!getAlternateAlleles().isEmpty()) {
@@ -1473,7 +1473,7 @@ public class VariantContext implements Feature, Serializable {
 
     // protected basic manipulation routines
     private static List<Allele> makeAlleles(Collection<Allele> alleles) {
-        final List<Allele> alleleList = new ArrayList<Allele>(alleles.size());
+        final List<Allele> alleleList = new ArrayList<>(alleles.size());
 
         boolean sawRef = false;
         for ( final Allele a : alleles ) {
@@ -1544,7 +1544,7 @@ public class VariantContext implements Feature, Serializable {
     private final Map<String, Object> fullyDecodeAttributes(final Map<String, Object> attributes,
                                                             final VCFHeader header,
                                                             final boolean lenientDecoding) {
-        final Map<String, Object> newAttributes = new HashMap<String, Object>(10);
+        final Map<String, Object> newAttributes = new HashMap<>(10);
 
         for ( final Map.Entry<String, Object> attr : attributes.entrySet() ) {
             final String field = attr.getKey();
@@ -1582,7 +1582,7 @@ public class VariantContext implements Feature, Serializable {
             final String string = (String)value;
             if ( string.indexOf(',') != -1 ) {
                 final String[] splits = string.split(",");
-                final List<Object> values = new ArrayList<Object>(splits.length);
+                final List<Object> values = new ArrayList<>(splits.length);
                 for ( int i = 0; i < splits.length; i++ )
                     values.add(decodeOne(field, splits[i], format));
                 return values;
@@ -1591,7 +1591,7 @@ public class VariantContext implements Feature, Serializable {
             }
         } else if ( value instanceof List && (((List) value).get(0)) instanceof String ) {
             final List<String> asList = (List<String>)value;
-            final List<Object> values = new ArrayList<Object>(asList.size());
+            final List<Object> values = new ArrayList<>(asList.size());
             for ( final String s : asList )
                 values.add(decodeOne(field, s, format));
             return values;

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextBuilder.java
@@ -160,7 +160,7 @@ public class VariantContextBuilder {
     }
 
     public VariantContextBuilder alleles(final List<String> alleleStrings) {
-        final List<Allele> alleles = new ArrayList<Allele>(alleleStrings.size());
+        final List<Allele> alleles = new ArrayList<>(alleleStrings.size());
 
         for ( int i = 0; i < alleleStrings.size(); i++ ) {
             alleles.add(Allele.create(alleleStrings.get(i), i == 0));
@@ -174,7 +174,7 @@ public class VariantContextBuilder {
     }
 
     public List<Allele> getAlleles() {
-        return new ArrayList<Allele>(alleles);
+        return new ArrayList<>(alleles);
     }
 
     /**
@@ -244,9 +244,9 @@ public class VariantContextBuilder {
         if ( ! attributesCanBeModified ) {
             this.attributesCanBeModified = true;
             if (attributes == null) {
-            	this.attributes = new HashMap<String, Object>();
+            	this.attributes = new HashMap<>();
             } else {
-            	this.attributes = new HashMap<String, Object>(attributes);
+            	this.attributes = new HashMap<>(attributes);
             }
         }
     }
@@ -269,12 +269,12 @@ public class VariantContextBuilder {
      * @return
      */
     public VariantContextBuilder filters(final String ... filters) {
-        filters(new LinkedHashSet<String>(Arrays.asList(filters)));
+        filters(new LinkedHashSet<>(Arrays.asList(filters)));
         return this;
     }
 
     public VariantContextBuilder filter(final String filter) {
-        if ( this.filters == null ) this.filters = new LinkedHashSet<String>(1);
+        if ( this.filters == null ) this.filters = new LinkedHashSet<>(1);
         this.filters.add(filter);
         return this;
     }

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextComparator.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextComparator.java
@@ -23,7 +23,7 @@ public class VariantContextComparator implements Comparator<VariantContext>, Ser
 	private static final long serialVersionUID = 1L;
 
 	public static List<String> getSequenceNameList(final SAMSequenceDictionary dictionary) {
-		final List<String> list = new ArrayList<String>();
+		final List<String> list = new ArrayList<>();
 		for (final SAMSequenceRecord record : dictionary.getSequences()) {
 			list.add(record.getSequenceName());
 		}
@@ -36,7 +36,7 @@ public class VariantContextComparator implements Comparator<VariantContext>, Ser
 	public VariantContextComparator(final List<String> contigs) {
 		if (contigs.isEmpty()) throw new IllegalArgumentException("One or more contigs must be in the contig list.");
 
-		final Map<String, Integer> protoContigIndexLookup = new HashMap<String, Integer>();
+		final Map<String, Integer> protoContigIndexLookup = new HashMap<>();
 		int index = 0;
 		for (final String contig : contigs) {
 			protoContigIndexLookup.put(contig, index++);
@@ -57,7 +57,7 @@ public class VariantContextComparator implements Comparator<VariantContext>, Ser
 	public VariantContextComparator(final Collection<VCFContigHeaderLine> headerLines) {
 		if (headerLines.isEmpty()) throw new IllegalArgumentException("One or more header lines must be in the header line collection.");
 
-		final Map<String, Integer> protoContigIndexLookup = new HashMap<String, Integer>();
+		final Map<String, Integer> protoContigIndexLookup = new HashMap<>();
 		for (final VCFContigHeaderLine headerLine : headerLines) {
 			protoContigIndexLookup.put(headerLine.getID(), headerLine.getContigIndex());
 		}
@@ -66,7 +66,7 @@ public class VariantContextComparator implements Comparator<VariantContext>, Ser
 			throw new IllegalArgumentException("There are duplicate contigs/chromosomes in the input header line collection.");
 		}
 
-		final Set<Integer> protoIndexValues = new HashSet<Integer>(protoContigIndexLookup.values());
+		final Set<Integer> protoIndexValues = new HashSet<>(protoContigIndexLookup.values());
 		if (protoIndexValues.size() != headerLines.size()) {
 			throw new IllegalArgumentException("One or more contigs share the same index number.");
 		}

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -48,11 +48,11 @@ import java.util.Map;
 import java.util.Set;
 
 public class VariantContextUtils {
-    private static Set<String> MISSING_KEYS_WARNED_ABOUT = new HashSet<String>();
+    private static Set<String> MISSING_KEYS_WARNED_ABOUT = new HashSet<>();
 
     /** Use a {@link Lazy} {@link JexlEngine} instance to avoid class-loading issues. (Applications that access this class are otherwise
      * forced to build a {@link JexlEngine} instance, which depends on some apache logging libraries that mightn't be packaged.) */
-    final public static Lazy<JexlEngine> engine = new Lazy<JexlEngine>(new Lazy.LazyInitializer<JexlEngine>() {
+    final public static Lazy<JexlEngine> engine = new Lazy<>(new Lazy.LazyInitializer<JexlEngine>() {
         @Override
         public JexlEngine make() {
             final JexlEngine jexl = new JexlEngine();
@@ -95,7 +95,7 @@ public class VariantContextUtils {
      * @return the attributes map provided as input, returned for programming convenience
      */
     public static Map<String, Object> calculateChromosomeCounts(VariantContext vc, Map<String, Object> attributes, boolean removeStaleValues) {
-        return calculateChromosomeCounts(vc, attributes,  removeStaleValues, new HashSet<String>(0));
+        return calculateChromosomeCounts(vc, attributes,  removeStaleValues, new HashSet<>(0));
     }
 
     /**
@@ -128,9 +128,9 @@ public class VariantContextUtils {
 
             // if there are alternate alleles, record the relevant tags
             if (!vc.getAlternateAlleles().isEmpty()) {
-                ArrayList<Double> alleleFreqs = new ArrayList<Double>();
-                ArrayList<Integer> alleleCounts = new ArrayList<Integer>();
-                ArrayList<Integer> foundersAlleleCounts = new ArrayList<Integer>();
+                ArrayList<Double> alleleFreqs = new ArrayList<>();
+                ArrayList<Integer> alleleCounts = new ArrayList<>();
+                ArrayList<Integer> foundersAlleleCounts = new ArrayList<>();
                 double totalFoundersChromosomes = (double)vc.getCalledChrCount(founderIds);
                 int foundersAltChromosomes;
                 for ( Allele allele : vc.getAlternateAlleles() ) {
@@ -240,7 +240,7 @@ public class VariantContextUtils {
         if ( names.length != exps.length )
             throw new IllegalArgumentException("Inconsistent number of provided filter names and expressions: names=" + Arrays.toString(names) + " exps=" + Arrays.toString(exps));
 
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         for ( int i = 0; i < names.length; i++ ) { map.put(names[i], exps[i]); }
 
         return VariantContextUtils.initializeMatchExps(map);
@@ -404,7 +404,7 @@ public class VariantContextUtils {
      * @return new VCs without genotypes
      */
     public static Collection<VariantContext> sitesOnlyVariantContexts(Collection<VariantContext> vcs) {
-        List<VariantContext> r = new ArrayList<VariantContext>();
+        List<VariantContext> r = new ArrayList<>();
         for ( VariantContext vc : vcs )
             r.add(sitesOnlyVariantContext(vc));
         return r;
@@ -415,7 +415,7 @@ public class VariantContextUtils {
     }
 
     public static Set<String> genotypeNames(final Collection<Genotype> genotypes) {
-        final Set<String> names = new HashSet<String>(genotypes.size());
+        final Set<String> names = new HashSet<>(genotypes.size());
         for ( final Genotype g : genotypes )
             names.add(g.getSampleName());
         return names;

--- a/src/main/java/htsjdk/variant/variantcontext/VariantJEXLContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantJEXLContext.java
@@ -55,7 +55,7 @@ class VariantJEXLContext implements JexlContext {
         public Object get(VariantContext vc);
     }
 
-    private static Map<String, AttributeGetter> attributes = new HashMap<String, AttributeGetter>();
+    private static Map<String, AttributeGetter> attributes = new HashMap<>();
 
     static {
         attributes.put("vc", (VariantContext vc) -> vc);

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Encoder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Encoder.java
@@ -253,7 +253,7 @@ public final class BCF2Encoder {
         else {
             // TODO -- this needs to be optimized away for efficiency
             final byte[] bytes = v.getBytes();
-            final List<Byte> l = new ArrayList<Byte>(bytes.length);
+            final List<Byte> l = new ArrayList<>(bytes.length);
             for ( int i = 0; i < bytes.length; i++) l.add(bytes[i]);
             return l;
         }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2FieldEncoder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2FieldEncoder.java
@@ -296,7 +296,7 @@ public abstract class BCF2FieldEncoder {
                 final List<String> l = (List<String>)value;
                 return BCF2Utils.collapseStringList(l);
             } else if ( value.getClass().isArray() ) {
-                final List<String> l = new ArrayList<String>();
+                final List<String> l = new ArrayList<>();
                 Collections.addAll(l, (String[])value);
                 return BCF2Utils.collapseStringList(l);
             } else

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2FieldWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2FieldWriter.java
@@ -175,7 +175,7 @@ public abstract class BCF2FieldWriter {
         @Override
         public void start(final BCF2Encoder encoder, final VariantContext vc) throws IOException {
             // the only value that is dynamic are integers
-            final List<Integer> values = new ArrayList<Integer>(vc.getNSamples());
+            final List<Integer> values = new ArrayList<>(vc.getNSamples());
             for ( final Genotype g : vc.getGenotypes() ) {
                 for ( final Integer i : BCF2Utils.toList(Integer.class, g.getExtendedAttribute(getField(), null)) ) {
                     if ( i != null ) values.add(i);
@@ -243,7 +243,7 @@ public abstract class BCF2FieldWriter {
     }
 
     public static class GTWriter extends GenotypesWriter {
-        final Map<Allele, Integer> alleleMapForTriPlus = new HashMap<Allele, Integer>(5);
+        final Map<Allele, Integer> alleleMapForTriPlus = new HashMap<>(5);
         Allele ref, alt1;
 
         public GTWriter(final VCFHeader header, final BCF2FieldEncoder fieldEncoder) {

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2FieldWriterManager.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2FieldWriterManager.java
@@ -43,8 +43,8 @@ import java.util.Map;
  * @since 06/12
  */
 public class BCF2FieldWriterManager {
-    final Map<String, BCF2FieldWriter.SiteWriter> siteWriters = new HashMap<String, BCF2FieldWriter.SiteWriter>();
-    final Map<String, BCF2FieldWriter.GenotypesWriter> genotypesWriters = new HashMap<String, BCF2FieldWriter.GenotypesWriter>();
+    final Map<String, BCF2FieldWriter.SiteWriter> siteWriters = new HashMap<>();
+    final Map<String, BCF2FieldWriter.GenotypesWriter> genotypesWriters = new HashMap<>();
     final IntGenotypeFieldAccessors intGenotypeFieldAccessors = new IntGenotypeFieldAccessors();
 
     public BCF2FieldWriterManager() { }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -108,8 +108,8 @@ class BCF2Writer extends IndexingVariantContextWriter {
 
     private final OutputStream outputStream;      // Note: do not flush until completely done writing, to avoid issues with eventual BGZF support
     private VCFHeader header;
-    private final Map<String, Integer> contigDictionary = new HashMap<String, Integer>();
-    private final Map<String, Integer> stringDictionaryMap = new LinkedHashMap<String, Integer>();
+    private final Map<String, Integer> contigDictionary = new HashMap<>();
+    private final Map<String, Integer> stringDictionaryMap = new LinkedHashMap<>();
     private final boolean doNotWriteGenotypes;
     private String[] sampleNames = null;
 
@@ -415,7 +415,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
     }
 
     private BCF2Type encodeStringsByRef(final Collection<String> strings) throws IOException {
-        final List<Integer> offsets = new ArrayList<Integer>(strings.size());
+        final List<Integer> offsets = new ArrayList<>(strings.size());
 
         // iterate over strings until we find one that needs 16 bits, and break
         for ( final String string : strings ) {

--- a/src/main/java/htsjdk/variant/variantcontext/writer/IntGenotypeFieldAccessors.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/IntGenotypeFieldAccessors.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
  */
 public class IntGenotypeFieldAccessors {
     // initialized once per writer to allow parallel writers to work
-    private final HashMap<String, Accessor> intGenotypeFieldEncoders = new HashMap<String, Accessor>();
+    private final HashMap<String, Accessor> intGenotypeFieldEncoders = new HashMap<>();
 
     public IntGenotypeFieldAccessors() {
         intGenotypeFieldEncoders.put(VCFConstants.DEPTH_KEY, new IntGenotypeFieldAccessors.DPAccessor());

--- a/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
@@ -71,11 +71,11 @@ abstract class SortingVariantContextWriterBase implements VariantContextWriter {
      */
     public SortingVariantContextWriterBase(VariantContextWriter innerWriter, boolean takeOwnershipOfInner) {
         this.innerWriter = innerWriter;
-        this.finishedChromosomes = new TreeSet<String>();
+        this.finishedChromosomes = new TreeSet<>();
         this.takeOwnershipOfInner = takeOwnershipOfInner;
 
         // has to be PriorityBlockingQueue to be thread-safe
-        this.queue = new PriorityBlockingQueue<VCFRecord>(50, new VariantContextComparator());
+        this.queue = new PriorityBlockingQueue<>(50, new VariantContextComparator());
 
         this.mostUpstreamWritableLoc = BEFORE_MOST_UPSTREAM_LOC;
     }

--- a/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -68,7 +68,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
     protected VCFHeaderVersion version = null;
 
     // a mapping of the allele
-    protected Map<String, List<Allele>> alleleMap = new HashMap<String, List<Allele>>(3);
+    protected Map<String, List<Allele>> alleleMap = new HashMap<>(3);
     
     // for performance testing purposes
     public static boolean validate = true;
@@ -80,14 +80,14 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
     protected final String[] locParts = new String[6];
 
     // for performance we cache the hashmap of filter encodings for quick lookup
-    protected HashMap<String,List<String>> filterHash = new HashMap<String,List<String>>();
+    protected HashMap<String,List<String>> filterHash = new HashMap<>();
 
     // we store a name to give to each of the variant contexts we emit
     protected String name = "Unknown";
 
     protected int lineNo = 0;
 
-    protected Map<String, String> stringCache = new HashMap<String, String>();
+    protected Map<String, String> stringCache = new HashMap<>();
 
     protected boolean warnedAboutNoEqualsForNonFlag = false;
 
@@ -146,8 +146,8 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
     protected VCFHeader parseHeaderFromLines( final List<String> headerStrings, final VCFHeaderVersion version ) {
         this.version = version;
 
-        Set<VCFHeaderLine> metaData = new LinkedHashSet<VCFHeaderLine>();
-        Set<String> sampleNames = new LinkedHashSet<String>();
+        Set<VCFHeaderLine> metaData = new LinkedHashSet<>();
+        Set<String> sampleNames = new LinkedHashSet<>();
         int contigCounter = 0;
         // iterate over all the passed in strings
         for ( String str : headerStrings ) {
@@ -318,7 +318,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
         builder.log10PError(parseQual(parts[5]));
 
         final List<String> filters = parseFilters(getCachedString(parts[6]));
-        if ( filters != null ) builder.filters(new HashSet<String>(filters));
+        if ( filters != null ) builder.filters(new HashSet<>(filters));
         final Map<String, Object> attrs = parseInfo(parts[7]);
         builder.attributes(attrs);
 
@@ -397,7 +397,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
      * @return a mapping of keys to objects
      */
     private Map<String, Object> parseInfo(String infoField) {
-        Map<String, Object> attributes = new HashMap<String, Object>();
+        Map<String, Object> attributes = new HashMap<>();
 
         if ( infoField.isEmpty() )
             generateException("The VCF specification requires a valid (non-zero length) info field");
@@ -488,7 +488,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
 
         if ( GTAlleles == null ) {
             StringTokenizer st = new StringTokenizer(GT, VCFConstants.PHASING_TOKENS);
-            GTAlleles = new ArrayList<Allele>(st.countTokens());
+            GTAlleles = new ArrayList<>(st.countTokens());
             while ( st.hasMoreTokens() ) {
                 String genotype = st.nextToken();
                 GTAlleles.add(oneAllele(genotype, alleles));
@@ -527,7 +527,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
      * @return a list of alleles, and a pair of the shortest and longest sequence
      */
     protected static List<Allele> parseAlleles(String ref, String alts, int lineNo) {
-        List<Allele> alleles = new ArrayList<Allele>(2); // we are almost always biallelic
+        List<Allele> alleles = new ArrayList<>(2); // we are almost always biallelic
         // ref
         checkAllele(ref, true, lineNo);
         Allele refAllele = Allele.create(ref, true);
@@ -661,7 +661,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
         if ( nParts != genotypeParts.length )
             generateException("there are " + (nParts-1) + " genotypes while the header requires that " + (genotypeParts.length-1) + " genotypes be present for all records at " + chr + ":" + pos, lineNo);
 
-        ArrayList<Genotype> genotypes = new ArrayList<Genotype>(nParts);
+        ArrayList<Genotype> genotypes = new ArrayList<>(nParts);
 
         // get the format keys
         List<String> genotypeKeys = ParsingUtils.split(genotypeParts[0], VCFConstants.GENOTYPE_FIELD_SEPARATOR_CHAR);
@@ -728,7 +728,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
             if ( genotypeAlleleLocation > 0 )
                 generateException("Saw GT field at position " + genotypeAlleleLocation + ", but it must be at the first position for genotypes when present");
 
-            final List<Allele> GTalleles = (genotypeAlleleLocation == -1 ? new ArrayList<Allele>(0) : parseGenotypeAlleles(genotypeValues.get(genotypeAlleleLocation), alleles, alleleMap));
+            final List<Allele> GTalleles = (genotypeAlleleLocation == -1 ? new ArrayList<>(0) : parseGenotypeAlleles(genotypeValues.get(genotypeAlleleLocation), alleles, alleleMap));
             gb.alleles(GTalleles);
             gb.phased(genotypeAlleleLocation != -1 && genotypeValues.get(genotypeAlleleLocation).indexOf(VCFConstants.PHASED) != -1);
 

--- a/src/main/java/htsjdk/variant/vcf/VCF3Codec.java
+++ b/src/main/java/htsjdk/variant/vcf/VCF3Codec.java
@@ -57,7 +57,7 @@ public class VCF3Codec extends AbstractVCFCodec {
      * @return the number of header lines
      */
     public Object readActualHeader(final LineIterator reader) {
-        final List<String> headerStrings = new ArrayList<String>();
+        final List<String> headerStrings = new ArrayList<>();
 
         VCFHeaderVersion version = null;
         boolean foundHeaderVersion = false;
@@ -104,17 +104,17 @@ public class VCF3Codec extends AbstractVCFCodec {
             return null;
 
         // empty set for passes filters
-        List<String> fFields = new ArrayList<String>();
+        List<String> fFields = new ArrayList<>();
 
         if ( filterString.equals(VCFConstants.PASSES_FILTERS_v3) )
-            return new ArrayList<String>(fFields);
+            return new ArrayList<>(fFields);
 
         if (filterString.isEmpty())
             generateException("The VCF specification requires a valid filter status");
 
         // do we have the filter string cached?
         if ( filterHash.containsKey(filterString) )
-            return new ArrayList<String>(filterHash.get(filterString));
+            return new ArrayList<>(filterHash.get(filterString));
 
         // otherwise we have to parse and cache the value
         if ( filterString.indexOf(VCFConstants.FILTER_CODE_SEPARATOR) == -1 )

--- a/src/main/java/htsjdk/variant/vcf/VCFCodec.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFCodec.java
@@ -82,7 +82,7 @@ public class VCFCodec extends AbstractVCFCodec {
      */
     @Override
     public Object readActualHeader(final LineIterator lineIterator) {
-        final List<String> headerStrings = new ArrayList<String>();
+        final List<String> headerStrings = new ArrayList<>();
 
         String line;
         boolean foundHeaderVersion = false;
@@ -142,7 +142,7 @@ public class VCFCodec extends AbstractVCFCodec {
             return filterHash.get(filterString);
 
         // empty set for passes filters
-        final List<String> fFields = new LinkedList<String>();
+        final List<String> fFields = new LinkedList<>();
         // otherwise we have to parse and cache the value
         if ( !filterString.contains(VCFConstants.FILTER_CODE_SEPARATOR) )
             fFields.add(filterString);

--- a/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
@@ -222,7 +222,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
      * @return a string representation
      */
     protected String toStringEncoding() {
-        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("ID", name);
         Object number;
         switch (countType) {

--- a/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
@@ -106,7 +106,7 @@ public class VCFEncoder {
 				.append(getFilterString(context)).append(VCFConstants.FIELD_SEPARATOR);
 
 		// INFO
-		final Map<String, String> infoFields = new TreeMap<String, String>();
+		final Map<String, String> infoFields = new TreeMap<>();
 		for (final Map.Entry<String, Object> field : context.getAttributes().entrySet() ) {
 			if ( ! this.header.hasInfoLine(field.getKey())) fieldIsMissingFromHeaderError(context, field.getKey(), "INFO");
 
@@ -255,7 +255,7 @@ public class VCFEncoder {
 			Genotype g = vc.getGenotype(sample);
 			if (g == null) g = GenotypeBuilder.createMissing(sample, ploidy);
 
-			final List<String> attrs = new ArrayList<String>(genotypeFormatKeys.size());
+			final List<String> attrs = new ArrayList<>(genotypeFormatKeys.size());
 			for (final String field : genotypeFormatKeys) {
 				if (field.equals(VCFConstants.GENOTYPE_KEY)) {
 					if ( ! g.isAvailable()) {
@@ -362,7 +362,7 @@ public class VCFEncoder {
 	}
 
 	public Map<Allele, String> buildAlleleStrings(final VariantContext vc) {
-		final Map<Allele, String> alleleMap = new HashMap<Allele, String>(vc.getAlleles().size()+1);
+		final Map<Allele, String> alleleMap = new HashMap<>(vc.getAlleles().size() + 1);
 		alleleMap.put(Allele.NO_CALL, VCFConstants.EMPTY_ALLELE); // convenience for lookup
 
 		final List<Allele> alleles = vc.getAlleles();

--- a/src/main/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeader.java
@@ -63,15 +63,15 @@ public class VCFHeader implements Serializable {
     }
 
     // the associated meta data
-    private final Set<VCFHeaderLine> mMetaData = new LinkedHashSet<VCFHeaderLine>();
-    private final Map<String, VCFInfoHeaderLine> mInfoMetaData = new LinkedHashMap<String, VCFInfoHeaderLine>();
-    private final Map<String, VCFFormatHeaderLine> mFormatMetaData = new LinkedHashMap<String, VCFFormatHeaderLine>();
-    private final Map<String, VCFFilterHeaderLine> mFilterMetaData = new LinkedHashMap<String, VCFFilterHeaderLine>();
-    private final Map<String, VCFHeaderLine> mOtherMetaData = new LinkedHashMap<String, VCFHeaderLine>();
-    private final List<VCFContigHeaderLine> contigMetaData = new ArrayList<VCFContigHeaderLine>();
+    private final Set<VCFHeaderLine> mMetaData = new LinkedHashSet<>();
+    private final Map<String, VCFInfoHeaderLine> mInfoMetaData = new LinkedHashMap<>();
+    private final Map<String, VCFFormatHeaderLine> mFormatMetaData = new LinkedHashMap<>();
+    private final Map<String, VCFFilterHeaderLine> mFilterMetaData = new LinkedHashMap<>();
+    private final Map<String, VCFHeaderLine> mOtherMetaData = new LinkedHashMap<>();
+    private final List<VCFContigHeaderLine> contigMetaData = new ArrayList<>();
 
     // the list of auxillary tags
-    private final List<String> mGenotypeSampleNames = new ArrayList<String>();
+    private final List<String> mGenotypeSampleNames = new ArrayList<>();
 
     // the character string that indicates meta data
     public static final String METADATA_INDICATOR = "##";
@@ -132,13 +132,13 @@ public class VCFHeader implements Serializable {
      * @param genotypeSampleNames the sample names
      */
     public VCFHeader(final Set<VCFHeaderLine> metaData, final Set<String> genotypeSampleNames) {
-        this(metaData, new ArrayList<String>(genotypeSampleNames));
+        this(metaData, new ArrayList<>(genotypeSampleNames));
     }
 
     public VCFHeader(final Set<VCFHeaderLine> metaData, final List<String> genotypeSampleNames) {
         this(metaData);
 
-        if ( genotypeSampleNames.size() != new HashSet<String>(genotypeSampleNames).size() )
+        if ( genotypeSampleNames.size() != new HashSet<>(genotypeSampleNames).size() )
             throw new TribbleException.InvalidHeader("BUG: VCF header has duplicate sample names");
 
         mGenotypeSampleNames.addAll(genotypeSampleNames);
@@ -155,8 +155,8 @@ public class VCFHeader implements Serializable {
      * @param genotypeSampleNamesInAppearenceOrder genotype sample names, must iterator in order of appearance
      */
     private void buildVCFReaderMaps(final Collection<String> genotypeSampleNamesInAppearenceOrder) {
-        sampleNamesInOrder = new ArrayList<String>(genotypeSampleNamesInAppearenceOrder.size());
-        sampleNameToOffset = new HashMap<String, Integer>(genotypeSampleNamesInAppearenceOrder.size());
+        sampleNamesInOrder = new ArrayList<>(genotypeSampleNamesInAppearenceOrder.size());
+        sampleNameToOffset = new HashMap<>(genotypeSampleNamesInAppearenceOrder.size());
 
         int i = 0;
         for (final String name : genotypeSampleNamesInAppearenceOrder) {
@@ -200,7 +200,7 @@ public class VCFHeader implements Serializable {
         final List<VCFContigHeaderLine> contigHeaderLines = this.getContigLines();
         if (contigHeaderLines.isEmpty()) return null;
 
-        final List<SAMSequenceRecord> sequenceRecords = new ArrayList<SAMSequenceRecord>(contigHeaderLines.size());
+        final List<SAMSequenceRecord> sequenceRecords = new ArrayList<>(contigHeaderLines.size());
         for (final VCFContigHeaderLine contigHeaderLine : contigHeaderLines) {
             sequenceRecords.add(contigHeaderLine.getSAMSequenceRecord());
         }
@@ -215,7 +215,7 @@ public class VCFHeader implements Serializable {
         this.contigMetaData.clear();
 
         // Also need to remove contig record lines from mMetaData
-        final List<VCFHeaderLine> toRemove = new ArrayList<VCFHeaderLine>();
+        final List<VCFHeaderLine> toRemove = new ArrayList<>();
         for (final VCFHeaderLine line : mMetaData) {
             if (line instanceof VCFContigHeaderLine) {
                 toRemove.add(line);
@@ -237,7 +237,7 @@ public class VCFHeader implements Serializable {
      * @return all of the VCF FILTER lines in their original file order, or an empty list if none were present
      */
     public List<VCFFilterHeaderLine> getFilterLines() {
-        final List<VCFFilterHeaderLine> filters = new ArrayList<VCFFilterHeaderLine>();
+        final List<VCFFilterHeaderLine> filters = new ArrayList<>();
         for (final VCFHeaderLine line : mMetaData) {
             if ( line instanceof VCFFilterHeaderLine )  {
                 filters.add((VCFFilterHeaderLine)line);
@@ -250,7 +250,7 @@ public class VCFHeader implements Serializable {
      * @return all of the VCF FILTER lines in their original file order, or an empty list if none were present
      */
     public List<VCFIDHeaderLine> getIDHeaderLines() {
-        final List<VCFIDHeaderLine> filters = new ArrayList<VCFIDHeaderLine>();
+        final List<VCFIDHeaderLine> filters = new ArrayList<>();
         for (final VCFHeaderLine line : mMetaData) {
             if (line instanceof VCFIDHeaderLine)  {
                 filters.add((VCFIDHeaderLine)line);
@@ -263,7 +263,7 @@ public class VCFHeader implements Serializable {
      * Remove all lines with a VCF version tag from the provided set of header lines
      */
     private void removeVCFVersionLines( final Set<VCFHeaderLine> headerLines ) {
-        final List<VCFHeaderLine> toRemove = new ArrayList<VCFHeaderLine>();
+        final List<VCFHeaderLine> toRemove = new ArrayList<>();
         for (final VCFHeaderLine line : headerLines) {
             if (VCFHeaderVersion.isFormatString(line.getKey())) {
                 toRemove.add(line);
@@ -385,7 +385,7 @@ public class VCFHeader implements Serializable {
      * @return a set of the header fields, in order
      */
     public Set<HEADER_FIELDS> getHeaderFields() {
-        return new LinkedHashSet<HEADER_FIELDS>(Arrays.asList(HEADER_FIELDS.values()));
+        return new LinkedHashSet<>(Arrays.asList(HEADER_FIELDS.values()));
     }
 
     /**
@@ -398,11 +398,11 @@ public class VCFHeader implements Serializable {
     }
 
     public Set<VCFHeaderLine> getMetaDataInSortedOrder() {
-        return makeGetMetaDataSet(new TreeSet<VCFHeaderLine>(mMetaData));
+        return makeGetMetaDataSet(new TreeSet<>(mMetaData));
     }
 
     private static Set<VCFHeaderLine> makeGetMetaDataSet(final Set<VCFHeaderLine> headerLinesInSomeOrder) {
-        final Set<VCFHeaderLine> lines = new LinkedHashSet<VCFHeaderLine>();
+        final Set<VCFHeaderLine> lines = new LinkedHashSet<>();
         lines.add(new VCFHeaderLine(VCFHeaderVersion.VCF4_2.getFormatString(), VCFHeaderVersion.VCF4_2.getVersionString()));
         lines.addAll(headerLinesInSomeOrder);
         return Collections.unmodifiableSet(lines);

--- a/src/main/java/htsjdk/variant/vcf/VCFHeaderLineTranslator.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeaderLineTranslator.java
@@ -39,7 +39,7 @@ public class VCFHeaderLineTranslator {
     private static Map<VCFHeaderVersion,VCFLineParser> mapping;
 
     static {
-        mapping = new HashMap<VCFHeaderVersion,VCFLineParser>();
+        mapping = new HashMap<>();
         mapping.put(VCFHeaderVersion.VCF4_0,new VCF4Parser());
         mapping.put(VCFHeaderVersion.VCF4_1,new VCF4Parser());
         mapping.put(VCFHeaderVersion.VCF4_2,new VCF4Parser());
@@ -69,7 +69,7 @@ class VCF4Parser implements VCFLineParser {
      */
     public Map<String, String> parseLine(String valueLine, List<String> expectedTagOrder) {
         // our return map
-        Map<String, String> ret = new LinkedHashMap<String, String>();
+        Map<String, String> ret = new LinkedHashMap<>();
 
         // a builder to store up characters as we go
         StringBuilder builder = new StringBuilder();
@@ -147,7 +147,7 @@ class VCF3Parser implements VCFLineParser {
 
     public Map<String, String> parseLine(String valueLine, List<String> expectedTagOrder) {
         // our return map
-        Map<String, String> ret = new LinkedHashMap<String, String>();
+        Map<String, String> ret = new LinkedHashMap<>();
 
         // a builder to store up characters as we go
         StringBuilder builder = new StringBuilder();

--- a/src/main/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
@@ -38,7 +38,7 @@ import java.util.Map;
 public class VCFSimpleHeaderLine extends VCFHeaderLine implements VCFIDHeaderLine {
 
     private String name;
-    private Map<String, String> genericFields = new LinkedHashMap<String, String>();
+    private Map<String, String> genericFields = new LinkedHashMap<>();
 
     /**
      * create a VCF filter header line
@@ -49,7 +49,7 @@ public class VCFSimpleHeaderLine extends VCFHeaderLine implements VCFIDHeaderLin
      */
     public VCFSimpleHeaderLine(String key, String name, String description) {
         super(key, "");
-        Map<String, String> map = new LinkedHashMap<String, String>(1);
+        Map<String, String> map = new LinkedHashMap<>(1);
         map.put("Description", description);
         initialize(name, map);
     }
@@ -93,7 +93,7 @@ public class VCFSimpleHeaderLine extends VCFHeaderLine implements VCFIDHeaderLin
     }
 
     protected String toStringEncoding() {
-        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("ID", name);
         map.putAll(genericFields);
         return getKey() + "=" + VCFHeaderLine.toStringEncoding(map);

--- a/src/main/java/htsjdk/variant/vcf/VCFStandardHeaderLines.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFStandardHeaderLines.java
@@ -52,15 +52,15 @@ public class VCFStandardHeaderLines {
      * Enabling this causes us to repair header lines even if only their descriptions differ.
      */
     private final static boolean REPAIR_BAD_DESCRIPTIONS = false;
-    private static Standards<VCFFormatHeaderLine> formatStandards = new Standards<VCFFormatHeaderLine>();
-    private static Standards<VCFInfoHeaderLine> infoStandards = new Standards<VCFInfoHeaderLine>();
+    private static Standards<VCFFormatHeaderLine> formatStandards = new Standards<>();
+    private static Standards<VCFInfoHeaderLine> infoStandards = new Standards<>();
 
     /**
      * Walks over the VCF header and repairs the standard VCF header lines in it, returning a freshly
      * allocated {@link VCFHeader} with standard VCF header lines repaired as necessary.
      */
     public static VCFHeader repairStandardHeaderLines(final VCFHeader header) {
-        final Set<VCFHeaderLine> newLines = new LinkedHashSet<VCFHeaderLine>(header.getMetaDataInInputOrder().size());
+        final Set<VCFHeaderLine> newLines = new LinkedHashSet<>(header.getMetaDataInInputOrder().size());
         for ( VCFHeaderLine line : header.getMetaDataInInputOrder() ) {
             if ( line instanceof VCFFormatHeaderLine ) {
                 line = formatStandards.repair((VCFFormatHeaderLine) line);
@@ -174,7 +174,7 @@ public class VCFStandardHeaderLines {
     }
 
     private static class Standards<T extends VCFCompoundHeaderLine> {
-        private final Map<String, T> standards = new HashMap<String, T>();
+        private final Map<String, T> standards = new HashMap<>();
 
         public T repair(final T line) {
             final T standard = get(line.getID(), false);
@@ -203,7 +203,7 @@ public class VCFStandardHeaderLines {
         }
 
         public Set<String> addToHeader(final Set<VCFHeaderLine> headerLines, final Collection<String> IDs, final boolean throwErrorForMissing) {
-            final Set<String> missing = new HashSet<String>();
+            final Set<String> missing = new HashSet<>();
             for ( final String ID : IDs ) {
                 final T line = get(ID, throwErrorForMissing);
                 if ( line == null )

--- a/src/main/java/htsjdk/variant/vcf/VCFUtils.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFUtils.java
@@ -46,7 +46,7 @@ public class VCFUtils {
     public static Set<VCFHeaderLine> smartMergeHeaders(final Collection<VCFHeader> headers, final boolean emitWarnings) throws IllegalStateException {
         // We need to maintain the order of the VCFHeaderLines, otherwise they will be scrambled in the returned Set.
         // This will cause problems for VCFHeader.getSequenceDictionary and anything else that implicitly relies on the line ordering.
-        final TreeMap<String, VCFHeaderLine> map = new TreeMap<String, VCFHeaderLine>(); // from KEY.NAME -> line
+        final TreeMap<String, VCFHeaderLine> map = new TreeMap<>(); // from KEY.NAME -> line
         final HeaderConflictWarner conflictWarner = new HeaderConflictWarner(emitWarnings);
 
         // todo -- needs to remove all version headers from sources and add its own VCF version line
@@ -107,7 +107,7 @@ public class VCFUtils {
             }
         }
         // returning a LinkedHashSet so that ordering will be preserved. Ensures the contig lines do not get scrambled.
-        return new LinkedHashSet<VCFHeaderLine>(map.values());
+        return new LinkedHashSet<>(map.values());
     }
 
     /**
@@ -126,7 +126,7 @@ public class VCFUtils {
     }
 
     public static Set<VCFHeaderLine> withUpdatedContigsAsLines(final Set<VCFHeaderLine> oldLines, final File referenceFile, final SAMSequenceDictionary refDict, final boolean referenceNameOnly) {
-        final Set<VCFHeaderLine> lines = new LinkedHashSet<VCFHeaderLine>(oldLines.size());
+        final Set<VCFHeaderLine> lines = new LinkedHashSet<>(oldLines.size());
 
         for ( final VCFHeaderLine line : oldLines ) {
             if ( line instanceof VCFContigHeaderLine )
@@ -161,7 +161,7 @@ public class VCFUtils {
      */
     public static List<VCFContigHeaderLine> makeContigHeaderLines(final SAMSequenceDictionary refDict,
                                                                   final File referenceFile) {
-        final List<VCFContigHeaderLine> lines = new ArrayList<VCFContigHeaderLine>();
+        final List<VCFContigHeaderLine> lines = new ArrayList<>();
         final String assembly = referenceFile != null ? getReferenceAssembly(referenceFile.getName()) : null;
         for ( final SAMSequenceRecord contig : refDict.getSequences() )
             lines.add(makeContigHeaderLine(contig, assembly));
@@ -169,7 +169,7 @@ public class VCFUtils {
     }
 
     private static VCFContigHeaderLine makeContigHeaderLine(final SAMSequenceRecord contig, final String assembly) {
-        final Map<String, String> map = new LinkedHashMap<String, String>(3);
+        final Map<String, String> map = new LinkedHashMap<>(3);
         map.put("ID", contig.getSequenceName());
         map.put("length", String.valueOf(contig.getSequenceLength()));
         if ( assembly != null ) map.put("assembly", assembly);
@@ -193,7 +193,7 @@ public class VCFUtils {
     /** Only displays a warning if warnings are enabled and an identical warning hasn't been already issued */
     private static final class HeaderConflictWarner {
         boolean emitWarnings;
-        Set<String> alreadyIssued = new HashSet<String>();
+        Set<String> alreadyIssued = new HashSet<>();
 
         private HeaderConflictWarner( final boolean emitWarnings ) {
             this.emitWarnings = emitWarnings;

--- a/src/test/java/htsjdk/samtools/BAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileIndexTest.java
@@ -238,8 +238,8 @@ public class BAMFileIndexTest {
         final List<String> referenceNames = getReferenceNames(BAM_FILE);
 
         final QueryInterval[] intervals = generateRandomIntervals(referenceNames.size(), 1000, new Random());
-        final Set<SAMRecord> multiIntervalRecords = new HashSet<SAMRecord>();
-        final Set<SAMRecord> singleIntervalRecords = new HashSet<SAMRecord>();
+        final Set<SAMRecord> multiIntervalRecords = new HashSet<>();
+        final Set<SAMRecord> singleIntervalRecords = new HashSet<>();
         final SamReader reader = SamReaderFactory.makeDefault().open(BAM_FILE);
         for (final QueryInterval interval : intervals) {
             consumeAll(singleIntervalRecords, reader.query(referenceNames.get(interval.referenceIndex), interval.start, interval.end, contained));
@@ -372,7 +372,7 @@ public class BAMFileIndexTest {
 
     private List<String> getReferenceNames(final File bamFile) {
         final SamReader reader = SamReaderFactory.makeDefault().open(bamFile);
-        final List<String> result = new ArrayList<String>();
+        final List<String> result = new ArrayList<>();
         final List<SAMSequenceRecord> seqRecords = reader.getFileHeader().getSequenceDictionary().getSequences();
         for (final SAMSequenceRecord seqRecord : seqRecords) {
             if (seqRecord.getSequenceName() != null) {

--- a/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
+++ b/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
@@ -137,7 +137,7 @@ public class BAMRemoteFileTest {
 
         final SamReader reader = SamReaderFactory.makeDefault().open(SamInputResource.of(bamFile.openStream()));
 
-        final List<String> result = new ArrayList<String>();
+        final List<String> result = new ArrayList<>();
         final List<SAMSequenceRecord> seqRecords = reader.getFileHeader().getSequenceDictionary().getSequences();
         for (final SAMSequenceRecord seqRecord : seqRecords) {
             if (seqRecord.getSequenceName() != null) {
@@ -159,8 +159,8 @@ public class BAMRemoteFileTest {
         final Iterator<SAMRecord> iter1 = reader1.query(sequence, startPos, endPos, contained);
         final Iterator<SAMRecord> iter2 = reader2.query(sequence, startPos, endPos, contained);
 
-        final List<SAMRecord> records1 = new ArrayList<SAMRecord>();
-        final List<SAMRecord> records2 = new ArrayList<SAMRecord>();
+        final List<SAMRecord> records1 = new ArrayList<>();
+        final List<SAMRecord> records2 = new ArrayList<>();
 
         while (iter1.hasNext()) {
             records1.add(iter1.next());

--- a/src/test/java/htsjdk/samtools/CRAMComplianceTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMComplianceTest.java
@@ -83,7 +83,7 @@ public class CRAMComplianceTest {
         SamReader reader = SamReaderFactory.make().validationStringency(ValidationStringency.SILENT).open(t.bamFile);
 
         final SAMRecordIterator samRecordIterator = reader.iterator();
-        List<SAMRecord> samRecords = new ArrayList<SAMRecord>();
+        List<SAMRecord> samRecords = new ArrayList<>();
         while (samRecordIterator.hasNext())
             samRecords.add(samRecordIterator.next());
         SAMFileHeader samFileHeader = reader.getFileHeader();

--- a/src/test/java/htsjdk/samtools/CRAMContainerStreamWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMContainerStreamWriterTest.java
@@ -31,7 +31,7 @@ public class CRAMContainerStreamWriterTest {
     }
 
     private List<SAMRecord> createRecords(int count) {
-        final List<SAMRecord> list = new ArrayList<SAMRecord>(count);
+        final List<SAMRecord> list = new ArrayList<>(count);
         final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         if (builder.getHeader().getReadGroups().isEmpty()) {
             throw new IllegalStateException("Read group expected in the header");

--- a/src/test/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
@@ -181,7 +181,7 @@ public class CRAMFileBAIIndexTest {
         Assert.assertNotNull(secondContainer);
         final Map<Integer, AlignmentSpan> references = new ContainerParser(it.getCramHeader().getSamFileHeader()).getReferences(secondContainer, ValidationStringency.STRICT);
         it.close();
-        int refId = new TreeSet<Integer>(references.keySet()).iterator().next();
+        int refId = new TreeSet<>(references.keySet()).iterator().next();
         final AlignmentSpan alignmentSpan = references.get(refId);
 
         CRAMFileReader reader = new CRAMFileReader(new ByteArraySeekableStream(cramBytes), new ByteArraySeekableStream(baiBytes), source, ValidationStringency.SILENT);

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
@@ -73,7 +73,7 @@ public class CRAMFileWriterTest {
     }
 
     private void unmappedSequenceAndQualityFieldHelper(boolean unmappedHasBasesAndQualities) throws Exception {
-        List<SAMRecord> list = new ArrayList<SAMRecord>(2);
+        List<SAMRecord> list = new ArrayList<>(2);
         final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         if (builder.getHeader().getReadGroups().isEmpty()) {
             throw new Exception("Read group expected in the header");
@@ -92,7 +92,7 @@ public class CRAMFileWriterTest {
     }
 
     private List<SAMRecord> createRecords(int count) {
-        List<SAMRecord> list = new ArrayList<SAMRecord>(count);
+        List<SAMRecord> list = new ArrayList<>(count);
         final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         if (builder.getHeader().getReadGroups().isEmpty()) {
             throw new IllegalStateException("Read group expected in the header");
@@ -233,7 +233,7 @@ public class CRAMFileWriterTest {
         final ReferenceSource source = new ReferenceSource(new File("src/test/resources/htsjdk/samtools/cram_tlen.fasta"));
         CRAMFileWriter writer = new CRAMFileWriter(baos, source, reader.getFileHeader(), "test.cram");
         SAMRecordIterator iterator = reader.iterator();
-        List<SAMRecord> records = new ArrayList<SAMRecord>();
+        List<SAMRecord> records = new ArrayList<>();
         while (iterator.hasNext()) {
             final SAMRecord record = iterator.next();
             writer.addAlignment(record);

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterWithIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterWithIndexTest.java
@@ -182,7 +182,7 @@ public class CRAMFileWriterWithIndexTest {
             }
         }
 
-        List<SAMRecord> list = new ArrayList<SAMRecord>(readPairsPerSequence);
+        List<SAMRecord> list = new ArrayList<>(readPairsPerSequence);
         list.addAll(builder.getRecords());
         Collections.sort(list, new SAMRecordCoordinateComparator());
 

--- a/src/test/java/htsjdk/samtools/DownsamplingIteratorTests.java
+++ b/src/test/java/htsjdk/samtools/DownsamplingIteratorTests.java
@@ -46,7 +46,7 @@ public class DownsamplingIteratorTests {
 
             for (final double p : new double[]{0, 0.01, 0.1, 0.5, 0.9, 1}) {
                 final DownsamplingIterator iterator = DownsamplingIteratorFactory.make(recs.iterator(), strategy, p, accuracy, 42);
-                final List<SAMRecord> out = new ArrayList<SAMRecord>();
+                final List<SAMRecord> out = new ArrayList<>();
                 while (iterator.hasNext()) out.add(iterator.next());
 
                 final String testcase = name + ": strategy=" + strategy.name() + ", p=" + p + ", accuracy=" + accuracy;

--- a/src/test/java/htsjdk/samtools/DuplicateSetIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/DuplicateSetIteratorTest.java
@@ -48,7 +48,7 @@ public class DuplicateSetIteratorTest {
         records.addFrag("UNSS0", 1, 1, false, true, "50M", null, DEFAULT_BASE_QUALITY, true, true);
         records.addFrag("UNSS1", 1, 1, false, true, "50M", null, DEFAULT_BASE_QUALITY, true, true);
 
-        Map<String, DuplicateSet> allSets = new HashMap<String, DuplicateSet>();
+        Map<String, DuplicateSet> allSets = new HashMap<>();
 
         DuplicateSetIterator duplicateSetIterator = new DuplicateSetIterator(records.iterator(), getSAMRecordSetBuilder().getHeader(), false);
         while (duplicateSetIterator.hasNext()) {

--- a/src/test/java/htsjdk/samtools/MergingSamRecordIteratorGroupCollisionTest.java
+++ b/src/test/java/htsjdk/samtools/MergingSamRecordIteratorGroupCollisionTest.java
@@ -68,11 +68,11 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         adapter.setBuilderGroup(builder2, group1);
         builder2.addFrag("read2", 19, 28833, addReadGroup);
 
-        final List<SamReader> readers = new ArrayList<SamReader>();
+        final List<SamReader> readers = new ArrayList<>();
         readers.add(builder1.getSamReader());
         readers.add(builder2.getSamReader());
 
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         headers.add(readers.get(0).getFileHeader());
         headers.add(readers.get(1).getFileHeader());
 
@@ -103,11 +103,11 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         adapter.setBuilderGroup(builder2, group1);
         builder2.addFrag("read2", 19, 28833, addReadGroup);
 
-        final List<SamReader> readers = new ArrayList<SamReader>();
+        final List<SamReader> readers = new ArrayList<>();
         readers.add(builder1.getSamReader());
         readers.add(builder2.getSamReader());
 
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         headers.add(readers.get(0).getFileHeader());
         headers.add(readers.get(1).getFileHeader());
 
@@ -138,11 +138,11 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         adapter.setBuilderGroup(builder2, group1);
         builder2.addFrag("read2", 19, 28833, addReadGroup);
 
-        final List<SamReader> readers = new ArrayList<SamReader>();
+        final List<SamReader> readers = new ArrayList<>();
         readers.add(builder1.getSamReader());
         readers.add(builder2.getSamReader());
 
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         headers.add(readers.get(0).getFileHeader());
         headers.add(readers.get(1).getFileHeader());
 
@@ -173,11 +173,11 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         adapter.setBuilderGroup(builder2, group1);
         builder2.addFrag("read2", 19, 28833, addReadGroup);
 
-        final List<SamReader> readers = new ArrayList<SamReader>();
+        final List<SamReader> readers = new ArrayList<>();
         readers.add(builder1.getSamReader());
         readers.add(builder2.getSamReader());
 
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         headers.add(readers.get(0).getFileHeader());
         headers.add(readers.get(1).getFileHeader());
 
@@ -236,11 +236,11 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         builder2.setProgramRecord(null);
         builder2.addFrag("read3", 19, 28833, false);
 
-        final List<SamReader> readers = new ArrayList<SamReader>();
+        final List<SamReader> readers = new ArrayList<>();
         readers.add(builder1.getSamReader());
         readers.add(builder2.getSamReader());
 
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         headers.add(readers.get(0).getFileHeader());
         headers.add(readers.get(1).getFileHeader());
 
@@ -305,12 +305,12 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         builder3.addFrag("read3", 19, 28833, false);
 
 
-        final List<SamReader> readers = new ArrayList<SamReader>();
+        final List<SamReader> readers = new ArrayList<>();
         readers.add(builder1.getSamReader());
         readers.add(builder2.getSamReader());
         readers.add(builder3.getSamReader());
 
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         headers.add(readers.get(0).getFileHeader());
         headers.add(readers.get(1).getFileHeader());
         headers.add(readers.get(2).getFileHeader());
@@ -356,11 +356,11 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         builder2.setReadGroup(createSAMReadGroupRecord("a2.4"));    //collision
         builder2.addFrag("read1", 20, 28833, false);
 
-        final List<SamReader> readers = new ArrayList<SamReader>();
+        final List<SamReader> readers = new ArrayList<>();
         readers.add(builder1.getSamReader());
         readers.add(builder2.getSamReader());
 
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         headers.add(readers.get(0).getFileHeader());
         headers.add(readers.get(1).getFileHeader());
 
@@ -437,17 +437,17 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         }
 
         List<? extends AbstractSAMHeaderRecord> createGroups(final String[] groupIds) {
-            final List<SamReader> readers = new ArrayList<SamReader>();
+            final List<SamReader> readers = new ArrayList<>();
             for (final String groupId : groupIds) {
                 final SamReader samReader = newFileReader();
-                final List<SAMProgramRecord> records = new ArrayList<SAMProgramRecord>();
+                final List<SAMProgramRecord> records = new ArrayList<>();
                 final SAMProgramRecord record = new SAMProgramRecord(groupId);
                 records.add(record);
                 samReader.getFileHeader().setProgramRecords(records);
                 readers.add(samReader);
             }
 
-            final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+            final List<SAMFileHeader> headers = new ArrayList<>();
             for (final SamReader reader : readers) {
                 headers.add(reader.getFileHeader());
             }
@@ -488,17 +488,17 @@ public class MergingSamRecordIteratorGroupCollisionTest {
         }
 
         List<? extends AbstractSAMHeaderRecord> createGroups(final String[] groupIds) {
-            final List<SamReader> readers = new ArrayList<SamReader>();
+            final List<SamReader> readers = new ArrayList<>();
 
             for (final String groupId : groupIds) {
                 final SamReader samReader = newFileReader();
-                final List<SAMReadGroupRecord> records = new ArrayList<SAMReadGroupRecord>();
+                final List<SAMReadGroupRecord> records = new ArrayList<>();
                 final SAMReadGroupRecord record = new SAMReadGroupRecord(groupId);
                 records.add(record);
                 samReader.getFileHeader().setReadGroups(records);
                 readers.add(samReader);
             }
-            final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+            final List<SAMFileHeader> headers = new ArrayList<>();
             for (final SamReader reader : readers) {
                 headers.add(reader.getFileHeader());
             }

--- a/src/test/java/htsjdk/samtools/MergingSamRecordIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/MergingSamRecordIteratorTest.java
@@ -58,11 +58,11 @@ public class MergingSamRecordIteratorTest {
         samReader2.getFileHeader().setSortOrder(SAMFileHeader.SortOrder.coordinate);
 
 
-        final List<SamReader> readerList = new ArrayList<SamReader>();
+        final List<SamReader> readerList = new ArrayList<>();
         readerList.add(samReader);
         readerList.add(samReader2);
 
-        final List<SAMFileHeader> headerList = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headerList = new ArrayList<>();
         headerList.add(samReader.getFileHeader());
         headerList.add(samReader2.getFileHeader());
 
@@ -102,11 +102,11 @@ public class MergingSamRecordIteratorTest {
         final SamReader samReader2 = builder2.getSamReader();
 
 
-        final List<SamReader> readerList = new ArrayList<SamReader>();
+        final List<SamReader> readerList = new ArrayList<>();
         readerList.add(samReader);
         readerList.add(samReader2);
 
-        final List<SAMFileHeader> headerList = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headerList = new ArrayList<>();
         headerList.add(samReader.getFileHeader());
         headerList.add(samReader2.getFileHeader());
 
@@ -146,11 +146,11 @@ public class MergingSamRecordIteratorTest {
         final SamReader samReader2 = builder2.getSamReader();
 
 
-        final List<SamReader> readerList = new ArrayList<SamReader>();
+        final List<SamReader> readerList = new ArrayList<>();
         readerList.add(samReader);
         readerList.add(samReader2);
 
-        final List<SAMFileHeader> headerList = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headerList = new ArrayList<>();
         headerList.add(samReader.getFileHeader());
         headerList.add(samReader2.getFileHeader());
 
@@ -196,11 +196,11 @@ public class MergingSamRecordIteratorTest {
         samReader2.getFileHeader().addSequence(sRec);
 
 
-        final List<SamReader> readerList = new ArrayList<SamReader>();
+        final List<SamReader> readerList = new ArrayList<>();
         readerList.add(samReader);
         readerList.add(samReader2);
 
-        final List<SAMFileHeader> headerList = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headerList = new ArrayList<>();
         headerList.add(samReader.getFileHeader());
         headerList.add(samReader2.getFileHeader());
 
@@ -227,11 +227,11 @@ public class MergingSamRecordIteratorTest {
         builder2.addFrag("read_28833_29006_6945", 20, 30000, false); // ok
         builder2.addFrag("read_28701_28881_323c", 22, 28835, false); // ok
 
-        final List<SamReader> readerList = new ArrayList<SamReader>();
+        final List<SamReader> readerList = new ArrayList<>();
         readerList.add(samReader);
         readerList.add(samReader2);
 
-        final List<SAMFileHeader> headerList = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headerList = new ArrayList<>();
         headerList.add(samReader.getFileHeader());
         headerList.add(samReader2.getFileHeader());
 
@@ -245,7 +245,7 @@ public class MergingSamRecordIteratorTest {
     public void testHeaderCommentMerge() throws Exception {
         final String[] comments1 = {"@CO\tHi, Mom!", "@CO\tHi, Dad!"};
         final String[] comments2 = {"@CO\tHello, World!", "@CO\tGoodbye, Cruel World!"};
-        final Set<String> bothComments = new HashSet<String>();
+        final Set<String> bothComments = new HashSet<>();
         bothComments.addAll(Arrays.asList(comments1));
         bothComments.addAll(Arrays.asList(comments2));
         final SAMRecordSetBuilder builder1 = new SAMRecordSetBuilder(false, SAMFileHeader.SortOrder.coordinate);
@@ -293,10 +293,10 @@ public class MergingSamRecordIteratorTest {
         // get a merging iterator with a merged header
         final SamReader samReader1 = builder1.getSamReader();
         final SamReader samReader2 = builder2.getSamReader();
-        final List<SamReader> readerList = new ArrayList<SamReader>();
+        final List<SamReader> readerList = new ArrayList<>();
         readerList.add(samReader1);
         readerList.add(samReader2);
-        final List<SAMFileHeader> headerList = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headerList = new ArrayList<>();
         headerList.add(samReader1.getFileHeader());
         headerList.add(samReader2.getFileHeader());
         final SamFileHeaderMerger samFileHeaderMerger = new SamFileHeaderMerger(SAMFileHeader.SortOrder.coordinate, headerList, true);

--- a/src/test/java/htsjdk/samtools/SAMIntegerTagTest.java
+++ b/src/test/java/htsjdk/samtools/SAMIntegerTagTest.java
@@ -275,7 +275,7 @@ public class SAMIntegerTagTest {
                 .open(inputFile);
 
         final SAMRecord rec = reader.iterator().next();
-        final Map<String, Number> expectedTags = new HashMap<String, Number>();
+        final Map<String, Number> expectedTags = new HashMap<>();
         expectedTags.put("SB", -128);
         expectedTags.put("UB", 129);
         expectedTags.put("SS", 32767);
@@ -292,7 +292,7 @@ public class SAMIntegerTagTest {
 
     @DataProvider(name = "valid_set")
     public static Object[][] valid_set() {
-        List<Object[]> params = new ArrayList<Object[]>();
+        List<Object[]> params = new ArrayList<>();
         for (FORMAT format:FORMAT.values()) {
             for (ValidationStringency stringency:ValidationStringency.values()) {
                 params.add(new Object[]{0, format, stringency});
@@ -313,7 +313,7 @@ public class SAMIntegerTagTest {
 
     @DataProvider(name = "invalid_set")
     public static Object[][] invalid_set() {
-        List<Object[]> params = new ArrayList<Object[]>();
+        List<Object[]> params = new ArrayList<>();
         for (FORMAT format:FORMAT.values()) {
             for (ValidationStringency stringency:ValidationStringency.values()) {
                 params.add(new Object[]{(long)Integer.MIN_VALUE -1L, format, stringency});

--- a/src/test/java/htsjdk/samtools/SAMTextWriterTest.java
+++ b/src/test/java/htsjdk/samtools/SAMTextWriterTest.java
@@ -83,7 +83,7 @@ public class SAMTextWriterTest {
         SamReader inputSAM = recordSetBuilder.getSamReader();
         final File samFile = File.createTempFile("tmp.", ".sam");
         samFile.deleteOnExit();
-        final Map<String, Object> tagMap = new HashMap<String, Object>();
+        final Map<String, Object> tagMap = new HashMap<>();
         tagMap.put("XC", new Character('q'));
         tagMap.put("XI", 12345);
         tagMap.put("XF", 1.2345f);

--- a/src/test/java/htsjdk/samtools/SamFileHeaderMergerTest.java
+++ b/src/test/java/htsjdk/samtools/SamFileHeaderMergerTest.java
@@ -67,7 +67,7 @@ public class SamFileHeaderMergerTest {
     public void testMergedException() {
         File INPUT[] = {new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/Chromosome1to10.bam"),
                 new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/Chromosome5to9.bam")};
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         for (final File inFile : INPUT) {
             IOUtil.assertFileIsReadable(inFile);
             headers.add(SamReaderFactory.makeDefault().getFileHeader(inFile));
@@ -80,8 +80,8 @@ public class SamFileHeaderMergerTest {
     public void testMerging() {
         File INPUT[] = {new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/Chromosome1to10.bam"),
                 new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/Chromosome5to9.bam")};
-        final List<SamReader> readers = new ArrayList<SamReader>();
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SamReader> readers = new ArrayList<>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         for (final File inFile : INPUT) {
             IOUtil.assertFileIsReadable(inFile);
             // We are now checking for zero-length reads, so suppress complaint about that.
@@ -96,7 +96,7 @@ public class SamFileHeaderMergerTest {
         headerMerger.getMergedHeader();
 
         // count the total reads, and record read counts for each sequence
-        Map<Integer, Integer> seqCounts = new HashMap<Integer, Integer>();
+        Map<Integer, Integer> seqCounts = new HashMap<>();
         int totalCount = 0;
 
         while (iterator.hasNext()) {
@@ -160,8 +160,8 @@ public class SamFileHeaderMergerTest {
             expected_output += line + "\n";
         }
 
-        final List<SamReader> readers = new ArrayList<SamReader>();
-        final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
+        final List<SamReader> readers = new ArrayList<>();
+        final List<SAMFileHeader> headers = new ArrayList<>();
         for (final File inFile : inputFiles) {
             IOUtil.assertFileIsReadable(inFile);
 
@@ -205,7 +205,7 @@ public class SamFileHeaderMergerTest {
 
     private static final boolean headersEquivalent(String a, String b) {
         if (a.length() != b.length()) return false;
-        List<String> remaining = new LinkedList<String>(Arrays.asList(a.split("\\t")));
+        List<String> remaining = new LinkedList<>(Arrays.asList(a.split("\\t")));
         for (final String item : b.split("\\t")) {
             if (!remaining.remove(item)) return false;
         }
@@ -259,7 +259,7 @@ public class SamFileHeaderMergerTest {
 
     @Test(dataProvider = "fourDigitBase36StrPositiveData")
     public void fourDigitBase36StrPositiveTest(final int toConvert, final String expectedValue) {
-        final SamFileHeaderMerger headerMerger = new SamFileHeaderMerger(SAMFileHeader.SortOrder.coordinate, new ArrayList<SAMFileHeader>(), true);
+        final SamFileHeaderMerger headerMerger = new SamFileHeaderMerger(SAMFileHeader.SortOrder.coordinate, new ArrayList<>(), true);
         Assert.assertEquals(expectedValue, headerMerger.positiveFourDigitBase36Str(toConvert));
     }
 }

--- a/src/test/java/htsjdk/samtools/SamHeaderRecordComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SamHeaderRecordComparatorTest.java
@@ -46,26 +46,26 @@ public class SamHeaderRecordComparatorTest {
 
 	@Test(dataProvider="UsualSuspects")
 	public void testEqualRecords(final SAMReadGroupRecord left, final SAMReadGroupRecord right) {
-		final SAMHeaderRecordComparator<SAMReadGroupRecord> comparator = new SAMHeaderRecordComparator<SAMReadGroupRecord>(SAMReadGroupRecord.PLATFORM_UNIT_TAG);
+		final SAMHeaderRecordComparator<SAMReadGroupRecord> comparator = new SAMHeaderRecordComparator<>(SAMReadGroupRecord.PLATFORM_UNIT_TAG);
 		Assert.assertEquals(0, comparator.compare(left, left)); // see what I did there?
 	}
 
 	@Test(dataProvider="UsualSuspects")
 	public void testUnequalRecords(final SAMReadGroupRecord left, final SAMReadGroupRecord right) {
-		final SAMHeaderRecordComparator<SAMReadGroupRecord> comparator = new SAMHeaderRecordComparator<SAMReadGroupRecord>(SAMReadGroupRecord.PLATFORM_UNIT_TAG);
+		final SAMHeaderRecordComparator<SAMReadGroupRecord> comparator = new SAMHeaderRecordComparator<>(SAMReadGroupRecord.PLATFORM_UNIT_TAG);
 		Assert.assertTrue(comparator.compare(left, right) < 0);
 		Assert.assertTrue(comparator.compare(right, left) > 0);
 	}
 
 	@Test(dataProvider="UsualSuspects")
 	public void testNullAttributes(final SAMReadGroupRecord left, final SAMReadGroupRecord right) {
-		final SAMHeaderRecordComparator<SAMReadGroupRecord> comparator = new SAMHeaderRecordComparator<SAMReadGroupRecord>(SAMReadGroupRecord.FLOW_ORDER_TAG);
+		final SAMHeaderRecordComparator<SAMReadGroupRecord> comparator = new SAMHeaderRecordComparator<>(SAMReadGroupRecord.FLOW_ORDER_TAG);
 		Assert.assertEquals(0, comparator.compare(left, right)); // neither record has this attribute
 	}
 
 	@Test(dataProvider="UsualSuspects")
 	public void testOneNullAttribute(final SAMReadGroupRecord left, final SAMReadGroupRecord right) {
-		final SAMHeaderRecordComparator<SAMReadGroupRecord> comparator = new SAMHeaderRecordComparator<SAMReadGroupRecord>(SAMReadGroupRecord.DESCRIPTION_TAG);
+		final SAMHeaderRecordComparator<SAMReadGroupRecord> comparator = new SAMHeaderRecordComparator<>(SAMReadGroupRecord.DESCRIPTION_TAG);
 		Assert.assertTrue(comparator.compare(left, right) < 0);
 		Assert.assertTrue(comparator.compare(right, left) > 0);
 	}

--- a/src/test/java/htsjdk/samtools/SamPairUtilTest.java
+++ b/src/test/java/htsjdk/samtools/SamPairUtilTest.java
@@ -76,8 +76,8 @@ public class SamPairUtilTest {
         final SAMFileHeader header = new SAMFileHeader();
         header.addSequence(new SAMSequenceRecord("chr1", 100000000));
 
-        final List<SAMRecord> records = new ArrayList<SAMRecord>();
-        final List<String> mateCigarList = new ArrayList<String>();
+        final List<SAMRecord> records = new ArrayList<>();
+        final List<String> mateCigarList = new ArrayList<>();
         final SAMRecord rec;
 
 

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -163,7 +163,7 @@ public class SamReaderFactoryTest {
 
     @DataProvider
     public Object[][] composeAllPermutationsOfSamInputResource() {
-        final List<SamInputResource> sources = new ArrayList<SamInputResource>();
+        final List<SamInputResource> sources = new ArrayList<>();
         for (final InputResource.Type dataType : InputResource.Type.values()) {
             if (dataType.equals(InputResource.Type.SRA_ACCESSION))
                 continue;
@@ -210,8 +210,8 @@ public class SamReaderFactoryTest {
         }
     }
 
-    final Set<SAMFileHeader> observedHeaders = new HashSet<SAMFileHeader>();
-    final Set<List<SAMRecord>> observedRecordOrdering = new HashSet<List<SAMRecord>>();
+    final Set<SAMFileHeader> observedHeaders = new HashSet<>();
+    final Set<List<SAMRecord>> observedRecordOrdering = new HashSet<>();
 
     @Test(dataProvider = "composeAllPermutationsOfSamInputResource")
     public void exhaustInputResourcePermutation(final SamInputResource resource) throws IOException {
@@ -251,9 +251,9 @@ public class SamReaderFactoryTest {
     }
 
 
-    final Set<List<SAMRecord>> observedRecordOrdering1 = new HashSet<List<SAMRecord>>();
-    final Set<List<SAMRecord>> observedRecordOrdering3 = new HashSet<List<SAMRecord>>();
-    final Set<List<SAMRecord>> observedRecordOrdering20 = new HashSet<List<SAMRecord>>();
+    final Set<List<SAMRecord>> observedRecordOrdering1 = new HashSet<>();
+    final Set<List<SAMRecord>> observedRecordOrdering3 = new HashSet<>();
+    final Set<List<SAMRecord>> observedRecordOrdering20 = new HashSet<>();
 
     @Test(dataProvider = "composeAllPermutationsOfSamInputResource")
     public void queryInputResourcePermutation(final SamInputResource resource) throws IOException {

--- a/src/test/java/htsjdk/samtools/SamSpecIntTest.java
+++ b/src/test/java/htsjdk/samtools/SamSpecIntTest.java
@@ -39,7 +39,7 @@ public class SamSpecIntTest {
 
     @Test
     public void testSamIntegers() throws IOException {
-        final List<String> errorMessages = new ArrayList<String>();
+        final List<String> errorMessages = new ArrayList<>();
         final SamReader samReader = SamReaderFactory.makeDefault().open(SAM_INPUT);
         final File bamOutput = File.createTempFile("test", ".bam");
         final File samOutput = File.createTempFile("test", ".sam");
@@ -68,7 +68,7 @@ public class SamSpecIntTest {
 
     @Test
     public void testBamIntegers() throws IOException {
-        final List<String> errorMessages = new ArrayList<String>();
+        final List<String> errorMessages = new ArrayList<>();
         final SamReader bamReader = SamReaderFactory.makeDefault().open(BAM_INPUT);
         final File bamOutput = File.createTempFile("test", ".bam");
         final File samOutput = File.createTempFile("test", ".sam");

--- a/src/test/java/htsjdk/samtools/cram/CRAIEntryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAIEntryTest.java
@@ -91,7 +91,7 @@ public class CRAIEntryTest {
 
     @Test
     public void testCompareTo () {
-        final List<CRAIEntry> list = new ArrayList<CRAIEntry>(2);
+        final List<CRAIEntry> list = new ArrayList<>(2);
         CRAIEntry e1;
         CRAIEntry e2;
 

--- a/src/test/java/htsjdk/samtools/cram/CRAIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAIIndexTest.java
@@ -30,7 +30,7 @@ public class CRAIIndexTest {
 
     @Test
     public void testFind() throws IOException, CloneNotSupportedException {
-        final List<CRAIEntry> index = new ArrayList<CRAIEntry>();
+        final List<CRAIEntry> index = new ArrayList<>();
 
         final int sequenceId = 1;
         CRAIEntry e = new CRAIEntry();
@@ -105,7 +105,7 @@ public class CRAIIndexTest {
     }
 
     private void doCRAITest(BiFunction<SAMSequenceDictionary, List<CRAIEntry>, SeekableStream> getBaiStreamForIndex) throws IOException {
-        final ArrayList<CRAIEntry> index = new ArrayList<CRAIEntry>();
+        final ArrayList<CRAIEntry> index = new ArrayList<>();
         final CRAIEntry entry = new CRAIEntry();
         entry.sequenceId = 0;
         entry.alignmentStart = 1;
@@ -171,7 +171,7 @@ public class CRAIIndexTest {
 
     @Test
     public void testGetLeftmost() throws CloneNotSupportedException {
-        final List<CRAIEntry> index = new ArrayList<CRAIEntry>();
+        final List<CRAIEntry> index = new ArrayList<>();
         Assert.assertNull(CRAIIndex.getLeftmost(index));
 
         final CRAIEntry e1 = new CRAIEntry();
@@ -193,7 +193,7 @@ public class CRAIIndexTest {
 
     @Test
     public void testFindLastAlignedEntry() {
-        final List<CRAIEntry> index = new ArrayList<CRAIEntry>();
+        final List<CRAIEntry> index = new ArrayList<>();
         Assert.assertEquals(-1, CRAIIndex.findLastAlignedEntry(index));
 
         // Scan all allowed combinations of 10 mapped/unmapped entries and assert the found last aligned entry:

--- a/src/test/java/htsjdk/samtools/cram/io/ITF8Test.java
+++ b/src/test/java/htsjdk/samtools/cram/io/ITF8Test.java
@@ -36,7 +36,7 @@ public class ITF8Test {
 
     @DataProvider(name = "testITF8")
     public static Object[][] testValues() {
-        List<Integer> list = new ArrayList<Integer>() ;
+        List<Integer> list = new ArrayList<>() ;
 
         // basics:
         list.add(0);
@@ -78,11 +78,11 @@ public class ITF8Test {
 
     @DataProvider(name = "predefined")
     public static Object[][] predefinedProvider() {
-        List<Tuple<Integer, byte[]>> list = new ArrayList<Tuple<Integer, byte[]>>() ;
-        list.add(new Tuple<Integer, byte[]>(4542278, new byte[]{(byte) (0xFF & 224), 69, 79, 70})) ;
-        list.add(new Tuple<Integer, byte[]>(16384, new byte[]{-64, 64, 0})) ;
-        list.add(new Tuple<Integer, byte[]>(192, new byte[]{-128, -64})) ;
-        list.add(new Tuple<Integer, byte[]>(-4757, new byte[]{-1, -1, -2, -42, 107})) ;
+        List<Tuple<Integer, byte[]>> list = new ArrayList<>() ;
+        list.add(new Tuple<>(4542278, new byte[]{(byte) (0xFF & 224), 69, 79, 70})) ;
+        list.add(new Tuple<>(16384, new byte[]{-64, 64, 0})) ;
+        list.add(new Tuple<>(192, new byte[]{-128, -64})) ;
+        list.add(new Tuple<>(-4757, new byte[]{-1, -1, -2, -42, 107})) ;
 
         Object[][] params = new Object[list.size()][] ;
         for (int i=0; i<params.length; i++)

--- a/src/test/java/htsjdk/samtools/cram/io/LTF8Test.java
+++ b/src/test/java/htsjdk/samtools/cram/io/LTF8Test.java
@@ -34,7 +34,7 @@ public class LTF8Test {
 
     @DataProvider(name = "testLTF8")
     public static Object[][] testValues() {
-        List<Long> list = new ArrayList<Long>() ;
+        List<Long> list = new ArrayList<>() ;
 
         // basics:
         list.add(0L);

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -33,7 +33,7 @@ public class CramCompressionRecordTest {
         r.alignmentStart = 1;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<ReadFeature>();
+        r.readFeatures = new ArrayList<>();
         String softClip = "AAA";
         r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
         Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1 - softClip.length());
@@ -42,7 +42,7 @@ public class CramCompressionRecordTest {
         r.alignmentStart = 1;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<ReadFeature>();
+        r.readFeatures = new ArrayList<>();
         int deletionLength = 5;
         r.readFeatures.add(new Deletion(1, deletionLength));
         Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1 + deletionLength);
@@ -51,7 +51,7 @@ public class CramCompressionRecordTest {
         r.alignmentStart = 1;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<ReadFeature>();
+        r.readFeatures = new ArrayList<>();
         String insertion = "CCCCCCCCCC";
         r.readFeatures.add(new Insertion(1, insertion.getBytes()));
         Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1 - insertion.length());
@@ -61,7 +61,7 @@ public class CramCompressionRecordTest {
         r.alignmentStart = 1;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<ReadFeature>();
+        r.readFeatures = new ArrayList<>();
         r.readFeatures.add(new InsertBase(1, (byte) 'A'));
         Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1 - 1);
     }

--- a/src/test/java/htsjdk/samtools/cram/structure/ReadTagTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/ReadTagTest.java
@@ -90,7 +90,7 @@ public class ReadTagTest {
         // For now, roll our own.
         final Object[][] allArgs = getParallelReadTagData();
         final long timeout = 1000L * 5; // just in case
-        final List<Thread> threads = new ArrayList<Thread>(allArgs.length);
+        final List<Thread> threads = new ArrayList<>(allArgs.length);
         final Map<Object[], Exception> results = Collections.synchronizedMap(new HashMap<Object[], Exception>());
         for (final Object[] argLine: allArgs) {
             threads.add(new Thread() {

--- a/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
+++ b/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
@@ -444,7 +444,7 @@ public class LiftOverTest {
         File outFile = File.createTempFile("test.", ".chain");
         outFile.deleteOnExit();
         PrintWriter pw = new PrintWriter(outFile);
-        final Map<Integer, Chain> originalChainMap = new TreeMap<Integer, Chain>();
+        final Map<Integer, Chain> originalChainMap = new TreeMap<>();
         for (final Chain chain : chains.getAll()) {
             chain.write(pw);
             originalChainMap.put(chain.id, chain);
@@ -452,7 +452,7 @@ public class LiftOverTest {
         pw.close();
 
         final OverlapDetector<Chain> newChains = Chain.loadChains(outFile);
-        final Map<Integer, Chain> newChainMap = new TreeMap<Integer, Chain>();
+        final Map<Integer, Chain> newChainMap = new TreeMap<>();
         for (final Chain chain : newChains.getAll()) {
             newChainMap.put(chain.id, chain);
         }

--- a/src/test/java/htsjdk/samtools/metrics/MetricsFileTest.java
+++ b/src/test/java/htsjdk/samtools/metrics/MetricsFileTest.java
@@ -85,7 +85,7 @@ public class MetricsFileTest {
 
     @Test
     public void testFloatingPointEquality() throws IOException {
-        MetricsFile<FloatingPointMetric,Integer> file = new MetricsFile<FloatingPointMetric,Integer>();
+        MetricsFile<FloatingPointMetric,Integer> file = new MetricsFile<>();
 
         FloatingPointMetric metric = new FloatingPointMetric();
         metric.DOUBLE_PRIMITIVE = .0000000000000000001d;
@@ -103,7 +103,7 @@ public class MetricsFileTest {
 
     @Test
     public void testWriteMetricsFile() throws IOException, ClassNotFoundException {
-        MetricsFile<TestMetric,Integer> file = new MetricsFile<TestMetric,Integer>();
+        MetricsFile<TestMetric,Integer> file = new MetricsFile<>();
         TestMetric metric = new TestMetric();
         metric.STRING_PROP       = "Hello World";
         metric.DATE_PROP         = new FormatUtil().parseDate("2008-12-31");
@@ -146,7 +146,7 @@ public class MetricsFileTest {
         Assert.assertEquals(file, file2);
 
         // Now add a Histogram and make sure it still works
-        Histogram<Integer> histo = new Histogram<Integer>();
+        Histogram<Integer> histo = new Histogram<>();
         histo.setBinLabel("small_number");
         histo.setValueLabel("big_number");
         histo.increment(1, 101);
@@ -203,7 +203,7 @@ public class MetricsFileTest {
         FileWriter out = new FileWriter(f);
         in.write(out);
 
-        MetricsFile<METRIC,Integer> retval = new MetricsFile<METRIC,Integer>();
+        MetricsFile<METRIC,Integer> retval = new MetricsFile<>();
         retval.read(new FileReader(f));
         return retval;
     }

--- a/src/test/java/htsjdk/samtools/reference/FakeReferenceSequenceFile.java
+++ b/src/test/java/htsjdk/samtools/reference/FakeReferenceSequenceFile.java
@@ -17,8 +17,8 @@ import java.util.Map;
  */
 public class FakeReferenceSequenceFile implements
         ReferenceSequenceFile {
-    Map<String, SAMSequenceRecord> map = new HashMap<String, SAMSequenceRecord>();
-    List<String> index= new ArrayList<String>() ;
+    Map<String, SAMSequenceRecord> map = new HashMap<>();
+    List<String> index= new ArrayList<>() ;
     int current = 0;
 
     public FakeReferenceSequenceFile(List<SAMSequenceRecord> sequences) {

--- a/src/test/java/htsjdk/samtools/reference/InMemoryReferenceSequenceFile.java
+++ b/src/test/java/htsjdk/samtools/reference/InMemoryReferenceSequenceFile.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 public class InMemoryReferenceSequenceFile implements
         ReferenceSequenceFile {
-    Map<String, ReferenceSequence> map = new HashMap<String, ReferenceSequence>();
+    Map<String, ReferenceSequence> map = new HashMap<>();
     List<String> index;
     int current = 0;
 

--- a/src/test/java/htsjdk/samtools/sra/SRAReferenceTest.java
+++ b/src/test/java/htsjdk/samtools/sra/SRAReferenceTest.java
@@ -65,7 +65,7 @@ public class SRAReferenceTest extends AbstractSRATest {
     public void testReferenceMt(String acc, List<TestReferenceMtData> parallelTests) throws Exception {
         final ReferenceSequenceFile refSeqFile = new SRAIndexedSequenceFile(new SRAAccession(acc));
         final long timeout = 1000L * 5; // just in case
-        final List<Thread> threads = new ArrayList<Thread>(parallelTests.size());
+        final List<Thread> threads = new ArrayList<>(parallelTests.size());
         final Map<TestReferenceMtData, Exception> runErrors = Collections.synchronizedMap(new HashMap<TestReferenceMtData, Exception>());
         for (final TestReferenceMtData testData: parallelTests) {
             threads.add(new Thread() {

--- a/src/test/java/htsjdk/samtools/util/AsyncBufferedIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/AsyncBufferedIteratorTest.java
@@ -52,7 +52,7 @@ public class AsyncBufferedIteratorTest {
     }
     @Test
     public void testWrapUnderlying() {
-        AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<Integer>(new TestCloseableIterator(new int[] { 0, 1, 2, 3}), 1, 1);
+        AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<>(new TestCloseableIterator(new int[]{0, 1, 2, 3}), 1, 1);
         for (int i = 0; i < 4; i++) {
             Assert.assertEquals(i, (int)abi.next());
         }
@@ -61,7 +61,7 @@ public class AsyncBufferedIteratorTest {
     @Test
     public void testClose() {
         TestCloseableIterator tci = new TestCloseableIterator(new int[] { 0, 1, 2, 3});
-        AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<Integer>(tci, 1, 1);
+        AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<>(tci, 1, 1);
         abi.close();
         Assert.assertTrue(tci.isClosed);
     }
@@ -71,7 +71,7 @@ public class AsyncBufferedIteratorTest {
     @Test
     public void testBackgroundBlocks() throws InterruptedException {
         TestCloseableIterator it = new TestCloseableIterator(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
-        AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<Integer>(it, 3, 2, "testBackgroundBlocks");
+        AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<>(it, 3, 2, "testBackgroundBlocks");
         Assert.assertNotNull(getThreadWithName("testBackgroundBlocks"));
         Thread.sleep(10); // how do we write this test and not be subject to race conditions?
         // should have read 9 records: 2*3 in the buffers, and another 3 read but
@@ -82,7 +82,7 @@ public class AsyncBufferedIteratorTest {
     @Test
     public void testBackgroundThreadCompletes() throws InterruptedException {
         TestCloseableIterator it = new TestCloseableIterator(new int[] { 0, 1, 2, 3, 4, 5 });
-        AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<Integer>(it, 3, 2, "testBackgroundThreadCompletes");
+        AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<>(it, 3, 2, "testBackgroundThreadCompletes");
         Assert.assertNotNull(getThreadWithName("testBackgroundThreadCompletes"));
         // both buffers should be full
         // clear out one buffer so the background thread can write the end of stream indicator

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedFilePointerUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedFilePointerUtilTest.java
@@ -36,7 +36,7 @@ public class BlockCompressedFilePointerUtilTest
     @Test
     public void basicTest() 
     {
-        List<Long> pointers = new ArrayList<Long>();
+        List<Long> pointers = new ArrayList<>();
         pointers.add(makeFilePointer(0, 0));
         pointers.add(makeFilePointer(0, BlockCompressedFilePointerUtil.MAX_OFFSET));
         final long BIG_BLOCK_ADDRESS = 1L << 46;

--- a/src/test/java/htsjdk/samtools/util/CigarUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/CigarUtilTest.java
@@ -48,7 +48,7 @@ public class CigarUtilTest {
                           final String expectedCigar, final int expectedAdjustedStart) throws IOException {
       List<CigarElement> cigar =  TextCigarCodec.decode(inputCigar).getCigarElements();
       if (negativeStrand){
-          List<CigarElement> copiedList = new ArrayList<CigarElement>(cigar);
+          List<CigarElement> copiedList = new ArrayList<>(cigar);
           Collections.reverse(copiedList);
           cigar = copiedList;
       }

--- a/src/test/java/htsjdk/samtools/util/IntervalListTest.java
+++ b/src/test/java/htsjdk/samtools/util/IntervalListTest.java
@@ -397,8 +397,8 @@ public class IntervalListTest {
         //assert that the intervals correspond
         Assert.assertEquals(intervals, compIntervals);
 
-        final List<String> intervalNames = new LinkedList<String>();
-        final List<String> compIntervalNames = new LinkedList<String>();
+        final List<String> intervalNames = new LinkedList<>();
+        final List<String> compIntervalNames = new LinkedList<>();
 
         for (final Interval interval : intervals) {
             intervalNames.add(interval.getName());

--- a/src/test/java/htsjdk/samtools/util/IntervalTreeMapTest.java
+++ b/src/test/java/htsjdk/samtools/util/IntervalTreeMapTest.java
@@ -31,7 +31,7 @@ import java.util.Iterator;
 public class IntervalTreeMapTest {
     @Test
     public void testBasic() {
-        IntervalTreeMap<Interval> m=new IntervalTreeMap<Interval>();
+        IntervalTreeMap<Interval> m= new IntervalTreeMap<>();
 
         Interval chr1Interval = new Interval("chr1", 10,100);
         m.put(chr1Interval, chr1Interval);

--- a/src/test/java/htsjdk/samtools/util/IntervalTreeTest.java
+++ b/src/test/java/htsjdk/samtools/util/IntervalTreeTest.java
@@ -36,7 +36,7 @@ public class IntervalTreeTest {
     public void testNoMatches()
     {
         // Test empty tree
-        final IntervalTree<String> intervalTree = new IntervalTree<String>();
+        final IntervalTree<String> intervalTree = new IntervalTree<>();
         Iterator<IntervalTree.Node<String>> results = intervalTree.overlappers(1, 500);
         Assert.assertEquals(countElements(results), 0, "Testing with no left-hand set failed.");
 
@@ -60,7 +60,7 @@ public class IntervalTreeTest {
     @Test
     public void testMatches()
     {
-        final IntervalTree<String> intervalTree = new IntervalTree<String>();
+        final IntervalTree<String> intervalTree = new IntervalTree<>();
         intervalTree.put(1, 10, "foo1");
         intervalTree.put(2, 9, "foo2");
         intervalTree.put(3, 8, "foo3");
@@ -94,7 +94,7 @@ public class IntervalTreeTest {
     @Test
     public void testNearEnds()
     {
-        final IntervalTree<String> intervalTree = new IntervalTree<String>();
+        final IntervalTree<String> intervalTree = new IntervalTree<>();
         intervalTree.put(10, 20, "foo");
         Assert.assertEquals(countElements(intervalTree.overlappers(10, 10)), 1, "Test overlap (no buffers) at near end exactly");
         Assert.assertEquals(countElements(intervalTree.overlappers(9, 10)), 1, "Test overlap (no buffers) at near end exactly");
@@ -107,7 +107,7 @@ public class IntervalTreeTest {
     @Test
     public void performanceTest()
     {
-        final IntervalTree<String> intervalTree = new IntervalTree<String>();
+        final IntervalTree<String> intervalTree = new IntervalTree<>();
         final long start = System.currentTimeMillis();
         for (int i = 1; i <= 50000; i++)  intervalTree.put(i, i, "frob");
         System.out.println("Time to construct a tree with 50000 nodes: " + (System.currentTimeMillis() - start) + " milliseconds" );
@@ -124,7 +124,7 @@ public class IntervalTreeTest {
     @Test
     public void testHandlingOfDuplicateMappings()
     {
-        final IntervalTree<String> intervalTree = new IntervalTree<String>();
+        final IntervalTree<String> intervalTree = new IntervalTree<>();
         intervalTree.put(1, 10, "foo1");
         // This call replaces foo1 with foo2
         Assert.assertEquals(intervalTree.put(1, 10, "foo2"), "foo1");
@@ -177,7 +177,7 @@ public class IntervalTreeTest {
                 {46379440, 46379674},
                 {46391117, 46391351},
         };
-        IntervalTree<String> intervalTree = new IntervalTree<String>();
+        IntervalTree<String> intervalTree = new IntervalTree<>();
         for (int[] add : adds) {
             intervalTree.put(add[0], add[1], "frob");
         }

--- a/src/test/java/htsjdk/samtools/util/MergingIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/MergingIteratorTest.java
@@ -73,30 +73,30 @@ public class MergingIteratorTest {
 
 	@Test
 	public void testOrderingAndCompleteness() {
-		final Queue<Integer> queueOne = new LinkedList<Integer>();
+		final Queue<Integer> queueOne = new LinkedList<>();
 		queueOne.add(1);
 		queueOne.add(3);
 		queueOne.add(5);
 
-		final Queue<Integer> queueTwo = new LinkedList<Integer>();
+		final Queue<Integer> queueTwo = new LinkedList<>();
 		queueTwo.add(2);
 		queueTwo.add(4);
 		queueTwo.add(6);
 
-		final Queue<Integer> queueThree = new LinkedList<Integer>();
+		final Queue<Integer> queueThree = new LinkedList<>();
 		queueThree.add(0);
 		queueThree.add(1);
 
-		final Collection<CloseableIterator<Integer>> iterators = new ArrayList<CloseableIterator<Integer>>(3);
+		final Collection<CloseableIterator<Integer>> iterators = new ArrayList<>(3);
 		Collections.addAll(
 				iterators,
-				new QueueBackedIterator<Integer>(queueOne),
-				new QueueBackedIterator<Integer>(queueTwo),
-				new QueueBackedIterator<Integer>(queueThree));
+                new QueueBackedIterator<>(queueOne),
+                new QueueBackedIterator<>(queueTwo),
+                new QueueBackedIterator<>(queueThree));
 
-		final MergingIterator<Integer> mergingIterator = new MergingIterator<Integer>(
-				INTEGER_COMPARATOR,
-				iterators);
+		final MergingIterator<Integer> mergingIterator = new MergingIterator<>(
+                INTEGER_COMPARATOR,
+                iterators);
 
 		int count = 0;
 		int last = -1;
@@ -113,7 +113,7 @@ public class MergingIteratorTest {
 
 	@Test
 	public void testIteratorsOfUnevenLength() {
-		final Queue<Integer> queueOne = new LinkedList<Integer>();
+		final Queue<Integer> queueOne = new LinkedList<>();
 		queueOne.add(1);
 		queueOne.add(3);
 		queueOne.add(5);
@@ -122,18 +122,18 @@ public class MergingIteratorTest {
 		queueOne.add(11);
 		queueOne.add(13);
 
-		final Queue<Integer> queueTwo = new LinkedList<Integer>();
+		final Queue<Integer> queueTwo = new LinkedList<>();
 		queueTwo.add(2);
 
-		final Collection<CloseableIterator<Integer>> iterators = new ArrayList<CloseableIterator<Integer>>(3);
+		final Collection<CloseableIterator<Integer>> iterators = new ArrayList<>(3);
 		Collections.addAll(
 				iterators,
-				new QueueBackedIterator<Integer>(queueOne),
-				new QueueBackedIterator<Integer>(queueTwo));
+                new QueueBackedIterator<>(queueOne),
+                new QueueBackedIterator<>(queueTwo));
 
-		final MergingIterator<Integer> mergingIterator = new MergingIterator<Integer>(
-				INTEGER_COMPARATOR,
-				iterators);
+		final MergingIterator<Integer> mergingIterator = new MergingIterator<>(
+                INTEGER_COMPARATOR,
+                iterators);
 
 		int count = 0;
 		int last = -1;
@@ -149,23 +149,23 @@ public class MergingIteratorTest {
 
 	@Test(expectedExceptions = IllegalStateException.class)
 	public void testOutOfOrderIterators() {
-		final Queue<Integer> queueOne = new LinkedList<Integer>();
+		final Queue<Integer> queueOne = new LinkedList<>();
 		queueOne.add(1);
 		queueOne.add(3);
 
-		final Queue<Integer> queueTwo = new LinkedList<Integer>();
+		final Queue<Integer> queueTwo = new LinkedList<>();
 		queueTwo.add(4);
 		queueTwo.add(2);
 
-		final Collection<CloseableIterator<Integer>> iterators = new ArrayList<CloseableIterator<Integer>>(3);
+		final Collection<CloseableIterator<Integer>> iterators = new ArrayList<>(3);
 		Collections.addAll(
 				iterators,
-				new QueueBackedIterator<Integer>(queueOne),
-				new QueueBackedIterator<Integer>(queueTwo));
+                new QueueBackedIterator<>(queueOne),
+                new QueueBackedIterator<>(queueTwo));
 
-		final MergingIterator<Integer> mergingIterator = new MergingIterator<Integer>(
-				INTEGER_COMPARATOR,
-				iterators);
+		final MergingIterator<Integer> mergingIterator = new MergingIterator<>(
+                INTEGER_COMPARATOR,
+                iterators);
 
 		Assert.assertEquals(mergingIterator.next().intValue(), 1);
 		Assert.assertEquals(mergingIterator.next().intValue(), 3);

--- a/src/test/java/htsjdk/samtools/util/SequenceUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/SequenceUtilTest.java
@@ -204,11 +204,11 @@ public class SequenceUtilTest {
 
     @Test(dataProvider = "testKmerGenerationTestCases")
     public void testKmerGeneration(final int length, final String[] expectedKmers) {
-        final Set<String> actualSet = new HashSet<String>();
+        final Set<String> actualSet = new HashSet<>();
         for (final byte[] kmer : SequenceUtil.generateAllKmers(length)) {
             actualSet.add(StringUtil.bytesToString(kmer));
         }
-        final Set<String> expectedSet = new HashSet<String>(Arrays.asList(expectedKmers));
+        final Set<String> expectedSet = new HashSet<>(Arrays.asList(expectedKmers));
         Assert.assertTrue(actualSet.equals(expectedSet));
     }
 

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -28,7 +28,7 @@ public class IndexTest {
 
     @DataProvider(name = "StartProvider")
     public Object[][] makeStartProvider() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
 //        for ( int mid = 0; mid <= end; mid += 1000000 ) {
 //            tests.add(new Object[]{0, mid, mid+1000000, end});

--- a/src/test/java/htsjdk/tribble/index/interval/IntervalTreeTest.java
+++ b/src/test/java/htsjdk/tribble/index/interval/IntervalTreeTest.java
@@ -119,7 +119,7 @@ public class IntervalTreeTest {
     public void testOverlappingFeatures() throws Exception {
         //chr2:179,222,066-179,262,059<- CONTAINS TTN
 
-        Set<String> names = new HashSet<String>(Arrays.asList("Hs.134602", "Hs.620337", "Hs.609465", "Hs.623987",
+        Set<String> names = new HashSet<>(Arrays.asList("Hs.134602", "Hs.620337", "Hs.609465", "Hs.623987",
                 "Hs.594545", "LONG_FEATURE"));
 
         String bedFile = TestUtils.DATA_DIR + "/bed/Unigene.sample.bed";

--- a/src/test/java/htsjdk/tribble/index/linear/LinearIndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/linear/LinearIndexTest.java
@@ -194,7 +194,7 @@ public class LinearIndexTest {
     public void testOverlappingFeatures() throws Exception {
         //chr2:179,222,066-179,262,059<- CONTAINS TTN
 
-        final Set<String> names = new HashSet<String>(Arrays.asList("Hs.134602", "Hs.620337", "Hs.609465", "Hs.623987",
+        final Set<String> names = new HashSet<>(Arrays.asList("Hs.134602", "Hs.620337", "Hs.609465", "Hs.623987",
                 "Hs.594545", "LONG_FEATURE"));
 
         final String bedFile = TestUtils.DATA_DIR + "bed/Unigene.sample.bed";

--- a/src/test/java/htsjdk/tribble/readers/PositionalBufferedStreamTest.java
+++ b/src/test/java/htsjdk/tribble/readers/PositionalBufferedStreamTest.java
@@ -88,7 +88,7 @@ public class PositionalBufferedStreamTest {
 
     @DataProvider(name = "ReadBytesTestData")
     public Object[][] createReadBytesTestData() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         for ( int byteReadSize : Arrays.asList(5, 10, 100, 255) )
             for ( int bufSize : Arrays.asList(1, 10, 100, 1000) )

--- a/src/test/java/htsjdk/tribble/readers/ReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/ReaderTest.java
@@ -138,7 +138,7 @@ public class ReaderTest {
     private void testLineReader(final String lines) throws IOException {
         // read all of the lines into the
         final BufferedReader br = new BufferedReader(new StringReader(lines));
-        final List<String> eachLine = new ArrayList<String>();
+        final List<String> eachLine = new ArrayList<>();
         while (true) {
             final String line = br.readLine();
             if ( line == null ) break;

--- a/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
@@ -32,7 +32,7 @@ public class TabixReaderTest {
     @BeforeClass
     public void setup() throws IOException {
         tabixReader = new TabixReader(tabixFile);
-        sequenceNames = new ArrayList<String>(tabixReader.getChromosomes());
+        sequenceNames = new ArrayList<>(tabixReader.getChromosomes());
     }
 
     @AfterClass

--- a/src/test/java/htsjdk/variant/VariantBaseTest.java
+++ b/src/test/java/htsjdk/variant/VariantBaseTest.java
@@ -81,8 +81,8 @@ public class VariantBaseTest {
     }
 
     public static final <T> void assertEqualsSet(final Set<T> actual, final Set<T> expected, final String info) {
-        final Set<T> actualSet = new HashSet<T>(actual);
-        final Set<T> expectedSet = new HashSet<T>(expected);
+        final Set<T> actualSet = new HashSet<>(actual);
+        final Set<T> expectedSet = new HashSet<>(expected);
         Assert.assertTrue(actualSet.equals(expectedSet), info); // note this is necessary due to testng bug for set comps
     }
 
@@ -108,7 +108,7 @@ public class VariantBaseTest {
         final int[] contigLengths = { 249250621, 243199373, 198022430, 191154276, 180915260, 171115067, 159138663, 146364022,
                                       141213431, 135534747, 135006516, 133851895, 115169878, 107349540, 102531392, 90354753,
                                       81195210, 78077248, 59128983, 63025520, 48129895, 51304566, 155270560, 59373566, 16569 };
-        List<SAMSequenceRecord> contigs = new ArrayList<SAMSequenceRecord>();
+        List<SAMSequenceRecord> contigs = new ArrayList<>();
 
         for ( int contig = 1; contig <= 22; contig++ ) {
             contigs.add(new SAMSequenceRecord(Integer.toString(contig), contigLengths[contig - 1]));
@@ -198,7 +198,7 @@ public class VariantBaseTest {
      * @param expected expected mapping of attributes
      */
     private static void assertAttributesEquals(final Map<String, Object> actual, Map<String, Object> expected) {
-        final Set<String> expectedKeys = new HashSet<String>(expected.keySet());
+        final Set<String> expectedKeys = new HashSet<>(expected.keySet());
 
         for ( final Map.Entry<String, Object> act : actual.entrySet() ) {
             final Object actualValue = act.getValue();

--- a/src/test/java/htsjdk/variant/bcf2/BCF2EncoderDecoderUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2EncoderDecoderUnitTest.java
@@ -45,9 +45,9 @@ import java.util.List;
 
 public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
     private final double FLOAT_TOLERANCE = 1e-6;
-    final List<BCF2TypedValue> primitives = new ArrayList<BCF2TypedValue>();
-    final List<BCF2TypedValue> basicTypes = new ArrayList<BCF2TypedValue>();
-    final List<BCF2TypedValue> forCombinations = new ArrayList<BCF2TypedValue>();
+    final List<BCF2TypedValue> primitives = new ArrayList<>();
+    final List<BCF2TypedValue> basicTypes = new ArrayList<>();
+    final List<BCF2TypedValue> forCombinations = new ArrayList<>();
 
     @BeforeSuite
     public void before() {
@@ -179,7 +179,7 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "BCF2EncodingTestProviderBasicTypes")
     public Object[][] BCF2EncodingTestProviderBasicTypes() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
         for ( BCF2TypedValue tv : basicTypes )
             tests.add(new Object[]{Arrays.asList(tv)});
         return tests.toArray(new Object[][]{});
@@ -271,7 +271,7 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "BCF2EncodingTestProviderSingletons")
     public Object[][] BCF2EncodingTestProviderSingletons() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
         for ( BCF2TypedValue tv : primitives )
             tests.add(new Object[]{Arrays.asList(tv)});
         return tests.toArray(new Object[][]{});
@@ -291,7 +291,7 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "BCF2EncodingTestProviderSequences")
     public Object[][] BCF2EncodingTestProviderSequences() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
         for ( BCF2TypedValue tv1 : forCombinations )
             for ( BCF2TypedValue tv2 : forCombinations )
                 for ( BCF2TypedValue tv3 : forCombinations )
@@ -336,7 +336,7 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "ListOfStrings")
     public Object[][] listOfStringsProvider() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
         tests.add(new Object[]{Arrays.asList("s1", "s2"), ",s1,s2"});
         tests.add(new Object[]{Arrays.asList("s1", "s2", "s3"), ",s1,s2,s3"});
         tests.add(new Object[]{Arrays.asList("s1", "s2", "s3", "s4"), ",s1,s2,s3,s4"});
@@ -358,7 +358,7 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "BestIntTypeTests")
     public Object[][] BestIntTypeTests() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
         tests.add(new Object[]{Arrays.asList(1), BCF2Type.INT8});
         tests.add(new Object[]{Arrays.asList(1, 10), BCF2Type.INT8});
         tests.add(new Object[]{Arrays.asList(1, 10, 100), BCF2Type.INT8});
@@ -427,7 +427,7 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
 
         // test combining the streams
         final byte[] combined = combineRecords(record1, record2);
-        final List<BCF2TypedValue> combinedObjects = new ArrayList<BCF2TypedValue>(block1);
+        final List<BCF2TypedValue> combinedObjects = new ArrayList<>(block1);
         combinedObjects.addAll(block2);
 
         // the combined bytes is the same as the combined objects
@@ -458,13 +458,13 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "IntArrays")
     public Object[][] makeIntArrays() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         for ( int nValues : Arrays.asList(0, 1, 2, 5, 10, 100) ) {
             for ( int nPad : Arrays.asList(0, 1, 2, 5, 10, 100) ) {
                 int nElements = nValues + nPad;
 
-                List<Integer> values = new ArrayList<Integer>(nElements);
+                List<Integer> values = new ArrayList<>(nElements);
 
                 // add nValues from 0 to nValues - 1
                 for ( int i = 0; i < nValues; i++ )

--- a/src/test/java/htsjdk/variant/bcf2/BCF2UtilsUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2UtilsUnitTest.java
@@ -53,7 +53,7 @@ import java.util.List;
 public final class BCF2UtilsUnitTest extends VariantBaseTest {
     @DataProvider(name = "CollapseExpandTest")
     public Object[][] makeCollapseExpandTest() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
         tests.add(new Object[]{Arrays.asList("A"), "A", false});
         tests.add(new Object[]{Arrays.asList("A", "B"), ",A,B", true});
         tests.add(new Object[]{Arrays.asList("AB"), "AB", false});
@@ -73,7 +73,7 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
 
     @Test
     public void testCreateDictionary() {
-        final List<VCFHeaderLine> inputLines = new ArrayList<VCFHeaderLine>();
+        final List<VCFHeaderLine> inputLines = new ArrayList<>();
         int counter = 0;
         inputLines.add(new VCFFilterHeaderLine(String.valueOf(counter++)));
         inputLines.add(new VCFFilterHeaderLine(String.valueOf(counter++)));
@@ -87,7 +87,7 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
         inputLines.add(new VCFFormatHeaderLine(String.valueOf(counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
         inputLines.add(new VCFFormatHeaderLine(String.valueOf(counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
         final int inputLineCounter = counter;
-        final VCFHeader inputHeader = new VCFHeader(new LinkedHashSet<VCFHeaderLine>(inputLines));
+        final VCFHeader inputHeader = new VCFHeader(new LinkedHashSet<>(inputLines));
         final ArrayList<String> dict = BCF2Utils.makeDictionary(inputHeader);
         final int dict_size = dict.size();
         Assert.assertEquals(7,dict_size);
@@ -111,8 +111,8 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "HeaderOrderTestProvider")
     public Object[][] makeHeaderOrderTestProvider() {
-        final List<VCFHeaderLine> inputLines = new ArrayList<VCFHeaderLine>();
-        final List<VCFHeaderLine> extraLines = new ArrayList<VCFHeaderLine>();
+        final List<VCFHeaderLine> inputLines = new ArrayList<>();
+        final List<VCFHeaderLine> extraLines = new ArrayList<>();
 
         int counter = 0;
         inputLines.add(new VCFFilterHeaderLine(String.valueOf(counter++)));
@@ -124,7 +124,7 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
         inputLines.add(new VCFFormatHeaderLine(String.valueOf(counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
         inputLines.add(new VCFFormatHeaderLine(String.valueOf(counter++), VCFHeaderLineCount.UNBOUNDED, VCFHeaderLineType.Integer, "x"));
         final int inputLineCounter = counter;
-        final VCFHeader inputHeader = new VCFHeader(new LinkedHashSet<VCFHeaderLine>(inputLines));
+        final VCFHeader inputHeader = new VCFHeader(new LinkedHashSet<>(inputLines));
 
         extraLines.add(new VCFFilterHeaderLine(String.valueOf(counter++)));
         extraLines.add(new VCFContigHeaderLine(Collections.singletonMap("ID", String.valueOf(counter++)), counter));
@@ -133,7 +133,7 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
         extraLines.add(new VCFHeaderLine("x", "misc"));
         extraLines.add(new VCFHeaderLine("y", "misc"));
 
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
         for ( final int extrasToTake : Arrays.asList(0, 1, 2, 3) ) {
             final List<VCFHeaderLine> empty = Collections.emptyList();
             final List<List<VCFHeaderLine>> permutations = extrasToTake == 0
@@ -141,11 +141,11 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
                     : GeneralUtils.makePermutations(extraLines, extrasToTake, false);
             for ( final List<VCFHeaderLine> permutation : permutations ) {
                 for ( int i = -1; i < inputLines.size(); i++ ) {
-                    final List<VCFHeaderLine> allLines = new ArrayList<VCFHeaderLine>(inputLines);
+                    final List<VCFHeaderLine> allLines = new ArrayList<>(inputLines);
                     if ( i >= 0 )
                         allLines.remove(i);
                     allLines.addAll(permutation);
-                    final VCFHeader testHeader = new VCFHeader(new LinkedHashSet<VCFHeaderLine>(allLines));
+                    final VCFHeader testHeader = new VCFHeader(new LinkedHashSet<>(allLines));
                     final boolean expectedConsistent = expectedConsistent(testHeader, inputLineCounter);
                     tests.add(new Object[]{new HeaderOrderTestCase(inputHeader, testHeader, expectedConsistent)});
                 }
@@ -177,7 +177,7 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
     }
 
     private static boolean expectedConsistent(final VCFHeader combinationHeader, final int minCounterForInputLines) {
-        final List<Integer> ids = new ArrayList<Integer>();
+        final List<Integer> ids = new ArrayList<>();
         for ( final VCFHeaderLine line : combinationHeader.getMetaDataInInputOrder() ) {
             if ( line instanceof VCFIDHeaderLine) {
                 ids.add(Integer.valueOf(((VCFIDHeaderLine) line).getID()));
@@ -211,7 +211,7 @@ public final class BCF2UtilsUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "toListTestProvider")
     public Object[][] makeToListTest() {
-        final List<Object[]> tests = new ArrayList<Object[]>();
+        final List<Object[]> tests = new ArrayList<>();
         tests.add(new Object[]{Object.class, null, Collections.emptyList()});
         tests.add(new Object[]{Integer.class, 1, Arrays.asList(1)});
         tests.add(new Object[]{Integer.class, new int[]{1, 2, 3}, Arrays.asList(1, 2, 3)});

--- a/src/test/java/htsjdk/variant/variantcontext/GenotypeLikelihoodsUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/GenotypeLikelihoodsUnitTest.java
@@ -270,7 +270,7 @@ public class GenotypeLikelihoodsUnitTest extends VariantBaseTest {
     @Test(dataProvider = "testCalculateAnyploidPLcacheData")
     public void testInitializeAnyploidPLIndexToAlleleIndices(final int altAlleles, final int ploidy, final List<List<Integer>> expected) {
         if ( altAlleles >= 1 && ploidy >= 1 ) { // Bypass test with bad data
-            Map<Integer, List<List<Integer>>> expectedMap = new HashMap<Integer, List<List<Integer>>>();
+            Map<Integer, List<List<Integer>>> expectedMap = new HashMap<>();
             expectedMap.put(ploidy, expected);
             for (Map.Entry<Integer, List<List<Integer>>> entry : GenotypeLikelihoods.anyploidPloidyToPLIndexToAlleleIndices.entrySet()) {
                 if (expectedMap.containsKey(entry.getKey()))

--- a/src/test/java/htsjdk/variant/variantcontext/GenotypesContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/GenotypesContextUnitTest.java
@@ -129,7 +129,7 @@ public class GenotypesContextUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "GenotypesContextProvider")
     public Object[][] MakeSampleNamesTest() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         for ( ContextMaker maker : allMakers ) {
             for ( int i = 0; i < allGenotypes.size(); i++ ) {
@@ -190,7 +190,7 @@ public class GenotypesContextUnitTest extends VariantBaseTest {
         Assert.assertTrue(ParsingUtils.isSorted(gc.iterateInSampleNameOrder()));
         Assert.assertTrue(gc.containsSamples(genotypeNames));
 
-        final Set<String> withMissing = new HashSet<String>(Arrays.asList(MISSING.getSampleName()));
+        final Set<String> withMissing = new HashSet<>(Arrays.asList(MISSING.getSampleName()));
         withMissing.addAll(genotypeNames);
         Assert.assertFalse(gc.containsSamples(withMissing));
     }
@@ -218,13 +218,13 @@ public class GenotypesContextUnitTest extends VariantBaseTest {
     }
 
     private static final List<Genotype> with(List<Genotype> genotypes, Genotype ... add) {
-        List<Genotype> l = new ArrayList<Genotype>(genotypes);
+        List<Genotype> l = new ArrayList<>(genotypes);
         l.addAll(Arrays.asList(add));
         return l;
     }
 
     private static final List<Genotype> without(List<Genotype> genotypes, Genotype ... remove) {
-        List<Genotype> l = new ArrayList<Genotype>(genotypes);
+        List<Genotype> l = new ArrayList<>(genotypes);
         l.removeAll(Arrays.asList(remove));
         return l;
     }
@@ -274,13 +274,13 @@ public class GenotypesContextUnitTest extends VariantBaseTest {
         testGenotypesContextContainsExpectedSamples(gc, without(cfg.initialSamples, rm1, rm2));
 
         gc = cfg.makeContext();
-        HashSet<Genotype> expected = new HashSet<Genotype>();
+        HashSet<Genotype> expected = new HashSet<>();
         if ( gc.contains(rm1) ) expected.add(rm1);
         if ( gc.contains(rm2) ) expected.add(rm2);
         gc.retainAll(Arrays.asList(rm1, rm2));
 
         // ensure that the two lists are the same
-        assertEqualsSet(new HashSet<Genotype>(gc.getGenotypes()), expected, "gc genotypes vs. expected");
+        assertEqualsSet(new HashSet<>(gc.getGenotypes()), expected, "gc genotypes vs. expected");
         // because the list order can change, we use the gc's list itself
         testGenotypesContextContainsExpectedSamples(gc, gc.getGenotypes());
     }
@@ -293,7 +293,7 @@ public class GenotypesContextUnitTest extends VariantBaseTest {
             GenotypesContext gc = cfg.makeContext();
             Genotype setted = gc.set(i, set);
             Assert.assertNotNull(setted);
-            ArrayList<Genotype> l = new ArrayList<Genotype>(cfg.initialSamples);
+            ArrayList<Genotype> l = new ArrayList<>(cfg.initialSamples);
             l.set(i, set);
             testGenotypesContextContainsExpectedSamples(gc, l);
         }
@@ -307,7 +307,7 @@ public class GenotypesContextUnitTest extends VariantBaseTest {
             Genotype toReplace = gc.get(i);
             Genotype replacement = GenotypeBuilder.create(toReplace.getSampleName(), Arrays.asList(Aref, Aref));
             gc.replace(replacement);
-            ArrayList<Genotype> l = new ArrayList<Genotype>(cfg.initialSamples);
+            ArrayList<Genotype> l = new ArrayList<>(cfg.initialSamples);
             l.set(i, replacement);
             Assert.assertEquals(replacement, gc.get(i));
             testGenotypesContextContainsExpectedSamples(gc, l);

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
@@ -81,10 +81,10 @@ public class VariantContextTestProvider {
     final private static List<Integer> TWENTY_INTS = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20);
 
     private static VCFHeader syntheticHeader;
-    final static List<VariantContextTestData> TEST_DATAs = new ArrayList<VariantContextTestData>();
+    final static List<VariantContextTestData> TEST_DATAs = new ArrayList<>();
     private static VariantContext ROOT;
 
-    private final static List<File> testSourceVCFs = new ArrayList<File>();
+    private final static List<File> testSourceVCFs = new ArrayList<>();
     static {
         testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "ILLUMINA.wex.broad_phase2_baseline.20111114.both.exome.genotypes.1000.vcf"));
         testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "ex2.vcf"));
@@ -142,7 +142,7 @@ public class VariantContextTestProvider {
         }
 
         public VariantContextTestData(final VCFHeader header, final List<VariantContext> vcs) {
-            final Set<String> samples = new HashSet<String>();
+            final Set<String> samples = new HashSet<>();
             for ( final VariantContext vc : vcs )
                 if ( vc.hasGenotypes() )
                     samples.addAll(vc.getSampleNames());
@@ -193,7 +193,7 @@ public class VariantContextTestProvider {
             for ( final File file : testSourceVCFs ) {
                 VCFCodec codec = new VCFCodec();
                 VariantContextContainer x = readAllVCs( file, codec );
-                List<VariantContext> fullyDecoded = new ArrayList<VariantContext>();
+                List<VariantContext> fullyDecoded = new ArrayList<>();
 
                 for ( final VariantContext raw : x.getVCs() ) {
                     if ( raw != null )
@@ -218,7 +218,7 @@ public class VariantContextTestProvider {
     }
 
     private static void createSyntheticHeader() {
-        Set<VCFHeaderLine> metaData = new TreeSet<VCFHeaderLine>();
+        Set<VCFHeaderLine> metaData = new TreeSet<>();
 
         addHeaderLine(metaData, "STRING1", 1, VCFHeaderLineType.String);
         addHeaderLine(metaData, "END", 1, VCFHeaderLineType.Integer);
@@ -336,7 +336,7 @@ public class VariantContextTestProvider {
     }
 
     private static void addGenotypesToTestData() {
-        final ArrayList<VariantContext> sites = new ArrayList<VariantContext>();
+        final ArrayList<VariantContext> sites = new ArrayList<>();
 
         sites.add(builder().alleles("A").make());
         sites.add(builder().alleles("A", "C", "T").make());
@@ -391,7 +391,7 @@ public class VariantContextTestProvider {
             addGenotypeTests(site, homRef, het, homVar);
 
             // test no GT at all
-            addGenotypeTests(site, new GenotypeBuilder("noGT", new ArrayList<Allele>(0)).attribute("INT1", 10).make());
+            addGenotypeTests(site, new GenotypeBuilder("noGT", new ArrayList<>(0)).attribute("INT1", 10).make());
 
             final List<Allele> noCall = Arrays.asList(Allele.NO_CALL, Allele.NO_CALL);
 
@@ -598,12 +598,12 @@ public class VariantContextTestProvider {
                 final Allele ref = site.getReference();
 
                 // base genotype is ref/.../ref up to ploidy
-                final List<Allele> baseGenotype = new ArrayList<Allele>(ploidy);
+                final List<Allele> baseGenotype = new ArrayList<>(ploidy);
                 for ( int i = 0; i < ploidy; i++) baseGenotype.add(ref);
                 final int nPLs = GenotypeLikelihoods.numLikelihoods(nAlleles, ploidy);
 
                 // ada is 0, 1, ..., nAlleles - 1
-                final List<Integer> ada = new ArrayList<Integer>(nAlleles);
+                final List<Integer> ada = new ArrayList<>(nAlleles);
                 for ( int i = 0; i < nAlleles - 1; i++ ) ada.add(i);
 
                 // pl is 0, 1, ..., up to nPLs (complex calc of nAlleles and ploidy)
@@ -650,9 +650,9 @@ public class VariantContextTestProvider {
             final EnumSet<Options> options = EnumSet.of(Options.INDEX_ON_THE_FLY);
             final VariantContextWriter writer = tester.makeWriter(tmpFile, options);
 
-            final Set<String> samplesInVCF = new HashSet<String>(data.header.getGenotypeSamples());
+            final Set<String> samplesInVCF = new HashSet<>(data.header.getGenotypeSamples());
             final List<String> missingSamples = Arrays.asList("MISSING1", "MISSING2");
-            final List<String> allSamples = new ArrayList<String>(missingSamples);
+            final List<String> allSamples = new ArrayList<>(missingSamples);
             allSamples.addAll(samplesInVCF);
 
             final VCFHeader header = new VCFHeader(data.header.getMetaDataInInputOrder(), allSamples);
@@ -885,7 +885,7 @@ public class VariantContextTestProvider {
     }
 
     private static void assertAttributesEquals(final Map<String, Object> actual, Map<String, Object> expected) {
-        final Set<String> expectedKeys = new HashSet<String>(expected.keySet());
+        final Set<String> expectedKeys = new HashSet<>(expected.keySet());
 
         for ( final Map.Entry<String, Object> act : actual.entrySet() ) {
             final Object actualValue = act.getValue();
@@ -948,7 +948,7 @@ public class VariantContextTestProvider {
                 final List<Allele> siteAlleles = allAlleles.subList(0, nAlleles);
 
                 // possible alleles for genotypes
-                final List<Allele> possibleGenotypeAlleles = new ArrayList<Allele>(siteAlleles);
+                final List<Allele> possibleGenotypeAlleles = new ArrayList<>(siteAlleles);
                 possibleGenotypeAlleles.add(Allele.NO_CALL);
 
                 // there are n^ploidy possible genotypes
@@ -959,14 +959,14 @@ public class VariantContextTestProvider {
 
                 // first test -- create n copies of each genotype
                 for ( int i = 0; i < nPossibleGenotypes; i++ ) {
-                    final List<Genotype> samples = new ArrayList<Genotype>(3);
+                    final List<Genotype> samples = new ArrayList<>(3);
                     samples.add(GenotypeBuilder.create("sample" + i, possibleGenotypes.get(i)));
                     add(vb.genotypes(samples));
                 }
 
                 // second test -- create one sample with each genotype
                 {
-                    final List<Genotype> samples = new ArrayList<Genotype>(nPossibleGenotypes);
+                    final List<Genotype> samples = new ArrayList<>(nPossibleGenotypes);
                     for ( int i = 0; i < nPossibleGenotypes; i++ ) {
                         samples.add(GenotypeBuilder.create("sample" + i, possibleGenotypes.get(i)));
                     }
@@ -976,7 +976,7 @@ public class VariantContextTestProvider {
                 // test mixed ploidy
                 for ( int i = 0; i < nPossibleGenotypes; i++ ) {
                     for ( int ploidy = 1; ploidy < highestPloidy; ploidy++ ) {
-                        final List<Genotype> samples = new ArrayList<Genotype>(highestPloidy);
+                        final List<Genotype> samples = new ArrayList<>(highestPloidy);
                         final List<Allele> genotype = possibleGenotypes.get(i).subList(0, ploidy);
                         samples.add(GenotypeBuilder.create("sample" + i, genotype));
                         add(vb.genotypes(samples));
@@ -995,8 +995,8 @@ public class VariantContextTestProvider {
 
         // for some reason set.equals() is returning false but all paired elements are .equals().  Perhaps compare to is busted?
         //Assert.assertEquals(actual.getMetaDataInInputOrder(), expected.getMetaDataInInputOrder());
-        final List<VCFHeaderLine> actualLines = new ArrayList<VCFHeaderLine>(actual.getMetaDataInSortedOrder());
-        final List<VCFHeaderLine> expectedLines = new ArrayList<VCFHeaderLine>(expected.getMetaDataInSortedOrder());
+        final List<VCFHeaderLine> actualLines = new ArrayList<>(actual.getMetaDataInSortedOrder());
+        final List<VCFHeaderLine> expectedLines = new ArrayList<>(expected.getMetaDataInSortedOrder());
         for ( int i = 0; i < actualLines.size(); i++ ) {
             Assert.assertEquals(actualLines.get(i), expectedLines.get(i), "VCF header lines");
         }

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -178,8 +178,8 @@ public class VariantContextUnitTest extends VariantBaseTest {
         final List<Allele> allelesUnnaturalOrder = Arrays.asList(Aref, T, C);
         VariantContext naturalVC = snpBuilder.alleles(allelesNaturalOrder).make();
         VariantContext unnaturalVC = snpBuilder.alleles(allelesUnnaturalOrder).make();
-        Assert.assertEquals(new ArrayList<Allele>(naturalVC.getAlleles()), allelesNaturalOrder);
-        Assert.assertEquals(new ArrayList<Allele>(unnaturalVC.getAlleles()), allelesUnnaturalOrder);
+        Assert.assertEquals(new ArrayList<>(naturalVC.getAlleles()), allelesNaturalOrder);
+        Assert.assertEquals(new ArrayList<>(unnaturalVC.getAlleles()), allelesUnnaturalOrder);
     }
 
     @Test
@@ -528,7 +528,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Assert.assertTrue(vc.filtersWereApplied());
         Assert.assertNotNull(vc.getFiltersMaybeNull());
 
-        Set<String> filters = new HashSet<String>(Arrays.asList("BAD_SNP_BAD!", "REALLY_BAD_SNP", "CHRIST_THIS_IS_TERRIBLE"));
+        Set<String> filters = new HashSet<>(Arrays.asList("BAD_SNP_BAD!", "REALLY_BAD_SNP", "CHRIST_THIS_IS_TERRIBLE"));
         vc = new VariantContextBuilder(vc).filters(filters).make();
 
         Assert.assertFalse(vc.isNotFiltered());
@@ -570,12 +570,12 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Genotype g5 = GenotypeBuilder.create("AC", Arrays.asList(Aref, C));
         VariantContext vc = new VariantContextBuilder("genotypes", snpLoc, snpLocStart, snpLocStop, alleles).genotypes(g1,g2,g3,g4,g5).make();
 
-        VariantContext vc12 = vc.subContextFromSamples(new HashSet<String>(Arrays.asList(g1.getSampleName(), g2.getSampleName())), true);
-        VariantContext vc1 = vc.subContextFromSamples(new HashSet<String>(Arrays.asList(g1.getSampleName())), true);
-        VariantContext vc23 = vc.subContextFromSamples(new HashSet<String>(Arrays.asList(g2.getSampleName(), g3.getSampleName())), true);
-        VariantContext vc4 = vc.subContextFromSamples(new HashSet<String>(Arrays.asList(g4.getSampleName())), true);
-        VariantContext vc14 = vc.subContextFromSamples(new HashSet<String>(Arrays.asList(g1.getSampleName(), g4.getSampleName())), true);
-        VariantContext vc125 = vc.subContextFromSamples(new HashSet<String>(Arrays.asList(g1.getSampleName(), g2.getSampleName(), g5.getSampleName())), true);
+        VariantContext vc12 = vc.subContextFromSamples(new HashSet<>(Arrays.asList(g1.getSampleName(), g2.getSampleName())), true);
+        VariantContext vc1 = vc.subContextFromSamples(new HashSet<>(Arrays.asList(g1.getSampleName())), true);
+        VariantContext vc23 = vc.subContextFromSamples(new HashSet<>(Arrays.asList(g2.getSampleName(), g3.getSampleName())), true);
+        VariantContext vc4 = vc.subContextFromSamples(new HashSet<>(Arrays.asList(g4.getSampleName())), true);
+        VariantContext vc14 = vc.subContextFromSamples(new HashSet<>(Arrays.asList(g1.getSampleName(), g4.getSampleName())), true);
+        VariantContext vc125 = vc.subContextFromSamples(new HashSet<>(Arrays.asList(g1.getSampleName(), g2.getSampleName(), g5.getSampleName())), true);
 
         Assert.assertTrue(vc12.isPolymorphicInSamples());
         Assert.assertTrue(vc23.isPolymorphicInSamples());
@@ -676,7 +676,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "getAlleles")
     public Object[][] mergeAllelesData() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         tests.add(new Object[]{new GetAllelesTest("A*",   Aref)});
         tests.add(new Object[]{new GetAllelesTest("A*/C", Aref, C)});
@@ -747,7 +747,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         VariantContext sites = new VariantContextBuilder("sites", snpLoc, snpLocStart, snpLocStop, Arrays.asList(Aref, T)).make();
         VariantContext genotypes = new VariantContextBuilder(sites).source("genotypes").genotypes(g1, g2, g3).make();
 
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         tests.add(new Object[]{new SitesAndGenotypesVC("sites", sites)});
         tests.add(new Object[]{new SitesAndGenotypesVC("genotypes", genotypes)});
@@ -822,7 +822,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         boolean updateAlleles;
 
         private SubContextTest(Collection<String> samples, boolean updateAlleles) {
-            this.samples = new HashSet<String>(samples);
+            this.samples = new HashSet<>(samples);
             this.updateAlleles = updateAlleles;
         }
 
@@ -833,7 +833,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "SubContextTest")
     public Object[][] MakeSubContextTest() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         for ( boolean updateAlleles : Arrays.asList(true, false)) {
             tests.add(new Object[]{new SubContextTest(Collections.<String>emptySet(), updateAlleles)});
@@ -871,7 +871,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Assert.assertEquals(sub.getID(), vc.getID());
         Assert.assertEquals(sub.getAttributes(), vc.getAttributes());
 
-        Set<Genotype> expectedGenotypes = new HashSet<Genotype>();
+        Set<Genotype> expectedGenotypes = new HashSet<>();
         if ( cfg.samples.contains(g1.getSampleName()) ) expectedGenotypes.add(g1);
         if ( cfg.samples.contains(g2.getSampleName()) ) expectedGenotypes.add(g2);
         if ( cfg.samples.contains(g3.getSampleName()) ) expectedGenotypes.add(g3);
@@ -881,10 +881,10 @@ public class VariantContextUnitTest extends VariantBaseTest {
         // these values depend on the results of sub
         if ( cfg.updateAlleles ) {
             // do the work to see what alleles should be here, and which not
-            List<Allele> expectedAlleles = new ArrayList<Allele>();
+            List<Allele> expectedAlleles = new ArrayList<>();
             expectedAlleles.add(Aref);
 
-            Set<Allele> genotypeAlleles = new HashSet<Allele>();
+            Set<Allele> genotypeAlleles = new HashSet<>();
             for ( final Genotype g : expectedGC )
                 genotypeAlleles.addAll(g.getAlleles());
             genotypeAlleles.remove(Aref);
@@ -925,7 +925,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "SampleNamesTest")
     public Object[][] MakeSampleNamesTest() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         tests.add(new Object[]{new SampleNamesTest(Arrays.asList("1"), Arrays.asList("1"))});
         tests.add(new Object[]{new SampleNamesTest(Arrays.asList("2", "1"), Arrays.asList("1", "2"))});
@@ -959,7 +959,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         VariantContext vc = new VariantContextBuilder("genotypes", snpLoc, snpLocStart, snpLocStop, Arrays.asList(Aref, T)).genotypes(gc).make();
 
         // same sample names => success
-        Assert.assertTrue(vc.getSampleNames().equals(new HashSet<String>(cfg.sampleNames)), "vc.getSampleNames() = " + vc.getSampleNames());
+        Assert.assertTrue(vc.getSampleNames().equals(new HashSet<>(cfg.sampleNames)), "vc.getSampleNames() = " + vc.getSampleNames());
         Assert.assertEquals(vc.getSampleNamesOrderedByName(), cfg.sampleNamesInOrder, "vc.getSampleNamesOrderedByName() = " + vc.getSampleNamesOrderedByName());
 
         assertGenotypesAreInOrder(vc.getGenotypesOrderedByName(), cfg.sampleNamesInOrder);
@@ -1147,7 +1147,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
                 fullyDecoded, toValidate);
     }
     private Set<String> makeRsIDsSet(final String... rsIds) {
-        return new HashSet<String>(Arrays.asList(rsIds));
+        return new HashSet<>(Arrays.asList(rsIds));
     }
 
 
@@ -1226,14 +1226,14 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
         /** AN : total number of alleles in called genotypes **/
         // with AN set and hom-ref, we expect AN to be 2 for Aref/Aref
-        final Map<String, Object> attributesAN = new HashMap<String, Object>();
+        final Map<String, Object> attributesAN = new HashMap<>();
         attributesAN.put(VCFConstants.ALLELE_NUMBER_KEY, "2");
         final VariantContext vcANSet =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref), attributesAN, homRef);
 
         // with AN set, one no-call (no-calls get ignored by getCalledChrCount() in VariantContext)
         // we expect AN to be 1 for Aref/no-call
-        final Map<String, Object> attributesANNoCall = new HashMap<String, Object>();
+        final Map<String, Object> attributesANNoCall = new HashMap<>();
         attributesANNoCall.put(VCFConstants.ALLELE_NUMBER_KEY, "1");
         final VariantContext vcANSetNoCall =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref), attributesANNoCall, homRefNoCall);
@@ -1241,20 +1241,20 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
         /** AC : allele count in genotypes, for each ALT allele, in the same order as listed **/
         // with AC set, and T/T, we expect AC to be 2 (for 2 counts of ALT T)
-        final Map<String, Object> attributesAC = new HashMap<String, Object>();
+        final Map<String, Object> attributesAC = new HashMap<>();
         attributesAC.put(VCFConstants.ALLELE_COUNT_KEY, "2");
         final VariantContext vcACSet =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref, T), attributesAC, homVarT);
 
         // with AC set and no ALT (GT is 0/0), we expect AC count to be 0
-        final Map<String, Object> attributesACNoAlts = new HashMap<String, Object>();
+        final Map<String, Object> attributesACNoAlts = new HashMap<>();
         attributesACNoAlts.put(VCFConstants.ALLELE_COUNT_KEY, "0");
         final VariantContext vcACSetNoAlts =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref), attributesACNoAlts, homRef);
 
         // with AC set, and two different ALTs (T and C), with GT of 1/2, we expect a count of 1 for each.
         // With two ALTs, a list is expected, so we set the attribute as a list of 1,1
-        final Map<String, Object> attributesACTwoAlts = new HashMap<String, Object>();
+        final Map<String, Object> attributesACTwoAlts = new HashMap<>();
         attributesACTwoAlts.put(VCFConstants.ALLELE_COUNT_KEY, Arrays.asList("1", "1"));
         final VariantContext vcACSetTwoAlts =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref, T, C), attributesACTwoAlts, hetVarTC);
@@ -1282,39 +1282,39 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
         /** AN : total number of alleles in called genotypes **/
         // with AN set and hom-ref, we expect AN to be 2 for Aref/Aref, so 3 will fail
-        final Map<String, Object> attributesAN = new HashMap<String, Object>();
+        final Map<String, Object> attributesAN = new HashMap<>();
         attributesAN.put(VCFConstants.ALLELE_NUMBER_KEY, "3");
         final VariantContext vcANSet =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref), attributesAN, homRef);
 
         // with AN set, one no-call (no-calls get ignored by getCalledChrCount() in VariantContext)
         // we expect AN to be 1 for Aref/no-call, so 2 will fail
-        final Map<String, Object> attributesANNoCall = new HashMap<String, Object>();
+        final Map<String, Object> attributesANNoCall = new HashMap<>();
         attributesANNoCall.put(VCFConstants.ALLELE_NUMBER_KEY, "2");
         final VariantContext vcANSetNoCall =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref), attributesANNoCall, homRefNoCall);
 
         /** AC : allele count in genotypes, for each ALT allele, in the same order as listed **/
         // with AC set but no ALTs, we expect a count of 0, so the wrong count will fail here
-        final Map<String, Object> attributesACWrongCount = new HashMap<String, Object>();
+        final Map<String, Object> attributesACWrongCount = new HashMap<>();
         attributesACWrongCount.put(VCFConstants.ALLELE_COUNT_KEY, "2");
         final VariantContext vcACWrongCount =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref), attributesACWrongCount, homRef);
 
         // with AC set, two ALTs, but AC is not a list with count for each ALT
-        final Map<String, Object> attributesACTwoAlts = new HashMap<String, Object>();
+        final Map<String, Object> attributesACTwoAlts = new HashMap<>();
         attributesACTwoAlts.put(VCFConstants.ALLELE_COUNT_KEY, "1");
         final VariantContext vcACSetTwoAlts =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref, T, C), attributesACTwoAlts, hetVarTC);
 
         // with AC set, two ALTs, and a list is correctly used, but wrong counts (we expect counts to be 1,1)
-        final Map<String, Object> attributesACTwoAltsWrongCount = new HashMap<String, Object>();
+        final Map<String, Object> attributesACTwoAltsWrongCount = new HashMap<>();
         attributesACTwoAltsWrongCount.put(VCFConstants.ALLELE_COUNT_KEY, Arrays.asList("1", "2"));
         final VariantContext vcACSetTwoAltsWrongCount =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref, T, C), attributesACTwoAltsWrongCount, hetVarTC);
 
         // with AC set, two ALTs, but only count for one ALT (we expect two items in the list: 1,1)
-        final Map<String, Object> attributesACTwoAltsOneAltCount = new HashMap<String, Object>();
+        final Map<String, Object> attributesACTwoAltsOneAltCount = new HashMap<>();
         attributesACTwoAltsOneAltCount.put(VCFConstants.ALLELE_COUNT_KEY, Arrays.asList("1"));
         final VariantContext vcACSetTwoAltsOneAltCount =
                 createValidateChromosomeCountsContext(Arrays.asList(Aref, T, C), attributesACTwoAltsOneAltCount, hetVarTC);

--- a/src/test/java/htsjdk/variant/variantcontext/filter/CompoundFilterTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/filter/CompoundFilterTest.java
@@ -27,7 +27,7 @@ public class CompoundFilterTest {
 
     @DataProvider
     Iterator<Object[]> testCompoundFilterProvider() {
-        final List<Object[]> filters = new ArrayList<Object[]>(10);
+        final List<Object[]> filters = new ArrayList<>(10);
 
         // requireAll = TRUE
         { // all pass

--- a/src/test/java/htsjdk/variant/variantcontext/filter/GenotypeQualityFilterTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/filter/GenotypeQualityFilterTest.java
@@ -47,7 +47,7 @@ public class GenotypeQualityFilterTest {
 
         final VariantContextBuilder vc_builder = new VariantContextBuilder("testCode", "chr1", 1, 1, Arrays.asList(refA, G));
         final GenotypeBuilder gt_builder = new GenotypeBuilder("test").alleles(Arrays.asList(refA, G));
-        final List<Object[]> variants = new ArrayList<Object[]>(10);
+        final List<Object[]> variants = new ArrayList<>(10);
 
         //without gq
         variants.add(new Object[]{vc_builder.genotypes(gt_builder.make()).make(), null, false});
@@ -78,7 +78,7 @@ public class GenotypeQualityFilterTest {
 
         final VariantContextBuilder vc_builder = new VariantContextBuilder("testCode", "chr1", 1, 1, Arrays.asList(refA, G));
         final GenotypeBuilder gt_builder = new GenotypeBuilder();
-        final List<Object[]> hets = new ArrayList<Object[]>(10);
+        final List<Object[]> hets = new ArrayList<>(10);
 
         hets.add(new Object[]{vc_builder.make(), null});
         hets.add(new Object[]{vc_builder.genotypes(Arrays.asList(gt_builder.name("test1").make(), gt_builder.name("test2").make())).make(), "notNull"});

--- a/src/test/java/htsjdk/variant/variantcontext/filter/HeterozygosityFilterTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/filter/HeterozygosityFilterTest.java
@@ -47,7 +47,7 @@ public class HeterozygosityFilterTest {
 
         final VariantContextBuilder vc_builder = new VariantContextBuilder("testCode", "chr1", 1, 1, Arrays.asList(refA, G));
         final GenotypeBuilder gt_builder = new GenotypeBuilder("test");
-        final List<Object[]> hets = new ArrayList<Object[]>(10);
+        final List<Object[]> hets = new ArrayList<>(10);
 
         hets.add(new Object[]{vc_builder.genotypes(gt_builder.alleles(Arrays.asList(refA, G)).make()).make(), null, true});
         hets.add(new Object[]{vc_builder.genotypes(gt_builder.alleles(Arrays.asList(refA, G)).make()).make(), "test", true});
@@ -71,7 +71,7 @@ public class HeterozygosityFilterTest {
 
         final VariantContextBuilder vc_builder = new VariantContextBuilder("testCode", "chr1", 1, 1, Arrays.asList(refA, G));
         final GenotypeBuilder gt_builder = new GenotypeBuilder();
-        final List<Object[]> hets = new ArrayList<Object[]>(10);
+        final List<Object[]> hets = new ArrayList<>(10);
 
         hets.add(new Object[]{vc_builder.make(), null});
         hets.add(new Object[]{vc_builder.genotypes(Arrays.asList(gt_builder.name("test1").make(), gt_builder.name("test2").make())).make(), "notNull"});
@@ -93,7 +93,7 @@ public class HeterozygosityFilterTest {
 
         final VariantContextBuilder vc_builder = new VariantContextBuilder("testCode", "chr1", 1, 1, Arrays.asList(refA, G));
         final GenotypeBuilder gt_builder = new GenotypeBuilder("test");
-        final List<VariantContext> vcs = new ArrayList<VariantContext>(10);
+        final List<VariantContext> vcs = new ArrayList<>(10);
 
         //hets:
         vcs.add(vc_builder.genotypes(gt_builder.alleles(Arrays.asList(refA, G)).make()).make());

--- a/src/test/java/htsjdk/variant/variantcontext/filter/PassingVariantFilterTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/filter/PassingVariantFilterTest.java
@@ -24,7 +24,7 @@ public class PassingVariantFilterTest {
     public Iterator<Object[]> variantProvider() {
 
         final VariantContextBuilder vc_builder = new VariantContextBuilder("test", "chr1", 1, 1, Arrays.asList(refA, G));
-        final List<Object[]> variants = new ArrayList<Object[]>(10);
+        final List<Object[]> variants = new ArrayList<>(10);
 
         // unfiltered
         variants.add(new Object[]{vc_builder.alleles(Arrays.asList(refA, G)).make(), true});

--- a/src/test/java/htsjdk/variant/variantcontext/filter/SnpFilterTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/filter/SnpFilterTest.java
@@ -31,7 +31,7 @@ public class SnpFilterTest {
     public Iterator<Object[]> variantProvider() {
 
         final VariantContextBuilder vc_builder = new VariantContextBuilder("testCode", "chr1", 1, 1, Collections.<Allele>emptyList());
-        final List<Object[]> variants = new ArrayList<Object[]>(10);
+        final List<Object[]> variants = new ArrayList<>(10);
 
         variants.add(new Object[]{vc_builder.alleles(Arrays.asList(refA, G))         .make(), true});    // SNP
         variants.add(new Object[]{vc_builder.alleles(Arrays.asList(refA, G, T))      .make(), true});    // SNP

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -97,8 +97,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         } else {
             Tribble.indexFile(fakeVCFFile).deleteOnExit();
         }
-        metaData = new HashSet<VCFHeaderLine>();
-        additionalColumns = new HashSet<String>();
+        metaData = new HashSet<>();
+        additionalColumns = new HashSet<>();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         final VariantContextWriter writer = new VariantContextWriterBuilder()
@@ -161,8 +161,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     }
 
     private VariantContext createVCGeneral(final VCFHeader header, final String chrom, final int position) {
-        final List<Allele> alleles = new ArrayList<Allele>();
-        final Map<String, Object> attributes = new HashMap<String,Object>();
+        final List<Allele> alleles = new ArrayList<>();
+        final Map<String, Object> attributes = new HashMap<>();
         final GenotypesContext genotypes = GenotypesContext.create(header.getGenotypeSamples().size());
 
         alleles.add(Allele.create("A",true));
@@ -201,8 +201,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     @Test(dataProvider = "vcfExtensionsDataProvider")
     public void TestWritingLargeVCF(final String extension) throws FileNotFoundException, InterruptedException {
 
-        final Set<VCFHeaderLine> metaData = new HashSet<VCFHeaderLine>();
-        final Set<String> Columns = new HashSet<String>();
+        final Set<VCFHeaderLine> metaData = new HashSet<>();
+        final Set<String> Columns = new HashSet<>();
         for (int i = 0; i < 123; i++) {
 
             Columns.add(String.format("SAMPLE_%d", i));

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -74,8 +74,8 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
         unknown = File.createTempFile(TEST_BASENAME, ".unknown");
         unknown.deleteOnExit();
 
-        blockCompressedVCFs = new ArrayList<File>();
-        blockCompressedIndices = new ArrayList<File>();
+        blockCompressedVCFs = new ArrayList<>();
+        blockCompressedIndices = new ArrayList<>();
         for (final String extension : AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS) {
             final File blockCompressed = File.createTempFile(TEST_BASENAME, ".vcf" + extension);
             blockCompressed.deleteOnExit();

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWritersUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWritersUnitTest.java
@@ -59,7 +59,7 @@ public class VariantContextWritersUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "VariantContextTest_SingleContexts")
     public Object[][] SiteVCsTest() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
         for ( VariantContextTestProvider.VariantContextTestData testData : VariantContextTestProvider.generateSiteTests() )
             tests.add(new Object[]{testData});
         return tests.toArray(new Object[][]{});
@@ -132,7 +132,7 @@ public class VariantContextWritersUnitTest extends VariantBaseTest {
 
         @Override
         public List<VariantContext> postprocess(final VCFHeader header, final List<VariantContext> vcsAfterIO) {
-            final List<VariantContext> fullyDecoded = new ArrayList<VariantContext>(vcsAfterIO.size());
+            final List<VariantContext> fullyDecoded = new ArrayList<>(vcsAfterIO.size());
 
             for ( final VariantContext withStrings : vcsAfterIO )
                 fullyDecoded.add(withStrings.fullyDecode(header, false));

--- a/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
@@ -22,7 +22,7 @@ public class VCFEncoderTest {
 
 	@DataProvider(name = "VCFWriterDoubleFormatTestData")
 	public Object[][] makeVCFWriterDoubleFormatTestData() {
-		final List<Object[]> tests = new ArrayList<Object[]>();
+		final List<Object[]> tests = new ArrayList<>();
 		tests.add(new Object[]{1.0, "1.00"});
 		tests.add(new Object[]{10.1, "10.10"});
 		tests.add(new Object[]{10.01, "10.01"});
@@ -61,13 +61,13 @@ public class VCFEncoderTest {
         final VCFEncoder keepMissing = new VCFEncoder(header, false, true);
         final VariantContextBuilder baseVC = new VariantContextBuilder().chr("1").start(1).stop(1).noID().passFilters().log10PError(1).alleles("A", "C");
         final GenotypeBuilder baseGT = new GenotypeBuilder("Sample1").alleles(Arrays.asList(Allele.NO_CALL, Allele.NO_CALL));
-        final Map<Allele, String> alleleMap = new HashMap<Allele, String>(3);
+        final Map<Allele, String> alleleMap = new HashMap<>(3);
         final List<String> formatKeys = Arrays.asList("GT", "AA", "BB");
         alleleMap.put(Allele.NO_CALL, VCFConstants.EMPTY_ALLELE);
         alleleMap.put(Allele.create("A", true), "0");
         alleleMap.put(Allele.create("C", false), "1");
 
-        final List<Object[]> tests = new ArrayList<Object[]>();
+        final List<Object[]> tests = new ArrayList<>();
 
         VariantContext vc = baseVC.genotypes(baseGT.attribute("AA", "a").make()).make();
         tests.add(new Object[]{dropMissing, vc, "./.:a", alleleMap, formatKeys});
@@ -103,7 +103,7 @@ public class VCFEncoderTest {
     }
 
     private Set<VCFHeaderLine> createSyntheticMetadata() {
-        final Set<VCFHeaderLine> metaData = new TreeSet<VCFHeaderLine>();
+        final Set<VCFHeaderLine> metaData = new TreeSet<>();
 
         metaData.add(new VCFContigHeaderLine(Collections.singletonMap("ID", "1"), 0));
 

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -124,7 +124,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     public void testVCFHeaderDictionaryMerging() {
         VCFHeader headerOne = new VCFFileReader(new File(variantTestDataRoot + "dbsnp_135.b37.1000.vcf"), false).getFileHeader();
         VCFHeader headerTwo = new VCFHeader(headerOne); // deep copy
-        final List<String> sampleList = new ArrayList<String>();
+        final List<String> sampleList = new ArrayList<>();
         sampleList.addAll(headerOne.getSampleNamesInOrder());
 
         // Check that the two dictionaries start out the same

--- a/src/test/java/htsjdk/variant/vcf/VCFStandardHeaderLinesUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFStandardHeaderLinesUnitTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class VCFStandardHeaderLinesUnitTest extends VariantBaseTest {
     @DataProvider(name = "getStandardLines")
     public Object[][] makeGetStandardLines() {
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         // info
         tests.add(new Object[]{"AC", "info", true});
@@ -159,7 +159,7 @@ public class VCFStandardHeaderLinesUnitTest extends VariantBaseTest {
         final VCFFormatHeaderLine standardGT = VCFStandardHeaderLines.getFormatLine("GT");
         final VCFFormatHeaderLine goodGT = new VCFFormatHeaderLine("GT", 1, VCFHeaderLineType.String, "x");
 
-        List<Object[]> tests = new ArrayList<Object[]>();
+        List<Object[]> tests = new ArrayList<>();
 
         tests.add(new Object[]{new RepairHeaderTest( standardGT, standardGT)});
         tests.add(new Object[]{new RepairHeaderTest( goodGT, goodGT )});


### PR DESCRIPTION
replacing redundantly specified explicit types with `<>` where possible using intellij autofixing magic