### PR TITLE
Shl edit samrecord docs

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -572,14 +572,14 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
-     * @return 1-based inclusive leftmost position of the clipped sequence, or 0 if there is no position.
+     * @return 1-based inclusive leftmost position of the sequence remaining after clipping. If no position, as would occur e.g. for the unmapped mate of a singly mapping pair, returns 0.
      */
     public int getAlignmentStart() {
         return mAlignmentStart;
     }
 
     /**
-     * @param value 1-based inclusive leftmost position of the clipped sequence, or 0 if there is no position.
+     * @param value 1-based inclusive leftmost position of the sequence remaining after clipping. If no position, e.g. for unmapped mate of a singly mapping pair, returns 0.
      */
     public void setAlignmentStart(final int value) {
         mAlignmentStart = value;
@@ -590,7 +590,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
-     * @return 1-based inclusive rightmost position of the clipped sequence, or 0 read if unmapped.
+     * @return 1-based inclusive rightmost position of the sequence remaining after clipping. If no position, e.g. for unmapped mate of a singly mapping pair, returns 0.
      */
     public int getAlignmentEnd() {
         if (getReadUnmappedFlag()) {

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -572,14 +572,16 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
-     * @return 1-based inclusive leftmost position of the sequence remaining after clipping. If no position, as would occur e.g. for the unmapped mate of a singly mapping pair, returns 0.
+     * @return 1-based inclusive leftmost position of the sequence remaining after clipping. 
+     * If no position, as would occur e.g. for the unmapped mate of a singly mapping pair, returns 0.
      */
     public int getAlignmentStart() {
         return mAlignmentStart;
     }
 
     /**
-     * @param value 1-based inclusive leftmost position of the sequence remaining after clipping. If no position, e.g. for unmapped mate of a singly mapping pair, returns 0.
+     * @param value 1-based inclusive leftmost position of the sequence remaining after clipping. 
+     * If no position, e.g. for unmapped mate of a singly mapping pair, returns 0.
      */
     public void setAlignmentStart(final int value) {
         mAlignmentStart = value;
@@ -590,7 +592,8 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
-     * @return 1-based inclusive rightmost position of the sequence remaining after clipping. If no position, e.g. for unmapped mate of a singly mapping pair, returns 0.
+     * @return 1-based inclusive rightmost position of the sequence remaining after clipping. 
+     * If no position, e.g. for unmapped mate of a singly mapping pair, returns 0.
      */
     public int getAlignmentEnd() {
         if (getReadUnmappedFlag()) {

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -572,16 +572,16 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
-     * @return 1-based inclusive leftmost position of the sequence remaining after clipping. 
-     * If no position, as would occur e.g. for the unmapped mate of a singly mapping pair, returns 0.
+     * @return 1-based inclusive leftmost position of the sequence remaining after clipping, or 0 
+     * if there is no position, e.g. for unmapped read.
      */
     public int getAlignmentStart() {
         return mAlignmentStart;
     }
 
     /**
-     * @param value 1-based inclusive leftmost position of the sequence remaining after clipping. 
-     * If no position, e.g. for unmapped mate of a singly mapping pair, returns 0.
+     * @param value 1-based inclusive leftmost position of the sequence remaining after clipping or 0 
+     * if there is no position, e.g. for unmapped read.
      */
     public void setAlignmentStart(final int value) {
         mAlignmentStart = value;
@@ -592,8 +592,8 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
-     * @return 1-based inclusive rightmost position of the sequence remaining after clipping. 
-     * If no position, e.g. for unmapped mate of a singly mapping pair, returns 0.
+     * @return 1-based inclusive rightmost position of the sequence remaining after clipping or 0 
+     * if there is no position, e.g. for unmapped read.
      */
     public int getAlignmentEnd() {
         if (getReadUnmappedFlag()) {


### PR DESCRIPTION
Clarify SAMRecord documentation so that users are not confused by thinking the opposite of what is meant.

- Three variable descriptions changed: getAlignmentStart, setAlignmentStart and getAlignmentEnd. Before, each read, "position of the clipped sequence," and now each reads, "position of the sequence remaining after clipping," for all three variable descriptions. 
- In addition, took liberty to clarify "or 0 if there is no position" further. Now reads, "If no position, as would occur e.g. for the unmapped mate of a singly mapping pair, returns 0." Talked briefly to LB and agreed _not_ to link to GATK documentation within htsjdk given it is a standalone project.

