### PR TITLE
Make public constructors in CustomGzipOutputStream

### DIFF
--- a/src/main/java/htsjdk/samtools/util/CustomGzipOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/CustomGzipOutputStream.java
@@ -11,13 +11,13 @@ import java.util.zip.GZIPOutputStream;
  * @author Tim Fennell
  */
 public class CustomGzipOutputStream extends GZIPOutputStream {
-    CustomGzipOutputStream(final OutputStream outputStream, final int bufferSize, final int compressionLevel) throws
+    public CustomGzipOutputStream(final OutputStream outputStream, final int bufferSize, final int compressionLevel) throws
             IOException {
         super(outputStream, bufferSize);
         this.def.setLevel(compressionLevel);
     }
 
-    CustomGzipOutputStream(final OutputStream outputStream, final int compressionLevel) throws IOException {
+    public CustomGzipOutputStream(final OutputStream outputStream, final int compressionLevel) throws IOException {
         super(outputStream);
         this.def.setLevel(compressionLevel);
     }


### PR DESCRIPTION
### Description

I made public the `CustomGzipOutputStream` in #746 to use it outside `IOUtils`, but I forgot to made the constructors public too. This fix the problem and makes the custom gzip wrapper available for use it outside the package.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

