### PR TITLE
Fixed bug disallowing file-based index and seekable path based source

### DIFF
--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -316,23 +316,17 @@ public abstract class SamReaderFactory {
                             final SeekableStream indexSeekable = indexMaybe == null ? null : indexMaybe.asUnbufferedSeekableStream();
                             // do not close bufferedStream, it's the same stream we're getting here.
                             SeekableStream sourceSeekable = data.asUnbufferedSeekableStream();
-                            if (indexFile!=null || null == sourceSeekable || null == indexSeekable) {
-                                if (null == sourceSeekable || null == indexSeekable) {
-                                    // not seekable.
-                                    // it's OK that we consumed a bit of the stream already, this ctor expects it.
-                                    primitiveSamReader = new BAMFileReader(bufferedStream, indexFile, false, asynchronousIO, validationStringency, this.samRecordFactory);
-                                } else {
-                                    sourceSeekable.seek(0);
-                                    primitiveSamReader = new BAMFileReader(
-                                            sourceSeekable, indexSeekable, false, asynchronousIO, validationStringency, this.samRecordFactory);
-                                }
+                            if (null == sourceSeekable || null == indexSeekable) {
+                                // not seekable.
+                                // it's OK that we consumed a bit of the stream already, this ctor expects it.
+                                primitiveSamReader = new BAMFileReader(bufferedStream, indexFile, false, asynchronousIO, validationStringency, this.samRecordFactory);
                             } else {
                                 // seekable.
                                 // need to return to the beginning because it's the same stream we used earlier
                                 // and read a bit from, and that form of the ctor expects the stream to start at 0.
                                 sourceSeekable.seek(0);
                                 primitiveSamReader = new BAMFileReader(
-                                    sourceSeekable, indexSeekable, false, asynchronousIO, validationStringency, this.samRecordFactory);
+                                        sourceSeekable, indexSeekable, false, asynchronousIO, validationStringency, this.samRecordFactory);
                             }
                         } else {
                             bufferedStream.close();

--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -317,9 +317,15 @@ public abstract class SamReaderFactory {
                             // do not close bufferedStream, it's the same stream we're getting here.
                             SeekableStream sourceSeekable = data.asUnbufferedSeekableStream();
                             if (indexFile!=null || null == sourceSeekable || null == indexSeekable) {
-                                // not seekable.
-                                // it's OK that we consumed a bit of the stream already, this ctor expects it.
-                                primitiveSamReader = new BAMFileReader(bufferedStream, indexFile, false, asynchronousIO, validationStringency, this.samRecordFactory);
+                                if (null == sourceSeekable || null == indexSeekable) {
+                                    // not seekable.
+                                    // it's OK that we consumed a bit of the stream already, this ctor expects it.
+                                    primitiveSamReader = new BAMFileReader(bufferedStream, indexFile, false, asynchronousIO, validationStringency, this.samRecordFactory);
+                                } else {
+                                    sourceSeekable.seek(0);
+                                    primitiveSamReader = new BAMFileReader(
+                                            sourceSeekable, indexSeekable, false, asynchronousIO, validationStringency, this.samRecordFactory);
+                                }
                             } else {
                                 // seekable.
                                 // need to return to the beginning because it's the same stream we used earlier

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -290,7 +290,7 @@ public class SamReaderFactoryTest {
      * A path that pretends it's not based upon a file.  This helps in cases where we want to test branches
      * that apply to non-file based paths without actually having to use non-file based resources (like cloud urls)
      */
-    public static class NeverFilePathInputResource extends PathInputResource {
+    private static class NeverFilePathInputResource extends PathInputResource {
         public NeverFilePathInputResource(Path pathResource) {
             super(pathResource);
         }

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -285,8 +285,13 @@ public class SamReaderFactoryTest {
         reader.close();
     }
 
-    public class NeverFilePathInpurResource extends PathInputResource {
-        public NeverFilePathInpurResource(Path pathResource) {
+
+    /**
+     * A path that pretends it's not based upon a file.  This helps in cases where we want to test branches
+     * that apply to non-file based paths without actually having to use non-file based resources (like cloud urls)
+     */
+    public static class NeverFilePathInputResource extends PathInputResource {
+        public NeverFilePathInputResource(Path pathResource) {
             super(pathResource);
         }
 
@@ -297,18 +302,19 @@ public class SamReaderFactoryTest {
     }
 
     @Test
-    public void streamingPathBamWithFileIndex() throws IOException {
-        InputResource bam = new NeverFilePathInpurResource(localBam.toPath());
+    public void checkHasIndexForStreamingPathBamWithFileIndex() throws IOException {
+        InputResource bam = new NeverFilePathInputResource(localBam.toPath());
         InputResource index = new FileInputResource(localBamIndex);
 
         // ensure that the index is being used, not checked in queryInputResourcePermutation
-        final SamReader reader = SamReaderFactory.makeDefault().open(new SamInputResource(bam, index));
-        Assert.assertTrue(reader.hasIndex());
+        try (final SamReader reader = SamReaderFactory.makeDefault().open(new SamInputResource(bam, index))) {
+            Assert.assertTrue(reader.hasIndex());
+        }
     }
 
     @Test
     public void queryStreamingPathBamWithFileIndex() throws IOException {
-        InputResource bam = new NeverFilePathInpurResource(localBam.toPath());
+        InputResource bam = new NeverFilePathInputResource(localBam.toPath());
         InputResource index = new FileInputResource(localBamIndex);
 
         final SamInputResource resource = new SamInputResource(bam, index);

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -284,7 +284,37 @@ public class SamReaderFactoryTest {
         }
         reader.close();
     }
-    
+
+    public class NeverFilePathInpurResource extends PathInputResource {
+        public NeverFilePathInpurResource(Path pathResource) {
+            super(pathResource);
+        }
+
+        @Override
+        public File asFile() {
+            return null;
+        }
+    }
+
+    @Test
+    public void streamingPathBamWithFileIndex() throws IOException {
+        InputResource bam = new NeverFilePathInpurResource(localBam.toPath());
+        InputResource index = new FileInputResource(localBamIndex);
+
+        // ensure that the index is being used, not checked in queryInputResourcePermutation
+        final SamReader reader = SamReaderFactory.makeDefault().open(new SamInputResource(bam, index));
+        Assert.assertTrue(reader.hasIndex());
+    }
+
+    @Test
+    public void queryStreamingPathBamWithFileIndex() throws IOException {
+        InputResource bam = new NeverFilePathInpurResource(localBam.toPath());
+        InputResource index = new FileInputResource(localBamIndex);
+
+        final SamInputResource resource = new SamInputResource(bam, index);
+        queryInputResourcePermutation(new SamInputResource(bam, index));
+    }
+
     @Test
     public void customReaderFactoryTest() throws IOException {
         try {


### PR DESCRIPTION
### Description

Added support for use case where index is a file, and the source stream is a seekable path.  This is important to allow users to pull down an index locally while querying a BAM in GCS.  Currently the performance of leaving the index in GCS in unacceptable.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
