### PR TITLE
Support for partial VCF writing

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriter.java
@@ -55,8 +55,8 @@ public class AsyncVariantContextWriter extends AbstractAsyncWriter<VariantContex
     }
 
     @Override
-    public void setVcfHeader(VCFHeader header) {
-        this.underlyingWriter.setVcfHeader(header);
+    public void setVCFHeader(final VCFHeader header) {
+        this.underlyingWriter.setVCFHeader(header);
     }
 
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriter.java
@@ -53,4 +53,10 @@ public class AsyncVariantContextWriter extends AbstractAsyncWriter<VariantContex
     public boolean checkError() {
         return false;
     }
+
+    @Override
+    public void setVcfHeader(VCFHeader header) {
+        this.underlyingWriter.setVcfHeader(header);
+    }
+
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -221,6 +221,11 @@ class BCF2Writer extends IndexingVariantContextWriter {
         super.close();
     }
 
+    @Override
+    public void setVcfHeader(VCFHeader header) {
+        //no-op
+    }
+
     // --------------------------------------------------------------------------------
     //
     // implicit block

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -207,9 +207,8 @@ class BCF2Writer extends IndexingVariantContextWriter {
             throw new IllegalStateException("The header cannot be modified after the header or variants have been written to the output stream.");
         }
         // make sure the header is sorted correctly
-        this.header = new VCFHeader(header.getMetaDataInSortedOrder(), header.getGenotypeSamples());
-
-        this.header = doNotWriteGenotypes ? new VCFHeader(this.header.getMetaDataInSortedOrder()) : this.header;
+        this.header = doNotWriteGenotypes ? new VCFHeader(header.getMetaDataInSortedOrder()) : new VCFHeader(
+                header.getMetaDataInSortedOrder(), header.getGenotypeSamples());
         // create the config offsets map
         if ( header.getContigLines().isEmpty() ) {
             if ( ALLOW_MISSING_CONTIG_LINES ) {

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -238,6 +238,16 @@ class BCF2Writer extends IndexingVariantContextWriter {
         } else {
             createContigDictionary(header.getContigLines());
         }
+        // set up the map from dictionary string values -> offset
+        final ArrayList<String> dict = BCF2Utils.makeDictionary(header);
+        for ( int i = 0; i < dict.size(); i++ ) {
+            stringDictionaryMap.put(dict.get(i), i);
+        }
+
+        sampleNames = header.getGenotypeSamples().toArray(new String[header.getNGenotypeSamples()]);
+        // setup the field encodings
+        fieldManager.setup(header, encoder, stringDictionaryMap);
+
     }
 
     // --------------------------------------------------------------------------------

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -122,11 +122,9 @@ class BCF2Writer extends IndexingVariantContextWriter {
     private VCFHeader lastVCFHeaderOfUnparsedGenotypes = null;
     private boolean canPassOnUnparsedGenotypeDataForLastVCFHeader = false;
 
-    // is the header written to the output stream?
-    private boolean isHeaderWritten;
+    // is the header or body written to the output stream?
+    private boolean isWrittenToOutput;
 
-    // is at least one part of body written to the output stream?
-    private boolean isBodyWritten;
 
     public BCF2Writer(final File location, final OutputStream output, final SAMSequenceDictionary refDict,
                       final boolean enableOnTheFlyIndexing, final boolean doNotWriteGenotypes) {
@@ -151,16 +149,13 @@ class BCF2Writer extends IndexingVariantContextWriter {
 
     @Override
     public void writeHeader(VCFHeader header) {
-        if (isHeaderWritten) {
-            throw new IllegalStateException("Header is already written");
-        }
-        setVcfHeader(header);
+        setVCFHeader(header);
 
         try {
             // write out the header into a byte stream, get its length, and write everything to the file
             final ByteArrayOutputStream capture = new ByteArrayOutputStream();
             final OutputStreamWriter writer = new OutputStreamWriter(capture);
-            this.header = VCFWriter.writeHeader(header, writer, VCFWriter.getVersionLine(), "BCF2 stream");
+            this.header = VCFWriter.writeHeader(this.header, writer, VCFWriter.getVersionLine(), "BCF2 stream");
             writer.append('\0'); // the header is null terminated by a byte
             writer.close();
 
@@ -168,7 +163,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
             new BCFVersion(MAJOR_VERSION, MINOR_VERSION).write(outputStream);
             BCF2Type.INT32.write(headerBytes.length, outputStream);
             outputStream.write(headerBytes);
-            isHeaderWritten = true;
+            isWrittenToOutput = true;
         } catch (IOException e) {
             throw new RuntimeIOException("BCF2 stream: Got IOException while trying to write BCF2 header", e);
         }
@@ -188,7 +183,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
 
             // write the two blocks to disk
             writeBlock(infoBlock, genotypesBlock);
-            isBodyWritten = true;
+            isWrittenToOutput = true;
         }
         catch ( IOException e ) {
             throw new RuntimeIOException("Error writing record to BCF2 file: " + vc.toString(), e);
@@ -207,17 +202,14 @@ class BCF2Writer extends IndexingVariantContextWriter {
     }
 
     @Override
-    public void setVcfHeader(VCFHeader header) {
-        if (isHeaderWritten) {
-            throw new IllegalStateException("Header is already written");
-        }
-        if (isBodyWritten) {
-            throw new IllegalStateException("Body is already written");
+    public void setVCFHeader(final VCFHeader header) {
+        if (isWrittenToOutput) {
+            throw new IllegalStateException("The header cannot be modified after the header or variants have been written to the output stream.");
         }
         // make sure the header is sorted correctly
-        header = new VCFHeader(header.getMetaDataInSortedOrder(), header.getGenotypeSamples());
+        this.header = new VCFHeader(header.getMetaDataInSortedOrder(), header.getGenotypeSamples());
 
-        this.header = doNotWriteGenotypes ? new VCFHeader(header.getMetaDataInSortedOrder()) : header;
+        this.header = doNotWriteGenotypes ? new VCFHeader(this.header.getMetaDataInSortedOrder()) : this.header;
         // create the config offsets map
         if ( header.getContigLines().isEmpty() ) {
             if ( ALLOW_MISSING_CONTIG_LINES ) {

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -210,7 +210,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
         this.header = doNotWriteGenotypes ? new VCFHeader(header.getMetaDataInSortedOrder()) : new VCFHeader(
                 header.getMetaDataInSortedOrder(), header.getGenotypeSamples());
         // create the config offsets map
-        if ( header.getContigLines().isEmpty() ) {
+        if ( this.header.getContigLines().isEmpty() ) {
             if ( ALLOW_MISSING_CONTIG_LINES ) {
                 if ( GeneralUtils.DEBUG_MODE_ENABLED ) {
                     System.err.println("No contig dictionary found in header, falling back to reference sequence dictionary");
@@ -220,17 +220,17 @@ class BCF2Writer extends IndexingVariantContextWriter {
                 throw new IllegalStateException("Cannot write BCF2 file with missing contig lines");
             }
         } else {
-            createContigDictionary(header.getContigLines());
+            createContigDictionary(this.header.getContigLines());
         }
         // set up the map from dictionary string values -> offset
-        final ArrayList<String> dict = BCF2Utils.makeDictionary(header);
+        final ArrayList<String> dict = BCF2Utils.makeDictionary(this.header);
         for ( int i = 0; i < dict.size(); i++ ) {
             stringDictionaryMap.put(dict.get(i), i);
         }
 
         sampleNames = this.header.getGenotypeSamples().toArray(new String[this.header.getNGenotypeSamples()]);
         // setup the field encodings
-        fieldManager.setup(header, encoder, stringDictionaryMap);
+        fieldManager.setup(this.header, encoder, stringDictionaryMap);
 
     }
 

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -223,7 +223,21 @@ class BCF2Writer extends IndexingVariantContextWriter {
 
     @Override
     public void setVcfHeader(VCFHeader header) {
-        //no-op
+        header = new VCFHeader(header.getMetaDataInSortedOrder(), header.getGenotypeSamples());
+        this.header = doNotWriteGenotypes ? new VCFHeader(header.getMetaDataInSortedOrder()) : header;
+        // create the config offsets map
+        if ( header.getContigLines().isEmpty() ) {
+            if ( ALLOW_MISSING_CONTIG_LINES ) {
+                if ( GeneralUtils.DEBUG_MODE_ENABLED ) {
+                    System.err.println("No contig dictionary found in header, falling back to reference sequence dictionary");
+                }
+                createContigDictionary(VCFUtils.makeContigHeaderLines(getRefDict(), null));
+            } else {
+                throw new IllegalStateException("Cannot write BCF2 file with missing contig lines");
+            }
+        } else {
+            createContigDictionary(header.getContigLines());
+        }
     }
 
     // --------------------------------------------------------------------------------

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -123,7 +123,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
     private boolean canPassOnUnparsedGenotypeDataForLastVCFHeader = false;
 
     // is the header or body written to the output stream?
-    private boolean isWrittenToOutput;
+    private boolean outputHasBeenWritten;
 
 
     public BCF2Writer(final File location, final OutputStream output, final SAMSequenceDictionary refDict,
@@ -163,7 +163,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
             new BCFVersion(MAJOR_VERSION, MINOR_VERSION).write(outputStream);
             BCF2Type.INT32.write(headerBytes.length, outputStream);
             outputStream.write(headerBytes);
-            isWrittenToOutput = true;
+            outputHasBeenWritten = true;
         } catch (IOException e) {
             throw new RuntimeIOException("BCF2 stream: Got IOException while trying to write BCF2 header", e);
         }
@@ -183,7 +183,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
 
             // write the two blocks to disk
             writeBlock(infoBlock, genotypesBlock);
-            isWrittenToOutput = true;
+            outputHasBeenWritten = true;
         }
         catch ( IOException e ) {
             throw new RuntimeIOException("Error writing record to BCF2 file: " + vc.toString(), e);
@@ -203,7 +203,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
 
     @Override
     public void setVCFHeader(final VCFHeader header) {
-        if (isWrittenToOutput) {
+        if (outputHasBeenWritten) {
             throw new IllegalStateException("The header cannot be modified after the header or variants have been written to the output stream.");
         }
         // make sure the header is sorted correctly

--- a/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
@@ -132,6 +132,11 @@ abstract class SortingVariantContextWriterBase implements VariantContextWriter {
         emitSafeRecords();
     }
 
+    @Override
+    public void setVcfHeader(VCFHeader header) {
+        innerWriter.setVcfHeader(header);
+    }
+
     /**
      * Gets a string representation of this object.
      * @return a string representation of this object

--- a/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
@@ -133,8 +133,8 @@ abstract class SortingVariantContextWriterBase implements VariantContextWriter {
     }
 
     @Override
-    public void setVcfHeader(VCFHeader header) {
-        innerWriter.setVcfHeader(header);
+    public void setVCFHeader(final VCFHeader header) {
+        innerWriter.setVCFHeader(header);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -136,7 +136,7 @@ class VCFWriter extends IndexingVariantContextWriter {
         // may have genotypes trimmed out of it, if doNotWriteGenotypes is true
         try {
             setVCFHeader(header);
-            writeHeader(header, writer, getVersionLine(), getStreamName());
+            writeHeader(this.mHeader, writer, getVersionLine(), getStreamName());
             writeAndResetBuffer();
             isWrittenToOutput = true;
         } catch ( IOException e ) {

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -67,7 +67,7 @@ class VCFWriter extends IndexingVariantContextWriter {
     private final boolean writeFullFormatField;
 
     // is the header or body written to the output stream?
-    private boolean isWrittenToOutput;
+    private boolean outputHasBeenWritten;
 
     /*
      * The VCF writer uses an internal Writer, based by the ByteArrayOutputStream lineBuffer,
@@ -138,7 +138,7 @@ class VCFWriter extends IndexingVariantContextWriter {
         try {
             writeHeader(this.mHeader, writer, getVersionLine(), getStreamName());
             writeAndResetBuffer();
-            isWrittenToOutput = true;
+            outputHasBeenWritten = true;
         } catch ( IOException e ) {
             throw new RuntimeIOException("Couldn't write file " + getStreamName(), e);
         }
@@ -225,7 +225,7 @@ class VCFWriter extends IndexingVariantContextWriter {
             write("\n");
 
             writeAndResetBuffer();
-            isWrittenToOutput = true;
+            outputHasBeenWritten = true;
         } catch (IOException e) {
             throw new RuntimeIOException("Unable to write the VCF object to " + getStreamName(), e);
         }
@@ -233,7 +233,7 @@ class VCFWriter extends IndexingVariantContextWriter {
 
     @Override
     public void setVCFHeader(final VCFHeader header) {
-        if (isWrittenToOutput) {
+        if (outputHasBeenWritten) {
             throw new IllegalStateException("The header cannot be modified after the header or variants have been written to the output stream.");
         }
         this.mHeader = doNotWriteGenotypes ? new VCFHeader(header.getMetaDataInSortedOrder()) : header;

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -131,8 +131,8 @@ class VCFWriter extends IndexingVariantContextWriter {
         // note we need to update the mHeader object after this call because they header
         // may have genotypes trimmed out of it, if doNotWriteGenotypes is true
         try {
-            this.mHeader = writeHeader(header, writer, doNotWriteGenotypes, getVersionLine(), getStreamName());
-            this.vcfEncoder = new VCFEncoder(this.mHeader, this.allowMissingFieldsInHeader, this.writeFullFormatField);
+            setVcfHeader(header);
+            writeHeader(header, writer, getVersionLine(), getStreamName());
             writeAndResetBuffer();
 
         } catch ( IOException e ) {
@@ -146,11 +146,9 @@ class VCFWriter extends IndexingVariantContextWriter {
 
     public static VCFHeader writeHeader(VCFHeader header,
                                         final Writer writer,
-                                        final boolean doNotWriteGenotypes,
                                         final String versionLine,
                                         final String streamNameForError) {
-        header = doNotWriteGenotypes ? new VCFHeader(header.getMetaDataInSortedOrder()) : header;
-        
+
         try {
             // the file format field needs to be written first
             writer.write(versionLine + "\n");

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -231,7 +231,7 @@ class VCFWriter extends IndexingVariantContextWriter {
 
     @Override
     public void setVcfHeader(VCFHeader header) {
-        this.mHeader = header;
+        this.mHeader = doNotWriteGenotypes ? new VCFHeader(header.getMetaDataInSortedOrder()) : header;
         this.vcfEncoder = new VCFEncoder(this.mHeader, this.allowMissingFieldsInHeader, this.writeFullFormatField);
     }
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -228,4 +228,10 @@ class VCFWriter extends IndexingVariantContextWriter {
             throw new RuntimeIOException("Unable to write the VCF object to " + getStreamName(), e);
         }
     }
+
+    @Override
+    public void setVcfHeader(VCFHeader header) {
+        this.mHeader = header;
+        this.vcfEncoder = new VCFEncoder(this.mHeader, this.allowMissingFieldsInHeader, this.writeFullFormatField);
+    }
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -134,8 +134,8 @@ class VCFWriter extends IndexingVariantContextWriter {
 
         // note we need to update the mHeader object after this call because they header
         // may have genotypes trimmed out of it, if doNotWriteGenotypes is true
+        setVCFHeader(header);
         try {
-            setVCFHeader(header);
             writeHeader(this.mHeader, writer, getVersionLine(), getStreamName());
             writeAndResetBuffer();
             isWrittenToOutput = true;

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
@@ -59,6 +59,8 @@ public interface VariantContextWriter extends Closeable {
     /**
      * Sets the VCF header so that data blocks can be written without writing the header
      *
+     * Exactly one of writeHeader() or setVCFHeader() should be called when using a writer
+     *
      * @param header VCF header
      * @throws IllegalStateException if header or body is already written
 

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
@@ -35,6 +35,12 @@ import htsjdk.variant.vcf.VCFHeader;
  */
 public interface VariantContextWriter extends Closeable {
 
+    /**
+     * Writes the header
+     *
+     * @param header header
+     * @throws IllegalStateException if header is already written
+     */
     public void writeHeader(VCFHeader header);
 
     /**
@@ -54,6 +60,8 @@ public interface VariantContextWriter extends Closeable {
      * Sets the VCF header so that data blocks can be written without writing the header
      *
      * @param header VCF header
+     * @throws IllegalStateException if header or body is already written
+
      */
     void setVcfHeader(VCFHeader header);
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
@@ -49,4 +49,6 @@ public interface VariantContextWriter extends Closeable {
     public boolean checkError();
     
     public void add(VariantContext vc);
+
+    void setVcfHeader(VCFHeader header);
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
@@ -50,5 +50,10 @@ public interface VariantContextWriter extends Closeable {
     
     public void add(VariantContext vc);
 
+    /**
+     * Sets the VCF header so that data blocks can be written without writing the header
+     *
+     * @param header VCF header
+     */
     void setVcfHeader(VCFHeader header);
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
@@ -63,5 +63,5 @@ public interface VariantContextWriter extends Closeable {
      * @throws IllegalStateException if header or body is already written
 
      */
-    void setVcfHeader(VCFHeader header);
+    void setVCFHeader(VCFHeader header);
 }

--- a/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
@@ -106,6 +106,7 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
     @Test
     public void testWriteAndReadBCF() throws IOException {
         final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
+        bcfOutputFile.deleteOnExit();
         final VCFHeader header = createFakeHeader();
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
                 .setOutputFile(bcfOutputFile).setReferenceDictionary(header.getSequenceDictionary())
@@ -134,6 +135,7 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
     @Test
     public void testWriteAndReadBCFWithIndex() throws IOException {
         final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
+        bcfOutputFile.deleteOnExit();
         Tribble.indexFile(bcfOutputFile).deleteOnExit();
         final VCFHeader header = createFakeHeader();
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
@@ -161,7 +163,9 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
     @Test
     public void testWriteAndReadBCFHeaderless() throws IOException {
         final File bcfOutputFile = File.createTempFile("testWriteAndReadBCFWithHeader.", ".bcf", tempDir);
+        bcfOutputFile.deleteOnExit();
         final File bcfOutputHeaderlessFile = File.createTempFile("testWriteAndReadBCFHeaderless.", ".bcf", tempDir);
+        bcfOutputHeaderlessFile.deleteOnExit();
 
         final VCFHeader header = createFakeHeader();
         // we write two files, bcfOutputFile with the header, and bcfOutputHeaderlessFile with just the body
@@ -203,46 +207,49 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testWriteHeaderTwice() throws IOException {
         final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
+        bcfOutputFile.deleteOnExit();
 
         final VCFHeader header = createFakeHeader();
         // prevent writing header twice
-        try (final VariantContextWriter writer1 = new VariantContextWriterBuilder()
+        try (final VariantContextWriter writer = new VariantContextWriterBuilder()
                 .setOutputFile(bcfOutputFile).setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
-            writer1.writeHeader(header);
-            writer1.writeHeader(header);
+            writer.writeHeader(header);
+            writer.writeHeader(header);
         }
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingHeader() throws IOException {
         final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
+        bcfOutputFile.deleteOnExit();
 
         final VCFHeader header = createFakeHeader();
         // prevent changing header if it's already written
-        try (final VariantContextWriter writer2 = new VariantContextWriterBuilder()
+        try (final VariantContextWriter writer = new VariantContextWriterBuilder()
                 .setOutputFile(bcfOutputFile).setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
-            writer2.writeHeader(header);
-            writer2.setVCFHeader(header);
+            writer.writeHeader(header);
+            writer.setVCFHeader(header);
         }
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingBody() throws IOException {
         final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
+        bcfOutputFile.deleteOnExit();
 
         final VCFHeader header = createFakeHeader();
         // prevent changing header if part of body is already written
-        try (final VariantContextWriter writer3 = new VariantContextWriterBuilder()
+        try (final VariantContextWriter writer = new VariantContextWriterBuilder()
                 .setOutputFile(bcfOutputFile).setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
-            writer3.setVCFHeader(header);
-            writer3.add(createVC(header));
-            writer3.setVCFHeader(header);
+            writer.setVCFHeader(header);
+            writer.add(createVC(header));
+            writer.setVCFHeader(header);
         }
     }
 

--- a/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
@@ -208,15 +208,15 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
                             return bodyPbs;
                         }
                     });
-        }
 
-        int counter = 0;
-        final Iterator<VariantContext> it = container.getVCs().iterator();
-        while (it.hasNext()) {
-            it.next();
-            counter++;
+            int counter = 0;
+            final Iterator<VariantContext> it = container.getVCs().iterator();
+            while (it.hasNext()) {
+                it.next();
+                counter++;
+            }
+            Assert.assertEquals(counter, 2);
         }
-        Assert.assertEquals(counter, 2);
     }
 
     /**

--- a/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
@@ -164,14 +164,12 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
         final File bcfOutputHeaderlessFile = File.createTempFile("testWriteAndReadBCFHeaderless.", ".bcf", tempDir);
 
         final VCFHeader header = createFakeHeader();
-        // we write two files, bcfOutputFile with the header and body, and bcfOutputHeaderlessFile with just the body
+        // we write two files, bcfOutputFile with the header, and bcfOutputHeaderlessFile with just the body
         try (final VariantContextWriter fakeBCFFileWriter = new VariantContextWriterBuilder()
                 .setOutputFile(bcfOutputFile).setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
             fakeBCFFileWriter.writeHeader(header); // writes header
-            fakeBCFFileWriter.add(createVC(header));
-            fakeBCFFileWriter.add(createVC(header));
         }
 
         try (final VariantContextWriter fakeBCFBodyFileWriter = new VariantContextWriterBuilder()

--- a/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
@@ -132,6 +132,37 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
             counter++;
         }
         Assert.assertEquals(counter, 2);
+
+
+        // prevent writing header twice
+        final VariantContextWriter writer2 = new VariantContextWriterBuilder()
+                .setOutputFile(bcfOutputFile).setReferenceDictionary(sequenceDict)
+                .setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY))
+                .build();
+        writer2.writeHeader(header);
+        try {
+            writer2.writeHeader(header);
+            Assert.fail("Should not allow writing header twice");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof IllegalStateException);
+        }
+        writer2.add(createVC(header));
+        writer2.close();
+
+        // prevent changing header if it's already written
+        final VariantContextWriter writer3 = new VariantContextWriterBuilder()
+                .setOutputFile(bcfOutputFile).setReferenceDictionary(sequenceDict)
+                .setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY))
+                .build();
+        writer3.writeHeader(header);
+        try {
+            writer3.setVcfHeader(header);
+            Assert.fail("Should not allow changing header if header is already written");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof IllegalStateException);
+        }
+        writer3.add(createVC(header));
+        writer3.close();
     }
 
     /**
@@ -200,6 +231,22 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
             }
             Assert.assertEquals(counter, 2);
         }
+
+        // prevent changing header if part of body is already written
+        final VariantContextWriter writer2 = new VariantContextWriterBuilder()
+                .setOutputFile(bcfOutputFile).setReferenceDictionary(sequenceDict)
+                .setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY))
+                .build();
+        writer2.setVcfHeader(header);
+        writer2.add(createVC(header));
+        try {
+            writer2.setVcfHeader(header);
+            Assert.fail("Should not allow changing header if body is already written");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof IllegalStateException);
+        }
+        writer2.close();
+
     }
 
     /**

--- a/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
@@ -1,0 +1,181 @@
+/*
+* Copyright (c) 2012 The Broad Institute
+* 
+* Permission is hereby granted, free of charge, to any person
+* obtaining a copy of this software and associated documentation
+* files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use,
+* copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following
+* conditions:
+* 
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+* THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package htsjdk.variant.bcf2;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.TestUtil;
+import htsjdk.tribble.Tribble;
+import htsjdk.variant.VariantBaseTest;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.GenotypesContext;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.variantcontext.VariantContextTestProvider;
+import htsjdk.variant.variantcontext.writer.Options;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
+import htsjdk.variant.vcf.VCFFormatHeaderLine;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import htsjdk.variant.vcf.VCFHeaderLineType;
+import htsjdk.variant.vcf.VCFHeaderVersion;
+import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author amila
+ *         <p/>
+ *         Class VCFWriterUnitTest
+ *         <p/>
+ *         This class tests out the ability of the VCF writer to correctly write VCF files
+ */
+public class BCF2WriterUnitTest extends VariantBaseTest {
+    private Set<VCFHeaderLine> metaData;
+
+    private Set<String> additionalColumns;
+
+    private File tempDir;
+
+    /**
+     * create a fake header of known quantity
+     *
+     * @param metaData          the header lines
+     * @param additionalColumns the additional column names
+     * @return a fake VCF header
+     */
+    public static VCFHeader createFakeHeader(final Set<VCFHeaderLine> metaData, final Set<String> additionalColumns,
+                                             final SAMSequenceDictionary sequenceDict) {
+        metaData.add(new VCFHeaderLine(VCFHeaderVersion.VCF4_0.getFormatString(),
+                                       VCFHeaderVersion.VCF4_0.getVersionString()));
+        metaData.add(new VCFHeaderLine("two", "2"));
+        additionalColumns.add("extra1");
+        additionalColumns.add("extra2");
+        final VCFHeader ret = new VCFHeader(metaData, additionalColumns);
+        ret.addMetaDataLine(new VCFInfoHeaderLine("GT", 1, VCFHeaderLineType.String, "x"));
+        ret.addMetaDataLine(new VCFInfoHeaderLine("DP", 1, VCFHeaderLineType.String, "x"));
+        ret.addMetaDataLine(new VCFInfoHeaderLine("BB", 1, VCFHeaderLineType.String, "x"));
+        ret.addMetaDataLine(new VCFInfoHeaderLine("GQ", 1, VCFHeaderLineType.String, "x"));
+        ret.addMetaDataLine(new VCFFormatHeaderLine("GT", 1, VCFHeaderLineType.String, "x"));
+        ret.addMetaDataLine(new VCFFormatHeaderLine("DP", 1, VCFHeaderLineType.String, "x"));
+        ret.addMetaDataLine(new VCFFormatHeaderLine("BB", 1, VCFHeaderLineType.String, "x"));
+        ret.addMetaDataLine(new VCFFormatHeaderLine("GQ", 1, VCFHeaderLineType.String, "x"));
+        ret.setSequenceDictionary(sequenceDict);
+        return ret;
+    }
+
+    @BeforeClass
+    private void createTemporaryDirectory() {
+        tempDir = TestUtil.getTempDirectory("BCFWriter", "StaleIndex");
+    }
+
+    @AfterClass
+    private void deleteTemporaryDirectory() {
+        for (File f : tempDir.listFiles()) {
+            f.delete();
+        }
+        tempDir.delete();
+    }
+
+    /**
+     * test, using the writer and reader, that we can output and input a VCF body without problems
+     */
+    @Test()
+    public void testWriteAndReadBCFBody() throws IOException {
+        final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadVCFBody.", ".bcf");
+
+        Tribble.indexFile(fakeVCFFile).deleteOnExit();
+        metaData = new HashSet<VCFHeaderLine>();
+        additionalColumns = new HashSet<String>();
+        final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
+        final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
+        try (final VariantContextWriter writer = new VariantContextWriterBuilder()
+                .setOutputFile(fakeVCFFile).setReferenceDictionary(sequenceDict)
+                .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
+                .build()) {
+            //writer.setVcfHeader(header);
+            writer.writeHeader(header);
+            writer.add(createVC(header));
+            writer.add(createVC(header));
+        }
+        VariantContextTestProvider.VariantContextContainer container = VariantContextTestProvider
+                .readAllVCs(fakeVCFFile, new BCF2Codec());
+        int counter = 0;
+        final Iterator<VariantContext> it = container.getVCs().iterator();
+        while (it.hasNext()) {
+            it.next();
+            counter++;
+        }
+        Assert.assertEquals(counter, 2);
+    }
+
+    /**
+     * create a fake VCF record
+     *
+     * @param header the VCF header
+     * @return a VCFRecord
+     */
+    private VariantContext createVC(final VCFHeader header) {
+
+        return createVCGeneral(header, "1", 1);
+    }
+
+    private VariantContext createVCGeneral(final VCFHeader header, final String chrom, final int position) {
+        final List<Allele> alleles = new ArrayList<Allele>();
+        final Map<String, Object> attributes = new HashMap<String, Object>();
+        final GenotypesContext genotypes = GenotypesContext.create(header.getGenotypeSamples().size());
+
+        alleles.add(Allele.create("A", true));
+        alleles.add(Allele.create("ACC", false));
+
+        attributes.put("DP", "50");
+        for (final String name : header.getGenotypeSamples()) {
+            final Genotype gt = new GenotypeBuilder(name, alleles.subList(1, 2)).GQ(0).attribute("BB", "1").phased(true)
+                    .make();
+            genotypes.add(gt);
+        }
+        return new VariantContextBuilder("RANDOM", chrom, position, position, alleles)
+                .genotypes(genotypes).attributes(attributes).make();
+    }
+
+
+}
+

--- a/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
@@ -85,7 +85,7 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
                 .setOutputFile(fakeVCFFile).setReferenceDictionary(sequenceDict)
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY, Options.USE_ASYNC_IO))
                 .build()) {
-            writer.setVcfHeader(header);
+            writer.setVCFHeader(header);
             writer.add(createVC(header));
             writer.add(createVC(header));
         }

--- a/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
@@ -77,8 +77,8 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
         final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadAsyncVCFHeaderless.", ".vcf");
 
         Tribble.indexFile(fakeVCFFile).deleteOnExit();
-        Set<VCFHeaderLine> metaData = new HashSet<VCFHeaderLine>();
-        Set<String> additionalColumns = new HashSet<String>();
+        final Set<VCFHeaderLine> metaData = new HashSet<>();
+        final Set<String> additionalColumns = new HashSet<>();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
@@ -93,7 +93,7 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
         codec.setVCFHeader(header, VCFHeaderVersion.VCF4_2);
 
         try (final FileInputStream fis = new FileInputStream(fakeVCFFile)) {
-            AsciiLineReaderIterator iterator = new AsciiLineReaderIterator(new AsciiLineReader(fis));
+            final AsciiLineReaderIterator iterator = new AsciiLineReaderIterator(new AsciiLineReader(fis));
             int counter = 0;
             while (iterator.hasNext()) {
                 VariantContext context = codec.decode(iterator.next());

--- a/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
@@ -75,6 +75,7 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
     @Test
     public void testWriteAndReadAsyncVCFHeaderless() throws IOException {
         final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadAsyncVCFHeaderless.", ".vcf");
+        fakeVCFFile.deleteOnExit();
 
         Tribble.indexFile(fakeVCFFile).deleteOnExit();
         final Set<VCFHeaderLine> metaData = new HashSet<>();

--- a/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
@@ -92,10 +92,8 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
         final VCFCodec codec = new VCFCodec();
         codec.setVCFHeader(header, VCFHeaderVersion.VCF4_2);
 
-        try (FileInputStream fis = new FileInputStream(fakeVCFFile)) {
-            AsciiLineReaderIterator iterator;
-
-            iterator = new AsciiLineReaderIterator(new AsciiLineReader(fis));
+        try (final FileInputStream fis = new FileInputStream(fakeVCFFile)) {
+            AsciiLineReaderIterator iterator = new AsciiLineReaderIterator(new AsciiLineReader(fis));
             int counter = 0;
             while (iterator.hasNext()) {
                 VariantContext context = codec.decode(iterator.next());
@@ -128,10 +126,6 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
      */
     private VariantContext createVC(final VCFHeader header) {
 
-       return createVCGeneral(header,"1",1);
-    }
-
-    private VariantContext createVCGeneral(final VCFHeader header, final String chrom, final int position) {
         final List<Allele> alleles = new ArrayList<Allele>();
         final Map<String, Object> attributes = new HashMap<String,Object>();
         final GenotypesContext genotypes = GenotypesContext.create(header.getGenotypeSamples().size());
@@ -144,12 +138,8 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
             final Genotype gt = new GenotypeBuilder(name,alleles.subList(1,2)).GQ(0).attribute("BB", "1").phased(true).make();
             genotypes.add(gt);
         }
-        return new VariantContextBuilder("RANDOM", chrom, position, position, alleles)
+        return new VariantContextBuilder("RANDOM", "1", 1, 1, alleles)
                 .genotypes(genotypes).attributes(attributes).make();
     }
-
-
-
-
 }
 

--- a/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
@@ -1,0 +1,169 @@
+/*
+* Copyright (c) 2012 The Broad Institute
+* 
+* Permission is hereby granted, free of charge, to any person
+* obtaining a copy of this software and associated documentation
+* files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use,
+* copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following
+* conditions:
+* 
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+* THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package htsjdk.variant.variantcontext.writer;
+
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.TestUtil;
+import htsjdk.tribble.Tribble;
+import htsjdk.tribble.readers.AsciiLineReader;
+import htsjdk.tribble.readers.AsciiLineReaderIterator;
+import htsjdk.variant.VariantBaseTest;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
+import htsjdk.variant.variantcontext.GenotypeBuilder;
+import htsjdk.variant.variantcontext.GenotypesContext;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.vcf.VCFCodec;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLine;
+import htsjdk.variant.vcf.VCFHeaderVersion;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author amila
+ *         <p/>
+ *         Class AsyncVariantContextWriterUnitTest
+ *         <p/>
+ *         This class tests out the ability of the VCF writer to correctly write VCF files with Asynchronous IO
+ */
+public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
+    private Set<VCFHeaderLine> metaData;
+    private Set<String> additionalColumns;
+    private File tempDir;
+
+    @BeforeClass
+    private void createTemporaryDirectory() {
+        tempDir = TestUtil.getTempDirectory("VCFWriter", "StaleIndex");
+    }
+
+    @AfterClass
+    private void deleteTemporaryDirectory() {
+        for (File f : tempDir.listFiles()) {
+            f.delete();
+        }
+        tempDir.delete();
+    }
+
+    /** test, using the writer and reader, that we can output and input a VCF body without problems */
+    @Test
+    public void testWriteAndReadAsyncVCFBody() throws IOException {
+        final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadVCFBody.", ".vcf");
+
+        Tribble.indexFile(fakeVCFFile).deleteOnExit();
+        metaData = new HashSet<VCFHeaderLine>();
+        additionalColumns = new HashSet<String>();
+        final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
+        final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
+        try (final VariantContextWriter writer = new VariantContextWriterBuilder()
+                .setOutputFile(fakeVCFFile).setReferenceDictionary(sequenceDict)
+                .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY, Options.USE_ASYNC_IO))
+                .build()) {
+            writer.setVcfHeader(header);
+            writer.add(createVC(header));
+            writer.add(createVC(header));
+        }
+        final VCFCodec codec = new VCFCodec();
+        codec.setVCFHeader(header, VCFHeaderVersion.VCF4_2);
+
+        try (FileInputStream fis = new FileInputStream(fakeVCFFile)) {
+            AsciiLineReaderIterator iterator;
+
+            iterator = new AsciiLineReaderIterator(new AsciiLineReader(fis));
+            int counter = 0;
+            while (iterator.hasNext()) {
+                VariantContext context = codec.decode(iterator.next());
+                if (context != null) {
+                    counter++;
+                }
+            }
+            Assert.assertEquals(counter, 2);
+        }
+    }
+
+    /**
+     * create a fake header of known quantity
+     * @param metaData           the header lines
+     * @param additionalColumns  the additional column names
+     * @return a fake VCF header
+     */
+    public static VCFHeader createFakeHeader(final Set<VCFHeaderLine> metaData, final Set<String> additionalColumns,
+                                             final SAMSequenceDictionary sequenceDict) {
+        metaData.add(new VCFHeaderLine(VCFHeaderVersion.VCF4_0.getFormatString(), VCFHeaderVersion.VCF4_0.getVersionString()));
+        metaData.add(new VCFHeaderLine("two", "2"));
+        additionalColumns.add("extra1");
+        additionalColumns.add("extra2");
+        final VCFHeader ret = new VCFHeader(metaData, additionalColumns);
+        ret.setSequenceDictionary(sequenceDict);
+        return ret;
+    }
+
+    /**
+     * create a fake VCF record
+     * @param header the VCF header
+     * @return a VCFRecord
+     */
+    private VariantContext createVC(final VCFHeader header) {
+
+       return createVCGeneral(header,"1",1);
+    }
+
+    private VariantContext createVCGeneral(final VCFHeader header, final String chrom, final int position) {
+        final List<Allele> alleles = new ArrayList<Allele>();
+        final Map<String, Object> attributes = new HashMap<String,Object>();
+        final GenotypesContext genotypes = GenotypesContext.create(header.getGenotypeSamples().size());
+
+        alleles.add(Allele.create("A",true));
+        alleles.add(Allele.create("ACC",false));
+
+        attributes.put("DP","50");
+        for (final String name : header.getGenotypeSamples()) {
+            final Genotype gt = new GenotypeBuilder(name,alleles.subList(1,2)).GQ(0).attribute("BB", "1").phased(true).make();
+            genotypes.add(gt);
+        }
+        return new VariantContextBuilder("RANDOM", chrom, position, position, alleles)
+                .genotypes(genotypes).attributes(attributes).make();
+    }
+
+
+
+
+}
+

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -88,6 +88,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     @Test(dataProvider = "vcfExtensionsDataProvider")
     public void testBasicWriteAndRead(final String extension) throws IOException {
         final File fakeVCFFile = File.createTempFile("testBasicWriteAndRead.", extension, tempDir);
+        fakeVCFFile.deleteOnExit();
         if (".vcf.gz".equals(extension)) {
             new File(fakeVCFFile.getAbsolutePath() + ".tbi");
         } else {
@@ -133,6 +134,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     @Test(dataProvider = "vcfExtensionsDataProvider")
     public void testWriteAndReadVCFHeaderless(final String extension) throws IOException {
         final File fakeVCFFile = File.createTempFile("testWriteAndReadVCFHeaderless.", extension, tempDir);
+        fakeVCFFile.deleteOnExit();
         if (".vcf.gz".equals(extension)) {
             new File(fakeVCFFile.getAbsolutePath() + ".tbi");
         } else {
@@ -170,6 +172,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testWriteHeaderTwice() {
         final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", ".vcf");
+        fakeVCFFile.deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         // prevent writing header twice
@@ -186,6 +189,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingHeader() {
         final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", ".vcf");
+        fakeVCFFile.deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         // prevent changing header if it's already written
@@ -201,6 +205,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingBody() {
         final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", ".vcf");
+        fakeVCFFile.deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         // prevent changing header if part of body is already written

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -180,11 +180,9 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         final VariantContextWriter writer1 = new VariantContextWriterBuilder()
                 .setOutputFile(fakeVCFFile)
                 .setReferenceDictionary(sequenceDict)
-                .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build();
         writer1.writeHeader(header);
         writer1.writeHeader(header);
-        writer1.add(createVC(header));
         writer1.close();
     }
 
@@ -198,11 +196,9 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         final VariantContextWriter writer2 = new VariantContextWriterBuilder()
                 .setOutputFile(fakeVCFFile)
                 .setReferenceDictionary(sequenceDict)
-                .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build();
         writer2.writeHeader(header);
         writer2.setVCFHeader(header);
-        writer2.add(createVC(header));
         writer2.close();
     }
 
@@ -215,7 +211,6 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         final VariantContextWriter writer3 = new VariantContextWriterBuilder()
                 .setOutputFile(fakeVCFFile)
                 .setReferenceDictionary(sequenceDict)
-                .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build();
         writer3.setVCFHeader(header);
         writer3.add(createVC(header));

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -93,8 +93,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         } else {
             Tribble.indexFile(fakeVCFFile).deleteOnExit();
         }
-        metaData = new HashSet<VCFHeaderLine>();
-        additionalColumns = new HashSet<String>();
+        metaData = new HashSet<>();
+        additionalColumns = new HashSet<>();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         final VariantContextWriter writer = new VariantContextWriterBuilder()
@@ -220,7 +220,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
      * @param additionalColumns  the additional column names
      * @return a fake VCF header
      */
-    public static VCFHeader createFakeHeader(final Set<VCFHeaderLine> metaData, final Set<String> additionalColumns,
+    private static VCFHeader createFakeHeader(final Set<VCFHeaderLine> metaData, final Set<String> additionalColumns,
                                              final SAMSequenceDictionary sequenceDict) {
         metaData.add(new VCFHeaderLine(VCFHeaderVersion.VCF4_0.getFormatString(), VCFHeaderVersion.VCF4_0.getVersionString()));
         metaData.add(new VCFHeaderLine("two", "2"));
@@ -263,7 +263,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
      * validate a VCF header
      * @param header the header to validate
      */
-    public void validateHeader(final VCFHeader header, final SAMSequenceDictionary sequenceDictionary) {
+    private void validateHeader(final VCFHeader header, final SAMSequenceDictionary sequenceDictionary) {
         // check the fields
         int index = 0;
         for (final VCFHeader.HEADER_FIELDS field : header.getHeaderFields()) {

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -87,12 +87,11 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     /** test, using the writer and reader, that we can output and input a VCF file without problems */
     @Test(dataProvider = "vcfExtensionsDataProvider")
     public void testBasicWriteAndRead(final String extension) throws IOException {
-        final File fakeVCFFile = File.createTempFile("testBasicWriteAndRead.", extension);
-        fakeVCFFile.deleteOnExit();
+        final File fakeVCFFile = File.createTempFile("testBasicWriteAndRead.", extension, tempDir);
         if (".vcf.gz".equals(extension)) {
-            new File(fakeVCFFile.getAbsolutePath() + ".tbi").deleteOnExit();
+            new File(fakeVCFFile.getAbsolutePath() + ".tbi");
         } else {
-            Tribble.indexFile(fakeVCFFile).deleteOnExit();
+            Tribble.indexFile(fakeVCFFile);
         }
         metaData = new HashSet<VCFHeaderLine>();
         additionalColumns = new HashSet<String>();
@@ -133,11 +132,11 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     /** test, using the writer and reader, that we can output and input a VCF body without problems */
     @Test(dataProvider = "vcfExtensionsDataProvider")
     public void testWriteAndReadVCFHeaderless(final String extension) throws IOException {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadVCFHeaderless.", extension);
+        final File fakeVCFFile = File.createTempFile("testWriteAndReadVCFHeaderless.", extension, tempDir);
         if (".vcf.gz".equals(extension)) {
-            new File(fakeVCFFile.getAbsolutePath() + ".tbi").deleteOnExit();
+            new File(fakeVCFFile.getAbsolutePath() + ".tbi");
         } else {
-            Tribble.indexFile(fakeVCFFile).deleteOnExit();
+            Tribble.indexFile(fakeVCFFile);
         }
         metaData = new HashSet<VCFHeaderLine>();
         additionalColumns = new HashSet<String>();

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -81,15 +80,9 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     @BeforeClass
     private void createTemporaryDirectory() {
         tempDir = TestUtil.getTempDirectory("VCFWriter", "StaleIndex");
+        tempDir.deleteOnExit();
     }
 
-    @AfterClass
-    private void deleteTemporaryDirectory() {
-        for (File f : tempDir.listFiles()) {
-            f.delete();
-        }
-        tempDir.delete();
-    }
 
     /** test, using the writer and reader, that we can output and input a VCF file without problems */
     @Test(dataProvider = "vcfExtensionsDataProvider")
@@ -139,8 +132,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
     /** test, using the writer and reader, that we can output and input a VCF body without problems */
     @Test(dataProvider = "vcfExtensionsDataProvider")
-    public void testWriteAndReadVCFBody(final String extension) throws IOException {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadVCFBody.", extension);
+    public void testWriteAndReadVCFHeaderless(final String extension) throws IOException {
+        final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadVCFHeaderless.", extension);
         if (".vcf.gz".equals(extension)) {
             new File(fakeVCFFile.getAbsolutePath() + ".tbi").deleteOnExit();
         } else {
@@ -172,9 +165,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
             int counter = 0;
             while (iterator.hasNext()) {
                 VariantContext context = codec.decode(iterator.next());
-                if (context != null) {
-                    counter++;
-                }
+                counter++;
             }
             Assert.assertEquals(counter, 2);
         }


### PR DESCRIPTION
### Description

This PR addresses Issue #902.

Added support for setting and writing the header in two different steps for the classes derived from `VariantContextWriter`.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

