### PR TITLE
Tribble/Tabix index path support

### DIFF
--- a/src/main/java/htsjdk/tribble/TabixFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TabixFeatureReader.java
@@ -23,7 +23,6 @@
  */
 package htsjdk.tribble;
 
-import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.readers.*;

--- a/src/main/java/htsjdk/tribble/Tribble.java
+++ b/src/main/java/htsjdk/tribble/Tribble.java
@@ -37,9 +37,9 @@ public class Tribble {
     public final static String STANDARD_INDEX_EXTENSION = ".idx";
 
     /**
-     * Return the name of the index file for the provided vcf {@code filename}
+     * Return the name of the index file for the provided {@code filename}
      * Does not actually create an index
-     * @param filename  name of the vcf file
+     * @param filename  name of the file
      * @return non-null String representing the index filename
      */
     public static String indexFile(final String filename) {
@@ -47,9 +47,9 @@ public class Tribble {
     }
 
     /**
-     * Return the File of the index file for the provided vcf {@code file}
+     * Return the File of the index file for the provided {@code file}
      * Does not actually create an index
-     * @param file  the vcf file
+     * @param file  the file
      * @return a non-null File representing the index
      */
     public static File indexFile(final File file) {
@@ -57,9 +57,9 @@ public class Tribble {
     }
 
     /**
-     * Return the name of the tabix index file for the provided vcf {@code filename}
+     * Return the name of the tabix index file for the provided {@code filename}
      * Does not actually create an index
-     * @param filename  name of the vcf file
+     * @param filename  name of the file
      * @return non-null String representing the index filename
      */
     public static String tabixIndexFile(final String filename) {
@@ -67,9 +67,9 @@ public class Tribble {
     }
 
     /**
-     * Return the File of the tabix index file for the provided vcf {@code file}
+     * Return the File of the tabix index file for the provided {@code file}
      * Does not actually create an index
-     * @param file  the vcf file
+     * @param file  the file
      * @return a non-null File representing the index
      */
     public static File tabixIndexFile(final File file) {
@@ -77,9 +77,9 @@ public class Tribble {
     }
 
     /**
-     * Return the name of the index file for the provided vcf {@code filename} and {@code extension}
+     * Return the name of the index file for the provided {@code filename} and {@code extension}
      * Does not actually create an index
-     * @param filename  name of the vcf file
+     * @param filename  name of the file
      * @param extension the extension to use for the index
      * @return non-null String representing the index filename
      */
@@ -88,9 +88,9 @@ public class Tribble {
     }
 
     /**
-     * Return the File of the index file for the provided vcf {@code file} and {@code extension}
+     * Return the File of the index file for the provided {@code file} and {@code extension}
      * Does not actually create an index
-     * @param file  the vcf file
+     * @param file  the file
      * @param extension the extension to use for the index
      * @return a non-null File representing the index
      */

--- a/src/main/java/htsjdk/tribble/Tribble.java
+++ b/src/main/java/htsjdk/tribble/Tribble.java
@@ -58,13 +58,13 @@ public class Tribble {
     }
 
     /**
-     * Return the name of the index file for the provided {@code filename}
+     * Return the name of the index file for the provided {@code path}
      * Does not actually create an index
-     * @param path  name of the path
-     * @return non-null String representing the index filename
+     * @param path the path
+     * @return Path representing the index filename
      */
-    public static String indexPath(final Path path) {
-        return indexFile(path.toAbsolutePath().toString());
+    public static Path indexPath(final Path path) {
+        return path.getFileSystem().getPath(indexFile(path.toAbsolutePath().toString()));
     }
 
     /**
@@ -90,7 +90,7 @@ public class Tribble {
     /**
      * Return the name of the tabix index file for the provided {@code path}
      * Does not actually create an index
-     * @param path  name of the path
+     * @param path the path
      * @return non-null String representing the index filename
      */
     public static String tabixIndexPath(final Path path) {

--- a/src/main/java/htsjdk/tribble/Tribble.java
+++ b/src/main/java/htsjdk/tribble/Tribble.java
@@ -91,10 +91,10 @@ public class Tribble {
      * Return the name of the tabix index file for the provided {@code path}
      * Does not actually create an index
      * @param path the path
-     * @return non-null String representing the index filename
+     * @return Path representing the index filename
      */
-    public static String tabixIndexPath(final Path path) {
-        return indexFile(path.toAbsolutePath().toString());
+    public static Path tabixIndexPath(final Path path) {
+        return path.getFileSystem().getPath(tabixIndexFile(path.toAbsolutePath().toString()));
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/Tribble.java
+++ b/src/main/java/htsjdk/tribble/Tribble.java
@@ -27,6 +27,7 @@ import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.tribble.util.TabixUtils;
 
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Common, tribble wide constants and static functions
@@ -57,6 +58,16 @@ public class Tribble {
     }
 
     /**
+     * Return the name of the index file for the provided {@code filename}
+     * Does not actually create an index
+     * @param path  name of the path
+     * @return non-null String representing the index filename
+     */
+    public static String indexPath(final Path path) {
+        return indexFile(path.toAbsolutePath().toString());
+    }
+
+    /**
      * Return the name of the tabix index file for the provided {@code filename}
      * Does not actually create an index
      * @param filename  name of the file
@@ -74,6 +85,16 @@ public class Tribble {
      */
     public static File tabixIndexFile(final File file) {
         return indexFile(file.getAbsoluteFile(), TabixUtils.STANDARD_INDEX_EXTENSION);
+    }
+
+    /**
+     * Return the name of the tabix index file for the provided {@code path}
+     * Does not actually create an index
+     * @param path  name of the path
+     * @return non-null String representing the index filename
+     */
+    public static String tabixIndexPath(final Path path) {
+        return indexFile(path.toAbsolutePath().toString());
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -33,11 +33,9 @@ import htsjdk.tribble.readers.PositionalBufferedStream;
 import htsjdk.tribble.util.ParsingUtils;
 
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.channels.SeekableByteChannel;
 import java.util.ArrayList;

--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -212,6 +212,12 @@ public abstract class AbstractIndex implements MutableIndex {
         return version == VERSION;
     }
 
+    /**
+     * Gets the indexed file.
+     * @throws UnsupportedOperationException if the path cannot be represented as a file.
+     * @deprecated on 03/2017. Use {@link #getIndexedPath()} instead.
+     */
+    @Deprecated
     public File getIndexedFile() {
         return getIndexedPath().toFile();
     }
@@ -271,7 +277,7 @@ public abstract class AbstractIndex implements MutableIndex {
         dos.writeInt(MAGIC_NUMBER);
         dos.writeInt(getType());
         dos.writeInt(version);
-        dos.writeString(indexedPath.toString());
+        dos.writeString(indexedPath.toUri().toString());
         dos.writeLong(indexedFileSize);
         dos.writeLong(indexedFileTS);
         dos.writeString(indexedFileMD5);
@@ -388,7 +394,7 @@ public abstract class AbstractIndex implements MutableIndex {
     @Override
     public void writeBasedOnFeaturePath(final Path featurePath) throws IOException {
         if (!Files.isRegularFile(featurePath)) return;
-        write(IOUtil.getPath(Tribble.indexPath(featurePath)));
+        write(Tribble.indexPath(featurePath));
     }
 
 

--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -375,20 +375,10 @@ public abstract class AbstractIndex implements MutableIndex {
     }
 
     @Override
-    public void write(final File idxFile) throws IOException {
-        write(idxFile.toPath());
-    }
-
-    @Override
     public void write(final Path idxPath) throws IOException {
         try(final LittleEndianOutputStream idxStream = new LittleEndianOutputStream(new BufferedOutputStream(Files.newOutputStream(idxPath)))) {
             write(idxStream);
         }
-    }
-
-    @Override
-    public void writeBasedOnFeatureFile(final File featureFile) throws IOException {
-        writeBasedOnFeaturePath(featureFile.toPath());
     }
 
     @Override

--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -19,6 +19,7 @@
 package htsjdk.tribble.index;
 
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.Tribble;
 import htsjdk.tribble.TribbleException;
@@ -75,6 +76,7 @@ public abstract class AbstractIndex implements MutableIndex {
     protected long indexedFileTS = NO_TS;      // The timestamp
     protected String indexedFileMD5 = NO_MD5;        // The MD5 value, generally not filled in (expensive to calc)
     protected int flags;
+    protected final Log logger = Log.getInstance(this.getClass());
 
     public boolean hasFileSize() {
         return indexedFileSize != NO_FILE_SIZE;
@@ -383,7 +385,10 @@ public abstract class AbstractIndex implements MutableIndex {
 
     @Override
     public void writeBasedOnFeaturePath(final Path featurePath) throws IOException {
-        if (!Files.isRegularFile(featurePath)) return;
+        if (!Files.isRegularFile(featurePath)) {
+            logger.warn("Index not written into ", featurePath);
+            return;
+        }
         write(Tribble.indexPath(featurePath));
     }
 

--- a/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
@@ -57,13 +57,10 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
     MathUtils.RunningStat stats = new MathUtils.RunningStat();
     long basesSeen = 0;
     Feature lastFeature = null;
-    // TODO: actually this field is not needed
-    Path inputPath;
 
     public DynamicIndexCreator(final Path inputPath, final IndexFactory.IndexBalanceApproach iba) {
         this.iba = iba;
         // get a list of index creators
-        this.inputPath = inputPath;
         creators = getIndexCreators(inputPath, iba);
     }
 

--- a/src/main/java/htsjdk/tribble/index/Index.java
+++ b/src/main/java/htsjdk/tribble/index/Index.java
@@ -81,13 +81,13 @@ public interface Index {
     /**
      * Writes the index into a path.
      *
-     * Default implementation converts the path to a file and uses {@link #write(File)}.
+     * Default implementation throws {@link UnsupportedOperationException}.
      *
      * @param indexPath Where to write the index.
      * @throws IOException if the index is unable to write to the specified path.
      */
     public default void write(final Path indexPath) throws IOException {
-        write(indexPath.toFile());
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -101,12 +101,12 @@ public interface Index {
      * Write an appropriately named and located Index file based on the name and location of the featureFile.
      * If featureFile is not a normal file, the index will silently not be written.
      *
-     * Default implementation converts the path to a file and uses {@link #writeBasedOnFeatureFile(File)}.
+     * Default implementation throws {@link UnsupportedOperationException}.
      *
      * @param featurePath
      */
     public default void writeBasedOnFeaturePath(Path featurePath) throws IOException {
-        writeBasedOnFeatureFile(featurePath.toFile());
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/index/Index.java
+++ b/src/main/java/htsjdk/tribble/index/Index.java
@@ -73,7 +73,7 @@ public interface Index {
     /**
      * Writes the index into a file.
      *
-     * Default implementation delegates in {@link #write(Path)}
+     * Default implementation delegates to {@link #write(Path)}
      *
      * @param idxFile Where to write the index.
      * @throws IOException if the index is unable to write to the specified file
@@ -94,7 +94,7 @@ public interface Index {
      * Write an appropriately named and located Index file based on the name and location of the featureFile.
      * If featureFile is not a normal file, the index will silently not be written.
      *
-     * Default implementation delegates in {@link #writeBasedOnFeaturePath(Path)}
+     * Default implementation delegates to {@link #writeBasedOnFeaturePath(Path)}
      *
      * @param featureFile
      */

--- a/src/main/java/htsjdk/tribble/index/Index.java
+++ b/src/main/java/htsjdk/tribble/index/Index.java
@@ -27,6 +27,7 @@ import htsjdk.tribble.util.LittleEndianOutputStream;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -78,11 +79,35 @@ public interface Index {
     public void write(final File idxFile) throws IOException;
 
     /**
+     * Writes the index into a path.
+     *
+     * Default implementation converts the path to a file and uses {@link #write(File)}.
+     *
+     * @param indexPath Where to write the index.
+     * @throws IOException if the index is unable to write to the specified path.
+     */
+    public default void write(final Path indexPath) throws IOException {
+        write(indexPath.toFile());
+    }
+
+    /**
      * Write an appropriately named and located Index file based on the name and location of the featureFile.
      * If featureFile is not a normal file, the index will silently not be written.
      * @param featureFile
      */
     public void writeBasedOnFeatureFile(File featureFile) throws IOException;
+
+    /**
+     * Write an appropriately named and located Index file based on the name and location of the featureFile.
+     * If featureFile is not a normal file, the index will silently not be written.
+     *
+     * Default implementation converts the path to a file and uses {@link #writeBasedOnFeatureFile(File)}.
+     *
+     * @param featurePath
+     */
+    public default void writeBasedOnFeaturePath(Path featurePath) throws IOException {
+        writeBasedOnFeatureFile(featurePath.toFile());
+    }
 
     /**
      * @return get the list of properties for this index.  Returns null if no properties.

--- a/src/main/java/htsjdk/tribble/index/Index.java
+++ b/src/main/java/htsjdk/tribble/index/Index.java
@@ -73,41 +73,42 @@ public interface Index {
     /**
      * Writes the index into a file.
      *
+     * Default implementation delegates in {@link #write(Path)}
+     *
      * @param idxFile Where to write the index.
      * @throws IOException if the index is unable to write to the specified file
      */
-    public void write(final File idxFile) throws IOException;
+    public default void write(final File idxFile) throws IOException {
+        write(idxFile.toPath());
+    }
 
     /**
      * Writes the index into a path.
      *
-     * Default implementation throws {@link UnsupportedOperationException}.
-     *
      * @param indexPath Where to write the index.
      * @throws IOException if the index is unable to write to the specified path.
      */
-    public default void write(final Path indexPath) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Write an appropriately named and located Index file based on the name and location of the featureFile.
-     * If featureFile is not a normal file, the index will silently not be written.
-     * @param featureFile
-     */
-    public void writeBasedOnFeatureFile(File featureFile) throws IOException;
+    public void write(final Path indexPath) throws IOException;
 
     /**
      * Write an appropriately named and located Index file based on the name and location of the featureFile.
      * If featureFile is not a normal file, the index will silently not be written.
      *
-     * Default implementation throws {@link UnsupportedOperationException}.
+     * Default implementation delegates in {@link #writeBasedOnFeaturePath(Path)}
+     *
+     * @param featureFile
+     */
+    public default void writeBasedOnFeatureFile(File featureFile) throws IOException {
+        writeBasedOnFeaturePath(featureFile.toPath());
+    }
+
+    /**
+     * Write an appropriately named and located Index file based on the name and location of the featureFile.
+     * If featureFile is not a normal file, the index will silently not be written.
      *
      * @param featurePath
      */
-    public default void writeBasedOnFeaturePath(Path featurePath) throws IOException {
-        throw new UnsupportedOperationException();
-    }
+    public void writeBasedOnFeaturePath(Path featurePath) throws IOException;
 
     /**
      * @return get the list of properties for this index.  Returns null if no properties.

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
@@ -25,6 +25,7 @@ import htsjdk.tribble.index.TribbleIndexCreator;
 import htsjdk.tribble.index.interval.IntervalTreeIndex.ChrIndex;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedList;
 
@@ -51,15 +52,23 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
 
     private final ArrayList<MutableInterval> intervals = new ArrayList<MutableInterval>();
 
-    File inputFile;
+    Path inputPath;
 
-    public IntervalIndexCreator(final File inputFile, final int featuresPerInterval) {
-        this.inputFile = inputFile;
+    public IntervalIndexCreator(final Path inputPath, final int featuresPerInterval) {
+        this.inputPath = inputPath;
         this.featuresPerInterval = featuresPerInterval;
     }
 
+    public IntervalIndexCreator(final File inputFile, final int featuresPerInterval) {
+        this(inputFile.toPath(), featuresPerInterval);
+    }
+
     public IntervalIndexCreator(final File inputFile) {
-        this(inputFile, DEFAULT_FEATURE_COUNT);
+        this(inputFile.toPath());
+    }
+
+    public IntervalIndexCreator(final Path inputPath) {
+        this(inputPath, DEFAULT_FEATURE_COUNT);
     }
 
     @Override
@@ -108,7 +117,7 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
      */
     @Override
     public Index finalizeIndex(final long finalFilePosition) {
-        final IntervalTreeIndex featureIndex = new IntervalTreeIndex(inputFile.getAbsolutePath());
+        final IntervalTreeIndex featureIndex = new IntervalTreeIndex(inputPath);
         // dump the remaining bins to the index
         addIntervalsToLastChr(finalFilePosition);
         featureIndex.setChrIndex(chrList);

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalTreeIndex.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalTreeIndex.java
@@ -25,6 +25,7 @@ import htsjdk.tribble.util.LittleEndianOutputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -50,6 +51,15 @@ public class IntervalTreeIndex extends AbstractIndex {
         final LittleEndianInputStream dis = new LittleEndianInputStream(inputStream);
         validateIndexHeader(INDEX_TYPE, dis);
         read(dis);
+    }
+
+    /**
+     * Prepare to build an index.
+     *
+     * @param featureFile File which we are indexing
+     */
+    public IntervalTreeIndex(final Path featureFile) {
+        super(featureFile);
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -102,6 +102,14 @@ public class LinearIndex extends AbstractIndex {
     }
 
     /**
+     * Initialize with default parameters
+     * @param featurePath Path for which this is an index
+     */
+    public LinearIndex(final Path featurePath) {
+        super(featurePath);
+    }
+
+    /**
      * Load from file.
      * @param inputStream This method assumes that the input stream is already buffered as appropriate.
      */

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -71,10 +72,19 @@ public class LinearIndex extends AbstractIndex {
      * @param indices
      * @param featureFile
      */
-    public LinearIndex(final List<ChrIndex> indices, final File featureFile) {
-        super(featureFile.getAbsolutePath());
+    public LinearIndex(final List<ChrIndex> indices, final Path featureFile) {
+        super(featureFile);
         for (final ChrIndex index : indices)
             chrIndices.put(index.getName(), index);
+    }
+
+    /**
+     * Initialize using the specified {@code indices}
+     * @param indices
+     * @param featureFile
+     */
+    public LinearIndex(final List<ChrIndex> indices, final File featureFile) {
+        this(indices, featureFile.toPath());
     }
 
     private LinearIndex(final LinearIndex parent, final List<ChrIndex> indices) {

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
@@ -29,6 +29,7 @@ import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.TribbleIndexCreator;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedList;
 
@@ -43,20 +44,28 @@ public class LinearIndexCreator  extends TribbleIndexCreator {
     private int binWidth = DEFAULT_BIN_WIDTH;
 
     // the input file
-    private final File inputFile;
+    private final Path inputFile;
 
     private final LinkedList<LinearIndex.ChrIndex> chrList = new LinkedList<LinearIndex.ChrIndex>();
     private int longestFeature= 0;
 
     private final ArrayList<Block> blocks = new ArrayList<Block>();
 
-    public LinearIndexCreator(final File inputFile, final int binSize) {
-        this.inputFile = inputFile;
+    public LinearIndexCreator(final Path inputPath, final int binSize) {
+        this.inputFile = inputPath;
         binWidth = binSize;
     }
 
+    public LinearIndexCreator(final File inputFile, final int binSize) {
+        this(inputFile.toPath(), binSize);
+    }
+
     public LinearIndexCreator(final File inputFile) {
-        this(inputFile, DEFAULT_BIN_WIDTH);
+        this(inputFile.toPath());
+    }
+
+    public LinearIndexCreator(final Path inputPath) {
+        this(inputPath, DEFAULT_BIN_WIDTH);
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -31,6 +31,7 @@ import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.StringUtil;
 import htsjdk.tribble.Tribble;
 import htsjdk.tribble.TribbleException;
@@ -64,6 +65,8 @@ public class TabixIndex implements Index {
         bb.flip();
         MAGIC_NUMBER = bb.order(ByteOrder.LITTLE_ENDIAN).getInt();
     }
+
+    private static final Log LOGGER = Log.getInstance(TabixIndex.class);
 
     private final TabixFormat formatSpec;
     private final List<String> sequenceNames;
@@ -219,7 +222,10 @@ public class TabixIndex implements Index {
      */
     @Override
     public void writeBasedOnFeaturePath(final Path featurePath) throws IOException {
-        if (!Files.isRegularFile(featurePath)) return;
+        if (!Files.isRegularFile(featurePath)) {
+            LOGGER.warn("Index not written into ", featurePath);
+            return;
+        }
         write(Tribble.tabixIndexPath(featurePath));
     }
 

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -219,8 +219,8 @@ public class TabixIndex implements Index {
      */
     @Override
     public void writeBasedOnFeaturePath(final Path featurePath) throws IOException {
-        if (Files.isRegularFile(featurePath)) return;
-        write(IOUtil.getPath(Tribble.tabixIndexPath(featurePath)));
+        if (!Files.isRegularFile(featurePath)) return;
+        write(Tribble.tabixIndexPath(featurePath));
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -102,6 +102,13 @@ public class TabixIndex implements Index {
         this(new BlockCompressedInputStream(tabixFile), true);
     }
 
+    /**
+     * Convenient ctor that opens the path, wraps with with BGZF reader, and closes after reading index.
+     */
+    public TabixIndex(final Path tabixPath) throws IOException {
+        this(new BlockCompressedInputStream(Files.newInputStream(tabixPath)), true);
+    }
+
     private TabixIndex(final InputStream inputStream, final boolean closeInputStream) throws IOException {
         final LittleEndianInputStream dis = new LittleEndianInputStream(inputStream);
         if (dis.readInt() != MAGIC_NUMBER) {

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -203,16 +203,6 @@ public class TabixIndex implements Index {
     /**
      * Writes the index with BGZF.
      *
-     * @param tabixFile Where to write the index.
-     */
-    @Override
-    public void write(final File tabixFile) throws IOException {
-        write(tabixFile.toPath());
-    }
-
-    /**
-     * Writes the index with BGZF.
-     *
      * @param tabixPath Where to write the index.
      */
     @Override
@@ -220,16 +210,6 @@ public class TabixIndex implements Index {
         try(final LittleEndianOutputStream los = new LittleEndianOutputStream(new BlockCompressedOutputStream(Files.newOutputStream(tabixPath), null))) {
             write(los);
         }
-    }
-
-    /**
-     * Writes to a file with appropriate name and directory based on feature file.
-     *
-     * @param featureFile File being indexed.
-     */
-    @Override
-    public void writeBasedOnFeatureFile(final File featureFile) throws IOException {
-        writeBasedOnFeaturePath(featureFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -207,9 +207,7 @@ public class TabixIndex implements Index {
      */
     @Override
     public void write(final File tabixFile) throws IOException {
-        try(final LittleEndianOutputStream los = new LittleEndianOutputStream(new BlockCompressedOutputStream(tabixFile))) {
-            write(los);
-        }
+        write(tabixFile.toPath());
     }
 
     /**
@@ -231,8 +229,7 @@ public class TabixIndex implements Index {
      */
     @Override
     public void writeBasedOnFeatureFile(final File featureFile) throws IOException {
-        if (!featureFile.isFile()) return;
-        write(new File(featureFile.getAbsolutePath() + TabixUtils.STANDARD_INDEX_EXTENSION));
+        writeBasedOnFeaturePath(featureFile.toPath());
     }
 
     /**

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -1,6 +1,9 @@
 package htsjdk.tribble.index;
 
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.TestUtils;
 import htsjdk.tribble.Tribble;
@@ -18,6 +21,11 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,4 +102,14 @@ public class IndexTest {
         index.write(new LittleEndianOutputStream(nullOutputStrem));
     }
 
+    @Test(dataProvider = "writeIndexData")
+    public void testWritePathIndex(final File inputFile, final IndexFactory.IndexType type, final  FeatureCodec codec) throws Exception {
+        try (final FileSystem fs = Jimfs.newFileSystem("test", Configuration.unix())) {
+            // create the index
+            final Index index = IndexFactory.createIndex(inputFile, codec, type);
+            final Path path = fs.getPath(inputFile.getName() + ".index");
+            // write the index to a file
+            index.write(path);
+        }
+    }
 }

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -8,6 +8,7 @@ import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.TestUtils;
 import htsjdk.tribble.Tribble;
 import htsjdk.tribble.bed.BEDCodec;
+import htsjdk.tribble.index.interval.IntervalTreeIndex;
 import htsjdk.tribble.index.linear.LinearIndex;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.index.tabix.TabixIndex;
@@ -110,6 +111,19 @@ public class IndexTest {
             final Path path = fs.getPath(inputFile.getName() + ".index");
             // write the index to a file
             index.write(path);
+
+            // test if the index does not blow up with the path constructor
+            switch (type) {
+                case TABIX:
+                    new TabixIndex(path);
+                    break;
+                case LINEAR:
+                    new LinearIndex(path);
+                    break;
+                case INTERVAL_TREE:
+                    new IntervalTreeIndex(path);
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

#### Motivation
While trying to index a `Path` (no convertible to `File`) using the `Index` interface, the client should:
- Create the `LittleEndianOutputStream`by its own. This may lead to wrong indexes because they aren't block-compressed.
- Get the index file name by its own if it is based on a feature file. This may lead to incorrect index names.
In addition, this is part of a bigger change for include support of writing in whatever filesystem (and also reading).
#### Changes
- Clean up (first commit):  removing mentions to vcf in javadoc for `Tribble` and unused imports.
- Path support for `Index` interface: methods with default values use `Path.toFile()`
- Implementation of the new methods in `AbstractIndex` and `TabixIndex`

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

