### PR TITLE
Fix DateParserTest unit tests that were failing in my locale.

### DIFF
--- a/src/test/java/htsjdk/samtools/util/DateParserTest.java
+++ b/src/test/java/htsjdk/samtools/util/DateParserTest.java
@@ -76,7 +76,6 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.text.DateFormat;
 import java.util.Date;
 
 /**
@@ -107,8 +106,7 @@ public class DateParserTest {
         final Date dateRoundTrip = DateParser.parse(isodate);
 
         assertDatesAreClose(date, dateRoundTrip);
-        Assert.assertTrue(Math.abs(Date.parse(date.toString()) - Date.parse(dateRoundTrip.toString())) < 10);
-
+        Assert.assertTrue(Math.abs(date.getTime() - dateRoundTrip.getTime()) < 10);
     }
 
     @DataProvider(name="dateDate")


### PR DESCRIPTION
### Description

Several of the DateParserTest unit tests were failing in my locale due to their use of the deprecated Date.parse() method. It seems to me that the existing steps of Date.parse(date.toString()) weren't really accomplishing anything related to htsjdk code (perhaps it was required in past JREs in order to get unix timestamps), so have simplified the assertion to just compare the time stamps directly.

### Checklist

- [X] Code compiles correctly
- [X] All tests passing

