### PR TITLE
Fix ordering of assignments in FastQReader constructor.

### DIFF
--- a/src/main/java/htsjdk/samtools/fastq/FastqReader.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqReader.java
@@ -90,8 +90,8 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
     public FastqReader(final File file, final BufferedReader reader,boolean skipBlankLines) {
         this.fastqFile = file;
         this.reader = reader;
-        this.nextRecord = readNextRecord();
         this.skipBlankLines = skipBlankLines;
+        this.nextRecord = readNextRecord();
     }
 
     public FastqReader(final File file, final BufferedReader reader) {

--- a/src/test/scala/htsjdk/samtools/fastq/FastqReaderWriterTest.scala
+++ b/src/test/scala/htsjdk/samtools/fastq/FastqReaderWriterTest.scala
@@ -3,7 +3,7 @@ package htsjdk.samtools.fastq
 import java.io.{BufferedReader, File, StringReader}
 
 import htsjdk.UnitSpec
-import htsjdk.samtools.SAMUtils
+import htsjdk.samtools.{SAMException, SAMUtils}
 import htsjdk.samtools.util.IOUtil
 
 import scala.util.Random
@@ -104,6 +104,33 @@ class FastqReaderWriterTest extends UnitSpec {
     while (in.hasNext) in.next()
     an[Exception] shouldBe thrownBy { in.next() }
     in.close()
+  }
+
+  it should "honor skipBlankLines when requested" in {
+    val fastq =
+      """
+        |
+        |@SL-XBG:1:1:4:1663#0/2
+        |NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+        |+SL-XBG:1:1:4:1663#0/2
+        |BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+      """.stripMargin
+    val reader = new BufferedReader(new StringReader(fastq))
+    val in = new FastqReader(null, reader, true)
+    while (in.hasNext) in.next()
+  }
+
+  it should "fail on blank lines when skipBlankLines is false" in {
+    val fastq =
+      """
+        |
+        |@SL-XBG:1:1:4:1663#0/2
+        |NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+        |+SL-XBG:1:1:4:1663#0/2
+        |BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+      """.stripMargin
+    val reader = new BufferedReader(new StringReader(fastq))
+    an[SAMException] shouldBe thrownBy { val in = new FastqReader(null, reader, false) }
   }
 
   it should "fail on a truncated file" in {


### PR DESCRIPTION
FastQReader doesn't handle leading blank lines correctly in all constructors.

- [x ] Code compiles correctly
- [x ] New tests covering changes and new functionality
- [x ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

