### PR TITLE
Fixed bug where calling IntervalList.uniqued(false) would fail if the…

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -356,11 +356,9 @@ public class IntervalList implements Iterable<Interval> {
             end   = Math.max(end, i.getEnd());
         }
 
-        if (concatenateNames) {
-            if (names.isEmpty()) name = null;
-            else name = StringUtil.join("|", names);
-        }
-        else { name = names.iterator().next(); }
+        if (names.isEmpty()) name = null;
+        else if (concatenateNames) name = StringUtil.join("|", names);
+        else name = names.iterator().next();
 
         return new Interval(chrom, start, end, neg, name);
     }

--- a/src/test/java/htsjdk/samtools/util/IntervalListTest.java
+++ b/src/test/java/htsjdk/samtools/util/IntervalListTest.java
@@ -517,4 +517,16 @@ public class IntervalListTest {
         Assert.assertTrue(false);
 
     }
+
+    @Test public void uniqueIntervalsWithoutNames() {
+        final IntervalList test = new IntervalList(this.fileHeader);
+        test.add(new Interval("1", 100, 200));
+        test.add(new Interval("1", 500, 600));
+        test.add(new Interval("1", 550, 700));
+
+        for (final boolean concat : new boolean[]{true, false}) {
+            final IntervalList unique = test.uniqued(concat);
+            Assert.assertEquals(unique.size(), 2);
+        }
+    }
 }


### PR DESCRIPTION
… interval names were null.

### Description

`IntervalList.uniqued(false)` would throw an exception if called on Interval objects that had null names (which is allowed).

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

