### PR TITLE
Defensive programming around test case race condition to address #776

### DIFF
--- a/src/test/java/htsjdk/samtools/util/AsyncBufferedIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/AsyncBufferedIteratorTest.java
@@ -73,9 +73,15 @@ public class AsyncBufferedIteratorTest {
         TestCloseableIterator it = new TestCloseableIterator(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
         AsyncBufferedIterator<Integer> abi = new AsyncBufferedIterator<Integer>(it, 3, 2, "testBackgroundBlocks");
         Assert.assertNotNull(getThreadWithName("testBackgroundBlocks"));
-        Thread.sleep(10); // how do we write this test and not be subject to race conditions?
+        // how do we write this test and not be subject to race conditions?
         // should have read 9 records: 2*3 in the buffers, and another 3 read but
-        // blocking waiting to be added 
+        // blocking waiting to be added
+        for (int i = 0; i < 64; i++) {
+        	if (it.consumed() >= 9) {
+        		break;
+        	}
+        	Thread.sleep(1);
+        }
         Assert.assertEquals(it.consumed(), 9);
         abi.close();
     }


### PR DESCRIPTION
### Description

AsyncBufferedIteratorTest.testBackgroundBlocks() is subject to a race condition as it is a testing the async loading of records in AsyncBufferedIterator, but is not privy to the internal state of the iterator. Additional logic has been added such that the test case race condition is now extremely unlikely to be encountered.