### PR TITLE
Fix SAMRecord.getReadLength() so it does not throw an exception if null bases

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -238,7 +238,9 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             mReadBases = NULL_SEQUENCE;
         } else {
             final byte[] bases = StringUtil.stringToBytes(value);
-            SAMUtils.normalizeBases(bases);
+            if (bases != null) {
+                SAMUtils.normalizeBases(bases);
+            }
             setReadBases(bases);
         }
     }

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -262,7 +262,8 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return number of bases in the read.
      */
     public int getReadLength() {
-        return getReadBases().length;
+        final byte[] readBases = getReadBases();
+        return readBases == null ? 0 : readBases.length;
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/StringUtil.java
+++ b/src/main/java/htsjdk/samtools/util/StringUtil.java
@@ -312,6 +312,9 @@ public class StringUtil {
         }
         return byteBuffer;
 */
+        if (s == null) {
+            return null;
+        }
         final byte[] byteBuffer = new byte[s.length()];
         s.getBytes(0, byteBuffer.length, byteBuffer, 0);
         return byteBuffer;
@@ -319,6 +322,9 @@ public class StringUtil {
 
     @SuppressWarnings("deprecation")
     public static byte[] stringToBytes(final String s, final int offset, final int length) {
+        if (s == null) {
+            return null;
+        }
         final byte[] byteBuffer = new byte[length];
         s.getBytes(offset, offset + length, byteBuffer, 0);
         return byteBuffer;

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -776,7 +776,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     }
 
     @Test
-    private void testNullHeaderDeepCopy() {
+    public void testNullHeaderDeepCopy() {
         SAMRecord sam = createTestRecordHelper();
         sam.setHeader(null);
         final SAMRecord deepCopy = sam.deepCopy();
@@ -805,13 +805,13 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     }
 
     @Test
-    private void testNullHeadGetCigarSAM() {
-        SAMRecord sam = createTestRecordHelper();
+    public void testNullHeadGetCigarSAM() {
+        final SAMRecord sam = createTestRecordHelper();
         testNullHeaderCigar(sam);
     }
 
     @Test
-    private void testNullHeadGetCigarBAM() {
+    public void testNullHeadGetCigarBAM() {
         SAMRecord sam = createTestRecordHelper();
         SAMRecordFactory factory = new DefaultSAMRecordFactory();
         BAMRecord bamRec = factory.createBAMRecord(
@@ -1038,5 +1038,21 @@ public class SAMRecordUnitTest extends HtsjdkTest {
         rec.setAttribute("Y1", "AAAAGAAAAC");
 
         return(rec);
+    }
+
+    @DataProvider
+    public Object [][] readBasesGetReadLengthData() {
+        return new Object[][]{
+                { null, 0 },
+                { SAMRecord.NULL_SEQUENCE, 0 },
+                { new byte[] {'A', 'C'}, 2 }
+        };
+    }
+
+    @Test(dataProvider = "readBasesGetReadLengthData")
+    public void testNullReadBasesGetReadLength(final byte[] readBases, final int readLength) {
+        final SAMRecord sam = createTestRecordHelper();
+        sam.setReadBases(readBases);
+        Assert.assertEquals(sam.getReadLength(), readLength);
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -1041,7 +1041,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     }
 
     @DataProvider
-    public Object [][] readBasesGetReadLengthData() {
+    public Object [][] readBasesArrayGetReadLengthData() {
         return new Object[][]{
                 { null, 0 },
                 { SAMRecord.NULL_SEQUENCE, 0 },
@@ -1049,10 +1049,26 @@ public class SAMRecordUnitTest extends HtsjdkTest {
         };
     }
 
-    @Test(dataProvider = "readBasesGetReadLengthData")
-    public void testNullReadBasesGetReadLength(final byte[] readBases, final int readLength) {
+    @Test(dataProvider = "readBasesArrayGetReadLengthData")
+    public void testReadBasesGetReadLength(final byte[] readBases, final int readLength) {
         final SAMRecord sam = createTestRecordHelper();
         sam.setReadBases(readBases);
+        Assert.assertEquals(sam.getReadLength(), readLength);
+    }
+
+    @DataProvider
+    public Object [][] readBasesStringGetReadLengthData() {
+        return new Object[][]{
+                { null, 0 },
+                { SAMRecord.NULL_SEQUENCE_STRING, 0 },
+                { "AC", 2 }
+        };
+    }
+
+    @Test(dataProvider = "readBasesStringGetReadLengthData")
+    public void testReadStringGetReadLength(final String readBases, final int readLength) {
+        final SAMRecord sam = createTestRecordHelper();
+        sam.setReadString(readBases);
         Assert.assertEquals(sam.getReadLength(), readLength);
     }
 }


### PR DESCRIPTION
### Description

Fixes https://github.com/samtools/htsjdk/issues/297.
Fixed SAMRecord.getReadLength by not calling getReadBases().length read bases is null.
Added a unit test.
Made private unit tests public so they can be run.

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

