### PR TITLE
Upgraded snappy-java to the latest released version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ jacocoTestReport {
 dependencies {
     compile "org.apache.commons:commons-jexl:2.1.1"
     compile "commons-logging:commons-logging:1.1.1"
-    compile "org.xerial.snappy:snappy-java:1.0.3-rc3"
+    compile "org.xerial.snappy:snappy-java:1.1.2.6"
     compile "org.apache.commons:commons-compress:1.4.1"
     compile "org.tukaani:xz:1.5"
     compile "gov.nih.nlm.ncbi:ngs-java:1.2.4"

--- a/src/main/java/htsjdk/samtools/util/TempStreamFactory.java
+++ b/src/main/java/htsjdk/samtools/util/TempStreamFactory.java
@@ -51,7 +51,7 @@ public class TempStreamFactory {
      */
     public InputStream wrapTempInputStream(final InputStream inputStream, final int bufferSize) {
         InputStream is = IOUtil.maybeBufferInputStream(inputStream, bufferSize);
-        if (getSnappyLoader().SnappyAvailable) {
+        if (getSnappyLoader().isSnappyAvailable()) {
             try {
                 return getSnappyLoader().wrapInputStream(is);
             } catch (Exception e) {
@@ -71,7 +71,7 @@ public class TempStreamFactory {
     public OutputStream wrapTempOutputStream(final OutputStream outputStream, final int bufferSize) {
         OutputStream os = outputStream;
         if (bufferSize > 0) os = new BufferedOutputStream(os, bufferSize);
-        if (getSnappyLoader().SnappyAvailable) {
+        if (getSnappyLoader().isSnappyAvailable()) {
             try {
                 os = getSnappyLoader().wrapOutputStream(os);
             } catch (Exception e) {


### PR DESCRIPTION
### Description

Upgrade snappy-java to the latest released version.  The version in HTSJDK was no longer working on macs as best I can tell (I only have one to test on).  The new version appears to work fine on my mac, and also on a single linux machine I tested on.

I've also added the option in SnappyLoader to log failures but be quiet on successes.

I also manually tested the loader with and without native libraries available, and it works as expected, which is nice as I was able to simplify quite a bit.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

