### PR TITLE
A little more caution when checking terminator blocks on close of BlockCompressedOutputStream

### DIFF
--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.util.zip.DeflaterFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 
@@ -282,7 +283,7 @@ public class BlockCompressedOutputStream
         codec.writeBytes(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK);
         codec.close();
         // Can't re-open something that is not a regular file, e.g. a named pipe or an output stream
-        if (this.file == null || !this.file.isFile()) return;
+        if (this.file == null || !this.file.isFile() || !Files.isRegularFile(this.file.toPath())) return;
         if (BlockCompressedInputStream.checkTermination(this.file) !=
                 BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) {
             throw new IOException("Terminator block not found after closing BGZF file " + this.file);


### PR DESCRIPTION
### Description

On some systems `BlockCompressedOutputStream.close()` will try to open `/dev/stdout` for reading in order to check that it wrote the terminator block correctly.  This attempts to prevent that.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

