### PR TITLE
Fix for SamLocusIterator.RecordAndOffset

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AbstractRecordAndOffset.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractRecordAndOffset.java
@@ -49,16 +49,6 @@ public class AbstractRecordAndOffset {
     /**
      * @param record inner SAMRecord
      * @param offset from the start of the read
-     * @param length of alignment block
-     * @param refPos corresponding to read offset reference position
-     */
-    public AbstractRecordAndOffset(final SAMRecord record, final int offset, int length, int refPos) {
-        this(record, offset);
-    }
-
-    /**
-     * @param record inner SAMRecord
-     * @param offset from the start of the read
      */
     public AbstractRecordAndOffset(final SAMRecord record, final int offset) {
         this.offset = offset;
@@ -91,13 +81,6 @@ public class AbstractRecordAndOffset {
      */
     public int getLength() {
         return 1;
-    }
-
-    /**
-     * @return the position in reference sequence, to which the start of alignment block is aligned.
-     */
-    public int getRefPos() {
-        return -1;
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/EdgingRecordAndOffset.java
+++ b/src/main/java/htsjdk/samtools/util/EdgingRecordAndOffset.java
@@ -56,6 +56,8 @@ public abstract class EdgingRecordAndOffset extends AbstractRecordAndOffset {
 
     public abstract byte getBaseQuality(int position);
 
+    public abstract int getRefPos();
+
     public static EdgingRecordAndOffset createBeginRecord(SAMRecord record, int offset, int length, int refPos) {
         return new StartEdgingRecordAndOffset(record, offset, length, refPos);
     }

--- a/src/test/java/htsjdk/samtools/util/AbstractRecordAndOffsetTest.java
+++ b/src/test/java/htsjdk/samtools/util/AbstractRecordAndOffsetTest.java
@@ -52,12 +52,11 @@ public class AbstractRecordAndOffsetTest {
 
     @Test
     public void testConstructor(){
-        AbstractRecordAndOffset abstractRecordAndOffset = new AbstractRecordAndOffset(record, 0, 10, 3);
+        AbstractRecordAndOffset abstractRecordAndOffset = new AbstractRecordAndOffset(record, 0);
         assertArrayEquals(qualities, abstractRecordAndOffset.getBaseQualities());
         assertArrayEquals(bases, abstractRecordAndOffset.getRecord().getReadBases());
         assertEquals('A', abstractRecordAndOffset.getReadBase());
         assertEquals(30, abstractRecordAndOffset.getBaseQuality());
         assertEquals(0, abstractRecordAndOffset.getOffset());
-        assertEquals(-1, abstractRecordAndOffset.getRefPos());
     }
 }


### PR DESCRIPTION
### Fix for issue: https://github.com/samtools/htsjdk/issues/828
In current version of master branch there is a problem with SamLocusIterator.RecordAndOffset class. This class inherits public method getRefPos that always returned -1.

We suggest to remove this method from AbstractRecordAndOffset class and replace it in abstract class EdgingRecordAndOffset, which heritors use this method.

