### PR TITLE
Obey the tmpDir setting in several constructors that currently ignore it

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -253,7 +253,6 @@ public class SAMFileWriterFactory implements Cloneable {
             if (this.createIndex && !createIndex) {
                 log.warn("Cannot create index for BAM because output file is not a regular file: " + outputFile.getAbsolutePath());
             }
-            if (this.tmpDir != null) ret.setTempDirectory(this.tmpDir);
             initializeBAMWriter(ret, header, presorted, createIndex);
 
             if (this.useAsyncIo) return new AsyncSAMFileWriter(ret, this.asyncOutputBufferSize);
@@ -268,6 +267,7 @@ public class SAMFileWriterFactory implements Cloneable {
         if (maxRecordsInRam != null) {
             writer.setMaxRecordsInRam(maxRecordsInRam);
         }
+        if (this.tmpDir != null) writer.setTempDirectory(this.tmpDir);
         writer.setHeader(header);
         if (createIndex && writer.getSortOrder().equals(SAMFileHeader.SortOrder.coordinate)) {
             writer.enableBamIndexConstruction();
@@ -294,14 +294,7 @@ public class SAMFileWriterFactory implements Cloneable {
                     ? new SAMTextWriter(new Md5CalculatingOutputStream(new FileOutputStream(outputFile, false),
                     new File(outputFile.getAbsolutePath() + ".md5")), samFlagFieldOutput)
                     : new SAMTextWriter(outputFile, samFlagFieldOutput);
-            ret.setSortOrder(header.getSortOrder(), presorted);
-            if (maxRecordsInRam != null) {
-                ret.setMaxRecordsInRam(maxRecordsInRam);
-            }
-            ret.setHeader(header);
-
-            if (this.useAsyncIo) return new AsyncSAMFileWriter(ret, this.asyncOutputBufferSize);
-            else return ret;
+            return initWriter(header, presorted, ret);
         } catch (final IOException ioe) {
             throw new RuntimeIOException("Error opening file: " + outputFile.getAbsolutePath());
         }
@@ -324,7 +317,7 @@ public class SAMFileWriterFactory implements Cloneable {
         if (samFlagFieldOutput == SamFlagField.NONE) {
             samFlagFieldOutput = Defaults.SAM_FLAG_FIELD_FORMAT;
         }
-        return initWriter(header, presorted, false, new SAMTextWriter(stream, samFlagFieldOutput));
+        return initWriter(header, presorted, new SAMTextWriter(stream, samFlagFieldOutput));
     }
 
     /**
@@ -338,24 +331,23 @@ public class SAMFileWriterFactory implements Cloneable {
      */
 
     public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final OutputStream stream) {
-        return initWriter(header, presorted, true, new BAMFileWriter(stream, null, this.getCompressionLevel(), this.deflaterFactory));
+        return initWriter(header, presorted, new BAMFileWriter(stream, null, this.getCompressionLevel(), this.deflaterFactory));
     }
 
     /**
      * Initialize SAMTextWriter or a BAMFileWriter and possibly wrap in AsyncSAMFileWriter
-     *
      * @param header    entire header. Sort order is determined by the sortOrder property of this arg.
      * @param presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param binary    do we want to generate a BAM or a SAM
      * @param writer    SAM or BAM writer to initialize and maybe wrap.
      */
 
-    private SAMFileWriter initWriter(final SAMFileHeader header, final boolean presorted, final boolean binary,
+    private SAMFileWriter initWriter(final SAMFileHeader header, final boolean presorted,
                                      final SAMFileWriterImpl writer) {
         writer.setSortOrder(header.getSortOrder(), presorted);
         if (maxRecordsInRam != null) {
             writer.setMaxRecordsInRam(maxRecordsInRam);
         }
+        if (this.tmpDir != null) writer.setTempDirectory(this.tmpDir);
         writer.setHeader(header);
 
         if (this.useAsyncIo) return new AsyncSAMFileWriter(writer, this.asyncOutputBufferSize);

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -174,6 +174,14 @@ public class SAMFileWriterFactory implements Cloneable {
     }
 
     /**
+     * Gets the maximum number of records held in RAM before spilling to disk during sorting.
+     * @see #setMaxRecordsInRam(int)
+     */
+    public int getMaxRecordsInRam() {
+        return maxRecordsInRam;
+    }
+
+    /**
      * Turn on or off the use of asynchronous IO for writing output SAM and BAM files.  If true then
      * each SAMFileWriter creates a dedicated thread which is used for compression and IO activities.
      */
@@ -208,6 +216,14 @@ public class SAMFileWriterFactory implements Cloneable {
     public SAMFileWriterFactory setTempDirectory(final File tmpDir) {
         this.tmpDir = tmpDir;
         return this;
+    }
+
+    /**
+     * Gets the temporary directory that will be used when sorting data.
+     * @see #setTempDirectory(File)
+     */
+    public File getTempDirectory() {
+        return tmpDir;
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -111,7 +111,11 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
         }
         this.maxRecordsInRam = maxRecordsInRam;
     }
-    
+
+    int getMaxRecordsInRam() {
+        return maxRecordsInRam;
+    }
+
     /**
      * When writing records that are not presorted, specify the path of the temporary directory 
      * for spilling to disk.  Must be called before setHeader().
@@ -121,6 +125,10 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
         if (tmpDir!=null) {
             this.tmpDir = tmpDir;
         }
+    }
+
+    File getTempDirectory() {
+        return tmpDir;
     }
 
     /**

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -167,7 +167,29 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
         fillSmallBam(writer);
         writer.close();
     }
-   
+
+    @Test(description="check that factory settings are propagated to writer")
+    public void testFactorySettings()  throws Exception {
+        final SAMFileWriterFactory factory = new SAMFileWriterFactory();
+        factory.setCreateIndex(false);
+        factory.setCreateMd5File(false);
+        final File wontBeUsed = new File("wontBeUsed.tmp");
+        final int maxRecsInRam = 271828;
+        factory.setMaxRecordsInRam(maxRecsInRam);
+        factory.setTempDirectory(wontBeUsed);
+        final SAMFileHeader header = new SAMFileHeader();
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        header.addSequence(new SAMSequenceRecord("chr1", 123));
+        try (final SAMFileWriter writer = factory.makeBAMWriter(header, false, new ByteArrayOutputStream())) {
+            Assert.assertEquals(maxRecsInRam, ((SAMFileWriterImpl) writer).getMaxRecordsInRam());
+            Assert.assertEquals(wontBeUsed, ((SAMFileWriterImpl) writer).getTempDirectory());
+        }
+        try (final SAMFileWriter writer = factory.makeSAMWriter(header, false, new ByteArrayOutputStream())) {
+            Assert.assertEquals(maxRecsInRam, ((SAMFileWriterImpl) writer).getMaxRecordsInRam());
+            Assert.assertEquals(wontBeUsed, ((SAMFileWriterImpl) writer).getTempDirectory());
+        }
+    }
+
    private int fillSmallBam(SAMFileWriter writer) {
        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
        builder.addUnmappedFragment("HiMom!");


### PR DESCRIPTION
### Description

Several constructors don't do what they should regarding tmpDir.

Ensured that both initWriter and initializeBAMWriter both call setTempDirectory() when needed, and made one of the existing constructors make use of initWriter() (This private method had an unused parameter, which has been removed)

We encountered this by running out of disk space while sorting a file during output.

### Checklist

- [X] Code compiles correctly
- [x] New tests covering changes and new functionality
- [X] All tests passing


