### PR TITLE
Update javadoc for Feature

### DIFF
--- a/src/main/java/htsjdk/tribble/Feature.java
+++ b/src/main/java/htsjdk/tribble/Feature.java
@@ -27,13 +27,14 @@ package htsjdk.tribble;
 import htsjdk.samtools.util.Locatable;
 
 /**
- * Represents a locus on a reference sequence.   All Features are expected to return 1-based closed-ended intervals.
+ * Marker interface for locatables with Tribble support.
+ * As {@link Locatable}, represents a locus on a reference sequence and is expected to return 1-based closed-ended intervals.
  */
 public interface Feature extends Locatable {
 
     /**
      * Return the features reference sequence name, e.g chromosome or contig
-     * @deprecated use getContig() instead
+     * @deprecated before 05-2017. Use getContig() instead.
      */
     @Deprecated
     default public String getChr() {

--- a/src/main/java/htsjdk/tribble/Feature.java
+++ b/src/main/java/htsjdk/tribble/Feature.java
@@ -27,14 +27,14 @@ package htsjdk.tribble;
 import htsjdk.samtools.util.Locatable;
 
 /**
- * Marker interface for locatables with Tribble support.
+ * Marker interface for Locatables with Tribble support. A Feature represents a record in a tribble-supported file format.
  * As {@link Locatable}, represents a locus on a reference sequence and is expected to return 1-based closed-ended intervals.
  */
 public interface Feature extends Locatable {
 
     /**
      * Return the features reference sequence name, e.g chromosome or contig
-     * @deprecated before 05-2017. Use getContig() instead.
+     * @deprecated on 03/2015. Use getContig() instead.
      */
     @Deprecated
     default public String getChr() {


### PR DESCRIPTION
### Description

As pointed out in #813, the `Feature` interface is meant to be a marker for a `Locatable` with tribble support. This is a simple documentation patch to:
1.  point out what is the purpose of this class.
2. add a date note to the deprecation of  `getChr()`. Because of the move to the gradle structure, I cannot pinpoint the exact date of deprecation, but at least we know that is before 2016 May.

The first point is to clarify why tribble is using `Feature` instead of `Locatable` (and avoid proposals like #812), and the second is to help in the API evolution (to be able to remove at some point deprecated methods).

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

