### PR TITLE
Use Locatable in tribble instead of Feature (DO NOT MERGE: discussion)

### DIFF
--- a/src/main/java/htsjdk/tribble/AbstractFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureCodec.java
@@ -23,6 +23,8 @@
  */
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.Locatable;
+
 import java.io.IOException;
 
 /**
@@ -31,7 +33,7 @@ import java.io.IOException;
  * Note that that method is the only way that the right codec for a file is identified and that <bold>only one</bold> codec
  * is allowed to identify itself as being able to decode any given file.
  */
-public abstract class AbstractFeatureCodec<FEATURE_TYPE extends Feature, SOURCE> implements FeatureCodec<FEATURE_TYPE, SOURCE> {
+public abstract class AbstractFeatureCodec<FEATURE_TYPE extends Locatable, SOURCE> implements FeatureCodec<FEATURE_TYPE, SOURCE> {
     private final Class<FEATURE_TYPE> myClass;
 
     protected AbstractFeatureCodec(final Class<FEATURE_TYPE> myClass) {
@@ -39,7 +41,7 @@ public abstract class AbstractFeatureCodec<FEATURE_TYPE extends Feature, SOURCE>
     }
     
     @Override
-    public Feature decodeLoc(final SOURCE source) throws IOException {
+    public Locatable decodeLoc(final SOURCE source) throws IOException {
         return decode(source);
     }
 

--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -18,6 +18,7 @@
 
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.tribble.util.TabixUtils;
@@ -38,7 +39,7 @@ import java.util.function.Function;
  * <p/>
  * the feature reader class, which uses indices and codecs to read in Tribble file formats.
  */
-public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implements FeatureReader<T> {
+public abstract class AbstractFeatureReader<T extends Locatable, SOURCE> implements FeatureReader<T> {
     // the logging destination for this source
     //private final static Logger log = Logger.getLogger("BasicFeatureSource");
 
@@ -62,7 +63,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
     /**
      * Calls {@link #getFeatureReader(String, FeatureCodec, boolean)} with {@code requireIndex} = true
      */
-    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureFile, final FeatureCodec<FEATURE, SOURCE> codec) throws TribbleException {
+    public static <FEATURE extends Locatable, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureFile, final FeatureCodec<FEATURE, SOURCE> codec) throws TribbleException {
         return getFeatureReader(featureFile, codec, true);
     }
 
@@ -70,7 +71,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      * {@link #getFeatureReader(String, String, FeatureCodec, boolean, Function, Function)} with {@code null} for indexResource, wrapper, and indexWrapper
      * @throws TribbleException
      */
-    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, final FeatureCodec<FEATURE, SOURCE> codec, final boolean requireIndex) throws TribbleException {
+    public static <FEATURE extends Locatable, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, final FeatureCodec<FEATURE, SOURCE> codec, final boolean requireIndex) throws TribbleException {
         return getFeatureReader(featureResource, null, codec, requireIndex, null, null);
     }
 
@@ -79,7 +80,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      * {@link #getFeatureReader(String, String, FeatureCodec, boolean, Function, Function)} with {@code null} for wrapper, and indexWrapper
      * @throws TribbleException
      */
-    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, String indexResource, final FeatureCodec<FEATURE, SOURCE> codec, final boolean requireIndex) throws TribbleException {
+    public static <FEATURE extends Locatable, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, String indexResource, final FeatureCodec<FEATURE, SOURCE> codec, final boolean requireIndex) throws TribbleException {
         return getFeatureReader(featureResource, indexResource, codec, requireIndex, null, null);
     }
 
@@ -97,7 +98,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      *
      * @throws TribbleException
      */
-    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, String indexResource, final FeatureCodec<FEATURE, SOURCE> codec, final boolean requireIndex, Function<SeekableByteChannel, SeekableByteChannel> wrapper, Function<SeekableByteChannel, SeekableByteChannel> indexWrapper) throws TribbleException {
+    public static <FEATURE extends Locatable, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, String indexResource, final FeatureCodec<FEATURE, SOURCE> codec, final boolean requireIndex, Function<SeekableByteChannel, SeekableByteChannel> wrapper, Function<SeekableByteChannel, SeekableByteChannel> indexWrapper) throws TribbleException {
         try {
             // Test for tabix index
             if (methods.isTabix(featureResource, indexResource)) {
@@ -126,7 +127,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      * @return a reader for this data
      * @throws TribbleException
      */
-    public static <FEATURE extends Feature, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, final FeatureCodec<FEATURE, SOURCE>  codec, final Index index) throws TribbleException {
+    public static <FEATURE extends Locatable, SOURCE> AbstractFeatureReader<FEATURE, SOURCE> getFeatureReader(final String featureResource, final FeatureCodec<FEATURE, SOURCE>  codec, final Index index) throws TribbleException {
         try {
             return new TribbleIndexedFeatureReader<>(featureResource, codec, index);
         } catch (final IOException e) {
@@ -202,7 +203,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
         return header.getHeaderValue();
     }
 
-    static class EmptyIterator<T extends Feature> implements CloseableTribbleIterator<T> {
+    static class EmptyIterator<T extends Locatable> implements CloseableTribbleIterator<T> {
         @Override public Iterator<T> iterator() { return this; }
         @Override public boolean hasNext() { return false; }
         @Override public T next() { return null; }

--- a/src/main/java/htsjdk/tribble/AsciiFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/AsciiFeatureCodec.java
@@ -19,6 +19,7 @@
 package htsjdk.tribble;
 
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.tribble.readers.*;
 
@@ -33,7 +34,7 @@ import java.io.InputStream;
  *
  * @param <T> The feature type this codec reads
  */
-public abstract class AsciiFeatureCodec<T extends Feature> extends AbstractFeatureCodec<T, LineIterator> {
+public abstract class AsciiFeatureCodec<T extends Locatable> extends AbstractFeatureCodec<T, LineIterator> {
     protected AsciiFeatureCodec(final Class<T> myClass) {
         super(myClass);
     }

--- a/src/main/java/htsjdk/tribble/BinaryFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/BinaryFeatureCodec.java
@@ -1,6 +1,7 @@
 package htsjdk.tribble;
 
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.tabix.TabixFormat;
@@ -13,7 +14,7 @@ import java.io.InputStream;
  * Implements common methods of {@link FeatureCodec}s that read from {@link htsjdk.tribble.readers.PositionalBufferedStream}s.
  * @author mccowan
  */
-abstract public class BinaryFeatureCodec<T extends Feature> implements FeatureCodec<T, PositionalBufferedStream> {
+abstract public class BinaryFeatureCodec<T extends Locatable> implements FeatureCodec<T, PositionalBufferedStream> {
     @Override
     public PositionalBufferedStream makeSourceFromStream(final InputStream bufferedInputStream) {
         if (bufferedInputStream instanceof PositionalBufferedStream)

--- a/src/main/java/htsjdk/tribble/CloseableTribbleIterator.java
+++ b/src/main/java/htsjdk/tribble/CloseableTribbleIterator.java
@@ -19,9 +19,10 @@
 package htsjdk.tribble;
 
 import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.Locatable;
 
 /**
  * The basic iterator we use in Tribble, which allows closing and basic iteration.
  * @param <T> the feature type
  */
-public interface CloseableTribbleIterator<T extends Feature> extends CloseableIterator<T>, Iterable<T> {}
+public interface CloseableTribbleIterator<T extends Locatable> extends CloseableIterator<T>, Iterable<T> {}

--- a/src/main/java/htsjdk/tribble/Feature.java
+++ b/src/main/java/htsjdk/tribble/Feature.java
@@ -28,7 +28,9 @@ import htsjdk.samtools.util.Locatable;
 
 /**
  * Represents a locus on a reference sequence.   All Features are expected to return 1-based closed-ended intervals.
+ * @deprecated since 02-2017. Use {@link Locatable} instead. TODO: set removal date/release
  */
+@Deprecated
 public interface Feature extends Locatable {
 
     /**

--- a/src/main/java/htsjdk/tribble/FeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/FeatureCodec.java
@@ -18,6 +18,7 @@
 
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.tribble.index.tabix.TabixFormat;
 
@@ -30,15 +31,15 @@ import java.io.InputStream;
  * FeatureCodecs have to implement two key methods:
  * <p/>
  * {@link #readHeader(SOURCE)} - Reads the header, provided a {@link SOURCE} pointing at the beginning of the source input.
- * {@link #decode(SOURCE)} - Reads a {@link Feature} record, provided a {@link SOURCE} pointing at the beginning of a record within the 
+ * {@link #decode(SOURCE)} - Reads a {@link Locatable} record, provided a {@link SOURCE} pointing at the beginning of a record within the
  * source input.
  * <p/>
  * Note that it's not safe to carry state about the {@link SOURCE} within the codec.  There's no guarantee about its  state between calls.
  *
- * @param <FEATURE_TYPE> The type of {@link Feature} this codec generates
+ * @param <FEATURE_TYPE> The type of {@link Locatable} this codec generates
  * @param <SOURCE> The type of the data source this codec reads from
  */
-public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
+public interface FeatureCodec<FEATURE_TYPE extends Locatable, SOURCE> {
     /**
      * Decode a line to obtain just its FeatureLoc for indexing -- contig, start, and stop.
      *
@@ -46,10 +47,10 @@ public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
      * @return Return the FeatureLoc encoded by the line, or null if the line does not represent a feature (e.g. is
      *         a comment)
      */
-    public Feature decodeLoc(final SOURCE source) throws IOException;
+    public Locatable decodeLoc(final SOURCE source) throws IOException;
 
     /**
-     * Decode a single {@link Feature} from the {@link SOURCE}, reading no further in the underlying source than beyond that feature.
+     * Decode a single {@link Locatable} from the {@link SOURCE}, reading no further in the underlying source than beyond that feature.
      *
      * @param source the input stream from which to decode the next record
      * @return Return the Feature encoded by the line,  or null if the line does not represent a feature (e.g. is
@@ -61,7 +62,7 @@ public interface FeatureCodec<FEATURE_TYPE extends Feature, SOURCE> {
      * Read and return the header, or null if there is no header.
      * 
      * Note: Implementers of this method must be careful to read exactly as much from {@link SOURCE} as needed to parse the header, and no 
-     * more. Otherwise, data that might otherwise be fed into parsing a {@link Feature} may be lost.
+     * more. Otherwise, data that might otherwise be fed into parsing a {@link Locatable} may be lost.
      *
      * @param source the source from which to decode the header
      * @return header object

--- a/src/main/java/htsjdk/tribble/FeatureReader.java
+++ b/src/main/java/htsjdk/tribble/FeatureReader.java
@@ -18,6 +18,8 @@
 
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.Locatable;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
@@ -26,7 +28,7 @@ import java.util.List;
  * the basic interface that feature sources need to match
  * @param <T> a feature type
  */
-public interface FeatureReader<T extends Feature> extends Closeable {
+public interface FeatureReader<T extends Locatable> extends Closeable {
     
     public CloseableTribbleIterator<T> query(final String chr, final int start, final int end) throws IOException;
 

--- a/src/main/java/htsjdk/tribble/TabixFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TabixFeatureReader.java
@@ -25,6 +25,7 @@ package htsjdk.tribble;
 
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.readers.*;
 import htsjdk.tribble.util.ParsingUtils;
@@ -41,7 +42,7 @@ import java.util.function.Function;
  * @author Jim Robinson
  * @since 2/11/12
  */
-public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatureReader<T, SOURCE> {
+public class TabixFeatureReader<T extends Locatable, SOURCE> extends AbstractFeatureReader<T, SOURCE> {
 
     TabixReader tabixReader;
     List<String> sequenceNames;
@@ -153,7 +154,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
     }
 
 
-    class FeatureIterator<T extends Feature> implements CloseableTribbleIterator<T> {
+    class FeatureIterator<T extends Locatable> implements CloseableTribbleIterator<T> {
         private T currentRecord;
         private LineReader lineReader;
         private int start;
@@ -176,7 +177,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
             currentRecord = null;
             String nextLine;
             while (currentRecord == null && (nextLine = lineReader.readLine()) != null) {
-                final Feature f;
+                final Locatable f;
                 try {
                     f = ((AsciiFeatureCodec)codec).decode(nextLine);
                     if (f == null) {

--- a/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -25,6 +25,7 @@ package htsjdk.tribble;
 
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
@@ -55,7 +56,7 @@ import java.util.zip.GZIPInputStream;
  * @author Jim Robinson
  * @since 2/11/12
  */
-public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends AbstractFeatureReader<T, SOURCE> {
+public class TribbleIndexedFeatureReader<T extends Locatable, SOURCE> extends AbstractFeatureReader<T, SOURCE> {
 
     private Index index;
 

--- a/src/main/java/htsjdk/tribble/example/CountRecords.java
+++ b/src/main/java/htsjdk/tribble/example/CountRecords.java
@@ -23,9 +23,9 @@
  */
 package htsjdk.tribble.example;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.AbstractFeatureReader;
-import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.Tribble;
 import htsjdk.tribble.bed.BEDCodec;
@@ -100,11 +100,11 @@ public class CountRecords {
             long recordCount = 0l;
 
             // this call could be replaced with a query
-            Iterator<Feature> iter = reader.iterator();
+            Iterator<Locatable> iter = reader.iterator();
 
             // cycle through the iterators
             while (iter.hasNext()) {
-                Feature feat = iter.next();
+                Locatable feat = iter.next();
                 ++recordCount;
             }
 

--- a/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
+++ b/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
@@ -23,10 +23,10 @@
  */
 package htsjdk.tribble.example;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.SimpleFeature;
 import htsjdk.tribble.BinaryFeatureCodec;
-import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.FeatureCodecHeader;
 import htsjdk.tribble.FeatureReader;
@@ -49,16 +49,16 @@ import java.util.List;
  *
  * @author Mark DePristo
  */
-public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
+public class ExampleBinaryCodec extends BinaryFeatureCodec<Locatable> {
     public final static String HEADER_LINE = "# BinaryTestFeature";
 
     @Override
-    public Feature decodeLoc(final PositionalBufferedStream stream) throws IOException {
+    public Locatable decodeLoc(final PositionalBufferedStream stream) throws IOException {
         return decode(stream);
     }
 
     @Override
-    public Feature decode(final PositionalBufferedStream stream) throws IOException {
+    public Locatable decode(final PositionalBufferedStream stream) throws IOException {
         DataInputStream dis = new DataInputStream(stream);
         String contig = dis.readUTF();
         int start = dis.readInt();
@@ -80,9 +80,9 @@ public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
     }
 
     @Override
-    public Class<Feature> getFeatureType() {
+    public Class<Locatable> getFeatureType() {
 
-        return Feature.class;
+        return Locatable.class;
     }
     @Override
     public boolean canDecode(final String path) {
@@ -99,7 +99,7 @@ public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
      * @param codec of the source file features
      * @throws IOException
      */
-    public static <FEATURE_TYPE extends Feature> void convertToBinaryTest(final File source, final File dest, final FeatureCodec<FEATURE_TYPE, LineIterator> codec) throws IOException {
+    public static <FEATURE_TYPE extends Locatable> void convertToBinaryTest(final File source, final File dest, final FeatureCodec<FEATURE_TYPE, LineIterator> codec) throws IOException {
         final FeatureReader<FEATURE_TYPE> reader = AbstractFeatureReader.getFeatureReader(source.getAbsolutePath(), codec, false); // IndexFactory.loadIndex(idxFile));
         final OutputStream output = new FileOutputStream(dest);
         ExampleBinaryCodec.convertToBinaryTest(reader, output);
@@ -112,12 +112,12 @@ public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
      *
      * @throws IOException
      */
-    public static <FEATURE_TYPE extends Feature> void convertToBinaryTest(final FeatureReader<FEATURE_TYPE> reader, final OutputStream out) throws IOException {
+    public static <FEATURE_TYPE extends Locatable> void convertToBinaryTest(final FeatureReader<FEATURE_TYPE> reader, final OutputStream out) throws IOException {
         DataOutputStream dos = new DataOutputStream(out);
         dos.writeBytes(HEADER_LINE + "\n");
         Iterator<FEATURE_TYPE> it = reader.iterator();
         while ( it.hasNext() ) {
-            final Feature f = it.next();
+            final Locatable f = it.next();
             dos.writeUTF(f.getContig());
             dos.writeInt(f.getStart());
             dos.writeInt(f.getEnd());

--- a/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
@@ -24,7 +24,7 @@
 
 package htsjdk.tribble.index;
 
-import htsjdk.tribble.Feature;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.index.interval.IntervalIndexCreator;
 import htsjdk.tribble.index.linear.LinearIndexCreator;
@@ -55,7 +55,7 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
 
     MathUtils.RunningStat stats = new MathUtils.RunningStat();
     long basesSeen = 0;
-    Feature lastFeature = null;
+    Locatable lastFeature = null;
     File inputFile;
 
     public DynamicIndexCreator(final File inputFile, final IndexFactory.IndexBalanceApproach iba) {
@@ -125,7 +125,7 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
 
 
     @Override
-    public void addFeature(final Feature f, final long filePosition) {
+    public void addFeature(final Locatable f, final long filePosition) {
         // protected static Map<Double,Index> createIndex(FileBasedFeatureIterator<Feature> iterator, Map<IndexType,IndexCreator> creators, IndexBalanceApproach iba) {
         // feed each feature to the indexes we've created
         // first take care of the stats

--- a/src/main/java/htsjdk/tribble/index/IndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/IndexCreator.java
@@ -24,7 +24,7 @@
 package htsjdk.tribble.index;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.tribble.Feature;
+import htsjdk.samtools.util.Locatable;
 
 /**
  *
@@ -38,7 +38,7 @@ public interface IndexCreator {
      * @param feature the feature, of which start, end, and contig must be filled in
      * @param filePosition the current file position, at the beginning of the specified feature
      */
-    public void addFeature(Feature feature, long filePosition);
+    public void addFeature(Locatable feature, long filePosition);
 
     /**
      * Create the index, given the stream of features passed in to this point

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
@@ -18,7 +18,7 @@
 
 package htsjdk.tribble.index.interval;
 
-import htsjdk.tribble.Feature;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.TribbleIndexCreator;
@@ -63,7 +63,7 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
     }
 
     @Override
-    public void addFeature(final Feature feature, final long filePosition) {
+    public void addFeature(final Locatable feature, final long filePosition) {
         // if we don't have a chrIndex yet, or if the last one was for the previous contig, create a new one
         if (chrList.isEmpty() || !chrList.getLast().getName().equals(feature.getContig())) {
             // if we're creating a new chrIndex (not the first), make sure to dump the intervals to the old chrIndex

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
@@ -23,7 +23,7 @@
  */
 package htsjdk.tribble.index.linear;
 
-import htsjdk.tribble.Feature;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.TribbleIndexCreator;
@@ -65,7 +65,7 @@ public class LinearIndexCreator  extends TribbleIndexCreator {
      * @param filePosition the position of the file at the BEGINNING of the current feature
      */
     @Override
-    public void addFeature(final Feature feature, final long filePosition) {
+    public void addFeature(final Locatable feature, final long filePosition) {
         // fi we don't have a chrIndex yet, or if the last one was for the previous contig, create a new one
         if (chrList.isEmpty() || !chrList.getLast().getName().equals(feature.getContig())) {
             // if we're creating a new chrIndex (not the first), make sure to dump the blocks to the old chrIndex

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndexCreator.java
@@ -27,7 +27,7 @@ import htsjdk.samtools.BinningIndexBuilder;
 import htsjdk.samtools.BinningIndexContent;
 import htsjdk.samtools.Chunk;
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.tribble.Feature;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexCreator;
 
@@ -72,7 +72,7 @@ public class TabixIndexCreator implements IndexCreator {
     }
 
     @Override
-    public void addFeature(final Feature feature, final long filePosition) {
+    public void addFeature(final Locatable feature, final long filePosition) {
         final String sequenceName = feature.getContig();
         final int referenceIndex;
         if (sequenceName.equals(currentSequenceName)) {

--- a/src/main/java/htsjdk/variant/bcf2/BCF2Codec.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2Codec.java
@@ -26,8 +26,8 @@
 package htsjdk.variant.bcf2;
 
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.BinaryFeatureCodec;
-import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodecHeader;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.*;
@@ -110,7 +110,7 @@ public final class BCF2Codec extends BinaryFeatureCodec<VariantContext> {
     // ----------------------------------------------------------------------
 
     @Override
-    public Feature decodeLoc( final PositionalBufferedStream inputStream ) {
+    public Locatable decodeLoc( final PositionalBufferedStream inputStream ) {
         return decode(inputStream);
     }
 

--- a/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -27,8 +27,8 @@ package htsjdk.variant.vcf;
 
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.AsciiFeatureCodec;
-import htsjdk.tribble.Feature;
 import htsjdk.tribble.NameAwareCodec;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.index.tabix.TabixFormat;
@@ -42,7 +42,6 @@ import htsjdk.variant.variantcontext.LazyGenotypesContext;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
 
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -248,7 +247,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
      * @param line the line of text for the record
      * @return a feature, (not guaranteed complete) that has the correct start and stop
      */
-    public Feature decodeLoc(String line) {
+    public Locatable decodeLoc(String line) {
         return decodeLine(line, false);
     }
 

--- a/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
@@ -3,6 +3,7 @@ package htsjdk.tribble;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import htsjdk.samtools.FileTruncatedException;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.bed.BEDFeature;
@@ -59,7 +60,7 @@ public class AbstractFeatureReaderTest {
         final AbstractFeatureReader<VariantContext, LineIterator> featureReaderLocal =
                 AbstractFeatureReader.getFeatureReader(LOCAL_MIRROR_HTTP_INDEXED_VCF_PATH, codec, false);
         final CloseableTribbleIterator<VariantContext> localIterator = featureReaderLocal.iterator();
-        for (final Feature feat : featureReaderHttp.iterator()) {
+        for (final Locatable feat : featureReaderHttp.iterator()) {
             assertEquals(feat.toString(), localIterator.next().toString());
         }
         assertFalse(localIterator.hasNext());
@@ -70,7 +71,7 @@ public class AbstractFeatureReaderTest {
         final String path = "ftp://ftp.broadinstitute.org/distribution/igv/TEST/cpgIslands with spaces.hg18.bed";
         final BEDCodec codec = new BEDCodec();
         final AbstractFeatureReader<BEDFeature, LineIterator> bfs = AbstractFeatureReader.getFeatureReader(path, codec, false);
-        for (final Feature feat : bfs.iterator()) {
+        for (final Locatable feat : bfs.iterator()) {
             assertNotNull(feat);
         }
     }
@@ -181,7 +182,7 @@ public class AbstractFeatureReaderTest {
         }
     }
 
-    private static <T extends Feature> AbstractFeatureReader<T, ?> getFeatureReader(String vcf, String index,
+    private static <T extends Locatable> AbstractFeatureReader<T, ?> getFeatureReader(String vcf, String index,
                                                                                     Function<SeekableByteChannel, SeekableByteChannel> wrapper,
                                                                                     Function<SeekableByteChannel, SeekableByteChannel> indexWrapper,
                                                                                     FeatureCodec<T, ?> codec,

--- a/src/test/java/htsjdk/tribble/BinaryFeaturesTest.java
+++ b/src/test/java/htsjdk/tribble/BinaryFeaturesTest.java
@@ -1,5 +1,6 @@
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.example.ExampleBinaryCodec;
 import htsjdk.tribble.readers.LineIterator;
@@ -24,26 +25,26 @@ public class BinaryFeaturesTest {
     }
 
     @Test(enabled = true, dataProvider = "BinaryFeatureSources")
-    public void testBinaryCodec(final File source, final FeatureCodec<Feature, LineIterator> codec) throws IOException {
+    public void testBinaryCodec(final File source, final FeatureCodec<Locatable, LineIterator> codec) throws IOException {
         final File tmpFile = File.createTempFile("testBinaryCodec", ".binary.bed");
         ExampleBinaryCodec.convertToBinaryTest(source, tmpFile, codec);
         tmpFile.deleteOnExit();
 
-        final FeatureReader<Feature> originalReader = AbstractFeatureReader.getFeatureReader(source.getAbsolutePath(), codec, false);
-        final FeatureReader<Feature> binaryReader = AbstractFeatureReader.getFeatureReader(tmpFile.getAbsolutePath(), new ExampleBinaryCodec(), false);
+        final FeatureReader<Locatable> originalReader = AbstractFeatureReader.getFeatureReader(source.getAbsolutePath(), codec, false);
+        final FeatureReader<Locatable> binaryReader = AbstractFeatureReader.getFeatureReader(tmpFile.getAbsolutePath(), new ExampleBinaryCodec(), false);
 
         // make sure the header is what we expect
         final List<String> header = (List<String>) binaryReader.getHeader();
         Assert.assertEquals(header.size(), 1, "We expect exactly one header line");
         Assert.assertEquals(header.get(0), ExampleBinaryCodec.HEADER_LINE, "Failed to read binary header line");
 
-        final Iterator<Feature> oit = originalReader.iterator();
-        final Iterator<Feature> bit = binaryReader.iterator();
+        final Iterator<Locatable> oit = originalReader.iterator();
+        final Iterator<Locatable> bit = binaryReader.iterator();
         while ( oit.hasNext() ) {
-            final Feature of = oit.next();
+            final Locatable of = oit.next();
 
             Assert.assertTrue(bit.hasNext(), "Original iterator has items, but there's no items left in binary iterator");
-            final Feature bf = bit.next();
+            final Locatable bf = bit.next();
 
             Assert.assertEquals(bf.getContig(), of.getContig(), "Chr not equal between original and binary encoding");
             Assert.assertEquals(bf.getStart(), of.getStart(), "Start not equal between original and binary encoding");

--- a/src/test/java/htsjdk/tribble/FeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/FeatureReaderTest.java
@@ -2,6 +2,7 @@ package htsjdk.tribble;
 
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.example.ExampleBinaryCodec;
@@ -51,8 +52,8 @@ public class FeatureReaderTest {
     }
 
     @Test(dataProvider = "indexProvider")
-    public void testBedQuery(final File featureFile, final IndexFactory.IndexType indexType, final FeatureCodec<Feature, LocationAware> codec) throws IOException {
-        final AbstractFeatureReader<Feature, ?> reader = getReader(featureFile, indexType, codec);
+    public void testBedQuery(final File featureFile, final IndexFactory.IndexType indexType, final FeatureCodec<Locatable, LocationAware> codec) throws IOException {
+        final AbstractFeatureReader<Locatable, ?> reader = getReader(featureFile, indexType, codec);
 
         // Query
         testQuery(reader, "chr1", 1, 500, 3);
@@ -76,12 +77,12 @@ public class FeatureReaderTest {
     }
 
     @Test(dataProvider = "indexProvider")
-    public void testLargeNumberOfQueries(final File featureFile, final IndexFactory.IndexType indexType, final FeatureCodec<Feature, LocationAware> codec) throws IOException {
-        final AbstractFeatureReader<Feature, LocationAware> reader = getReader(featureFile, indexType, codec);
+    public void testLargeNumberOfQueries(final File featureFile, final IndexFactory.IndexType indexType, final FeatureCodec<Locatable, LocationAware> codec) throws IOException {
+        final AbstractFeatureReader<Locatable, LocationAware> reader = getReader(featureFile, indexType, codec);
         for (int i = 0; i < 2000; i++) {
             for (final int start : Arrays.asList(500, 200, 201, 600, 100000)) {
                 for (final String chr : Arrays.asList("chr1", "chr2", "chr3")) {
-                    CloseableTribbleIterator<Feature> iter = null;
+                    CloseableTribbleIterator<Locatable> iter = null;
                     try {
                         iter = reader.query(chr, start, start + 1);
                         Assert.assertNotNull(iter, "Failed to create non-null iterator");
@@ -96,11 +97,11 @@ public class FeatureReaderTest {
         reader.close();
     }
 
-    private void testQuery(final AbstractFeatureReader<Feature, ?> reader, final String chr, final int start, final int stop, final int expectedNumRecords) throws IOException {
-        final Iterator<Feature> iter = reader.query(chr, start, stop);
+    private void testQuery(final AbstractFeatureReader<Locatable, ?> reader, final String chr, final int start, final int stop, final int expectedNumRecords) throws IOException {
+        final Iterator<Locatable> iter = reader.query(chr, start, stop);
         int count = 0;
         while (iter.hasNext()) {
-            final Feature f = iter.next();
+            final Locatable f = iter.next();
             Assert.assertTrue(f.getEnd() >= start && f.getStart() <= stop);
             count++;
         }
@@ -108,8 +109,8 @@ public class FeatureReaderTest {
     }
 
     @Test(dataProvider = "indexProvider")
-    public void testBedNames(final File featureFile, final IndexFactory.IndexType indexType, final FeatureCodec<Feature, LocationAware> codec) throws IOException {
-        final AbstractFeatureReader<Feature, ?> reader = getReader(featureFile, indexType, codec);
+    public void testBedNames(final File featureFile, final IndexFactory.IndexType indexType, final FeatureCodec<Locatable, LocationAware> codec) throws IOException {
+        final AbstractFeatureReader<Locatable, ?> reader = getReader(featureFile, indexType, codec);
         final String[] expectedSequences = {"chr1", "chr2"};
 
         final List<String> seqNames = reader.getSequenceNames();
@@ -121,7 +122,7 @@ public class FeatureReaderTest {
         }
     }
 
-    private static <FEATURE extends Feature, SOURCE extends LocationAware> AbstractFeatureReader<FEATURE, SOURCE> getReader(final File featureFile,
+    private static <FEATURE extends Locatable, SOURCE extends LocationAware> AbstractFeatureReader<FEATURE, SOURCE> getReader(final File featureFile,
                                                                                                                             final IndexFactory.IndexType indexType,
                                                                                                                             final FeatureCodec<FEATURE, SOURCE> codec)
             throws IOException {

--- a/src/test/java/htsjdk/tribble/TribbleIndexFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/TribbleIndexFeatureReaderTest.java
@@ -1,5 +1,6 @@
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.tribble.TestUtils;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -33,7 +34,7 @@ public class TribbleIndexFeatureReaderTest {
                 new TribbleIndexedFeatureReader<>(testPath, codec, false)) {
             final CloseableTribbleIterator<VariantContext> localIterator = featureReader.iterator();
             int count = 0;
-            for (final Feature feat : featureReader.iterator()) {
+            for (final Locatable feat : featureReader.iterator()) {
                 localIterator.next();
                 count++;
             }

--- a/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
@@ -24,8 +24,8 @@
 
 package htsjdk.tribble.bed;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.AbstractFeatureReader;
-import htsjdk.tribble.Feature;
 import htsjdk.tribble.TestUtils;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.bed.FullBEDFeature.Exon;
@@ -147,9 +147,9 @@ public class BEDCodecTest {
 
         AbstractFeatureReader reader = AbstractFeatureReader.getFeatureReader(filepath, codec, false);
 
-        Iterable<Feature> iter = reader.iterator();
+        Iterable<Locatable> iter = reader.iterator();
         int count = 0;
-        for (Feature feat : iter) {
+        for (Locatable feat : iter) {
             Assert.assertTrue(feat.getContig().length() > 0);
             Assert.assertTrue(feat.getEnd() >= feat.getStart());
 
@@ -196,9 +196,9 @@ public class BEDCodecTest {
 
         AbstractFeatureReader reader = AbstractFeatureReader.getFeatureReader(filepath, codec, false);
 
-        Iterable<Feature> iter = reader.iterator();
+        Iterable<Locatable> iter = reader.iterator();
         int count = 0;
-        for (Feature feat : iter) {
+        for (Locatable feat : iter) {
             count += 1;
         }
         reader.close();


### PR DESCRIPTION
### Description

- Deprecate `Feature` in favor of `Locatable`.
- Change tribble interfaces and generic classes to use `Locatable`. This is backwards compatible, because `Feature` extends `Locatable`. API client code implementing/extending this classes are already bounded with a `Feature`, and this won't introduce any change in their code (except for deprecation warnings).

### For  discussion
- [ ] Set a date/release for removal of `Feature` 
- [ ] Set a date/release for change HTSJDK `Feature` classes to implement `Locatable`: `BEDFeature`, `VariantContext` and `SimpleFeature`.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

