### PR TITLE
adding ability to control jexl expression behavior when missing values

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/JEXLMap.java
+++ b/src/main/java/htsjdk/variant/variantcontext/JEXLMap.java
@@ -6,7 +6,6 @@ import org.apache.commons.jexl2.JexlException;
 import org.apache.commons.jexl2.MapContext;
 
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * This is an implementation of a Map of {@link JexlVCMatchExp} to true or false values.
@@ -15,28 +14,11 @@ import java.util.function.Supplier;
 
 class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
 
-    public enum MissingValuesTreatment {
-        NO_MATCH(() -> false),
-        MATCH(() -> true),
-        THROW(() -> {throw new IllegalArgumentException("Jexl Expression couldn't be evaluated because there was a missing value.");});
-
-        private final Supplier<Boolean> resultSupplier;
-
-        MissingValuesTreatment(final Supplier<Boolean> resultSupplier){
-            this.resultSupplier = resultSupplier;
-        }
-
-        public boolean getMissingValue(){
-            return resultSupplier.get();
-        }
-
-    }
-
     // our variant context and/or Genotype
     private final VariantContext vc;
     private final Genotype g;
 
-    private final MissingValuesTreatment howToTreatMissingValues;
+    private final VariantContextUtils.JexlMissingValueTreatment howToTreatMissingValues;
 
     /**
      * our mapping from {@link JexlVCMatchExp} to {@link Boolean}s, which will be set to {@code NULL}
@@ -47,7 +29,7 @@ class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
     // our context
     private JexlContext jContext = null;
 
-    public JEXLMap(final Collection<JexlVCMatchExp> jexlCollection, final VariantContext vc, final Genotype g, final MissingValuesTreatment howToTreatMissingValues) {
+    public JEXLMap(final Collection<JexlVCMatchExp> jexlCollection, final VariantContext vc, final Genotype g, final VariantContextUtils.JexlMissingValueTreatment howToTreatMissingValues) {
         this.jexl = initialize(jexlCollection);
         this.vc = vc;
         this.g = g;
@@ -55,15 +37,11 @@ class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
     }
 
     public JEXLMap(final Collection<JexlVCMatchExp> jexlCollection, final VariantContext vc, final Genotype g) {
-        this(jexlCollection, vc, g, MissingValuesTreatment.NO_MATCH);
-    }
-
-    public JEXLMap(final Collection<JexlVCMatchExp> jexlCollection, final VariantContext vc, final MissingValuesTreatment howToTreatMissingValues) {
-        this(jexlCollection, vc, null, howToTreatMissingValues);
+        this(jexlCollection, vc, g, VariantContextUtils.JexlMissingValueTreatment.NO_MATCH);
     }
 
     public JEXLMap(final Collection<JexlVCMatchExp> jexlCollection, final VariantContext vc) {
-        this(jexlCollection, vc, MissingValuesTreatment.NO_MATCH);
+        this(jexlCollection, vc, null, VariantContextUtils.JexlMissingValueTreatment.NO_MATCH);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/JEXLMap.java
+++ b/src/main/java/htsjdk/variant/variantcontext/JEXLMap.java
@@ -17,13 +17,13 @@ class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
      * If a JEXL expression contains values that are not available in the given context, the default behavior is to
      * treat that expression as a miss match.
      */
-    public static final VariantContextUtils.JexlMissingValueTreatment DEFAULT_MISSING_VALUE_TREATMENT = VariantContextUtils.JexlMissingValueTreatment.MISMATCH;
+    public static final JexlMissingValueTreatment DEFAULT_MISSING_VALUE_TREATMENT = JexlMissingValueTreatment.TREAT_AS_MISMATCH;
 
     // our variant context and/or Genotype
     private final VariantContext vc;
     private final Genotype g;
 
-    private final VariantContextUtils.JexlMissingValueTreatment howToTreatMissingValues;
+    private final JexlMissingValueTreatment howToTreatMissingValues;
 
     /**
      * our mapping from {@link JexlVCMatchExp} to {@link Boolean}s, which will be set to {@code NULL}
@@ -41,7 +41,7 @@ class JEXLMap implements Map<JexlVCMatchExp, Boolean> {
      * @param g genotype to evaluate expressions against, may be null
      * @param howToTreatMissingValues how missing values in vc and g should be treated
      */
-    public JEXLMap(final Collection<JexlVCMatchExp> jexlCollection, final VariantContext vc, final Genotype g, final VariantContextUtils.JexlMissingValueTreatment howToTreatMissingValues) {
+    public JEXLMap(final Collection<JexlVCMatchExp> jexlCollection, final VariantContext vc, final Genotype g, final JexlMissingValueTreatment howToTreatMissingValues) {
         this.jexl = initializeMap(jexlCollection);
         this.vc = vc;
         this.g = g;

--- a/src/main/java/htsjdk/variant/variantcontext/JexlMissingValueTreatment.java
+++ b/src/main/java/htsjdk/variant/variantcontext/JexlMissingValueTreatment.java
@@ -29,7 +29,7 @@ public enum JexlMissingValueTreatment {
 
     /**
      * get the missing value that corresponds to this option or throw an exception
-     * @return the appropriate f
+     * @return the value that should be used in case of a missing value
      * @throws IllegalArgumentException if this should be treated as an error
      */
     boolean getMissingValueOrExplode(){

--- a/src/main/java/htsjdk/variant/variantcontext/JexlMissingValueTreatment.java
+++ b/src/main/java/htsjdk/variant/variantcontext/JexlMissingValueTreatment.java
@@ -1,0 +1,39 @@
+package htsjdk.variant.variantcontext;
+
+import java.util.function.Supplier;
+
+/**
+ * How to treat values that appear in a jexl expression but are missing in the context it's applied to
+ */
+public enum JexlMissingValueTreatment {
+    /**
+     * Treat expressions with a missing value as a mismatch and evaluate to false
+     */
+    TREAT_AS_MISMATCH(() -> false),
+
+    /**
+     * Treat expressions with a missing value as a match and evaluate to true
+     */
+    TREAT_AS_MATCH(() -> true),
+
+    /**
+     * Treat expressions with a missing value as an error and throw an {@link IllegalArgumentException}
+     */
+    THROW(() -> {throw new IllegalArgumentException("Jexl Expression couldn't be evaluated because there was a missing value.");});
+
+    private final Supplier<Boolean> resultSupplier;
+
+    JexlMissingValueTreatment(final Supplier<Boolean> resultSupplier){
+        this.resultSupplier = resultSupplier;
+    }
+
+    /**
+     * get the missing value that corresponds to this option or throw an exception
+     * @return the appropriate f
+     * @throws IllegalArgumentException if this should be treated as an error
+     */
+    boolean getMissingValueOrExplode(){
+        return resultSupplier.get();
+    }
+
+}

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -235,7 +235,7 @@ public class VariantContextUtils {
             this.resultSupplier = resultSupplier;
         }
 
-        public boolean getMissingValue(){
+        boolean getMissingValue(){
             return resultSupplier.get();
         }
 

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -224,9 +224,23 @@ public class VariantContextUtils {
         }
     }
 
+    /**
+     *
+     */
     public enum JexlMissingValueTreatment {
-        NO_MATCH(() -> false),
+        /**
+         * Treat expressions with a missing value as a mismatch and evaluate to false
+         */
+        MISMATCH(() -> false),
+
+        /**
+         * Treat expressions with a missing value as a match and evaluate to true
+         */
         MATCH(() -> true),
+
+        /**
+         * Treat expressions with a missing value as an error and throw an {@link IllegalArgumentException}
+         */
         THROW(() -> {throw new IllegalArgumentException("Jexl Expression couldn't be evaluated because there was a missing value.");});
 
         private final Supplier<Boolean> resultSupplier;
@@ -235,7 +249,12 @@ public class VariantContextUtils {
             this.resultSupplier = resultSupplier;
         }
 
-        boolean getMissingValue(){
+        /**
+         * get the missing value that corresponds to this option or throw an exception
+         * @return the appropriate f
+         * @throws IllegalArgumentException if this should be treated as an error
+         */
+        boolean getMissingValueOrExplode(){
             return resultSupplier.get();
         }
 
@@ -343,7 +362,7 @@ public class VariantContextUtils {
      * @return      true if there is a match
      */
     public static boolean match(VariantContext vc, Genotype g, JexlVCMatchExp exp) {
-        return match(vc, g, Collections.singletonList(exp), JexlMissingValueTreatment.NO_MATCH).get(exp);
+        return match(vc, g, Collections.singletonList(exp), JEXLMap.DEFAULT_MISSING_VALUE_TREATMENT).get(exp);
     }
 
     /**
@@ -372,7 +391,7 @@ public class VariantContextUtils {
      * @return      true if there is a match
      */
     public static Map<JexlVCMatchExp, Boolean> match(VariantContext vc, Genotype g, Collection<JexlVCMatchExp> exps) {
-        return match(vc, g, exps, JexlMissingValueTreatment.NO_MATCH);
+        return match(vc, g, exps, JEXLMap.DEFAULT_MISSING_VALUE_TREATMENT);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -46,7 +46,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 
 public class VariantContextUtils {
     private static Set<String> MISSING_KEYS_WARNED_ABOUT = new HashSet<String>();
@@ -222,42 +221,6 @@ public class VariantContextUtils {
             this.name = name;
             this.exp = exp;
         }
-    }
-
-    /**
-     *
-     */
-    public enum JexlMissingValueTreatment {
-        /**
-         * Treat expressions with a missing value as a mismatch and evaluate to false
-         */
-        MISMATCH(() -> false),
-
-        /**
-         * Treat expressions with a missing value as a match and evaluate to true
-         */
-        MATCH(() -> true),
-
-        /**
-         * Treat expressions with a missing value as an error and throw an {@link IllegalArgumentException}
-         */
-        THROW(() -> {throw new IllegalArgumentException("Jexl Expression couldn't be evaluated because there was a missing value.");});
-
-        private final Supplier<Boolean> resultSupplier;
-
-        JexlMissingValueTreatment(final Supplier<Boolean> resultSupplier){
-            this.resultSupplier = resultSupplier;
-        }
-
-        /**
-         * get the missing value that corresponds to this option or throw an exception
-         * @return the appropriate f
-         * @throws IllegalArgumentException if this should be treated as an error
-         */
-        boolean getMissingValueOrExplode(){
-            return resultSupplier.get();
-        }
-
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class VariantContextUtils {
     private static Set<String> MISSING_KEYS_WARNED_ABOUT = new HashSet<String>();
@@ -223,6 +224,23 @@ public class VariantContextUtils {
         }
     }
 
+    public enum JexlMissingValueTreatment {
+        NO_MATCH(() -> false),
+        MATCH(() -> true),
+        THROW(() -> {throw new IllegalArgumentException("Jexl Expression couldn't be evaluated because there was a missing value.");});
+
+        private final Supplier<Boolean> resultSupplier;
+
+        JexlMissingValueTreatment(final Supplier<Boolean> resultSupplier){
+            this.resultSupplier = resultSupplier;
+        }
+
+        public boolean getMissingValue(){
+            return resultSupplier.get();
+        }
+
+    }
+
     /**
      * Method for creating JexlVCMatchExp from input walker arguments names and exps.  These two arrays contain
      * the name associated with each JEXL expression. initializeMatchExps will parse each expression and return
@@ -307,6 +325,7 @@ public class VariantContextUtils {
      * This the best way to apply JEXL expressions to {@link VariantContext} records.
      * Use the various {@code initializeMatchExps()}'s to create the list of {@link JexlVCMatchExp} expressions.
      *
+     * Expressions that contain literals not available in the VariantContext or Genotype will be treated as not matching
      * @param vc    variant context
      * @param exps  expressions
      * @return      true if there is a match
@@ -324,7 +343,36 @@ public class VariantContextUtils {
      * @return      true if there is a match
      */
     public static boolean match(VariantContext vc, Genotype g, JexlVCMatchExp exp) {
-        return match(vc,g, Collections.singletonList(exp)).get(exp);
+        return match(vc, g, Collections.singletonList(exp), JexlMissingValueTreatment.NO_MATCH).get(exp);
+    }
+
+    /**
+     * Returns true if {@code exp} match {@code vc}, {@code g}.
+     * See {@link #match(VariantContext, Genotype, Collection)} for full docs.
+     * @param vc    variant context
+     * @param g     genotype
+     * @param exp   expression
+     * @param howToTreatMissingValues what to do if the jexl expression contains literals that aren't in the context
+     * @return      true if there is a match
+     */
+    public static boolean match(VariantContext vc, Genotype g, JexlVCMatchExp exp, JexlMissingValueTreatment howToTreatMissingValues) {
+        return match(vc, g, Collections.singletonList(exp), howToTreatMissingValues).get(exp);
+    }
+
+    /**
+     * Matches each {@link JexlVCMatchExp} exp against the data contained in {@code vc}, {@code g},
+     * and returns a map from these expressions to {@code true} (if they matched) or {@code false} (if they didn't).
+     * This the best way to apply JEXL expressions to {@link VariantContext} records.
+     * Use the various {@code initializeMatchExps()}'s to create the list of {@link JexlVCMatchExp} expressions.
+     *
+     * Expressions that contain literals not available in the VariantContext or Genotype will be treated as not matching
+     * @param vc    variant context
+     * @param g     genotype
+     * @param exps  expressions
+     * @return      true if there is a match
+     */
+    public static Map<JexlVCMatchExp, Boolean> match(VariantContext vc, Genotype g, Collection<JexlVCMatchExp> exps) {
+        return match(vc, g, exps, JexlMissingValueTreatment.NO_MATCH);
     }
 
     /**
@@ -336,10 +384,11 @@ public class VariantContextUtils {
      * @param vc    variant context
      * @param g     genotype
      * @param exps  expressions
+     * @param howToTreatMissingValues what to do if the jexl expression contains literals that aren't in the context
      * @return      true if there is a match
      */
-    public static Map<JexlVCMatchExp, Boolean> match(VariantContext vc, Genotype g, Collection<JexlVCMatchExp> exps) {
-        return new JEXLMap(exps,vc,g);
+    public static Map<JexlVCMatchExp, Boolean> match(VariantContext vc, Genotype g, Collection<JexlVCMatchExp> exps, JexlMissingValueTreatment howToTreatMissingValues) {
+        return new JEXLMap(exps, vc, g, howToTreatMissingValues);
     }
 
     /**

--- a/src/test/java/htsjdk/variant/variantcontext/VariantJEXLContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantJEXLContextUnitTest.java
@@ -31,12 +31,10 @@ import htsjdk.variant.variantcontext.VariantContextUtils.JexlVCMatchExp;
 
 import htsjdk.variant.vcf.VCFConstants;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 
 /**
@@ -52,6 +50,10 @@ public class VariantJEXLContextUnitTest extends VariantBaseTest {
 
     private static final VariantContextUtils.JexlVCMatchExp exp
             = new VariantContextUtils.JexlVCMatchExp("name", VariantContextUtils.engine.get().createExpression("QUAL > 500.0"));
+
+    private static final JexlVCMatchExp missingValueExpression = new VariantContextUtils.JexlVCMatchExp(
+            "Zis10", VariantContextUtils.engine.get().createExpression("Z==10"));
+
 
     // SNP alleles: A[ref]/T[alt] at chr1:10. One (crappy) sample, one (bare minimum) VC.
     private static final SimpleFeature eventLoc = new SimpleFeature("chr1", 10, 10);
@@ -86,25 +88,44 @@ public class VariantJEXLContextUnitTest extends VariantBaseTest {
         Assert.assertTrue(!jexlMap.get(exp));
     }
 
-    @Test
-    public void testMissingBehavior(){
-        final JexlVCMatchExp exp = new VariantContextUtils.JexlVCMatchExp(
-                "Zis10", VariantContextUtils.engine.get().createExpression("Z==10"));
+    @Test(dataProvider = "getMissingValueTestData")
+    public void testMissingBehaviorThroughMatch(VariantContext vc, VariantContextUtils.JexlMissingValueTreatment missingValueTreatment, boolean expected, Class<? extends Exception> expectedException){
+        if(expectedException == null) {
+            Assert.assertEquals(VariantContextUtils.match(vc, null, missingValueExpression, missingValueTreatment), expected);
+        } else {
+            Assert.assertThrows(expectedException, () -> VariantContextUtils.match(vc, null, missingValueExpression, missingValueTreatment));
+        }
+    }
 
+    @Test(dataProvider = "getMissingValueTestData")
+    public void testMissingBehavior(VariantContext vc, VariantContextUtils.JexlMissingValueTreatment missingValueTreatment, boolean expected, Class<? extends Exception> expectedException){
+        final JEXLMap jexlMap = new JEXLMap(Collections.singletonList(missingValueExpression), vc, null, missingValueTreatment);
+        if(expectedException == null) {
+            Assert.assertEquals((boolean) jexlMap.get(missingValueExpression), expected);
+        } else {
+            Assert.assertThrows(expectedException, () -> jexlMap.get(missingValueExpression));
+        }
+    }
+
+    @DataProvider
+    public Object[][] getMissingValueTestData(){
         final List<Allele> alleles = Arrays.asList(Aref, Talt);
         VariantContextBuilder vcb = new VariantContextBuilder("test", "chr1", 10, 10, alleles);
         VariantContext noZ = vcb.make();
         VariantContext hasZ = vcb.attribute("Z", 0).make();
 
-
-        Assert.assertFalse(VariantContextUtils.match(noZ, null, exp)); //default missing -> no match
-        Assert.assertFalse(VariantContextUtils.match(noZ, null, exp, VariantContextUtils.JexlMissingValueTreatment.MISMATCH));
-        Assert.assertTrue(VariantContextUtils.match(noZ, null, exp, VariantContextUtils.JexlMissingValueTreatment.MATCH));
-        Assert.assertThrows(IllegalArgumentException.class, () -> VariantContextUtils.match(noZ, null, exp, VariantContextUtils.JexlMissingValueTreatment.THROW));
-
-        Assert.assertFalse(VariantContextUtils.match(hasZ, null, exp, VariantContextUtils.JexlMissingValueTreatment.THROW)); //sanity check that we don't throw if its not missing
+        return new Object[][]{
+                {noZ, JEXLMap.DEFAULT_MISSING_VALUE_TREATMENT, false, null},
+                {hasZ, JEXLMap.DEFAULT_MISSING_VALUE_TREATMENT, false, null}, //the value isn't missing but the expression is false
+                {noZ, VariantContextUtils.JexlMissingValueTreatment.MATCH, true, null},
+                {hasZ,VariantContextUtils.JexlMissingValueTreatment.MATCH, false, null}, //the value isn't missing but the expression is false
+                {noZ, VariantContextUtils.JexlMissingValueTreatment.MISMATCH, false, null},
+                {hasZ, VariantContextUtils.JexlMissingValueTreatment.MISMATCH, false, null},
+                {noZ, VariantContextUtils.JexlMissingValueTreatment.THROW, false, IllegalArgumentException.class},
+                {hasZ, VariantContextUtils.JexlMissingValueTreatment.THROW, false, null}
+        };
     }
-    
+
     // Testing the new 'FT' and 'isPassFT' expressions in the JEXL map
     @Test
     public void testJEXLGenotypeFilters() {

--- a/src/test/java/htsjdk/variant/variantcontext/VariantJEXLContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantJEXLContextUnitTest.java
@@ -89,7 +89,7 @@ public class VariantJEXLContextUnitTest extends VariantBaseTest {
     }
 
     @Test(dataProvider = "getMissingValueTestData")
-    public void testMissingBehaviorThroughMatch(VariantContext vc, VariantContextUtils.JexlMissingValueTreatment missingValueTreatment, boolean expected, Class<? extends Exception> expectedException){
+    public void testMissingBehaviorThroughMatch(VariantContext vc, JexlMissingValueTreatment missingValueTreatment, boolean expected, Class<? extends Exception> expectedException){
         if(expectedException == null) {
             Assert.assertEquals(VariantContextUtils.match(vc, null, missingValueExpression, missingValueTreatment), expected);
         } else {
@@ -98,7 +98,7 @@ public class VariantJEXLContextUnitTest extends VariantBaseTest {
     }
 
     @Test(dataProvider = "getMissingValueTestData")
-    public void testMissingBehavior(VariantContext vc, VariantContextUtils.JexlMissingValueTreatment missingValueTreatment, boolean expected, Class<? extends Exception> expectedException){
+    public void testMissingBehavior(VariantContext vc, JexlMissingValueTreatment missingValueTreatment, boolean expected, Class<? extends Exception> expectedException){
         final JEXLMap jexlMap = new JEXLMap(Collections.singletonList(missingValueExpression), vc, null, missingValueTreatment);
         if(expectedException == null) {
             Assert.assertEquals((boolean) jexlMap.get(missingValueExpression), expected);
@@ -117,12 +117,12 @@ public class VariantJEXLContextUnitTest extends VariantBaseTest {
         return new Object[][]{
                 {noZ, JEXLMap.DEFAULT_MISSING_VALUE_TREATMENT, false, null},
                 {hasZ, JEXLMap.DEFAULT_MISSING_VALUE_TREATMENT, false, null}, //the value isn't missing but the expression is false
-                {noZ, VariantContextUtils.JexlMissingValueTreatment.MATCH, true, null},
-                {hasZ,VariantContextUtils.JexlMissingValueTreatment.MATCH, false, null}, //the value isn't missing but the expression is false
-                {noZ, VariantContextUtils.JexlMissingValueTreatment.MISMATCH, false, null},
-                {hasZ, VariantContextUtils.JexlMissingValueTreatment.MISMATCH, false, null},
-                {noZ, VariantContextUtils.JexlMissingValueTreatment.THROW, false, IllegalArgumentException.class},
-                {hasZ, VariantContextUtils.JexlMissingValueTreatment.THROW, false, null}
+                {noZ, JexlMissingValueTreatment.TREAT_AS_MATCH, true, null},
+                {hasZ, JexlMissingValueTreatment.TREAT_AS_MATCH, false, null}, //the value isn't missing but the expression is false
+                {noZ, JexlMissingValueTreatment.TREAT_AS_MISMATCH, false, null},
+                {hasZ, JexlMissingValueTreatment.TREAT_AS_MISMATCH, false, null},
+                {noZ, JexlMissingValueTreatment.THROW, false, IllegalArgumentException.class},
+                {hasZ, JexlMissingValueTreatment.THROW, false, null}
         };
     }
 

--- a/src/test/java/htsjdk/variant/variantcontext/VariantJEXLContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantJEXLContextUnitTest.java
@@ -98,7 +98,7 @@ public class VariantJEXLContextUnitTest extends VariantBaseTest {
 
 
         Assert.assertFalse(VariantContextUtils.match(noZ, null, exp)); //default missing -> no match
-        Assert.assertFalse(VariantContextUtils.match(noZ, null, exp, VariantContextUtils.JexlMissingValueTreatment.NO_MATCH));
+        Assert.assertFalse(VariantContextUtils.match(noZ, null, exp, VariantContextUtils.JexlMissingValueTreatment.MISMATCH));
         Assert.assertTrue(VariantContextUtils.match(noZ, null, exp, VariantContextUtils.JexlMissingValueTreatment.MATCH));
         Assert.assertThrows(IllegalArgumentException.class, () -> VariantContextUtils.match(noZ, null, exp, VariantContextUtils.JexlMissingValueTreatment.THROW));
 


### PR DESCRIPTION
adding the ability to control how jexl expressions are handled when the expression contains literals that are not present in the context

it is now possible to have a jexl expression either match, not match, or throw an exception if there is a missing value

did some refactoring of JexlMap to make methods less stateful