### PR TITLE
switching from coverals to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ jdk:
   - oraclejdk8
 script: ./gradlew jacocoTestReport testSRA;
 after_success:
+  - bash <(curl -s https://codecov.io/bash)
   - echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'";
     echo "JAVA_HOME='$JAVA_HOME'";
-    ./gradlew coveralls;
     if [ "$TRAVIS_BRANCH" == "master" ]; then
        ./gradlew uploadArchives;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
     - $HOME/.m2
 jdk:
   - oraclejdk8
-script: ./gradlew jacocoTestReport testSRA;
+script: ./gradlew testSRA jacocoTestReport;
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'";

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://coveralls.io/repos/github/samtools/htsjdk/badge.svg?branch=master)](https://coveralls.io/github/samtools/htsjdk?branch=master)
+[![Coverage Status](https://codecov.io/gh/samtools/htsjdk/branch/master/graph/badge.svg)](https://codecov.io/gh/samtools/htsjdk)
 [![Build Status](https://travis-ci.org/samtools/htsjdk.svg?branch=master)](https://travis-ci.org/samtools/htsjdk)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.samtools/htsjdk/badge.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.samtools%22%20AND%20a%3A%22htsjdk%22)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/samtools/htsjdk)

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ plugins {
     id 'jacoco'
     id 'com.palantir.git-version' version '0.5.1'
     id 'com.github.johnrengelman.shadow' version '1.2.3'
-    id "com.github.kt3k.coveralls" version "2.6.3"
 }
 
 repositories {
@@ -25,7 +24,7 @@ jacocoTestReport {
     additionalSourceDirs = files(sourceSets.main.allJava.srcDirs)
 
     reports {
-        xml.enabled = true // coveralls plugin depends on xml format report
+        xml.enabled = true // codecov depends on xml format report
         html.enabled = true
     }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  branch: master
+
+coverage:
+  precision: 3
+  round: nearest
+  range: "50...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: null
+        branches: null
+
+    patch:
+      default:
+        target: auto
+        branches: null
+
+    changes:
+      default:
+        branches: null
+
+
+comment:
+  layout: "header, diff, changes, sunburst, uncovered, tree"
+  branches: null
+  behavior: default


### PR DESCRIPTION
codecov seems to be more accurate since it incorporates a notion of "partially covered lines"
it also makes reviewing pr's easier since coverage can be shown inline during reviews with a browser plugin