### PR TITLE
check for negative length in CigarElement ctor

### DIFF
--- a/src/main/java/htsjdk/samtools/CigarElement.java
+++ b/src/main/java/htsjdk/samtools/CigarElement.java
@@ -36,7 +36,7 @@ public class CigarElement implements Serializable {
     private final CigarOperator operator;
 
     public CigarElement(final int length, final CigarOperator operator) {
-        if (length < 0) throw new IllegalArgumentException("Cigar element being constructed with negative length: " + length);
+        if (length < 0) throw new IllegalArgumentException(String.format("Cigar element being constructed with negative length: %d and operation: $s" , length, operator.name()));
         this.length = length;
         this.operator = operator;
     }

--- a/src/main/java/htsjdk/samtools/CigarElement.java
+++ b/src/main/java/htsjdk/samtools/CigarElement.java
@@ -36,7 +36,7 @@ public class CigarElement implements Serializable {
     private final CigarOperator operator;
 
     public CigarElement(final int length, final CigarOperator operator) {
-        if (length < 0) throw new IllegalArgumentException(String.format("Cigar element being constructed with negative length: %d and operation: $s" , length, operator.name()));
+        if (length < 0) throw new IllegalArgumentException(String.format("Cigar element being constructed with negative length: %d and operation: %s" , length, operator.name()));
         this.length = length;
         this.operator = operator;
     }

--- a/src/main/java/htsjdk/samtools/CigarElement.java
+++ b/src/main/java/htsjdk/samtools/CigarElement.java
@@ -36,6 +36,7 @@ public class CigarElement implements Serializable {
     private final CigarOperator operator;
 
     public CigarElement(final int length, final CigarOperator operator) {
+        if (length < 0) throw new IllegalArgumentException("Cigar element being constructed with negative length: " + length);
         this.length = length;
         this.operator = operator;
     }

--- a/src/test/java/htsjdk/samtools/util/CigarElementUnitTest.java
+++ b/src/test/java/htsjdk/samtools/util/CigarElementUnitTest.java
@@ -1,0 +1,14 @@
+package htsjdk.samtools.util;
+
+
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import org.testng.annotations.Test;
+
+public class CigarElementUnitTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeLengthCheck(){
+        final CigarElement element = new CigarElement(-1, CigarOperator.M);
+    }
+}


### PR DESCRIPTION
### Description

Class `CigarElement` currently doesn't check for the length provided in its ctor. This PR adds that check.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [NA] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
