### PR TITLE
Tribble writing support

### DIFF
--- a/src/main/java/htsjdk/tribble/bed/BEDSimpleEncoder.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDSimpleEncoder.java
@@ -42,7 +42,7 @@ public class BEDSimpleEncoder implements FeatureEncoder<Feature> {
 
     /**
      * Writes as a BED feature. Note: BED coordinates are 0-based, so the start position returned by
-     * {@link Feature#getStart()} may be different thant the output start position.
+     * {@link Feature#getStart()} may be different than the output start position.
      */
     @Override
     public void write(final Appendable out, final Feature feature) throws IOException {

--- a/src/main/java/htsjdk/tribble/bed/BEDSimpleEncoder.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDSimpleEncoder.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.bed;
+
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.writer.FeatureEncoder;
+import htsjdk.tribble.index.tabix.TabixFormat;
+
+import java.io.IOException;
+
+/**
+ * Encode any kind of feature into a simple BED format.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class BEDSimpleEncoder implements FeatureEncoder<Feature> {
+
+    // default separator for BED files written by this encoder
+    private static final char BED_SEPARATOR = '\t';
+
+    /**
+     * Writes as a BED feature. Note: BED coordinates are 0-based, so the start position returned by
+     * {@link Feature#getStart()} may be different thant the output start position.
+     */
+    @Override
+    public void write(final Appendable out, final Feature feature) throws IOException {
+        out.append(feature.getContig())
+                // The BED format uses a first-base-is-zero convention, Tribble features use 1 => subtract 1.
+                .append(BED_SEPARATOR).append(Integer.toString(feature.getStart() - 1))
+                .append(BED_SEPARATOR).append(Integer.toString(feature.getEnd()));
+    }
+
+    /** Simple BED encoder does not write any header. */
+    @Override
+    public void writeHeader(final Appendable out, final Object header) throws IOException {
+        // does not write anything
+    }
+
+    @Override
+    public TabixFormat getTabixFormat() {
+        return TabixFormat.BED;
+    }
+}

--- a/src/main/java/htsjdk/tribble/writer/AsyncFeatureWriter.java
+++ b/src/main/java/htsjdk/tribble/writer/AsyncFeatureWriter.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.samtools.util.AbstractAsyncWriter;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.tribble.Feature;
+
+import java.io.IOException;
+
+/**
+ * Asynchronous wrapper for {@link FeatureWriter}.
+ *
+ * @param <F> feature type.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+final class AsyncFeatureWriter<F extends Feature> extends AbstractAsyncWriter<F> implements FeatureWriter<F> {
+
+    // the underlying writer
+    private final FeatureWriter<F> underlyingWriter;
+
+    /**
+     * Wraps a feature writer with the {@link #DEFAULT_QUEUE_SIZE}.
+     */
+    AsyncFeatureWriter(final FeatureWriter<F> writer) {
+        this(writer, DEFAULT_QUEUE_SIZE);
+    }
+
+    /**
+     * Wraps a feature writer with a custom queue size.
+     */
+    AsyncFeatureWriter(final FeatureWriter<F> writer, final int queueSize) {
+        super(queueSize);
+        this.underlyingWriter = writer;
+    }
+
+    /**
+     * Writes the header in an synchronous way.
+     *
+     * Note: it is unsafe to write a header if a feature was already added.
+     */
+    @Override
+    public void writeHeader(final Object header) throws IOException {
+        this.underlyingWriter.writeHeader(header);
+    }
+
+    /** Adds the feature in an asynchronous way. */
+    @Override
+    public void add(final F feature) throws IOException {
+        write(feature);
+    }
+
+    @Override
+    protected String getThreadNamePrefix() {
+        return "FeatureWriterThread-";
+    }
+
+    /** Adds the feature to the underlying writer. */
+    @Override
+    protected void synchronouslyWrite(F item) {
+        try {
+            underlyingWriter.add(item);
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /** Closes the underlying writer. */
+    @Override
+    protected void synchronouslyClose() {
+        try {
+            underlyingWriter.close();
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+}

--- a/src/main/java/htsjdk/tribble/writer/FeatureEncoder.java
+++ b/src/main/java/htsjdk/tribble/writer/FeatureEncoder.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.TribbleException;
+import htsjdk.tribble.index.tabix.TabixFormat;
+
+import java.io.IOException;
+
+/**
+ * Encoder interface for features.
+ * <p/>
+ * FeatureEncoder have to implement two key methods:
+ * <p/>
+ * {@link #writeHeader(Appendable, Object)} - Encodes and writes the header to the output.
+ * {@link #write(Appendable, F)} - Encodes and writes a feature to the output.
+ * <p/>
+ *
+ * @param <F> feature type.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public interface FeatureEncoder<F extends Feature> {
+
+    /**
+     * Encodes the feature and add it to the output.
+     *
+     * @param out     the output to append the feature in.
+     * @param feature object to be encoded.
+     *
+     * @throws IOException if a IO error occurs.
+     * @throws TribbleException if an encoding error occurs.
+     */
+    public void write(final Appendable out, final F feature) throws IOException;
+
+    /**
+     * Encodes the header and add it to the output.
+     *
+     * @param out    the output to append the feature in.
+     * @param header object to be encoded. May have restrictions depending on the implementation.
+     *
+     * @throws IOException if a IO error occurs.
+     * @throws TribbleException if an encoding error occurs.
+     */
+    public void writeHeader(final Appendable out, final Object header) throws IOException;
+
+    /**
+     * Defines the tabix format for the feature, used for indexing.
+     *
+     * @return the format to use with tabix.
+     *
+     * @throws TribbleException if the format is not defined.
+     */
+    public default TabixFormat getTabixFormat() {
+        throw new TribbleException(
+                this.getClass().getSimpleName() + " does not have defined tabix format");
+    }
+}

--- a/src/main/java/htsjdk/tribble/writer/FeatureWriter.java
+++ b/src/main/java/htsjdk/tribble/writer/FeatureWriter.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.tribble.Feature;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Writer interface for features.
+ *
+ * @param <F> feature type.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public interface FeatureWriter<F extends Feature> extends Closeable {
+
+    /**
+     * Writes the header.
+     *
+     * @param header object to be written. May have restrictions depending on the implementation.
+     *
+     * @throws IOException                     if an IO error occurs.
+     * @throws htsjdk.tribble.TribbleException if an encoding error occurs.
+     */
+    public void writeHeader(final Object header) throws IOException;
+
+    /**
+     * Adds a feature into the writer.
+     *
+     * @throws IOException                     if an IO error occurs
+     * @throws htsjdk.tribble.TribbleException if an encoding error occurs.
+     */
+    public void add(final F feature) throws IOException;
+}

--- a/src/main/java/htsjdk/tribble/writer/FeatureWriterFactory.java
+++ b/src/main/java/htsjdk/tribble/writer/FeatureWriterFactory.java
@@ -66,6 +66,7 @@ public final class FeatureWriterFactory {
     // creates an MD5 for the output
     private boolean createMd5 = Defaults.CREATE_MD5;
     // if true, use BlockCompressedOutputStream; otherwise use CustomGzipOutputStream
+    // TODO - this should have a new Defaults (I believe)
     private boolean useBlockCompression = false;
 
     /**
@@ -176,6 +177,7 @@ public final class FeatureWriterFactory {
             final boolean blockCompressed = AbstractFeatureReader.hasBlockCompressedExtension(outputFileName);
             if (blockCompressed) {
                 outputStream = (useBlockCompression)
+                        // TODO - BGZIP should allow to set the location from a Path or String
                         ? BlockCompressedOutputStream.maybeBgzfWrapOutputStream(null, outputStream)
                         : new CustomGzipOutputStream(outputStream, Defaults.COMPRESSION_LEVEL);
             }

--- a/src/main/java/htsjdk/tribble/writer/FeatureWriterFactory.java
+++ b/src/main/java/htsjdk/tribble/writer/FeatureWriterFactory.java
@@ -186,18 +186,16 @@ public final class FeatureWriterFactory {
             }
 
             final IndexCreator idxCreator;
-            final String indexFile;
+            final Path indexPath;
             if (blockCompressed) {
                 idxCreator = new TabixIndexCreator(seqDict, encoder.getTabixFormat());
-                indexFile = Tribble.tabixIndexFile(outputFileName);
+                indexPath = Tribble.tabixIndexPath(outputPath);
             } else {
-                // TODO: https://github.com/samtools/htsjdk/pull/810
-                // TODO: the dynamic index should use the corresponding Path constructor
-                idxCreator = new DynamicIndexCreator(outputPath.toFile(), iba);
-                indexFile = Tribble.indexFile(outputFileName);
+                idxCreator = new DynamicIndexCreator(outputPath, iba);
+                indexPath = Tribble.indexPath(outputPath);
             }
             
-            return maybeAsync(new IndexingFeatureWriter<>(encoder, outputStream, idxCreator, indexFile, seqDict));
+            return maybeAsync(new IndexingFeatureWriter<>(encoder, outputStream, idxCreator, indexPath, seqDict));
 
         } catch (final IOException e) {
             throw new TribbleException("Unable to create writer for " + outputFileName, e);

--- a/src/main/java/htsjdk/tribble/writer/FeatureWriterFactory.java
+++ b/src/main/java/htsjdk/tribble/writer/FeatureWriterFactory.java
@@ -1,0 +1,211 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.samtools.Defaults;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.CustomGzipOutputStream;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Md5CalculatingOutputStream;
+import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.Tribble;
+import htsjdk.tribble.TribbleException;
+import htsjdk.tribble.index.DynamicIndexCreator;
+import htsjdk.tribble.index.IndexCreator;
+import htsjdk.tribble.index.IndexFactory;
+import htsjdk.tribble.index.tabix.TabixIndexCreator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Factory for creating {@link FeatureWriter}.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public final class FeatureWriterFactory {
+
+    /** Default approach for create tribble indexes. */
+    public static final IndexFactory.IndexBalanceApproach DEFAULT_INDEX_BALANCE_APPROACH = IndexFactory.IndexBalanceApproach.FOR_SEEK_TIME;
+
+    // if the index should be created
+    private boolean createIndex = Defaults.CREATE_INDEX;
+    // the index balance approach if the index type is not set and/or is not a tabix output
+    private IndexFactory.IndexBalanceApproach iba = DEFAULT_INDEX_BALANCE_APPROACH;
+    // reference dictionary to use for indexing
+    private SAMSequenceDictionary seqDict = null;
+
+    // use multi-thread writing
+    private boolean useAsyncIo = Defaults.USE_ASYNC_IO_WRITE_FOR_TRIBBLE;
+    // creates an MD5 for the output
+    private boolean createMd5 = Defaults.CREATE_MD5;
+    // if true, use BlockCompressedOutputStream; otherwise use CustomGzipOutputStream
+    private boolean useBlockCompression = false;
+
+    /**
+     * Creates a FeatureWriterFactory with default values:
+     *
+     * - Create index: {@link Defaults#CREATE_INDEX}
+     * - Create MD5: {@link Defaults#CREATE_MD5}
+     * - Index Balance Approach: {@link #DEFAULT_INDEX_BALANCE_APPROACH}
+     * - Use async IO: {@link Defaults#USE_ASYNC_IO_WRITE_FOR_TRIBBLE}
+     * - Use block compression: {@code false}
+     */
+    public FeatureWriterFactory() { }
+
+    /**
+     * Copy constructor.
+     */
+    public FeatureWriterFactory(final FeatureWriterFactory other) {
+        this.createIndex = other.createIndex;
+        this.iba = other.iba;
+        this.seqDict = other.seqDict;
+
+        this.useAsyncIo = other.useAsyncIo;
+        this.createMd5 = other.createMd5;
+        this.useBlockCompression = other.useBlockCompression;
+    }
+
+    /**
+     * Set to {@code true} if a index file should be created for the output; to {@code false} otherwise.
+     */
+    public FeatureWriterFactory setCreateIndex(final boolean createIndex) {
+        this.createIndex = createIndex;
+        return this;
+    }
+
+    /**
+     * Set the Index Balance approach for creating a dynamic index for no tabix indexes.
+     *
+     * Note: it does not have any effect if there is no index creation.
+     *
+     * @param iba non-null index balance approach.
+     */
+    public FeatureWriterFactory setIndexBalanceApproach(
+            final IndexFactory.IndexBalanceApproach iba) {
+        if (iba == null) {
+            throw new IllegalArgumentException("Index Balance Approach cannot be null");
+        }
+        this.iba = iba;
+        return this;
+    }
+
+    /**
+     * Set the sequence dictionary to include in the index.
+     *
+     * @param seqDict the sequence dictionary. May be {@code null}.
+     */
+    public FeatureWriterFactory setSequenceDictionary(final SAMSequenceDictionary seqDict) {
+        this.seqDict = seqDict;
+        return this;
+    }
+
+    /**
+     * Set to {@code true} for asynchronous writing; to {@code false} otherwise.
+     */
+    public FeatureWriterFactory setUseAsyncIo(final boolean useAsyncIo) {
+        this.useAsyncIo = useAsyncIo;
+        return this;
+    }
+    
+    /**
+     * Set to {@code true} if a MD5 digest file should be created for the output; to {@code false} otherwise.
+     */
+    public FeatureWriterFactory setCreateMd5(final boolean createMd5) {
+        this.createMd5 = createMd5;
+        return this;
+    }
+
+    /**
+     * If the output file ends with a block-compressed extension, use BGZF if this parameter is set
+     * to {@code true}; otherwise, use conventional gzip.
+     */
+    public FeatureWriterFactory setUseBlockCompression(final boolean useBlockCompression) {
+        this.useBlockCompression = useBlockCompression;
+        return this;
+    }
+
+    /**
+     * Creates a new {@link FeatureWriter} using the encoder and the output file name.
+     *
+     * Index file names will be generated with the {@link Tribble} methods, and the output may be
+     * block-compressed if it has that compression.
+     *
+     * @param outputFileName the output file name.
+     * @param encoder        the encoder to use.
+     *
+     * @return the feature writer.
+     */
+    public <F extends Feature> FeatureWriter<F> makeWriter(final String outputFileName, final FeatureEncoder<F> encoder) {
+        try {
+            // creates the output stream from the file
+            final Path outputPath = IOUtil.getPath(outputFileName);
+            OutputStream outputStream = Files.newOutputStream(outputPath);
+
+            if (createMd5) {
+                outputStream = new Md5CalculatingOutputStream(outputStream, IOUtil.getPath(outputFileName + ".md5"));
+            }
+
+            // wrap if it have a block-gzipped extension (block-compressed for use with tabix)
+            final boolean blockCompressed = AbstractFeatureReader.hasBlockCompressedExtension(outputFileName);
+            if (blockCompressed) {
+                outputStream = (useBlockCompression)
+                        ? BlockCompressedOutputStream.maybeBgzfWrapOutputStream(null, outputStream)
+                        : new CustomGzipOutputStream(outputStream, Defaults.COMPRESSION_LEVEL);
+            }
+
+            // if we should not index in the fly
+            if (!createIndex) {
+                return maybeAsync(new FeatureWriterImpl<>(encoder, outputStream));
+            }
+
+            final IndexCreator idxCreator;
+            final String indexFile;
+            if (blockCompressed) {
+                idxCreator = new TabixIndexCreator(seqDict, encoder.getTabixFormat());
+                indexFile = Tribble.tabixIndexFile(outputFileName);
+            } else {
+                // TODO: https://github.com/samtools/htsjdk/pull/810
+                // TODO: the dynamic index should use the corresponding Path constructor
+                idxCreator = new DynamicIndexCreator(outputPath.toFile(), iba);
+                indexFile = Tribble.indexFile(outputFileName);
+            }
+            
+            return maybeAsync(new IndexingFeatureWriter<>(encoder, outputStream, idxCreator, indexFile, seqDict));
+
+        } catch (final IOException e) {
+            throw new TribbleException("Unable to create writer for " + outputFileName, e);
+        }
+    }
+
+    // helper function to wrap a writer if useAsyncIo is used
+    private <F extends Feature> FeatureWriter<F> maybeAsync(final FeatureWriter<F> writer) {
+        return (useAsyncIo) ? new AsyncFeatureWriter<>(writer) : writer;
+    }
+}

--- a/src/main/java/htsjdk/tribble/writer/FeatureWriterImpl.java
+++ b/src/main/java/htsjdk/tribble/writer/FeatureWriterImpl.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.tribble.Feature;
+
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+/**
+ * Feature writer class, which uses codecs to write out Tribble file formats.
+ *
+ * @param <F> feature type.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+class FeatureWriterImpl<F extends Feature> implements FeatureWriter<F> {
+
+    // encoder for the feature and header
+    private final FeatureEncoder<F> encoder;
+
+    /*
+    * The FeatureWriterImpl writer uses an internal Writer, based by the ByteArrayOutputStream lineBuffer,
+    * to temp. buffer the header and per-site output before flushing the per line output in one go.
+    * This results in high-performance, proper encoding, and allows us to avoid flushing explicitly
+    * the output stream getOutputStream, which allows us to properly compress in gz format without
+    * breaking indexing on the fly for uncompressed streams.
+    */
+    private static final int INITIAL_BUFFER_SIZE = 1024 * 16;
+    private final ByteArrayOutputStream lineBuffer = new ByteArrayOutputStream(INITIAL_BUFFER_SIZE);
+    /* Wrapping in a {@link BufferedWriter} avoids frequent conversions with individual writes to OutputStreamWriter. */
+    private final Writer writer = new BufferedWriter(new OutputStreamWriter(lineBuffer));
+
+    // output stream to write it; keep it here for retrieve in IndexingFeatureWriter
+    private final OutputStream outputStream;
+
+    /**
+     * Constructor.
+     *
+     * @param encoder      encoder for the feature.
+     * @param outputStream underlying output stream.
+     */
+    FeatureWriterImpl(final FeatureEncoder<F> encoder,
+            final OutputStream outputStream) {
+        this.encoder = encoder;
+        this.outputStream = outputStream;
+    }
+
+    /** Gets the underlying output stream. Used for indexing on the fly. */
+    OutputStream getOutputStream() {
+        return outputStream;
+    }
+
+    /** Writes the header using the encoder. */
+    @Override
+    public void writeHeader(final Object header) throws IOException {
+        encoder.writeHeader(writer, header);
+    }
+
+    /** Adds and writes the feature using the encoder. */
+    @Override
+    public void add(final F feature) throws IOException {
+        encoder.write(writer, feature);
+        writer.append("\n");
+        writeAndResetBuffer();
+    }
+
+    /** Closes the writer. */
+    @Override
+    public void close() throws IOException {
+        // write the rest of the buffer
+        writeAndResetBuffer();
+        // close the writer and the output stream after it
+        writer.close();
+        outputStream.close();
+    }
+
+    /**
+     * Actually write the line buffer contents to the destination output stream. After calling this
+     * function the line buffer is reset so the contents of the buffer can be reused
+     */
+    private void writeAndResetBuffer() throws IOException {
+        writer.flush();
+        outputStream.write(lineBuffer.toByteArray());
+        lineBuffer.reset();
+    }
+}

--- a/src/main/java/htsjdk/tribble/writer/IndexingFeatureWriter.java
+++ b/src/main/java/htsjdk/tribble/writer/IndexingFeatureWriter.java
@@ -1,0 +1,118 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.LocationAware;
+import htsjdk.samtools.util.PositionalOutputStream;
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.index.Index;
+import htsjdk.tribble.index.IndexCreator;
+import htsjdk.tribble.index.tabix.TabixIndex;
+import htsjdk.tribble.util.LittleEndianOutputStream;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+
+/**
+ * Feature writer class for indexing on the fly.
+ *
+ * @param <F> feature type.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+final class IndexingFeatureWriter<F extends Feature> extends FeatureWriterImpl<F> {
+
+    private final LocationAware location;
+    private final IndexCreator indexer;
+    private final String indexPath;
+    private final SAMSequenceDictionary refDict;
+
+    /**
+     * Construct a new indexing feature writer.
+     *
+     * @param encoder      encoder for features.
+     * @param outputStream the underlying output stream.
+     * @param idxCreator   indexer.
+     * @param indexPath    the file to write the index.
+     * @param refDict      dictionary to write in the index. May be {@code null}.
+     */
+    public IndexingFeatureWriter(final FeatureEncoder<F> encoder, final OutputStream outputStream,
+            final IndexCreator idxCreator, final String indexPath,
+            final SAMSequenceDictionary refDict) {
+        super(encoder, asLocationAwareStream(outputStream));
+        this.indexer = idxCreator;
+        this.indexPath = indexPath;
+        this.refDict = refDict;
+        // this is already a LocationAware
+        this.location = (LocationAware) getOutputStream();
+    }
+
+    /** Wraps if necessary the output stream. */
+    private static OutputStream asLocationAwareStream(final OutputStream outputStream) {
+        return (outputStream instanceof LocationAware)
+                ? outputStream : new PositionalOutputStream(outputStream);
+    }
+
+    /**
+     * Adds the feature to the indexer, and then write using the {@link FeatureWriterImpl}
+     * implementation.
+     */
+    @Override
+    public void add(final F feature) throws IOException {
+        // should be added to the indexer first
+        indexer.addFeature(feature, location.getPosition());
+        super.add(feature);
+    }
+
+    /** Adds the reference dictionary (if not {@code null}), finalize/write the index and close. */
+    @Override
+    public void close() throws IOException {
+        if (refDict != null) {
+            indexer.setIndexSequenceDictionary(refDict);
+        }
+        final Index index = indexer.finalizeIndex(location.getPosition());
+        // TODO: uncomment next line after https://github.com/samtools/htsjdk/pull/810
+        // index.write(indexPath);
+        writeIndex(index);
+        super.close();
+    }
+
+    // TODO: remove comment and usage after https://github.com/samtools/htsjdk/pull/810
+    private final void writeIndex(final Index index) throws IOException {
+        OutputStream outputStream = Files.newOutputStream(IOUtil.getPath(indexPath));
+        if (index instanceof TabixIndex) {
+            outputStream = new BlockCompressedOutputStream(outputStream, null);
+        } else {
+            outputStream = new BufferedOutputStream(outputStream);
+        }
+        index.write(new LittleEndianOutputStream(outputStream));
+        outputStream.close();
+    }
+}

--- a/src/test/java/htsjdk/tribble/bed/BEDSimpleEncoderUnitTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDSimpleEncoderUnitTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.bed;
+
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.SimpleFeature;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class BEDSimpleEncoderUnitTest {
+
+    private static final BEDSimpleEncoder TEST_ENCODER = new BEDSimpleEncoder();
+
+    @DataProvider(name = "featuresToEncode")
+    public Object[][] getFeaturesToEncode() {
+        return new Object[][] {
+                {new SimpleFeature("chr1", 1, 100), "chr1\t0\t100"},
+                {new SimpleBEDFeature(100, 200, "chr20"), "chr20\t99\t200"}
+        };
+    }
+
+    @Test(dataProvider = "featuresToEncode")
+    public void testEncodeFeatures(final Feature feature, final String expected) throws Exception {
+        final StringBuilder stringBuilder = new StringBuilder();
+        TEST_ENCODER.write(stringBuilder, feature);
+        Assert.assertEquals(stringBuilder.toString(), expected);
+    }
+
+    @Test
+    public void testNoOpWriteHeader() throws Exception {
+        final StringBuilder builder = new StringBuilder();
+        TEST_ENCODER.writeHeader(builder, "StringHeader");
+        Assert.assertEquals(builder.toString(), "");
+    }
+
+}

--- a/src/test/java/htsjdk/tribble/bed/BEDSimpleEncoderUnitTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDSimpleEncoderUnitTest.java
@@ -24,6 +24,7 @@
 
 package htsjdk.tribble.bed;
 
+import htsjdk.HtsjdkTest;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.SimpleFeature;
 import org.testng.Assert;
@@ -33,7 +34,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class BEDSimpleEncoderUnitTest {
+public class BEDSimpleEncoderUnitTest extends HtsjdkTest {
 
     private static final BEDSimpleEncoder TEST_ENCODER = new BEDSimpleEncoder();
 

--- a/src/test/java/htsjdk/tribble/writer/AsyncFeatureWriterTest.java
+++ b/src/test/java/htsjdk/tribble/writer/AsyncFeatureWriterTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.FeatureCodec;
+import htsjdk.tribble.SimpleFeature;
+import htsjdk.tribble.bed.BEDCodec;
+import htsjdk.tribble.bed.BEDSimpleEncoder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class AsyncFeatureWriterTest extends FeatureWriterTester {
+
+    @Test(dataProvider = "bedFiles")
+    public void readWriteSimpleBed(final File bedFile) throws Exception {
+        testReadWrite(bedFile, (FeatureCodec) new BEDCodec(), (f) -> {
+            try {
+                return new AsyncFeatureWriter<>(new FeatureWriterImpl<>(new BEDSimpleEncoder(), new FileOutputStream(f)));
+            } catch (final FileNotFoundException e) {
+                throw new AssertionError(e.getMessage());
+            }
+        });
+    }
+
+    @DataProvider
+    public Object[][] featuresAndHeaders() {
+        return new Object[][] {
+                {Collections.singletonList(new SimpleFeature("chr1", 1, 100)),
+                        Collections.singletonList("header1")},
+                {Arrays.asList(new SimpleFeature("chr1", 10, 100),
+                        new SimpleFeature("chr2", 1, 100)), Arrays.asList("header1", "header2")}
+        };
+    }
+
+    @Test(dataProvider = "featuresAndHeaders")
+    public void testWriteHeaderAndFeatures(final List<Feature> featuresToWrite,
+            final List<Object> headersToWrite) throws Exception {
+        testWriteHeaderAndFeatures((encoder, file) ->
+                new AsyncFeatureWriter<>(new FeatureWriterImpl(encoder, file)),
+                featuresToWrite, headersToWrite);
+    }
+
+}

--- a/src/test/java/htsjdk/tribble/writer/AsyncFeatureWriterTest.java
+++ b/src/test/java/htsjdk/tribble/writer/AsyncFeatureWriterTest.java
@@ -46,7 +46,7 @@ public class AsyncFeatureWriterTest extends FeatureWriterTester {
 
     @Test(dataProvider = "bedFiles")
     public void readWriteSimpleBed(final File bedFile) throws Exception {
-        testReadWrite(bedFile, (FeatureCodec) new BEDCodec(), (f) -> {
+        testReadWrite(bedFile, ".bed", (FeatureCodec) new BEDCodec(), (f) -> {
             try {
                 return new AsyncFeatureWriter<>(new FeatureWriterImpl<>(new BEDSimpleEncoder(), new FileOutputStream(f)));
             } catch (final FileNotFoundException e) {

--- a/src/test/java/htsjdk/tribble/writer/FeatureWriterImplUnitTest.java
+++ b/src/test/java/htsjdk/tribble/writer/FeatureWriterImplUnitTest.java
@@ -24,117 +24,51 @@
 
 package htsjdk.tribble.writer;
 
-import htsjdk.HtsjdkTest;
-import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
-import htsjdk.tribble.FeatureReader;
+import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.SimpleFeature;
 import htsjdk.tribble.bed.BEDCodec;
-import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.bed.BEDSimpleEncoder;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FeatureWriterImplUnitTest extends HtsjdkTest {
-
-    @DataProvider
-    public Object[][] bedFiles() {
-        final File testDirectory = new File("src/test/resources/htsjdk/tribble/bed");
-        return new Object[][] {
-                {new File(testDirectory, "disconcontigs.bed")},
-                {new File(testDirectory, "NA12878.deletions.10kbp.het.gq99.hand_curated.hg19_fixed.bed")},
-                {new File(testDirectory, "Unigene.sample.bed")},
-                {new File(testDirectory, "unsorted.bed")}
-        };
-    }
+public class FeatureWriterImplUnitTest extends FeatureWriterTester {
 
     @Test(dataProvider = "bedFiles")
     public void readWriteSimpleBed(final File bedFile) throws Exception {
-        final File tmpFile = File.createTempFile(bedFile.getName(), ".bed");
-
-        // read the original file and write it down
-        final List<BEDFeature> featureList = new ArrayList<>();
-        try (final FeatureReader<BEDFeature> reader = AbstractFeatureReader.getFeatureReader(bedFile.toString(), new BEDCodec(), false);
-             final FeatureWriter<Feature> writer = new FeatureWriterImpl<>(new BEDSimpleEncoder(), new FileOutputStream(tmpFile))) {
-            for (final BEDFeature feature : reader.iterator()) {
-                // accumulate in the list
-                featureList.add(feature);
-                // write down
-                writer.add(feature);
+        testReadWrite(bedFile, (FeatureCodec) new BEDCodec(), (f) -> {
+            try {
+                return new FeatureWriterImpl<>(new BEDSimpleEncoder(), new FileOutputStream(f));
+            } catch (final FileNotFoundException e) {
+                throw new AssertionError(e.getMessage());
             }
-        }
-
-        // read the written file and check if the features are the same
-        try (final FeatureReader<BEDFeature> reader = AbstractFeatureReader.getFeatureReader(tmpFile.toString(), new BEDCodec(), false)) {
-            final Iterator<BEDFeature> it = reader.iterator();
-            for (final BEDFeature feature : featureList) {
-                Assert.assertTrue(it.hasNext(), "unexpected end of file");
-                final BEDFeature actual = it.next();
-                Assert.assertEquals(actual.getContig(), feature.getContig());
-                Assert.assertEquals(actual.getStart(), feature.getStart());
-                Assert.assertEquals(actual.getEnd(), feature.getEnd());
-            }
-        }
+        });
     }
-
-    private final static OutputStream NULL_OUTPUT_STREAM = new OutputStream() {
-        @Override
-        public void write(int b) throws IOException { }
-    };
-
-    // test encoder that keeps a list with all features added and a list of all headers added
-    private final static class TestEncoder implements FeatureEncoder<Feature> {
-
-        List<Feature> addedFeatures = new ArrayList<>();
-        List<Object> addedHeaders = new ArrayList<>();
-
-        @Override
-        public void write(Appendable out, Feature feature) throws IOException {
-            addedFeatures.add(feature);
-        }
-
-        @Override
-        public void writeHeader(Appendable out, Object header) throws IOException {
-            addedHeaders.add(header);
-        }
-    }
-
 
     @DataProvider
     public Object[][] featuresAndHeaders() {
         return new Object[][] {
-                {Collections.singletonList(new SimpleFeature("chr1", 1, 100)), Collections.singletonList("header1")},
-                {Arrays.asList(new SimpleFeature("chr1", 10, 100), new SimpleFeature("chr2", 1, 100)), Arrays.asList("header1", "header2")}
+                {Collections.singletonList(new SimpleFeature("chr1", 1, 100)),
+                        Collections.singletonList("header1")},
+                {Arrays.asList(new SimpleFeature("chr1", 10, 100),
+                        new SimpleFeature("chr2", 1, 100)), Arrays.asList("header1", "header2")}
         };
     }
 
     @Test(dataProvider = "featuresAndHeaders")
-    public void testWriteHeaderAndFeatures(final List<Feature> featuresToWrite, final List<Object> headersToWrite) throws Exception {
-        final TestEncoder encoder = new TestEncoder();
-        try(FeatureWriter<Feature> writer = new FeatureWriterImpl<>(encoder, NULL_OUTPUT_STREAM)) {
-            for (final Object o: headersToWrite) {
-                writer.writeHeader(o);
-            }
-            for (final Feature f: featuresToWrite) {
-                writer.add(f);
-            }
-        }
-        Assert.assertEquals(encoder.addedHeaders, headersToWrite);
-        Assert.assertEquals(encoder.addedFeatures, featuresToWrite);
+    public void testWriteHeaderAndFeatures(final List<Feature> featuresToWrite,
+            final List<Object> headersToWrite) throws Exception {
+        testWriteHeaderAndFeatures(FeatureWriterImpl::new, featuresToWrite, headersToWrite);
     }
 
 }

--- a/src/test/java/htsjdk/tribble/writer/FeatureWriterImplUnitTest.java
+++ b/src/test/java/htsjdk/tribble/writer/FeatureWriterImplUnitTest.java
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.FeatureReader;
+import htsjdk.tribble.SimpleFeature;
+import htsjdk.tribble.bed.BEDCodec;
+import htsjdk.tribble.bed.BEDFeature;
+import htsjdk.tribble.bed.BEDSimpleEncoder;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class FeatureWriterImplUnitTest extends HtsjdkTest {
+
+    @DataProvider
+    public Object[][] bedFiles() {
+        final File testDirectory = new File("src/test/resources/htsjdk/tribble/bed");
+        return new Object[][] {
+                {new File(testDirectory, "disconcontigs.bed")},
+                {new File(testDirectory, "NA12878.deletions.10kbp.het.gq99.hand_curated.hg19_fixed.bed")},
+                {new File(testDirectory, "Unigene.sample.bed")},
+                {new File(testDirectory, "unsorted.bed")}
+        };
+    }
+
+    @Test(dataProvider = "bedFiles")
+    public void readWriteSimpleBed(final File bedFile) throws Exception {
+        final File tmpFile = File.createTempFile(bedFile.getName(), ".bed");
+
+        // read the original file and write it down
+        final List<BEDFeature> featureList = new ArrayList<>();
+        try (final FeatureReader<BEDFeature> reader = AbstractFeatureReader.getFeatureReader(bedFile.toString(), new BEDCodec(), false);
+             final FeatureWriter<Feature> writer = new FeatureWriterImpl<>(new BEDSimpleEncoder(), new FileOutputStream(tmpFile))) {
+            for (final BEDFeature feature : reader.iterator()) {
+                // accumulate in the list
+                featureList.add(feature);
+                // write down
+                writer.add(feature);
+            }
+        }
+
+        // read the written file and check if the features are the same
+        try (final FeatureReader<BEDFeature> reader = AbstractFeatureReader.getFeatureReader(tmpFile.toString(), new BEDCodec(), false)) {
+            final Iterator<BEDFeature> it = reader.iterator();
+            for (final BEDFeature feature : featureList) {
+                Assert.assertTrue(it.hasNext(), "unexpected end of file");
+                final BEDFeature actual = it.next();
+                Assert.assertEquals(actual.getContig(), feature.getContig());
+                Assert.assertEquals(actual.getStart(), feature.getStart());
+                Assert.assertEquals(actual.getEnd(), feature.getEnd());
+            }
+        }
+    }
+
+    private final static OutputStream NULL_OUTPUT_STREAM = new OutputStream() {
+        @Override
+        public void write(int b) throws IOException { }
+    };
+
+    // test encoder that keeps a list with all features added and a list of all headers added
+    private final static class TestEncoder implements FeatureEncoder<Feature> {
+
+        List<Feature> addedFeatures = new ArrayList<>();
+        List<Object> addedHeaders = new ArrayList<>();
+
+        @Override
+        public void write(Appendable out, Feature feature) throws IOException {
+            addedFeatures.add(feature);
+        }
+
+        @Override
+        public void writeHeader(Appendable out, Object header) throws IOException {
+            addedHeaders.add(header);
+        }
+    }
+
+
+    @DataProvider
+    public Object[][] featuresAndHeaders() {
+        return new Object[][] {
+                {Collections.singletonList(new SimpleFeature("chr1", 1, 100)), Collections.singletonList("header1")},
+                {Arrays.asList(new SimpleFeature("chr1", 10, 100), new SimpleFeature("chr2", 1, 100)), Arrays.asList("header1", "header2")}
+        };
+    }
+
+    @Test(dataProvider = "featuresAndHeaders")
+    public void testWriteHeaderAndFeatures(final List<Feature> featuresToWrite, final List<Object> headersToWrite) throws Exception {
+        final TestEncoder encoder = new TestEncoder();
+        try(FeatureWriter<Feature> writer = new FeatureWriterImpl<>(encoder, NULL_OUTPUT_STREAM)) {
+            for (final Object o: headersToWrite) {
+                writer.writeHeader(o);
+            }
+            for (final Feature f: featuresToWrite) {
+                writer.add(f);
+            }
+        }
+        Assert.assertEquals(encoder.addedHeaders, headersToWrite);
+        Assert.assertEquals(encoder.addedFeatures, featuresToWrite);
+    }
+
+}

--- a/src/test/java/htsjdk/tribble/writer/FeatureWriterTester.java
+++ b/src/test/java/htsjdk/tribble/writer/FeatureWriterTester.java
@@ -87,11 +87,13 @@ public abstract class FeatureWriterTester extends HtsjdkTest {
     /**
      * Tests that reading a file with FeatureReader and writing to a FeatureWriter provides the same
      * result.
+     * @return temporary path where the file was written.
      */
-    protected final static <T extends Feature> void testReadWrite(final File featureFile,
+    protected final static <T extends Feature> File testReadWrite(final File featureFile,
+            final String ext,
             final FeatureCodec<T, ?> featureCodec,
             final Function<File, FeatureWriter<T>> writerProvider) throws Exception {
-        final File tmpFile = File.createTempFile(featureFile.getName(), ".bed");
+        final File tmpFile = File.createTempFile(featureFile.getName(), ext);
 
         // read the original file and write it down
         final List<T> featureList = new ArrayList<>();
@@ -118,6 +120,8 @@ public abstract class FeatureWriterTester extends HtsjdkTest {
                 Assert.assertEquals(actual.getEnd(), feature.getEnd());
             }
         }
+
+        return tmpFile;
     }
 
     public final static <T extends Feature> void testWriteHeaderAndFeatures(

--- a/src/test/java/htsjdk/tribble/writer/FeatureWriterTester.java
+++ b/src/test/java/htsjdk/tribble/writer/FeatureWriterTester.java
@@ -58,6 +58,26 @@ public abstract class FeatureWriterTester extends HtsjdkTest {
         };
     }
 
+    @DataProvider
+    public static Object[][] indexedBedFiles() {
+        final File testDirectory = new File("src/test/resources/htsjdk/tribble/bed");
+        return new Object[][] {
+                {new File(testDirectory,
+                        "NA12878.deletions.10kbp.het.gq99.hand_curated.hg19_fixed.bed")},
+                {new File(testDirectory, "Unigene.sample.bed")}
+        };
+    }
+
+    @DataProvider
+    public static Object[][] bgzipIndexedBedFiles() {
+        final File testDirectory = new File("src/test/resources/htsjdk/tribble/bed");
+        return new Object[][] {
+                {new File(testDirectory, "2featuresNoHeader.bed.gz")},
+                {new File(testDirectory, "2featuresWithHeader.bed.gz")},
+                {new File(testDirectory, "3featuresNoHeader.bed.gz")}
+        };
+    }
+
     /** NoOp OutputStream. */
     protected final static OutputStream NULL_OUTPUT_STREAM = new OutputStream() {
         @Override

--- a/src/test/java/htsjdk/tribble/writer/FeatureWriterTester.java
+++ b/src/test/java/htsjdk/tribble/writer/FeatureWriterTester.java
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.Feature;
+import htsjdk.tribble.FeatureCodec;
+import htsjdk.tribble.FeatureReader;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public abstract class FeatureWriterTester extends HtsjdkTest {
+
+    @DataProvider
+    public static Object[][] bedFiles() {
+        final File testDirectory = new File("src/test/resources/htsjdk/tribble/bed");
+        return new Object[][] {
+                {new File(testDirectory, "disconcontigs.bed")},
+                {new File(testDirectory,
+                        "NA12878.deletions.10kbp.het.gq99.hand_curated.hg19_fixed.bed")},
+                {new File(testDirectory, "Unigene.sample.bed")},
+                {new File(testDirectory, "unsorted.bed")}
+        };
+    }
+
+    /** NoOp OutputStream. */
+    protected final static OutputStream NULL_OUTPUT_STREAM = new OutputStream() {
+        @Override
+        public void write(int b) throws IOException { }
+    };
+
+
+    /**
+     * Test encoder that keeps a list with all features added and a list of all headers added
+     */
+    protected final static class TestEncoder implements FeatureEncoder<Feature> {
+
+        List<Feature> addedFeatures = new ArrayList<>();
+        List<Object> addedHeaders = new ArrayList<>();
+
+        @Override
+        public void write(Appendable out, Feature feature) throws IOException {
+            addedFeatures.add(feature);
+        }
+
+        @Override
+        public void writeHeader(Appendable out, Object header) throws IOException {
+            addedHeaders.add(header);
+        }
+    }
+
+    /**
+     * Tests that reading a file with FeatureReader and writing to a FeatureWriter provides the same
+     * result.
+     */
+    protected final static <T extends Feature> void testReadWrite(final File featureFile,
+            final FeatureCodec<T, ?> featureCodec,
+            final Function<File, FeatureWriter<T>> writerProvider) throws Exception {
+        final File tmpFile = File.createTempFile(featureFile.getName(), ".bed");
+
+        // read the original file and write it down
+        final List<T> featureList = new ArrayList<>();
+        try (final FeatureReader<T> reader = AbstractFeatureReader
+                .getFeatureReader(featureFile.toString(), featureCodec, false);
+                final FeatureWriter<T> writer = writerProvider.apply(tmpFile)) {
+            for (final T feature : reader.iterator()) {
+                // accumulate in the list
+                featureList.add(feature);
+                // write down
+                writer.add(feature);
+            }
+        }
+
+        // read the written file and check if the features are the same
+        try (final FeatureReader<T> reader = AbstractFeatureReader
+                .getFeatureReader(tmpFile.toString(), featureCodec, false)) {
+            final Iterator<T> it = reader.iterator();
+            for (final T feature : featureList) {
+                Assert.assertTrue(it.hasNext(), "unexpected end of file");
+                final T actual = it.next();
+                Assert.assertEquals(actual.getContig(), feature.getContig());
+                Assert.assertEquals(actual.getStart(), feature.getStart());
+                Assert.assertEquals(actual.getEnd(), feature.getEnd());
+            }
+        }
+    }
+
+    public final static <T extends Feature> void testWriteHeaderAndFeatures(
+            final BiFunction<FeatureEncoder<Feature>, OutputStream, FeatureWriter<Feature>> writerProvider,
+            final List<T> featuresToWrite,
+            final List<Object> headersToWrite) throws Exception {
+        final TestEncoder encoder = new TestEncoder();
+        try (FeatureWriter<Feature> writer = writerProvider.apply(encoder, NULL_OUTPUT_STREAM)) {
+            for (final Object o : headersToWrite) {
+                writer.writeHeader(o);
+            }
+            for (final T f : featuresToWrite) {
+                writer.add(f);
+            }
+        }
+        Assert.assertEquals(encoder.addedHeaders, headersToWrite);
+        Assert.assertEquals(encoder.addedFeatures, featuresToWrite);
+    }
+
+}

--- a/src/test/java/htsjdk/tribble/writer/IndexingFeatureWriterUnitTest.java
+++ b/src/test/java/htsjdk/tribble/writer/IndexingFeatureWriterUnitTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.tribble.writer;
+
+import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.tribble.FeatureCodec;
+import htsjdk.tribble.Tribble;
+import htsjdk.tribble.bed.BEDCodec;
+import htsjdk.tribble.bed.BEDSimpleEncoder;
+import htsjdk.tribble.index.DynamicIndexCreator;
+import htsjdk.tribble.index.Index;
+import htsjdk.tribble.index.IndexFactory;
+import htsjdk.tribble.index.tabix.TabixFormat;
+import htsjdk.tribble.index.tabix.TabixIndexCreator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class IndexingFeatureWriterUnitTest extends FeatureWriterTester {
+
+    @Test(dataProvider = "indexedBedFiles")
+    public void readWriteSimpleTribbleIndexedBed(final File bedFile) throws Exception {
+
+        final File output = testReadWrite(bedFile, ".bed", (FeatureCodec) new BEDCodec(), (f) -> {
+            try {
+                return new IndexingFeatureWriter<>(new BEDSimpleEncoder(), new FileOutputStream(f),
+                        // test with DynamicIndexCreator
+                        new DynamicIndexCreator(f, IndexFactory.IndexBalanceApproach.FOR_SEEK_TIME),
+                        // test with an index file without a sequence dictionary
+                        Tribble.indexFile(f).toPath(), null);
+            } catch (final FileNotFoundException e) {
+                throw new AssertionError(e.getMessage());
+            }
+        });
+
+        // assert that the indexes are the same
+        // actual index loaded from the output from read-write
+        final Index actual = IndexFactory.loadIndex(Tribble.indexFile(output).getAbsolutePath());
+        // create an index on-memory for the original to check concordance
+        final Index expected = IndexFactory.createDynamicIndex(bedFile, new BEDCodec());
+
+        assertEqualsIndexes(actual, expected);
+    }
+
+    @Test(dataProvider = "bgzipIndexedBedFiles")
+    public void readWriteSimpleTabixIndexedBed(final File bedFile) throws Exception {
+
+        final File output = testReadWrite(bedFile, ".bed.gz", (FeatureCodec) new BEDCodec(), (f) -> {
+            try {
+                return new IndexingFeatureWriter<>(new BEDSimpleEncoder(), new BlockCompressedOutputStream(new FileOutputStream(f), f),
+                        // test with TabixIndexCreator
+                        new TabixIndexCreator(null, TabixFormat.BED),
+                        // test with an index file without a sequence dictionary
+                        Tribble.tabixIndexFile(f).toPath(), null);
+            } catch (final FileNotFoundException e) {
+                throw new AssertionError(e.getMessage());
+            }
+        });
+
+        // assert that the indexes are the same
+        // actual index loaded from the output from read-write
+        final Index actual = IndexFactory.loadIndex(Tribble.tabixIndexFile(output).getAbsolutePath());
+        // create an index on-memory for the original to check concordance
+        final Index expected = IndexFactory.createTabixIndex(bedFile, new BEDCodec(), null);
+
+        assertEqualsIndexes(actual, expected);
+    }
+
+    public void assertEqualsIndexes(final Index actual, final Index expected) throws Exception {
+        Assert.assertEquals(actual.getClass(), expected.getClass(), "index class");
+        Assert.assertEquals(actual.getSequenceNames(), expected.getSequenceNames(), "sequences");
+        Assert.assertEquals(actual.getProperties(), expected.getProperties(), "properties");
+    }
+}


### PR DESCRIPTION
### Description

As described in #701, it will be nice to have a simple mechanism to write features in tribble not only for `VariantContext`. This is a port from one of my project that I think that a lot of API users will benefit. It includes the following:

* `FeatureWriter` interface to encapsulate adding features and writing headers. There is no support for comments yet, but it could be something added in the future.
* `FeatureEncoder` interface to encapsulate feature-specific output formats. Based on a very nice suggestion from @lindenb in one of my previous PRs, the purpose of this interface is to format the feature/header and add it to an `Appendable`. This allow to write directly the features without storing the `String` format, and give more flexibility. It also have a method to encapsulate the tabix format, to allow indexing on the fly.
* Example of `FeatureEncoder` to convert any `Feature` into a simple BED format (tab-delimited chromosome, start and end). It will be used also in tests.
* Package protected implementation of `FeatureWriter` similar to the VCF writer, which uses an encoder and an output stream to create the feature file. This class can be extended for other purposes as noted bellow.
* Package protected sub-class of `FeatureWriterImpl` to index on the fly. This one will require eventually #810 for use the `java.nio.Path` index method, but it is very useful for writing feature files already indexed.
* Wrapper for `FeatureWriter` to use asynchronous writing. This is a very simple wrapper extending the `AbstractAsyncWriter`. The only flaw is that the header could not be written asynchronously with the current implementation (and thus, it's not safe). I do not really need that, and if it is a problem that it's not safe, this support could be removed.
* Finally, for construction of feature writers, I decided to use a factory pattern instead of the static methods used in the tribble reader classes. This factory have support: 1) index on the fly, 2) block-gzip or gzip, 3) generate MD5 diggest files, 4) asynchronous wriitng and 5) sequence dictionary addition.

All the writing support use `java.nio.Path` to allow other filesystems. There are no tests for the writers yet (only for the simple encoder), because I want to know your opinion about this addition beforehand. I know that this is a very big PR, but I think that it may be useful for others and will be nice to included in HTSJDK for easier development of new bioinformatic tools.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

