### PR TITLE
Make BAMFileReader and some related classes public

### DIFF
--- a/src/main/java/htsjdk/samtools/SamReader.java
+++ b/src/main/java/htsjdk/samtools/SamReader.java
@@ -381,7 +381,11 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
             this.resource = resource;
         }
 
-        PrimitiveSamReader underlyingReader() {
+        /**
+         * Access the underlying {@link PrimitiveSamReader} used by this adapter.
+         * @return the {@link PrimitiveSamReader} used by this adapter.
+         */
+        public PrimitiveSamReader underlyingReader() {
             return p;
         }
 

--- a/src/test/java/htsjdk/samtools/BAMFileSpanTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileSpanTest.java
@@ -1,0 +1,70 @@
+package htsjdk.samtools;
+
+import java.util.Arrays;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class BAMFileSpanTest {
+  @Test(dataProvider = "testRemoveContentsBeforeProvider")
+  public void testRemoveContentsBefore(BAMFileSpan originalSpan, BAMFileSpan cutoff,
+      BAMFileSpan expectedSpan) {
+    // only start value in cutoff is used
+    Assert.assertEquals(
+        ((BAMFileSpan) originalSpan.removeContentsBefore(cutoff)).getChunks(),
+        expectedSpan.getChunks());
+  }
+
+  @DataProvider(name = "testRemoveContentsBeforeProvider")
+  private Object[][] testRemoveContentsBeforeProvider() {
+    return new Object[][] {
+        { span(chunk(6,10), chunk(11,15)), null, span(chunk(6,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(), span(chunk(6,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(6,0)), span(chunk(6,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(7,0)), span(chunk(7,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(9,0)), span(chunk(9,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(10,0)), span(chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(11,0)), span(chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(12,0)), span(chunk(12,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(15,0)), span() },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(16,0)), span() },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(6,10), chunk(7,16)), span(chunk(6, 10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(16,17), chunk(18,19)), span() },
+    };
+  }
+
+  @Test(dataProvider = "testRemoveContentsAfterProvider")
+  public void testRemoveContentsAfter(BAMFileSpan originalSpan, BAMFileSpan cutoff,
+      BAMFileSpan expectedSpan) {
+    // only end value in cutoff is used
+    Assert.assertEquals(
+        ((BAMFileSpan) originalSpan.removeContentsAfter(cutoff)).getChunks(),
+        expectedSpan.getChunks());
+  }
+
+  @DataProvider(name = "testRemoveContentsAfterProvider")
+  private Object[][] testRemoveContentsAfterProvider() {
+    return new Object[][] {
+        { span(chunk(6,10), chunk(11,15)), null, span(chunk(6,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(), span(chunk(6,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,6)), span() },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,7)), span(chunk(6,7)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,9)), span(chunk(6,9)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,10)), span(chunk(6,10)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,11)), span(chunk(6,10)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,12)), span(chunk(6,10), chunk(11,12)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,15)), span(chunk(6,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,16)), span(chunk(6,10), chunk(11,15)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,6), chunk(7,10)), span(chunk(6, 10)) },
+        { span(chunk(6,10), chunk(11,15)), span(chunk(0,6), chunk(7,16)), span(chunk(6, 10), chunk(11,15)) },
+    };
+  }
+
+  private BAMFileSpan span(Chunk... chunks) {
+    return new BAMFileSpan(Arrays.asList(chunks));
+  }
+
+  private Chunk chunk(long start, long end) {
+    return new Chunk(start, end);
+  }
+}


### PR DESCRIPTION
... and expose methods for iterating over a part of a BAM file (needed for Hadoop-BAM,
which processes BAM files in parallel, see https://github.com/HadoopGenomics/Hadoop-BAM/issues/91).

Also, add BAMFileSpan#removeContentsAfter method to mirror
removeContentsBefore.

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

