### PR TITLE
updating artifactory link to point to new artifactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ uploadArchives {
                 authentication(userName: project.findProperty("sonatypeUsername"), password: project.findProperty("sonatypePassword"))
             }
 
-            snapshotRepository(url: "https://artifactory.broadinstitute.org/artifactory/libs-snapshot-local/") {
+            snapshotRepository(url: "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/") {
                 authentication(userName: System.env.ARTIFACTORY_USERNAME, password: System.env.ARTIFACTORY_PASSWORD)
             }
 


### PR DESCRIPTION
* the Broad artifactory moved from a self hosted repository at artifactory.broadinstitute.org
to a web based artifactory at broadinstitute.jfrog.io/broadinstitute/
this was causing our snapshot uploads to fail
* updating our snapshot repository to point to the new link
* the old artifactory has a redirect in place to the new artifactory so
artifacts relying on the old url should still resolve.  For unknown
reasons this redirect doesn't work with gradle uploads, probably a
gradle bug.
