### PR TITLE
Added validation warning if the mapped length of the read is greater than the predicted insert size for FR pairs on the same chromosome.

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -24,6 +24,8 @@
 package htsjdk.samtools;
 
 
+import htsjdk.samtools.SAMValidationError.Type;
+import htsjdk.samtools.SamPairUtil.PairOrientation;
 import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.SequenceUtil;
@@ -32,6 +34,8 @@ import htsjdk.samtools.util.StringUtil;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.*;
+
+import static java.lang.Math.abs;
 
 
 /**
@@ -1954,6 +1958,16 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
                 if (ret == null) ret = new ArrayList<SAMValidationError>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.PAIRED_READ_NOT_MARKED_AS_FIRST_OR_SECOND,
                         "Paired read should be marked as first of pair or second of pair.", getReadName()));
+                if (firstOnly) return ret;
+            }
+
+            if (!getReadUnmappedFlag() && !getMateUnmappedFlag() && !isSecondaryOrSupplementary() &&
+                    getReferenceIndex().equals(getMateReferenceIndex()) &&
+                    SamPairUtil.getPairOrientation(this) == PairOrientation.FR &&
+                    CoordMath.getLength(getAlignmentStart(), getAlignmentEnd()) > abs(getInferredInsertSize())) {
+                if (ret == null) ret = new ArrayList<>();
+                ret.add(new SAMValidationError(Type.READ_EXTENDS_BEYOND_INSERT,
+                        "Mapped length of read is longer than the predicted insert size.", getReadName()));
                 if (firstOnly) return ret;
             }
 /*

--- a/src/main/java/htsjdk/samtools/SAMValidationError.java
+++ b/src/main/java/htsjdk/samtools/SAMValidationError.java
@@ -210,6 +210,12 @@ public class SAMValidationError implements Serializable {
         /** There is a Cigar String (stored in the MC Tag) for a read whose mate is NOT mapped. */
         MATE_CIGAR_STRING_INVALID_PRESENCE,
 
+        /**
+         * The alignment start or alignment end of the read extend beyond the insert based on the insert size
+         * stored on the read.
+         */
+        READ_EXTENDS_BEYOND_INSERT(Severity.WARNING),
+
         /** The mate reference of the unpaired read should be "*" */
         INVALID_UNPAIRED_MATE_REFERENCE,
 

--- a/src/test/java/htsjdk/samtools/CRAMContainerStreamWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMContainerStreamWriterTest.java
@@ -82,6 +82,7 @@ public class CRAMContainerStreamWriterTest extends HtsjdkTest {
 
         // read all the records back in
         final CRAMFileReader cReader = new CRAMFileReader(null, new ByteArrayInputStream(outStream.toByteArray()), refSource);
+        cReader.setValidationStringency(ValidationStringency.SILENT);
         final SAMRecordIterator iterator = cReader.getIterator();
         int count = 0;
         while (iterator.hasNext()) {
@@ -135,6 +136,7 @@ public class CRAMContainerStreamWriterTest extends HtsjdkTest {
 
         // now iterate through all the records in the aggregate file
         final CRAMFileReader cReader = new CRAMFileReader(null, new ByteArrayInputStream(aggregateStream.toByteArray()), refSource);
+        cReader.setValidationStringency(ValidationStringency.SILENT);
         final SAMRecordIterator iterator = cReader.getIterator();
         int count = 0;
         while (iterator.hasNext()) {

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
@@ -136,7 +136,8 @@ public class CRAMFileWriterTest extends HtsjdkTest {
     }
 
     private void validateRecords(final List<SAMRecord> expectedRecords, ByteArrayInputStream is, ReferenceSource referenceSource) {
-        CRAMFileReader cReader = new CRAMFileReader(null, is, referenceSource);
+        CRAMFileReader cReader = new CRAMFileReader(null, is, referenceSource );
+        cReader.setValidationStringency(ValidationStringency.SILENT);
 
         SAMRecordIterator iterator2 = cReader.getIterator();
         int index = 0;
@@ -165,6 +166,7 @@ public class CRAMFileWriterTest extends HtsjdkTest {
         final ByteArrayOutputStream os = new ByteArrayOutputStream();
 
         CRAMFileWriter writer = new CRAMFileWriter(os, refSource, header, null);
+
         writeRecordsToCRAM(writer, samRecords);
 
         validateRecords(samRecords, new ByteArrayInputStream(os.toByteArray()), refSource);
@@ -229,7 +231,7 @@ public class CRAMFileWriterTest extends HtsjdkTest {
 
     @Test
     public void test_roundtrip_tlen_preserved() throws IOException {
-        SamReader reader = SamReaderFactory.make().open(new File("src/test/resources/htsjdk/samtools/cram_tlen_reads.sorted.sam"));
+        SamReader reader = SamReaderFactory.make().validationStringency(ValidationStringency.SILENT).open(new File("src/test/resources/htsjdk/samtools/cram_tlen_reads.sorted.sam"));
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ReferenceSource source = new ReferenceSource(new File("src/test/resources/htsjdk/samtools/cram_tlen.fasta"));
         CRAMFileWriter writer = new CRAMFileWriter(baos, source, reader.getFileHeader(), "test.cram");

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -1029,6 +1029,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     @Test
     public void testReadMappingLongerThanInsert() {
         final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.setReadLength(150);
         final List<SAMRecord> recs = builder.addPair("q1", 0, 100, 100, false, false, "100M50S", "50S100M", false, true, 30);
         final SAMRecord r1 = recs.stream().filter(SAMRecord::getFirstOfPairFlag).findFirst().get();
 

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -68,7 +68,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testValidSamFile() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT).open(new File(TEST_DATA_DIR, "valid.sam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
-        Assert.assertTrue(results.isEmpty());
+        Assert.assertEquals(results.get(SAMValidationError.Type.READ_EXTENDS_BEYOND_INSERT.getHistogramString()).getValue(), 2.0);
     }
 
     @Test


### PR DESCRIPTION
### Description

I'm running into situations where I'm being handed BAM files that have reads with mapped lengths longer than their insert sizes.  E.g. a 100bp read is part of an `FR` pair, has the insert size on it recorded as `95` but has a cigar of `100M`.  This seems wrong to me - and this kind of situation is remedied by tools like `MergeBamAlignment` in Picard.  I'd like to be able to point users to `ValidateSamFile` and have it catalog these errors too.

Since this can be somewhat pervasive in pipelines that don't trim back alignments that extend past the end of the insert, I've made it a warning, not an error.

I've also adjusted the way validation errors are handled so that even in `STRICT` mode, exceptions are _not_ thrown for warnings, but only for errors.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
