### PR TITLE
IntervalTreeMap: use Locatable interface

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IntervalTreeMap.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalTreeMap.java
@@ -165,16 +165,16 @@ public class IntervalTreeMap<T>
     }
     /**
      * Test overlapping interval 
-     * @param key the interval
+     * @param key the Locatable
      * @return true if it contains an object overlapping the interval 
      */
-    public boolean containsOverlapping(final Interval key) {
+    public boolean containsOverlapping(final Locatable key) {
         final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         return tree!=null && tree.overlappers(key.getStart(), key.getEnd()).hasNext();
     	}
     
     
-    public Collection<T> getOverlapping(final Interval key) {
+    public Collection<T> getOverlapping(final Locatable key) {
         final List<T> result = new ArrayList<T>();
         final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree != null) {
@@ -187,10 +187,10 @@ public class IntervalTreeMap<T>
     }
     /**
      * Test if this contains an object that is contained by 'key'
-     * @param key the interval
+     * @param key the Locatable
      * @return true if it contains an object is contained by 'key'
      */
-    public boolean containsContained(final Interval key) {
+    public boolean containsContained(final Locatable key) {
         final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if(tree==null) return false;
             final Iterator<IntervalTree.Node<T>> iterator = tree.overlappers(key.getStart(), key.getEnd());
@@ -204,7 +204,7 @@ public class IntervalTreeMap<T>
     }
     
     
-    public Collection<T> getContained(final Interval key) {
+    public Collection<T> getContained(final Locatable key) {
         final List<T> result = new ArrayList<T>();
         final IntervalTree<T> tree = mSequenceMap.get(key.getContig());
         if (tree != null) {


### PR DESCRIPTION
### Description

I've changed the signature of four functions in **IntervalTreeMap**. Instead of using a concrete class  'Interval', they will use 'Locatable'. It shouldn't break the code.
Furthermore it avoids to create a new Interval for each query. 

```
map.containsOverlapping( new Interval(variantContext.getContig(), variantContext.getStart(), variantContext.getEnd()));
```

it's now

```
map.containsOverlapping(variantContext)
```



### Checklist

- [x ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

