### PR TITLE
add Path options for SAMFileWriterFactory

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMIndexer.java
+++ b/src/main/java/htsjdk/samtools/BAMIndexer.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.util.Log;
 
 import java.io.File;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.function.Function;
 
 /**
@@ -56,8 +57,16 @@ public class BAMIndexer {
      * @param output     binary BAM Index (.bai) file
      * @param fileHeader header for the corresponding bam file
      */
-    public BAMIndexer(final File output, final SAMFileHeader fileHeader) {
+    public BAMIndexer(final Path output, final SAMFileHeader fileHeader) {
         this(fileHeader, numRefs -> new BinaryBAMIndexWriter(numRefs, output));
+    }
+
+    /**
+     * @param output     binary BAM Index (.bai) file
+     * @param fileHeader header for the corresponding bam file
+     */
+    public BAMIndexer(final File output, final SAMFileHeader fileHeader) {
+        this(output.toPath(), fileHeader);
     }
 
     /**
@@ -283,9 +292,9 @@ public class BAMIndexer {
      * Generates a BAM index file from an input BAM file
      *
      * @param reader SamReader for input BAM file
-     * @param output File for output index file
+     * @param output Path for output index file
      */
-    public static void createIndex(SamReader reader, File output) {
+    public static void createIndex(SamReader reader, Path output) {
         createIndex(reader, output, null);
     }
 
@@ -295,7 +304,17 @@ public class BAMIndexer {
      * @param reader SamReader for input BAM file
      * @param output File for output index file
      */
-    public static void createIndex(SamReader reader, File output, Log log) {
+    public static void createIndex(SamReader reader, File output) {
+        createIndex(reader, output.toPath(), null);
+    }
+
+    /**
+     * Generates a BAM index file from an input BAM file
+     *
+     * @param reader SamReader for input BAM file
+     * @param output Path for output index file
+     */
+    public static void createIndex(SamReader reader, Path output, Log log) {
 
         BAMIndexer indexer = new BAMIndexer(output, reader.getFileHeader());
 
@@ -309,5 +328,15 @@ public class BAMIndexer {
             indexer.processAlignment(rec);
         }
         indexer.finish();
+    }
+
+    /**
+     * Generates a BAM index file from an input BAM file
+     *
+     * @param reader SamReader for input BAM file
+     * @param output File for output index file
+     */
+    public static void createIndex(SamReader reader, File output, Log log) {
+        createIndex(reader, output.toPath(), log);
     }
 }

--- a/src/main/java/htsjdk/samtools/BinaryBAMIndexWriter.java
+++ b/src/main/java/htsjdk/samtools/BinaryBAMIndexWriter.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.util.BinaryCodec;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -41,12 +42,20 @@ class BinaryBAMIndexWriter implements BAMIndexWriter {
     private int count = 0;
 
     /**
-     * constructor
      *
      * @param nRef    Number of reference sequences
      * @param output  BAM Index output file
      */
     public BinaryBAMIndexWriter(final int nRef, final File output) {
+        this(nRef, null == output ? null : output.toPath());
+    }
+
+    /**
+     *
+     * @param nRef    Number of reference sequences
+     * @param output  BAM Index output file
+     */
+    public BinaryBAMIndexWriter(final int nRef, final Path output) {
 
         this.nRef = nRef;
 

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -35,6 +35,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.zip.Deflater;
 
 /**
@@ -248,6 +250,17 @@ public class SAMFileWriterFactory implements Cloneable {
     }
 
     /**
+     * Create a BAMFileWriter that is ready to receive SAMRecords.  Uses default compression level.
+     *
+     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputPath where to write the output.
+     */
+    public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final Path outputPath) {
+        return makeBAMWriter(header, presorted, outputPath, this.getCompressionLevel());
+    }
+
+    /**
      * Create a BAMFileWriter that is ready to receive SAMRecords.
      *
      * @param header           entire header. Sort order is determined by the sortOrder property of this arg.
@@ -257,24 +270,37 @@ public class SAMFileWriterFactory implements Cloneable {
      */
     public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile,
                                        final int compressionLevel) {
+        return makeBAMWriter(header, presorted, outputFile.toPath(), compressionLevel);
+    }
+
+    /**
+     * Create a BAMFileWriter that is ready to receive SAMRecords.
+     *
+     * @param header           entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted        if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputPath       where to write the output.
+     * @param compressionLevel Override default compression level with the given value, between 0 (fastest) and 9 (smallest).
+     */
+    public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final Path outputPath,
+        final int compressionLevel) {
         try {
-            final boolean createMd5File = this.createMd5File && IOUtil.isRegularPath(outputFile);
+            final boolean createMd5File = this.createMd5File && IOUtil.isRegularPath(outputPath);
             if (this.createMd5File && !createMd5File) {
-                log.warn("Cannot create MD5 file for BAM because output file is not a regular file: " + outputFile.getAbsolutePath());
+                log.warn("Cannot create MD5 file for BAM because output file is not a regular file: " + outputPath.toUri());
             }
-            OutputStream os = IOUtil.maybeBufferOutputStream(new FileOutputStream(outputFile, false), bufferSize);
-            if (createMd5File) os = new Md5CalculatingOutputStream(os, new File(outputFile.getAbsolutePath() + ".md5"));
-            final BAMFileWriter ret = new BAMFileWriter(os, outputFile, compressionLevel, deflaterFactory);
-            final boolean createIndex = this.createIndex && IOUtil.isRegularPath(outputFile);
+            OutputStream os = IOUtil.maybeBufferOutputStream(Files.newOutputStream(outputPath), bufferSize);
+            if (createMd5File) os = new Md5CalculatingOutputStream(os, IOUtil.addExtension(outputPath,".md5"));
+            final BAMFileWriter ret = new BAMFileWriter(os, outputPath.toUri().toString(), compressionLevel, deflaterFactory);
+            final boolean createIndex = this.createIndex && IOUtil.isRegularPath(outputPath);
             if (this.createIndex && !createIndex) {
-                log.warn("Cannot create index for BAM because output file is not a regular file: " + outputFile.getAbsolutePath());
+                log.warn("Cannot create index for BAM because output file is not a regular file: " + outputPath.toUri());
             }
             initializeBAMWriter(ret, header, presorted, createIndex);
 
             if (this.useAsyncIo) return new AsyncSAMFileWriter(ret, this.asyncOutputBufferSize);
             else return ret;
         } catch (final IOException ioe) {
-            throw new RuntimeIOException("Error opening file: " + outputFile.getAbsolutePath());
+            throw new RuntimeIOException("Error opening file: " + outputPath.toUri());
         }
     }
 
@@ -298,6 +324,17 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param outputFile where to write the output.
      */
     public SAMFileWriter makeSAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile) {
+        return makeSAMWriter(header, presorted, outputFile.toPath());
+    }
+
+    /**
+     * Create a SAMTextWriter that is ready to receive SAMRecords.
+     *
+     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputPath where to write the output.
+     */
+    public SAMFileWriter makeSAMWriter(final SAMFileHeader header, final boolean presorted, final Path outputPath) {
         /**
          * Use the value specified from Defaults.SAM_FLAG_FIELD_FORMAT when samFlagFieldOutput value has not been set.  This should
          * be SamFlagField.DECIMAL when the user has not set Defaults.SAM_FLAG_FIELD_FORMAT.
@@ -307,12 +344,12 @@ public class SAMFileWriterFactory implements Cloneable {
         }
         try {
             final SAMTextWriter ret = this.createMd5File
-                    ? new SAMTextWriter(new Md5CalculatingOutputStream(new FileOutputStream(outputFile, false),
-                    new File(outputFile.getAbsolutePath() + ".md5")), samFlagFieldOutput)
+                    ? new SAMTextWriter(new Md5CalculatingOutputStream(Files.newOutputStream(outputPath),
+                          IOUtil.addExtension(outputPath, ".md5"), samFlagFieldOutput)
                     : new SAMTextWriter(outputFile, samFlagFieldOutput);
             return initWriter(header, presorted, ret);
         } catch (final IOException ioe) {
-            throw new RuntimeIOException("Error opening file: " + outputFile.getAbsolutePath());
+            throw new RuntimeIOException("Error opening file: " + outputPath.toUri());
         }
     }
 
@@ -347,7 +384,7 @@ public class SAMFileWriterFactory implements Cloneable {
      */
 
     public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final OutputStream stream) {
-        return initWriter(header, presorted, new BAMFileWriter(stream, null, this.getCompressionLevel(), this.deflaterFactory));
+        return initWriter(header, presorted, new BAMFileWriter(stream, (File)null, this.getCompressionLevel(), this.deflaterFactory));
     }
 
     /**
@@ -379,14 +416,26 @@ public class SAMFileWriterFactory implements Cloneable {
      * @return SAM or BAM writer based on file extension of outputFile.
      */
     public SAMFileWriter makeSAMOrBAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile) {
-        final String filename = outputFile.getName();
+       return makeSAMOrBAMWriter(header, presorted, outputFile.toPath());
+    }
+
+    /**
+     * Create either a SAM or a BAM writer based on examination of the outputPath extension.
+     *
+     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted  presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputPath where to write the output.  Must end with .sam or .bam.
+     * @return SAM or BAM writer based on file extension of outputPath.
+     */
+    public SAMFileWriter makeSAMOrBAMWriter(final SAMFileHeader header, final boolean presorted, final Path outputPath) {
+        final String filename = outputPath.getFileName().toString();
         if (filename.endsWith(BamFileIoUtils.BAM_FILE_EXTENSION)) {
-            return makeBAMWriter(header, presorted, outputFile);
+            return makeBAMWriter(header, presorted, outputPath);
         }
         if (filename.endsWith(".sam")) {
-            return makeSAMWriter(header, presorted, outputFile);
+            return makeSAMWriter(header, presorted, outputPath);
         }
-        return makeBAMWriter(header, presorted, outputFile);
+        return makeBAMWriter(header, presorted, outputPath);
     }
 
     /**
@@ -401,11 +450,26 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      */
     public SAMFileWriter makeWriter(final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
-        if (outputFile.getName().endsWith(SamReader.Type.CRAM_TYPE.fileExtension())) {
-            return makeCRAMWriter(header, presorted, outputFile, referenceFasta);
+        return makeWriter(header, presorted, null == outputFile ? null : outputFile.toPath(), referenceFasta);
+    }
+
+    /**
+     *
+     * Create a SAM, BAM or CRAM writer based on examination of the outputPath extension.
+     *
+     * @param header header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputPath where to write the output.  Must end with .sam, .bam or .cram.
+     * @param referenceFasta reference sequence file
+     * @return SAMFileWriter appropriate for the file type specified in outputPath
+     *
+     */
+    public SAMFileWriter makeWriter(final SAMFileHeader header, final boolean presorted, final Path outputPath, final File referenceFasta) {
+        if (null != outputPath && outputPath.toString().endsWith(SamReader.Type.CRAM_TYPE.fileExtension())) {
+            return makeCRAMWriter(header, presorted, outputPath, referenceFasta);
         }
         else {
-            return makeSAMOrBAMWriter(header, presorted, outputFile);
+            return makeSAMOrBAMWriter(header, presorted, outputPath);
         }
     }
 
@@ -440,7 +504,23 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      */
     public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final File outputFile, final File referenceFasta) {
-        return createCRAMWriterWithSettings(header, true, outputFile, referenceFasta);
+        return createCRAMWriterWithSettings(header, true, outputFile.toPath(), referenceFasta);
+    }
+
+    /**
+     * Create a CRAMFileWriter on an output file. Requires input record to be presorted to match the
+     * sort order defined by the input header.
+     *
+     * Note: does not honor factory settings for USE_ASYNC_IO.
+     *
+     * @param header entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param outputPath where to write the output.  Must end with .sam, .bam or .cram.
+     * @param referenceFasta reference sequence file
+     * @return CRAMFileWriter
+     *
+     */
+    public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final Path outputPath, final File referenceFasta) {
+        return createCRAMWriterWithSettings(header, true, outputPath, referenceFasta);
     }
 
     /**
@@ -456,7 +536,24 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      */
     public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
-        return createCRAMWriterWithSettings(header, presorted, outputFile, referenceFasta);
+        return makeCRAMWriter(header, presorted, outputFile.toPath(), referenceFasta);
+    }
+
+
+    /**
+     * Create a CRAMFileWriter on an output file.
+     *
+     * Note: does not honor factory setting for USE_ASYNC_IO.
+     *
+     * @param header entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param output where to write the output.  Must end with .sam, .bam or .cram.
+     * @param referenceFasta reference sequence file
+     * @return CRAMFileWriter
+     *
+     */
+    public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final boolean presorted, final Path output, final File referenceFasta) {
+        return createCRAMWriterWithSettings(header, presorted, output, referenceFasta);
     }
 
     /**
@@ -473,40 +570,41 @@ public class SAMFileWriterFactory implements Cloneable {
     private CRAMFileWriter createCRAMWriterWithSettings(
             final SAMFileHeader header,
             final boolean presorted,
-            final File outputFile,
+            final Path outputFile,
             final File referenceFasta) {
         OutputStream cramOS = null;
         OutputStream indexOS = null ;
 
         if (createIndex) {
             if (!IOUtil.isRegularPath(outputFile)) {
-                log.warn("Cannot create index for CRAM because output file is not a regular file: " + outputFile.getAbsolutePath());
+                log.warn("Cannot create index for CRAM because output file is not a regular file: " + outputFile.toUri());
             }
             else {
+                final Path indexPath = IOUtil.addExtension(outputFile, BAMIndex.BAMIndexSuffix);
                 try {
-                    final File indexFile = new File(outputFile.getAbsolutePath() + BAMIndex.BAMIndexSuffix) ;
-                    indexOS = new FileOutputStream(indexFile) ;
+                    indexOS = Files.newOutputStream(indexPath);
                 }
                 catch (final IOException ioe) {
-                    throw new RuntimeIOException("Error creating index file for: " + outputFile.getAbsolutePath()+ BAMIndex.BAMIndexSuffix);
+                    throw new RuntimeIOException("Error creating index file for: " + indexPath.toUri());
                 }
             }
         }
 
         try {
-            cramOS = IOUtil.maybeBufferOutputStream(new FileOutputStream(outputFile, false), bufferSize);
+            cramOS = IOUtil.maybeBufferOutputStream(Files.newOutputStream(outputFile), bufferSize);
         }
         catch (final IOException ioe) {
-            throw new RuntimeIOException("Error creating CRAM file: " + outputFile.getAbsolutePath());
+            throw new RuntimeIOException("Error creating CRAM file: " + outputFile.toUri());
         }
 
+        final Path md5Path = IOUtil.addExtension(outputFile, ".md5");
         final CRAMFileWriter writer = new CRAMFileWriter(
-                createMd5File ? new Md5CalculatingOutputStream(cramOS, new File(outputFile.getAbsolutePath() + ".md5")) : cramOS,
+                createMd5File ? new Md5CalculatingOutputStream(cramOS, md5Path) : cramOS,
                 indexOS,
                 presorted,
                 new ReferenceSource(referenceFasta),
                 header,
-                outputFile.getAbsolutePath());
+                outputFile.toUri().toString());
         setCRAMWriterDefaults(writer);
 
         return writer;

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -345,8 +345,11 @@ public class SAMFileWriterFactory implements Cloneable {
         try {
             final SAMTextWriter ret = this.createMd5File
                     ? new SAMTextWriter(new Md5CalculatingOutputStream(Files.newOutputStream(outputPath),
-                          IOUtil.addExtension(outputPath, ".md5"), samFlagFieldOutput)
-                    : new SAMTextWriter(outputFile, samFlagFieldOutput);
+                          IOUtil.addExtension(outputPath, ".md5")), samFlagFieldOutput)
+                    : new SAMTextWriter(null == outputPath
+                                        ? null
+                                        : Files.newOutputStream(outputPath),
+                                        samFlagFieldOutput);
             return initWriter(header, presorted, ret);
         } catch (final IOException ioe) {
             throw new RuntimeIOException("Error opening file: " + outputPath.toUri());

--- a/src/main/java/htsjdk/samtools/StreamInflatingIndexingOutputStream.java
+++ b/src/main/java/htsjdk/samtools/StreamInflatingIndexingOutputStream.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.file.Path;
 
 /**
  * OutputStream implementation that writes output to an underlying output stream while also copying the
@@ -22,11 +23,15 @@ class StreamInflatingIndexingOutputStream extends OutputStream {
     private final Thread thread;
 
     public StreamInflatingIndexingOutputStream(final OutputStream s1, final File indexFile) {
+        this(s1, indexFile.toPath());
+    }
+
+    public StreamInflatingIndexingOutputStream(final OutputStream s1, final Path indexPath) {
         try {
             this.s1 = s1;
             this.s2 = new PipedOutputStream();
             final PipedInputStream pin = new PipedInputStream(this.s2, Defaults.NON_ZERO_BUFFER_SIZE);
-            this.thread = new Thread(new Indexer(indexFile, pin), "BamIndexingThread");
+            this.thread = new Thread(new Indexer(indexPath, pin), "BamIndexingThread");
             this.thread.start();
         } catch (final IOException ioe) {
             throw new RuntimeIOException(ioe);
@@ -72,15 +77,15 @@ class StreamInflatingIndexingOutputStream extends OutputStream {
 
 /**
  * A little class that takes an InputStream from which it reads a BAM file, generates
- * a BAMIndex and then writes the index to the File provided.  All operations are designed
+ * a BAMIndex and then writes the index to the Path provided.  All operations are designed
  * to be carried out in a separate thread.
  */
 class Indexer implements Runnable {
-    private final File index;
+    private final Path index;
     private final InputStream stream;
 
-    /** Constructs an indexer that reads from the stream provided and writes an index to the File provided. */
-    Indexer(final File index, final InputStream stream) {
+    /** Constructs an indexer that reads from the stream provided and writes an index to the Path provided. */
+    Indexer(final Path index, final InputStream stream) {
         this.index = index;
         this.stream = stream;
     }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -249,6 +249,15 @@ public class IOUtil {
     }
 
     /**
+     * @return true if the path is not a device (e.g. /dev/null or /dev/stdin), and is not
+     * an existing directory.  I.e. is is a regular path that may correspond to an existing
+     * file, or a path that could be a regular output file.
+     */
+    public static boolean isRegularPath(final Path path) {
+        return !Files.exists(path) || Files.isRegularFile(path);
+    }
+
+    /**
      * Creates a new tmp file on one of the available temp filesystems, registers it for deletion
      * on JVM exit and then returns it.
      */
@@ -995,5 +1004,16 @@ public class IOUtil {
             }
             return FileSystems.newFileSystem(uri, new HashMap<>(), cl).provider().getPath(uri);
         }
+    }
+
+    /**
+     * Adds the extension to the given path.
+     *
+     * @param path       the path to start from, eg. "/folder/file.jpg"
+     * @param extension  the extension to add, eg. ".bak"
+     * @return           "/folder/file.jpg.bak"
+     */
+    public static Path addExtension(Path path, String extension) {
+        return path.resolveSibling(path.getFileName() + extension);
     }
 }

--- a/src/test/java/htsjdk/samtools/BAMIndexWriterTest.java
+++ b/src/test/java/htsjdk/samtools/BAMIndexWriterTest.java
@@ -58,7 +58,7 @@ public class BAMIndexWriterTest extends HtsjdkTest {
         final File javaBaiFile = File.createTempFile("javaBai.", "java.bai");
         final File javaBaiTxtFile = new File(javaBaiFile.getAbsolutePath() + ".txt");
         final SamReader bam = SamReaderFactory.makeDefault().enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS).open(BAM_FILE);
-        BAMIndexer.createIndex(bam, javaBaiFile);
+        BAMIndexer.createIndex(bam, javaBaiFile.toPath());
         verbose("Wrote binary Java BAM Index file " + javaBaiFile);
 
         // now, turn the bai file into text
@@ -77,7 +77,7 @@ public class BAMIndexWriterTest extends HtsjdkTest {
         // Compare java-generated bai file with c-generated and sorted bai file
         final File javaBaiFile = File.createTempFile("javaBai.", ".bai");
         final SamReader bam = SamReaderFactory.makeDefault().enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS).open(BAM_FILE);
-        BAMIndexer.createIndex(bam, javaBaiFile);
+        BAMIndexer.createIndex(bam, javaBaiFile.toPath());
         verbose("Wrote binary java BAM Index file " + javaBaiFile);
 
         final File cRegeneratedBaiFile = File.createTempFile("cBai.", ".bai");
@@ -214,7 +214,7 @@ public class BAMIndexWriterTest extends HtsjdkTest {
     private File createIndexFile(File bamFile) throws IOException {
         final File bamIndexFile = File.createTempFile("Bai.", ".bai");
         final SamReader bam = SamReaderFactory.makeDefault().open(bamFile);
-        BAMIndexer.createIndex(bam, bamIndexFile);
+        BAMIndexer.createIndex(bam, bamIndexFile.toPath());
         verbose("Wrote BAM Index file " + bamIndexFile);
         bam.close();
         return bamIndexFile;

--- a/src/test/java/htsjdk/samtools/util/IoUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IoUtilTest.java
@@ -24,6 +24,11 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.spi.FileSystemProvider;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -163,12 +168,35 @@ public class IoUtilTest extends HtsjdkTest {
     public void testFileType(final String path, boolean expectedIsRegularFile) {
         final File file = new File(path);
         Assert.assertEquals(IOUtil.isRegularPath(file), expectedIsRegularFile);
+        if (null != file) {
+            Assert.assertEquals(IOUtil.isRegularPath(file.toPath()), expectedIsRegularFile);
+        }
     }
 
     @Test(dataProvider = "unixFileTypeTestCases", groups = {"unix"})
     public void testFileTypeUnix(final String path, boolean expectedIsRegularFile) {
         final File file = new File(path);
         Assert.assertEquals(IOUtil.isRegularPath(file), expectedIsRegularFile);
+        if (null != file) {
+            Assert.assertEquals(IOUtil.isRegularPath(file.toPath()), expectedIsRegularFile);
+        }
+    }
+
+    @Test
+    public void testAddExtension() throws IOException {
+        Path p = IOUtil.getPath("/folder/file");
+        List<FileSystemProvider> fileSystemProviders = FileSystemProvider.installedProviders();
+        Assert.assertEquals(IOUtil.addExtension(p, ".ext"), IOUtil.getPath("/folder/file.ext"));
+        p = IOUtil.getPath("folder/file");
+        Assert.assertEquals(IOUtil.addExtension(p, ".ext"), IOUtil.getPath("folder/file.ext"));
+        try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            p = jimfs.getPath("folder/sub/file");
+            Assert.assertEquals(IOUtil.addExtension(p, ".ext"), jimfs.getPath("folder/sub/file.ext"));
+            p = jimfs.getPath("folder/file");
+            Assert.assertEquals(IOUtil.addExtension(p, ".ext"), jimfs.getPath("folder/file.ext"));
+            p = jimfs.getPath("file");
+            Assert.assertEquals(IOUtil.addExtension(p, ".ext"), jimfs.getPath("file.ext"));
+        }
     }
 
     @DataProvider(name = "fileTypeTestCases")


### PR DESCRIPTION
### Description

Add overloads to SAMFileWriterFactory that take `Path` as input instead of `File`. The old version that took `File` now just redirect to their `Path` equivalent, so there's the same amount of code to test.

The motivation for this change is to support Java NIO's pluggable file systems. This change (in combination with Google's NIO provider) allows one to directly write a SAM, BAM, or CRAM file to a Google Cloud Storage bucket. See eg. [GATK's matching issue](https://github.com/broadinstitute/gatk/issues/2422).

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary (not necessary)
- [x] *Is* backward compatible (does not break binary or source compatibility)

