### PR TITLE
Make exception message informative in SAMUtils.charToCompressedBase

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMRecord.java
+++ b/src/main/java/htsjdk/samtools/BAMRecord.java
@@ -342,7 +342,12 @@ public class BAMRecord extends SAMRecord {
             return NULL_SEQUENCE;
         }
         final int basesOffset = readNameSize() + cigarSize();
-        return SAMUtils.compressedBasesToBytes(mReadLength, mRestOfBinaryData, basesOffset, getReadName());
+        try {
+            return SAMUtils.compressedBasesToBytes(mReadLength, mRestOfBinaryData, basesOffset);
+        } catch ( final IllegalArgumentException ex ) {
+            final String msg = ex.getMessage() + " in read: " + getReadName();
+            throw new IllegalStateException(msg, ex);
+        }
     }
 
     /* methods for computing disk size of variably-sized elements, in order to locate

--- a/src/main/java/htsjdk/samtools/BAMRecord.java
+++ b/src/main/java/htsjdk/samtools/BAMRecord.java
@@ -342,7 +342,7 @@ public class BAMRecord extends SAMRecord {
             return NULL_SEQUENCE;
         }
         final int basesOffset = readNameSize() + cigarSize();
-        return SAMUtils.compressedBasesToBytes(mReadLength, mRestOfBinaryData, basesOffset);
+        return SAMUtils.compressedBasesToBytes(mReadLength, mRestOfBinaryData, basesOffset, getReadName());
     }
 
     /* methods for computing disk size of variably-sized elements, in order to locate

--- a/src/main/java/htsjdk/samtools/BAMRecordCodec.java
+++ b/src/main/java/htsjdk/samtools/BAMRecordCodec.java
@@ -154,7 +154,7 @@ public class BAMRecordCodec implements SortingCollection.Codec<SAMRecord> {
                 // that it is specced as a uint.
                 this.binaryCodec.writeInt(cigarElement);
             }
-            this.binaryCodec.writeBytes(SAMUtils.bytesToCompressedBases(alignment.getReadBases()));
+            this.binaryCodec.writeBytes(SAMUtils.bytesToCompressedBases(alignment.getReadBases(), alignment.getReadName()));
             byte[] qualities = alignment.getBaseQualities();
             if (qualities.length == 0) {
                 qualities = new byte[alignment.getReadLength()];

--- a/src/main/java/htsjdk/samtools/BAMRecordCodec.java
+++ b/src/main/java/htsjdk/samtools/BAMRecordCodec.java
@@ -154,7 +154,12 @@ public class BAMRecordCodec implements SortingCollection.Codec<SAMRecord> {
                 // that it is specced as a uint.
                 this.binaryCodec.writeInt(cigarElement);
             }
-            this.binaryCodec.writeBytes(SAMUtils.bytesToCompressedBases(alignment.getReadBases(), alignment.getReadName()));
+            try {
+                this.binaryCodec.writeBytes(SAMUtils.bytesToCompressedBases(alignment.getReadBases()));
+            } catch ( final IllegalArgumentException ex ) {
+                final String msg = ex.getMessage() + " in read: " +  alignment.getReadName();
+                throw new IllegalStateException(msg, ex);
+            }
             byte[] qualities = alignment.getBaseQualities();
             if (qualities.length == 0) {
                 qualities = new byte[alignment.getReadLength()];

--- a/src/test/java/htsjdk/samtools/SAMUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/SAMUtilsTest.java
@@ -24,8 +24,10 @@
 package htsjdk.samtools;
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class SAMUtilsTest {
@@ -244,7 +246,43 @@ public class SAMUtilsTest {
         Assert.assertEquals(other.getAttribute(SAMTagUtil.getSingleton().NM),null);
         Assert.assertEquals(other.getCigarString(),"8M2S");
         Assert.assertEquals(other.getInferredInsertSize(),-91);//100(mate) - 191(other)
-
     }
 
+    @Test()
+    public void testBytesToCompressedBases() {
+        final byte[] bases = new byte[]{'=', 'a', 'A', 'c', 'C', 'g', 'G', 't', 'T', 'n', 'N', '.', 'M', 'm',
+                'R', 'r', 'S', 's', 'V', 'v', 'W', 'w', 'Y', 'y', 'H', 'h', 'K', 'k', 'D', 'd', 'B', 'b'};
+        final byte[] compressedBases = SAMUtils.bytesToCompressedBases(bases, "readName");
+        String expectedCompressedBases = "[1, 18, 36, 72, -113, -1, 51, 85, 102, 119, -103, -86, -69, -52, -35, -18]";
+        Assert.assertEquals(Arrays.toString(compressedBases), expectedCompressedBases);
+    }
+
+    @DataProvider
+    public Object[][] testBadBase() {
+        return new Object[][]{
+                {new byte[]{'>', 'A'}, '>'},
+                {new byte[]{'A', '>'} , '>'}
+        };
+    }
+
+    @Test(dataProvider = "testBadBase", expectedExceptions = IllegalArgumentException.class)
+    public void testBytesToCompressedBasesException(final byte[] bases, final char failingBase) {
+        final String readName = "readName";
+        try {
+            SAMUtils.bytesToCompressedBases(bases, readName);
+        } catch ( final IllegalArgumentException ex ) {
+            Assert.assertTrue(ex.getMessage().contains(readName));
+            Assert.assertTrue(ex.getMessage().contains(Character.toString(failingBase)));
+            throw ex;
+        }
+    }
+
+    @Test
+    public void testCompressedBasesToBytes() {
+        final byte[] compressedBases = new byte[]{1, 18, 36, 72, -113, -1, 51, 85, 102, 119, -103, -86, -69, -52, -35, -18};
+        final byte[] bytes = SAMUtils.compressedBasesToBytes(2*compressedBases.length, compressedBases, 0, "readName");
+        final byte[] expectedBases = new byte[]{'=', 'A', 'A', 'C', 'C', 'G', 'G', 'T', 'T', 'N', 'N', 'N', 'M', 'M',
+                'R', 'R', 'S', 'S', 'V', 'V', 'W', 'W', 'Y', 'Y', 'H', 'H', 'K', 'K', 'D', 'D', 'B', 'B'};
+        Assert.assertEquals(new String(bytes), new String(expectedBases));
+    }
 }

--- a/src/test/java/htsjdk/samtools/SAMUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/SAMUtilsTest.java
@@ -252,7 +252,7 @@ public class SAMUtilsTest {
     public void testBytesToCompressedBases() {
         final byte[] bases = new byte[]{'=', 'a', 'A', 'c', 'C', 'g', 'G', 't', 'T', 'n', 'N', '.', 'M', 'm',
                 'R', 'r', 'S', 's', 'V', 'v', 'W', 'w', 'Y', 'y', 'H', 'h', 'K', 'k', 'D', 'd', 'B', 'b'};
-        final byte[] compressedBases = SAMUtils.bytesToCompressedBases(bases, "readName");
+        final byte[] compressedBases = SAMUtils.bytesToCompressedBases(bases);
         String expectedCompressedBases = "[1, 18, 36, 72, -113, -1, 51, 85, 102, 119, -103, -86, -69, -52, -35, -18]";
         Assert.assertEquals(Arrays.toString(compressedBases), expectedCompressedBases);
     }
@@ -267,11 +267,9 @@ public class SAMUtilsTest {
 
     @Test(dataProvider = "testBadBase", expectedExceptions = IllegalArgumentException.class)
     public void testBytesToCompressedBasesException(final byte[] bases, final char failingBase) {
-        final String readName = "readName";
         try {
-            SAMUtils.bytesToCompressedBases(bases, readName);
+            SAMUtils.bytesToCompressedBases(bases);
         } catch ( final IllegalArgumentException ex ) {
-            Assert.assertTrue(ex.getMessage().contains(readName));
             Assert.assertTrue(ex.getMessage().contains(Character.toString(failingBase)));
             throw ex;
         }
@@ -280,7 +278,7 @@ public class SAMUtilsTest {
     @Test
     public void testCompressedBasesToBytes() {
         final byte[] compressedBases = new byte[]{1, 18, 36, 72, -113, -1, 51, 85, 102, 119, -103, -86, -69, -52, -35, -18};
-        final byte[] bytes = SAMUtils.compressedBasesToBytes(2*compressedBases.length, compressedBases, 0, "readName");
+        final byte[] bytes = SAMUtils.compressedBasesToBytes(2*compressedBases.length, compressedBases, 0);
         final byte[] expectedBases = new byte[]{'=', 'A', 'A', 'C', 'C', 'G', 'G', 'T', 'T', 'N', 'N', 'N', 'M', 'M',
                 'R', 'R', 'S', 'S', 'V', 'V', 'W', 'W', 'Y', 'Y', 'H', 'H', 'K', 'K', 'D', 'D', 'B', 'B'};
         Assert.assertEquals(new String(bytes), new String(expectedBases));


### PR DESCRIPTION
### Description

Fixes https://github.com/broadinstitute/picard/issues/781.
Added the `base` and `read` names to the exception message in `SAMUtils.charToCompressedBase`.

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [X] Is not backward compatible (breaks binary or source compatibility)

