### PR TITLE
Fix for filtering of redundant containers

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -484,6 +484,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
                             getSeekableStreamOrFailWithRTE(),
                             referenceSource,
                             coordinates,
+                            queries,
                             validationStringency
                     );
                 } catch (final IOException e) {


### PR DESCRIPTION
The current 2.9.1 htsjdk version has dramatically lower performance in contrast with the version 2.2.4 while working with CRAM data on query intervals. As we could see, the one of the reasons is redundant containers processing. We suggest filter out the container in `CRAMIterator` class before its processing if that container doesn't match to query intervals. Our fragmental tests show that these changes increase the performance up to 2-2.5 times. 

However we believe there is a more fundamental and efficient solution, namely to avoid the case that `CRAMFileReader` doesn't work with native CRAI indices (it finds and reads CRAI file but then converts it internally to a BAI stream and, as a result, processes extra containers). We've created the following issue: #851