### PR TITLE
cleanup bam order checking code

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -27,16 +27,8 @@ package htsjdk.samtools;
 import htsjdk.samtools.util.StringLineReader;
 
 import java.io.StringWriter;
-import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Supplier;
 
 /**
  * Header information from a SAM or BAM file.
@@ -65,37 +57,30 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
      */
     public enum SortOrder {
 
-        unsorted(null),
-        queryname(SAMRecordQueryNameComparator.class),
-        coordinate(SAMRecordCoordinateComparator.class),
-        duplicate(SAMRecordDuplicateComparator.class); // NB: this is not in the SAM spec!
+        unsorted(() -> null),
+        queryname(SAMRecordQueryNameComparator::new),
+        coordinate(SAMRecordCoordinateComparator::new),
+        duplicate(SAMRecordDuplicateComparator::new); // NB: this is not in the SAM spec!
 
-        private final Class<? extends SAMRecordComparator> comparator;
+        private final Supplier<SAMRecordComparator> comparatorSupplier;
 
-        SortOrder(final Class<? extends SAMRecordComparator> comparatorClass) {
-            this.comparator = comparatorClass;
+        SortOrder(final Supplier<SAMRecordComparator> comparatorClass) {
+            this.comparatorSupplier = comparatorClass;
         }
 
         /**
          * @return Comparator class to sort in the specified order, or null if unsorted.
          */
         public Class<? extends SAMRecordComparator> getComparator() {
-            return comparator;
+            return comparatorSupplier.get().getClass();
         }
 
         /**
          * @return Comparator to sort in the specified order, or null if unsorted.
          */
         public SAMRecordComparator getComparatorInstance() {
-            if (comparator != null) {
-                try {
-                    final Constructor<? extends SAMRecordComparator> ctor = comparator.getConstructor();
-                    return ctor.newInstance();
-                }
-                catch (Exception e) {
-                    throw new IllegalStateException("Could not instantiate a comparator for sort order: " +
-                            this.name(), e);
-                }
+            if (comparatorSupplier != null) {
+                return comparatorSupplier.get();
             }
             return null;
         }

--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -149,26 +149,12 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
             }
         } else if (!sortOrder.equals(SAMFileHeader.SortOrder.unsorted)) {
             alignmentSorter = SortingCollection.newInstance(SAMRecord.class,
-                    new BAMRecordCodec(header), makeComparator(), maxRecordsInRam, tmpDir);
+                    new BAMRecordCodec(header), sortOrder.getComparatorInstance(), maxRecordsInRam, tmpDir);
         }
     }
 
     public SAMFileHeader getFileHeader() {
         return header;
-    }
-
-    private SAMRecordComparator makeComparator() {
-        switch (sortOrder) {
-            case coordinate:
-                return new SAMRecordCoordinateComparator();
-            case queryname:
-                return new SAMRecordQueryNameComparator();
-            case duplicate:
-                return new SAMRecordDuplicateComparator();
-            case unsorted:
-                return null;
-        }
-        throw new IllegalStateException("sortOrder should not be null");
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMSortOrderChecker.java
+++ b/src/main/java/htsjdk/samtools/SAMSortOrderChecker.java
@@ -34,21 +34,7 @@ public class SAMSortOrderChecker {
 
     public SAMSortOrderChecker(final SAMFileHeader.SortOrder sortOrder) {
         this.sortOrder = sortOrder;
-        switch (sortOrder) {
-            case coordinate:
-                comparator = new SAMRecordCoordinateComparator();
-                break;
-            case queryname:
-                comparator = new SAMRecordQueryNameComparator();
-                break;
-            case duplicate:
-                comparator = new SAMRecordDuplicateComparator();
-                break;
-            case unsorted:
-            default:
-                comparator = null;
-                break;
-        }
+        this.comparator = sortOrder == null ? null : sortOrder.getComparatorInstance();
     }
 
     /**
@@ -71,12 +57,15 @@ public class SAMSortOrderChecker {
         return prev;
     }
 
+    public SAMFileHeader.SortOrder getSortOrder() {
+        return sortOrder;
+    }
+
     /**
      * Return the sort key used for the given sort order.  Useful in error messages.
      */
     public String getSortKey(final SAMRecord rec) {
         switch (sortOrder) {
-
             case coordinate:
                 return rec.getReferenceName() + ":" + rec.getAlignmentStart();
             case queryname:

--- a/src/main/java/htsjdk/samtools/SamReader.java
+++ b/src/main/java/htsjdk/samtools/SamReader.java
@@ -559,13 +559,15 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
         }
 
         public SAMRecord next() {
-            final SAMRecord previous = checker.getPreviousRecord();
             final SAMRecord result = wrappedIterator.next();
-            if (checker != null && !checker.isSorted(result)) {
-                throw new IllegalStateException(String.format(
-                                "Records %s should come after %s when sorting with %s",
-                                checker.getSortKey(previous),
-                                checker.getSortKey(result), checker.getSortOrder()));
+            if (checker != null) {
+                final SAMRecord previous = checker.getPreviousRecord();
+                if (!checker.isSorted(result)) {
+                    throw new IllegalStateException(String.format(
+                            "Records %s should come after %s when sorting with %s",
+                            checker.getSortKey(previous),
+                            checker.getSortKey(result), checker.getSortOrder()));
+                }
             }
             return result;
         }


### PR DESCRIPTION
I noticed there was a lot of inconsistency dealing with `SamFileHeader.SortOrder` and did some refactoring to reduce it.

refactoring code involved in checking the bam order to use SAMSortOrderChecker in more places instead of reinventing it.
refactoring internals of `SortOrder` to use java 8 Suppliers instead of reflection
removing redundant methods that could be replaced with `SortOrder.getComparatorInstance()`

