### PR TITLE
New AsyncWriteSortingCollection

### DIFF
--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -15,7 +15,7 @@ import java.util.TreeMap;
  */
 public class Defaults {
     private static Log log = Log.getInstance(Defaults.class);
-    
+
     /** Should BAM index files be created when writing out coordinate sorted BAM files?  Default = false. */
     public static final boolean CREATE_INDEX;
 
@@ -84,6 +84,7 @@ public class Defaults {
      */
     public static final boolean SRA_LIBRARIES_DOWNLOAD;
 
+    public static final int SORTING_COLLECTION_THREADS;
 
     static {
         CREATE_INDEX = getBooleanProperty("create_index", false);
@@ -104,6 +105,7 @@ public class Defaults {
         CUSTOM_READER_FACTORY = getStringProperty("custom_reader", "");
         SAM_FLAG_FIELD_FORMAT = SamFlagField.valueOf(getStringProperty("sam_flag_field_format", SamFlagField.DECIMAL.name()));
         SRA_LIBRARIES_DOWNLOAD = getBooleanProperty("sra_libraries_download", false);
+        SORTING_COLLECTION_THREADS = getIntProperty("sort_col_threads", 0);
     }
 
     /**
@@ -126,6 +128,7 @@ public class Defaults {
         result.put("EBI_REFERENCE_SERVICE_URL_MASK", EBI_REFERENCE_SERVICE_URL_MASK);
         result.put("CUSTOM_READER_FACTORY", CUSTOM_READER_FACTORY);
         result.put("SAM_FLAG_FIELD_FORMAT", SAM_FLAG_FIELD_FORMAT);
+        result.put("SORTING_COLLECTION_THREADS", SORTING_COLLECTION_THREADS);
         return Collections.unmodifiableSortedMap(result);
     }
 

--- a/src/main/java/htsjdk/samtools/util/AsyncWriteSortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/AsyncWriteSortingCollection.java
@@ -1,0 +1,182 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.util;
+
+import htsjdk.samtools.Defaults;
+import htsjdk.samtools.SAMException;
+
+import java.io.File;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * This class has exactly the same API that SortingCollection, however,
+ * sorts and spills the data to disk in a separate ExecutorService. Identify the maximum number of records
+ * in memory that is guaranteed not to exceed the number of records that would have the object class SortingCollection.
+ *
+ * @author Pavel_Silin@epam.com, EPAM Systems, Inc. <www.epam.com>
+ */
+public class AsyncWriteSortingCollection<T> extends SortingCollection<T> {
+
+	private static final ExecutorService service = Executors.newFixedThreadPool(
+			Defaults.SORTING_COLLECTION_THREADS,
+			r -> {
+                Thread t = Executors.defaultThreadFactory().newThread(r);
+                t.setDaemon(true);
+                return t;
+            }
+	);
+
+	private final BlockingQueue<T[]> instancePool;
+	private CompletableFuture finishFlagFuture;
+
+	@SuppressWarnings("unchecked")
+	public AsyncWriteSortingCollection(final Class<T> componentType,
+									   final SortingCollection.Codec<T> codec,
+									   final Comparator<T> comparator, final int maxRecordsInRam,
+									   final File... tmpDir) {
+		super(componentType, codec, comparator,
+				// calculate available space for one buffer
+				maxRecordsInRam / (Defaults.SORTING_COLLECTION_THREADS + 1),
+				tmpDir
+		);
+
+		if (Defaults.SORTING_COLLECTION_THREADS <= 0) {
+			throw new IllegalArgumentException("JVM parameter sort_col_threads can't be <= 0");
+		}
+
+		instancePool = new LinkedBlockingQueue<>(Defaults.SORTING_COLLECTION_THREADS);
+		for (int i = 0; i < Defaults.SORTING_COLLECTION_THREADS; i++) {
+			instancePool.offer((T[]) Array.newInstance(componentType,
+                    maxRecordsInRam / (Defaults.SORTING_COLLECTION_THREADS + 1))
+            );
+		}
+		finishFlagFuture = CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public void doneAdding() {
+		super.doneAdding();
+		if (instancePool != null && !instancePool.isEmpty()) {
+			instancePool.clear();
+		}
+	}
+
+	/**
+	 * @see SortingCollection
+	 */
+	@SuppressWarnings("unused")
+	public static <T> AsyncWriteSortingCollection<T> newInstance(
+			final Class<T> componentType,
+			final SortingCollection.Codec<T> codec,
+			final Comparator<T> comparator, final int maxRecordsInRAM,
+			final File... tmpDir) {
+		return new AsyncWriteSortingCollection<>(componentType, codec,
+				comparator, maxRecordsInRAM, tmpDir);
+
+	}
+
+	/**
+	 * @see SortingCollection
+	 */
+	@SuppressWarnings("unused")
+	public static <T> AsyncWriteSortingCollection<T> newInstance(
+			final Class<T> componentType,
+			final SortingCollection.Codec<T> codec,
+			final Comparator<T> comparator, final int maxRecordsInRAM,
+			final Collection<File> tmpDirs) {
+		return new AsyncWriteSortingCollection<>(componentType, codec,
+				comparator, maxRecordsInRAM,
+				tmpDirs.toArray(new File[tmpDirs.size()]));
+	}
+
+	/**
+	 * @see SortingCollection
+	 */
+	@SuppressWarnings("unused")
+	public static <T> AsyncWriteSortingCollection<T> newInstance(
+			final Class<T> componentType,
+			final SortingCollection.Codec<T> codec,
+			final Comparator<T> comparator, final int maxRecordsInRAM) {
+
+		final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+		return new AsyncWriteSortingCollection<>(componentType, codec,
+				comparator, maxRecordsInRAM, tmpDir);
+	}
+
+	/**
+	 * This method is called from SortingCollection.add method to perform spill
+	 * to disk operation. The method puts collected rumRecords to the new task
+	 * and then it will be sorting and spilling to disk in a separate thread.
+	 */
+	@Override
+	protected void performSpillToDisk() {
+		try {
+			final T[] buffRamRecords = this.ramRecords;
+			final int buffNumRecordsInRam = this.numRecordsInRam;
+			this.ramRecords = instancePool.take();
+			this.numRecordsInRam = 0;
+
+			//run task, and when it's done, put buffer in pool
+			CompletableFuture<Void> sortSpillTask = CompletableFuture.supplyAsync(
+					() -> {
+						Arrays.sort(buffRamRecords, 0, buffNumRecordsInRam, comparator);
+						spill(buffRamRecords, buffNumRecordsInRam, codec.clone());
+						return buffRamRecords;
+					},
+					service
+			).thenAccept(this::returnRamRecordsToPool);
+
+			finishFlagFuture = CompletableFuture.allOf(finishFlagFuture, sortSpillTask);
+
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new SAMException("Failed to spill to disk once the tmp file.", e);
+		}
+	}
+
+	private void returnRamRecordsToPool(T[] t) {
+		try {
+			instancePool.put(t);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new SAMException(
+					"Failed to put in ramRecordPool once the ramRecords array.", e
+			);
+		}
+	}
+
+	// Wait until the end of the work.
+	@Override
+	protected void finish() {
+		finishFlagFuture.join();
+	}
+}

--- a/src/test/java/htsjdk/samtools/util/AsyncWriteSortingCollectionTest.java
+++ b/src/test/java/htsjdk/samtools/util/AsyncWriteSortingCollectionTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.util;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+
+public class AsyncWriteSortingCollectionTest extends SortingCollectionTest {
+
+    @BeforeClass void setupClass() {System.setProperty("samjdk.sort_col_threads", "2");}
+
+    @BeforeMethod void setup() { resetTmpDir(); }
+    @AfterMethod void tearDown() { resetTmpDir(); }
+
+    @DataProvider(name = "test1")
+    public Object[][] createTestData() {
+        return new Object[][] {
+                {"empty", 0, 100},
+                {"singleton", 1, 100},
+
+                // maxRecordInRam for AsyncWriteSortingCollection is equals to 300 / (sort_col_threads + 1) = 100
+                {"less than threshold", 100, 300},
+                {"threshold minus 1", 99, 300},
+                {"greater than threshold", 550, 300},
+                {"threshold multiple", 600, 300},
+                {"threshold multiple plus one", 101, 300},
+                {"exactly threshold", 100, 300},
+        };
+    }
+}

--- a/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
+++ b/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
@@ -90,9 +90,10 @@ public class SortingCollectionTest extends HtsjdkTest {
             sortingCollection.add(s);
             strings[numStringsGenerated++] = s;
         }
+        sortingCollection.doneAdding();
         Arrays.sort(strings, new StringComparator());
 
-        Assert.assertEquals(tmpDirIsEmpty(), numStringsToGenerate <= maxRecordsInRam);
+        Assert.assertEquals(tmpDirIsEmpty(), shouldTmpDirBeEmpty(numStringsToGenerate, maxRecordsInRam));
         sortingCollection.setDestructiveIteration(false);
         assertIteratorEqualsList(strings, sortingCollection.iterator());
         assertIteratorEqualsList(strings, sortingCollection.iterator());
@@ -101,7 +102,7 @@ public class SortingCollectionTest extends HtsjdkTest {
         Assert.assertEquals(tmpDir().list().length, 0);
     }
 
-    private void assertIteratorEqualsList(final String[] strings, final Iterator<String> sortingCollection) {
+    protected void assertIteratorEqualsList(final String[] strings, final Iterator<String> sortingCollection) {
         int i = 0;
         while (sortingCollection.hasNext()) {
             final String s = sortingCollection.next();
@@ -110,8 +111,13 @@ public class SortingCollectionTest extends HtsjdkTest {
         Assert.assertEquals(i, strings.length);
     }
 
-    private SortingCollection<String> makeSortingCollection(final int maxRecordsInRam) {
-        return SortingCollection.newInstance(String.class, new StringCodec(), new StringComparator(), maxRecordsInRam, tmpDir());
+    boolean shouldTmpDirBeEmpty(int numStringsToGenerate, int maxRecordsInRam) {
+        return numStringsToGenerate <= maxRecordsInRam;
+    }
+
+    SortingCollection<String> makeSortingCollection(final int maxRecordsInRam) {
+            return new SortingCollection<>(String.class, new StringCodec(),
+                    new StringComparator(), maxRecordsInRam, tmpDir());
     }
 
     /**

--- a/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
+++ b/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
@@ -26,9 +26,7 @@ package htsjdk.samtools.util;
 import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -47,7 +45,7 @@ public class SortingCollectionTest extends HtsjdkTest {
     protected File tmpDir() {
         return new File(System.getProperty("java.io.tmpdir") + "/" + System.getProperty("user.name"), getClass().getSimpleName());
     }
-    
+
     @BeforeMethod void setup() { resetTmpDir(); }
     @AfterMethod void tearDown() { resetTmpDir(); }
 


### PR DESCRIPTION
We present a multithreaded implementation of SortingCollection.
The main idea of this improvements is that data is being sorted and spilled in the sorting collection asynchronously by submitting tasks to the executor service.
Compared to the current implementation it looks as follows:

![compare](https://user-images.githubusercontent.com/11179595/27478925-52b3e8ec-581a-11e7-87aa-ba1421d3195f.png)

As we can see above, parallel version enables continuous sorting work without breaks for writing to the temporary file.
Method doneAdding() is blocking, since we have to wait until all spill tasks are completed. 

What is the effect?
Below are results of the SortingCollection benchmark. It is based on the random generation of data for SortingCollection, we just create random int, transform it to string and put into the sorting collection.

![image](https://user-images.githubusercontent.com/11179595/27478961-6c59bfe2-581a-11e7-9384-778dc008b45b.png)

```
Benchmark                                              Number of strings  Mode  Cnt      Score      Error  Units
SortingCollectionBenchmark.sortingCollectionBenchmark         50_000_000  avgt    5  42821.407 ± 2095.994  ms/op
SortingCollectionBenchmark.sortingCollectionBenchmark2th      50_000_000  avgt    5  19241.607 ±  353.917  ms/op
SortingCollectionBenchmark.sortingCollectionBenchmark4th      50_000_000  avgt    5  10750.524 ± 72.900    ms/op
```

Here is log output of SortSam metric for both SortingCollection implementattions:
```
AsyncSpillSortingCollection with 2 spilling threads:
INFO 2017-06-14 15:58:47 SortSam Read 10,000,000 records. Elapsed time: 00:00:22s. Time for last 10,000,000: 22s. Last read position: 1:148,346,706
INFO 2017-06-14 15:59:14 SortSam Read 20,000,000 records. Elapsed time: 00:00:49s. Time for last 10,000,000: 26s. Last read position: X:149,840,001
INFO 2017-06-14 15:59:41 SortSam Read 30,000,000 records. Elapsed time: 00:01:16s. Time for last 10,000,000: 27s. Last read position: 12:31,820,558
INFO 2017-06-14 16:00:09 SortSam Read 40,000,000 records. Elapsed time: 00:01:44s. Time for last 10,000,000: 27s. Last read position: 11:3,746,487
INFO 2017-06-14 16:00:36 SortSam Read 50,000,000 records. Elapsed time: 00:02:11s. Time for last 10,000,000: 27s. Last read position: 17:27,904,169
INFO 2017-06-14 16:00:47 SortSam Finished reading inputs, merging and writing to output now.
Total elapsed time = 129 sec - performance gain is 72%
```
```
Standard SortingCollection:
INFO 2017-06-14 16:05:36 SortSam Read 10,000,000 records. Elapsed time: 00:00:40s. Time for last 10,000,000: 40s. Last read position: 1:148,346,706
INFO 2017-06-14 16:06:20 SortSam Read 20,000,000 records. Elapsed time: 00:01:25s. Time for last 10,000,000: 44s. Last read position: X:149,840,001
INFO 2017-06-14 16:07:05 SortSam Read 30,000,000 records. Elapsed time: 00:02:10s. Time for last 10,000,000: 45s. Last read position: 12:31,820,558
INFO 2017-06-14 16:07:51 SortSam Read 40,000,000 records. Elapsed time: 00:02:55s. Time for last 10,000,000: 45s. Last read position: 11:3,746,487
INFO 2017-06-14 16:08:40 SortSam Read 50,000,000 records. Elapsed time: 00:03:44s. Time for last 10,000,000: 48s. Last read position: 17:27,904,169
INFO 2017-06-14 16:08:58 SortSam Finished reading inputs, merging and writing to output now.
       Total elapsed time = 222 sec 
```

```
Command for run:
standard version: java -Xmx4g -jar picard.jar SortSam I=/path/to/bam O=/path/to/bam SORT_ORDER=queryname VALIDATION_STRINGENCY=SILENT
parallel version: java -Dsamjdk.sort_col_threads=2 -Xmx4g -jar picard-unspecified-SNAPSHOT-all.jar SortSam I=/path/to/bam O=/path/to/out SORT_ORDER=queryname VALIDATION_STRINGENCY=SILENT
```
The parallel processing is turned ON by setting JVM option  -Dsamjdk.sort_col_threads=*number_of_threads*, if *number_of_threads* > 0, any metric/utility that uses SortingCollection will use the parallel implementation.

