### PR TITLE
Index.writeBasedOnFeaturePath should throw instead of silently Failing

### DIFF
--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -386,8 +386,7 @@ public abstract class AbstractIndex implements MutableIndex {
     @Override
     public void writeBasedOnFeaturePath(final Path featurePath) throws IOException {
         if (!Files.isRegularFile(featurePath)) {
-            logger.warn("Index not written into ", featurePath);
-            return;
+            throw new IOException("Cannot write based on a non-regular file: " + featurePath.toUri());
         }
         write(Tribble.indexPath(featurePath));
     }

--- a/src/main/java/htsjdk/tribble/index/Index.java
+++ b/src/main/java/htsjdk/tribble/index/Index.java
@@ -92,11 +92,11 @@ public interface Index {
 
     /**
      * Write an appropriately named and located Index file based on the name and location of the featureFile.
-     * If featureFile is not a normal file, the index will silently not be written.
      *
      * Default implementation delegates to {@link #writeBasedOnFeaturePath(Path)}
      *
      * @param featureFile
+     * @throws IOException if featureFile is not a normal file.
      */
     public default void writeBasedOnFeatureFile(File featureFile) throws IOException {
         writeBasedOnFeaturePath(featureFile.toPath());
@@ -107,6 +107,7 @@ public interface Index {
      * If featureFile is not a normal file, the index will silently not be written.
      *
      * @param featurePath
+     * @throws IOException if featureFile is not a normal file.
      */
     public void writeBasedOnFeaturePath(Path featurePath) throws IOException;
 

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -66,8 +66,6 @@ public class TabixIndex implements Index {
         MAGIC_NUMBER = bb.order(ByteOrder.LITTLE_ENDIAN).getInt();
     }
 
-    private static final Log LOGGER = Log.getInstance(TabixIndex.class);
-
     private final TabixFormat formatSpec;
     private final List<String> sequenceNames;
     private final BinningIndexContent[] indices;

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -230,8 +230,7 @@ public class TabixIndex implements Index {
     @Override
     public void writeBasedOnFeaturePath(final Path featurePath) throws IOException {
         if (!Files.isRegularFile(featurePath)) {
-            LOGGER.warn("Index not written into ", featurePath);
-            return;
+            throw new IOException("Cannot write based on a non-regular file: " + featurePath.toUri());
         }
         write(Tribble.tabixIndexPath(featurePath));
     }

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -224,6 +224,7 @@ public class TabixIndex implements Index {
      * Writes to a path with appropriate name and directory based on feature path.
      *
      * @param featurePath Path being indexed.
+     * @throws IOException if featureFile is not a normal file.
      */
     @Override
     public void writeBasedOnFeaturePath(final Path featurePath) throws IOException {

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -121,4 +121,13 @@ public class IndexTest extends HtsjdkTest {
             }
         }
     }
+
+    @Test(dataProvider = "writeIndexData")
+    public void testWriteBasedOnNonRegularFeatureFile(final File inputFile, final IndexFactory.IndexType type, final  FeatureCodec codec) throws Exception {
+        final File tmpFolder = IOUtil.createTempDir("NonRegultarFeatureFile", null);
+        // create the index
+        final Index index = IndexFactory.createIndex(inputFile, codec, type);
+        // try to write based on the tmpFolder
+        Assert.assertThrows(IOException.class, () -> index.writeBasedOnFeatureFile(tmpFolder));
+    }
 }

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -3,6 +3,7 @@ package htsjdk.tribble.index;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.TestUtils;
 import htsjdk.tribble.Tribble;


### PR DESCRIPTION
### Description

Solves #821

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

