### PR TITLE
Adding OpenJDK8 to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - $HOME/.m2
 jdk:
   - oraclejdk8
+  - openjdk8
 script: ./gradlew test jacocoTestReport;
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Added OpenJDK8 as a build configuration to be tested via Travis.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

