### PR TITLE
Support Filter For Genotype.getAnyAttribute ()

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Genotype.java
@@ -540,6 +540,8 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
             return getAlleles();
         } else if (key.equals(VCFConstants.GENOTYPE_QUALITY_KEY)) {
             return getGQ();
+        } else if (key.equals(VCFConstants.GENOTYPE_FILTER_KEY)) {
+            return getFilters();
         } else if (key.equals(VCFConstants.GENOTYPE_ALLELE_DEPTHS)) {
             if (hasAD()) {
                 final List<Integer> intList = new ArrayList<Integer>(getAD().length);


### PR DESCRIPTION
### Description

I ran into an NPE running GATK's VariantsToTable when requesting the genotype filter field.  They call Genotype.getAnyAttribute("FT").  The current code special-cases all the other values in PRIMARY_KEYS (GT, GQ, DP, AD, etc), but forgets FT.  This is a small addition to include it.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

