### PR TITLE
refactoring Lazy to take a Supplier()

### DIFF
--- a/src/main/java/htsjdk/samtools/SamInputResource.java
+++ b/src/main/java/htsjdk/samtools/SamInputResource.java
@@ -44,6 +44,7 @@ import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Describes a SAM-like resource, including its data (where the records are), and optionally an index.
@@ -223,9 +224,9 @@ abstract class InputResource {
 class FileInputResource extends InputResource {
 
     final File fileResource;
-    final Lazy<SeekableStream> lazySeekableStream = new Lazy<SeekableStream>(new Lazy.LazyInitializer<SeekableStream>() {
+    final Lazy<SeekableStream> lazySeekableStream = new Lazy<>(new Supplier<SeekableStream>() {
         @Override
-        public SeekableStream make() {
+        public SeekableStream get() {
             try {
                 return new SeekableFileStream(fileResource);
             } catch (final FileNotFoundException e) {
@@ -279,9 +280,9 @@ class PathInputResource extends InputResource {
 
     final Path pathResource;
     final Function<SeekableByteChannel, SeekableByteChannel> wrapper;
-    final Lazy<SeekableStream> lazySeekableStream = new Lazy<SeekableStream>(new Lazy.LazyInitializer<SeekableStream>() {
+    final Lazy<SeekableStream> lazySeekableStream = new Lazy<>(new Supplier<SeekableStream>() {
         @Override
-        public SeekableStream make() {
+        public SeekableStream get() {
             try {
                 return new SeekablePathStream(pathResource, wrapper);
             } catch (final IOException e) {
@@ -344,9 +345,9 @@ class PathInputResource extends InputResource {
 class UrlInputResource extends InputResource {
 
     final URL urlResource;
-    final Lazy<SeekableStream> lazySeekableStream = new Lazy<SeekableStream>(new Lazy.LazyInitializer<SeekableStream>() {
+    final Lazy<SeekableStream> lazySeekableStream = new Lazy<>(new Supplier<SeekableStream>() {
         @Override
-        public SeekableStream make() {
+        public SeekableStream get() {
             try { return SeekableStreamFactory.getInstance().getStreamFor(urlResource); }
             catch (final IOException ioe) { throw new RuntimeIOException(ioe); }
         }

--- a/src/main/java/htsjdk/samtools/util/Lazy.java
+++ b/src/main/java/htsjdk/samtools/util/Lazy.java
@@ -1,5 +1,7 @@
 package htsjdk.samtools.util;
 
+import java.util.function.Supplier;
+
 /**
  * Simple utility for building an on-demand (lazy) object-initializer.
  * 
@@ -9,29 +11,36 @@ package htsjdk.samtools.util;
  * @author mccowan
  */
 public class Lazy<T> {
-    private final LazyInitializer<T> initializer;
+    private final Supplier<T> initializer;
     private boolean isInitialized = false;
     private T instance;
 
-    /** Simple cons */
-    public Lazy(final LazyInitializer<T> initializer) {
+    public Lazy(final Supplier<T> initializer) {
         this.initializer = initializer;
     }
 
     /** Returns the instance associated with this {@link Lazy}, initializing it if necessary. */
     public synchronized T get() {
         if (!isInitialized) {
-            this.instance = initializer.make();
+            this.instance = initializer.get();
             isInitialized = true;
         }
         return instance;
     }
 
-    /** Describes how to build the instance of the lazy object. */
+    /** Describes how to build the instance of the lazy object.
+     * @deprecated since 1/2017 use a {@link Supplier} instead
+     * */
     @FunctionalInterface
-    public interface LazyInitializer<T> {
+    @Deprecated
+    public interface LazyInitializer<T> extends Supplier<T> {
         /** Returns the desired object instance. */
         T make();
+
+        @Override
+        default T get(){
+            return make();
+        }
     }
 
     public boolean isInitialized() {

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContextUtils.java
@@ -52,15 +52,12 @@ public class VariantContextUtils {
 
     /** Use a {@link Lazy} {@link JexlEngine} instance to avoid class-loading issues. (Applications that access this class are otherwise
      * forced to build a {@link JexlEngine} instance, which depends on some apache logging libraries that mightn't be packaged.) */
-    final public static Lazy<JexlEngine> engine = new Lazy<JexlEngine>(new Lazy.LazyInitializer<JexlEngine>() {
-        @Override
-        public JexlEngine make() {
-            final JexlEngine jexl = new JexlEngine();
-            jexl.setSilent(false); // will throw errors now for selects that don't evaluate properly
-            jexl.setLenient(false);
-            jexl.setDebug(false);
-            return jexl;
-        }
+    final public static Lazy<JexlEngine> engine = new Lazy<>(() -> {
+        final JexlEngine jexl = new JexlEngine();
+        jexl.setSilent(false); // will throw errors now for selects that don't evaluate properly
+        jexl.setLenient(false);
+        jexl.setDebug(false);
+        return jexl;
     });
     private final static boolean ASSUME_MISSING_FIELDS_ARE_STRINGS = false;
     


### PR DESCRIPTION
### Description
Lazy previously accepted a custom interface called LazyInitializer which is redundant with Supplier since java 8

made LazyInitializer extend Supplier
changed the constructor to take generic Supplier instead of only LazyInitializers

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

