### PR TITLE
More informative IO error for FASTQ reader

### DIFF
--- a/src/main/java/htsjdk/samtools/fastq/FastqReader.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqReader.java
@@ -136,7 +136,7 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
             return frec ;
 
         } catch (IOException e) {
-            throw new SAMException(String.format("Error reading fastq '%s'", getAbsolutePath()), e);
+            throw new SAMException(error(e.getMessage()), e);
         }
     }
 
@@ -177,7 +177,7 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
         try {
             reader.close();
         } catch (IOException e) {
-            throw new SAMException("IO problem in fastq file " + getAbsolutePath(), e);
+            throw new SAMException(error(e.getMessage()), e);
         }
     }
 


### PR DESCRIPTION
### Description

Simple patch for a more informative `IOException` handling in `FastqReader`, by including the message and the line.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

