### PR TITLE
Add InflaterFactory

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AsyncBlockCompressedInputStream.java
+++ b/src/main/java/htsjdk/samtools/util/AsyncBlockCompressedInputStream.java
@@ -26,6 +26,7 @@ package htsjdk.samtools.util;
 
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.zip.InflaterFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -79,19 +80,36 @@ public class AsyncBlockCompressedInputStream extends BlockCompressedInputStream 
         super(stream, true);
     }
 
+    public AsyncBlockCompressedInputStream(final InputStream stream, InflaterFactory inflaterFactory) {
+        super(stream, true, inflaterFactory);
+    }
+
     public AsyncBlockCompressedInputStream(final File file)
         throws IOException {
         super(file);
+    }
+
+    public AsyncBlockCompressedInputStream(final File file, InflaterFactory inflaterFactory)
+            throws IOException {
+        super(file, inflaterFactory);
     }
 
     public AsyncBlockCompressedInputStream(final URL url) {
         super(url);
     }
 
+    public AsyncBlockCompressedInputStream(final URL url, InflaterFactory inflaterFactory) {
+        super(url, inflaterFactory);
+    }
+
     public AsyncBlockCompressedInputStream(final SeekableStream strm) {
         super(strm);
     }
-    
+
+    public AsyncBlockCompressedInputStream(final SeekableStream strm, InflaterFactory inflaterFactory) {
+        super(strm, inflaterFactory);
+    }
+
     @Override
     protected DecompressedBlock nextBlock(byte[] bufferAvailableForReuse) {
         if (bufferAvailableForReuse != null) {

--- a/src/main/java/htsjdk/samtools/util/BlockGunzipper.java
+++ b/src/main/java/htsjdk/samtools/util/BlockGunzipper.java
@@ -24,6 +24,7 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMFormatException;
+import htsjdk.samtools.util.zip.InflaterFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -43,9 +44,34 @@ import java.util.zip.Inflater;
  * @author alecw@broadinstitute.org
  */
 public class BlockGunzipper {
-    private final Inflater inflater = new Inflater(true); // GZIP mode
+    private static InflaterFactory defaultInflaterFactory = new InflaterFactory();
+    private final Inflater inflater;
     private final CRC32 crc32 = new CRC32();
     private boolean checkCrcs = false;
+
+    /**
+     * Create BlockGunziper using the provided inflaterFactory
+     * @param inflaterFactory
+     */
+    BlockGunzipper(InflaterFactory inflaterFactory) {
+        inflater = inflaterFactory.makeInflater(true); // GZIP mode
+    }
+
+    /**
+     * Sets the default {@link InflaterFactory} that will be used for all instances unless specified otherwise in the constructor.
+     * If this method is not called the default is a factory that will create the JDK {@link Inflater}.
+     * @param inflaterFactory non-null default factory.
+     */
+    public static void setDefaultInflaterFactory(final InflaterFactory inflaterFactory) {
+        if (inflaterFactory == null) {
+            throw new IllegalArgumentException("null inflaterFactory");
+        }
+        defaultInflaterFactory = inflaterFactory;
+    }
+
+    public static InflaterFactory getDefaultInflaterFactory() {
+        return defaultInflaterFactory;
+    }
 
     /** Allows the caller to decide whether or not to check CRCs on when uncompressing blocks. */
     public void setCheckCrcs(final boolean check) {

--- a/src/main/java/htsjdk/samtools/util/zip/InflaterFactory.java
+++ b/src/main/java/htsjdk/samtools/util/zip/InflaterFactory.java
@@ -23,26 +23,27 @@
  */
 package htsjdk.samtools.util.zip;
 
-import htsjdk.samtools.util.BlockCompressedOutputStream;
-import java.util.zip.Deflater;
+import htsjdk.samtools.util.BlockGunzipper;
+import java.util.zip.Inflater;
 
 /**
- * Factory for {@link Deflater} objects used by {@link BlockCompressedOutputStream}.
- * This class may be extended to provide alternative deflaters (e.g., for improved performance).
+ * Factory for {@link Inflater} objects used by {@link BlockGunzipper}.
+ * This class may be extended to provide alternative inflaters (e.g., for improved performance).
+ * The default implementation returns a JDK {@link Inflater}
  */
-public class DeflaterFactory {
+public class InflaterFactory {
 
-    public DeflaterFactory() {
+    public InflaterFactory() {
         //Note: made explicit constructor to make searching for references easier
     }
 
     /**
-     * Returns a deflater object that will be used when writing BAM files.
-     * Subclasses may override to provide their own deflater implementation.
-     * @param compressionLevel the compression level (0-9)
+     * Returns an inflater object that will be used when reading DEFLATE compressed files.
+     * Subclasses may override to provide their own inflater implementation.
+     * The default implementation returns a JDK {@link Inflater}
      * @param gzipCompatible if true then use GZIP compatible compression
      */
-    public Deflater makeDeflater(final int compressionLevel, final boolean gzipCompatible) {
-        return new Deflater(compressionLevel, gzipCompatible);
+    public Inflater makeInflater(final boolean gzipCompatible) {
+        return new Inflater(gzipCompatible);
     }
 }

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
@@ -170,8 +170,8 @@ public class BlockCompressedOutputStreamTest {
         final int[] deflateCalls = {0}; //Note: using and array is a HACK to fool the compiler
 
         class MyDeflater extends Deflater{
-            MyDeflater(int level, boolean nowrap){
-                super(level, nowrap);
+            MyDeflater(int level, boolean gzipCompatible){
+                super(level, gzipCompatible);
             }
             @Override
             public int deflate(byte[] b, int off, int len) {
@@ -181,8 +181,8 @@ public class BlockCompressedOutputStreamTest {
 
         }
         final DeflaterFactory myDeflaterFactory= new DeflaterFactory(){
-            public Deflater makeDeflater(final int compressionLevel, final boolean nowrap) {
-                return new MyDeflater(compressionLevel, nowrap);
+            public Deflater makeDeflater(final int compressionLevel, final boolean gzipCompatible) {
+                return new MyDeflater(compressionLevel, gzipCompatible);
             }
         };
         final List<String> linesWritten = new ArrayList<>();


### PR DESCRIPTION
### Description

Created the `InflaterFactory` class and added a `defaultInflaterFactory` to `BlockGunzipper`. By default, the `defaultInflaterFactory` creates a Java `Inflater`, so `htsjdk` default behavior remains the same.

The `InflaterFactory` enables the use of accelerated `Inflater` implementations, like the one in an upcoming release of [GKL](https://github.com/Intel-HLS/GKL).

Applications can set the default `InflaterFactory` using this static method:
```java
BlockGunzipper.setDefaultInflaterFactory(myInflaterFactory);
```
Applications can override the default `InflaterFactory` using:
```java
SamReader reader = SamReaderFactory.makeDefault().inflaterFactory(myInflaterFactory);
```

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
