### PR TITLE
Sort and group order not updated when using setAttribute.

### DIFF
--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -71,6 +71,7 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
             mAttributes.put(key, value);
         }
     }
+
     /**
      * Returns the Set of attributes.
      */

--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -59,8 +59,6 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
     /**
      * Set the given value for the attribute named 'key'.  Replaces an existing value, if any.
      * If value is null, the attribute is removed.
-     * Supported types are Character, Integer, Float and String.  Byte and Short may also be
-     * passed in but they will be converted to Integer.
      * @param key attribute name
      * @param value attribute value
      */

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -325,12 +325,11 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     @Override
     public void setAttribute(final String key, final String value) {
         if (key.equals(SORT_ORDER_TAG)) {
-            this.setSortOrder(SortOrder.valueOf(value));
+            this.sortOrder = null;
         } else if (key.equals(GROUP_ORDER_TAG)) {
-            this.setGroupOrder(GroupOrder.valueOf(value));
-        } else {
-            super.setAttribute(key, value);
+            this.groupOrder = null;
         }
+        super.setAttribute(key, value);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -307,7 +307,6 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     @Deprecated
     @Override
     public void setAttribute(final String key, final Object value) {
-        super.setAttribute(key, value);
         if (key.equals(SORT_ORDER_TAG) || key.equals(GROUP_ORDER_TAG)) {
             this.setAttribute(key, value.toString());
         } else {
@@ -325,10 +324,11 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
      */
     @Override
     public void setAttribute(final String key, final String value) {
-        super.setAttribute(key, value);
-        if (key.equals(SORT_ORDER_TAG)) this.setSortOrder(SortOrder.valueOf(value));
-        else if (key.equals(GROUP_ORDER_TAG)) this.setGroupOrder(GroupOrder.valueOf(value));
-        else super.setAttribute(key, value);
+        if (key.equals(SORT_ORDER_TAG)) {
+            this.setSortOrder(SortOrder.valueOf(value));
+        } else if (key.equals(GROUP_ORDER_TAG)) {
+            this.setGroupOrder(GroupOrder.valueOf(value));
+        } else super.setAttribute(key, value);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -328,7 +328,9 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
             this.setSortOrder(SortOrder.valueOf(value));
         } else if (key.equals(GROUP_ORDER_TAG)) {
             this.setGroupOrder(GroupOrder.valueOf(value));
-        } else super.setAttribute(key, value);
+        } else {
+            super.setAttribute(key, value);
+        }
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -270,7 +270,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
 
     public void setSortOrder(final SortOrder so) {
         sortOrder = so;
-        setAttribute(SORT_ORDER_TAG, so.name());
+        super.setAttribute(SORT_ORDER_TAG, so.name());
     }
 
     public GroupOrder getGroupOrder() {
@@ -292,7 +292,43 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
 
     public void setGroupOrder(final GroupOrder go) {
         groupOrder = go;
-        setAttribute(GROUP_ORDER_TAG, go.name());
+        super.setAttribute(GROUP_ORDER_TAG, go.name());
+    }
+
+
+    /**
+     * Set the given value for the attribute named 'key'.  Replaces an existing value, if any.
+     * If value is null, the attribute is removed.
+     * Otherwise, the value will be converted to a String with toString.
+     * @param key attribute name
+     * @param value attribute value
+     * @deprecated Use {@link #setAttribute(String, String) instead
+     */
+    @Deprecated
+    @Override
+    public void setAttribute(final String key, final Object value) {
+        super.setAttribute(key, value);
+        if (key.equals(SORT_ORDER_TAG) || key.equals(GROUP_ORDER_TAG)) {
+            this.setAttribute(key, value.toString());
+        } else {
+            super.setAttribute(key, value);
+        }
+    }
+
+    /**
+     * Set the given value for the attribute named 'key'.  Replaces an existing value, if any.
+     * If value is null, the attribute is removed.
+     * Supported types are Character, Integer, Float and String.  Byte and Short may also be
+     * passed in but they will be converted to Integer.
+     * @param key attribute name
+     * @param value attribute value
+     */
+    @Override
+    public void setAttribute(final String key, final String value) {
+        super.setAttribute(key, value);
+        if (key.equals(SORT_ORDER_TAG)) this.setSortOrder(SortOrder.valueOf(value));
+        else if (key.equals(GROUP_ORDER_TAG)) this.setGroupOrder(GroupOrder.valueOf(value));
+        else super.setAttribute(key, value);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -317,8 +317,6 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     /**
      * Set the given value for the attribute named 'key'.  Replaces an existing value, if any.
      * If value is null, the attribute is removed.
-     * Supported types are Character, Integer, Float and String.  Byte and Short may also be
-     * passed in but they will be converted to Integer.
      * @param key attribute name
      * @param value attribute value
      */

--- a/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
@@ -34,9 +34,15 @@ public class SAMFileHeaderTest extends HtsjdkTest {
 
         header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.coordinate.name());
 
         header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, SAMFileHeader.SortOrder.queryname.name());
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.queryname);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.queryname.name());
+
+        header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, SAMFileHeader.SortOrder.coordinate);
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.coordinate.name());
     }
 
     @Test
@@ -45,8 +51,14 @@ public class SAMFileHeaderTest extends HtsjdkTest {
 
         header.setGroupOrder(SAMFileHeader.GroupOrder.query);
         Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.query);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.query.name());
 
         header.setAttribute(SAMFileHeader.GROUP_ORDER_TAG, SAMFileHeader.GroupOrder.reference.name());
         Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.reference);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.reference.name());
+
+        header.setAttribute(SAMFileHeader.GROUP_ORDER_TAG, SAMFileHeader.GroupOrder.query);
+        Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.query);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.query.name());
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 Nils Homer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ */
+package htsjdk.samtools;
+
+import htsjdk.HtsjdkTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SAMFileHeaderTest extends HtsjdkTest {
+
+    @Test
+    public void testSortOrder() {
+        final SAMFileHeader header = new SAMFileHeader();
+
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
+
+        header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, SAMFileHeader.SortOrder.queryname.name());
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.queryname);
+    }
+
+    @Test
+    public void testGroupOrder() {
+        final SAMFileHeader header = new SAMFileHeader();
+
+        header.setGroupOrder(SAMFileHeader.GroupOrder.query);
+        Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.query);
+
+        header.setAttribute(SAMFileHeader.GROUP_ORDER_TAG, SAMFileHeader.GroupOrder.reference.name());
+        Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.reference);
+    }
+}


### PR DESCRIPTION
@yfarjoun could you take a look since this fixes a bug you introduced, and @tfenne can a maintainer take a look?

The issue was that folks can call `setAttribute("SO", "queryname")` and the cached sort order introduced in ad8aa02aa2ed02b9cb2bb8801c3e6897e91ec3f6 would not get updated.  Similarly for the group order.