### PR TITLE
Fixed flipped sign when comparing read paired flags

### DIFF
--- a/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
+++ b/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
@@ -36,7 +36,7 @@ public class DuplicateScoringStrategy {
     public enum ScoringStrategy {
         SUM_OF_BASE_QUALITIES,
         TOTAL_MAPPED_REFERENCE_LENGTH,
-        RANDOM,
+        RANDOM
     }
 
     /** Hash used for the RANDOM scoring strategy. */

--- a/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
+++ b/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
@@ -128,7 +128,7 @@ public class DuplicateScoringStrategy {
         int cmp;
 
         // always prefer paired over non-paired
-        if (rec1.getReadPairedFlag() != rec2.getReadPairedFlag()) return rec1.getReadPairedFlag() ? 1 : -1;
+        if (rec1.getReadPairedFlag() != rec2.getReadPairedFlag()) return rec1.getReadPairedFlag() ? -1 : 1;
 
         cmp = computeDuplicateScore(rec2, scoringStrategy, assumeMateCigar) - computeDuplicateScore(rec1, scoringStrategy, assumeMateCigar);
 

--- a/src/test/java/htsjdk/samtools/DuplicateScoringStrategyTest.java
+++ b/src/test/java/htsjdk/samtools/DuplicateScoringStrategyTest.java
@@ -1,0 +1,25 @@
+package htsjdk.samtools;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class DuplicateScoringStrategyTest {
+
+    @DataProvider
+    public Object [][] compareData() {
+        return new Object[][]{
+                {SAMFlag.READ_PAIRED.flag, 0, true, DuplicateScoringStrategy.ScoringStrategy.RANDOM, -1},
+                {0, SAMFlag.READ_PAIRED.flag, true, DuplicateScoringStrategy.ScoringStrategy.RANDOM, 1},
+        };
+    }
+
+    @Test(dataProvider = "compareData")
+    public static void testCompare(final int samFlag1, final int samFlag2, final boolean assumeMateCigar, final DuplicateScoringStrategy.ScoringStrategy strategy, final int expected) {
+        final SAMRecord rec1 = new SAMRecordSetBuilder().addFrag("test", 0, 1, false, false, "36M", null, 2);
+        rec1.setFlags(samFlag1);
+        final SAMRecord rec2 = new SAMRecordSetBuilder().addFrag("test", 0, 1, true, false, "36M", null, 3);
+        rec2.setFlags(samFlag2);
+        Assert.assertEquals(DuplicateScoringStrategy.compare(rec1, rec2, strategy, assumeMateCigar), expected);
+    }
+}


### PR DESCRIPTION
### Description

Fixes https://github.com/samtools/htsjdk/issues/256.
The read comparing duplicates, if one of the reds is not paired, the first read in the comparison should return -1 if it is paired, not 1. 

### Checklist

- [X] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

