### PR TITLE
More support for java.nio.Path: DiskBackedQueue and SortingCollection 

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -243,13 +243,11 @@ public class IOUtil {
 
     public static void deletePaths(final Iterable<Path> paths) {
         for (final Path p : paths) {
-            boolean deleted;
             try {
                 Files.delete(p);
             } catch (IOException e) {
-                deleted = false;
+                System.err.println("Could not delete file " + p);
             }
-            if (!deleted) System.err.println("Could not delete file " + p);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -245,7 +245,7 @@ public class IOUtil {
         for (final Path p : paths) {
             boolean deleted;
             try {
-                deleted = Files.deleteIfExists(p);
+                deleted = Files.delete(p);
             } catch (IOException e) {
                 deleted = false;
             }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -238,15 +238,7 @@ public class IOUtil {
     }
 
     public static void deletePaths(final Path... paths) {
-        for (final Path p : paths) {
-            boolean deleted;
-            try {
-                deleted = Files.deleteIfExists(p);
-            } catch (IOException e) {
-                deleted = false;
-            }
-            if (!deleted) System.err.println("Could not delete file " + p);
-        }
+        deletePaths(Arrays.asList(paths));
     }
 
     public static void deletePaths(final Iterable<Path> paths) {

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -530,18 +530,8 @@ public class IOUtil {
      * @param dir the dir to check for writability
      */
     public static void assertDirectoryIsWritable(final File dir) {
-        if (dir == null) {
-            throw new IllegalArgumentException("Cannot check readability of null file.");
-        }
-        else if (!dir.exists()) {
-            throw new SAMException("Directory does not exist: " + dir.getAbsolutePath());
-        }
-        else if (!dir.isDirectory()) {
-            throw new SAMException("Cannot write to directory because it is not a directory: " + dir.getAbsolutePath());
-        }
-        else if (!dir.canWrite()) {
-            throw new SAMException("Directory exists but is not writable: " + dir.getAbsolutePath());
-        }
+        final Path asPath = (dir == null) ? null : dir.toPath();
+        assertDirectoryIsWritable(asPath);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -69,7 +69,6 @@ import java.util.Stack;
 import java.util.regex.Pattern;
 import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * Miscellaneous stateless static IO-oriented methods.
@@ -361,15 +360,30 @@ public class IOUtil {
      */
     public static void deleteOnExit(final Path path) {
         // add a shutdown hook to remove the path on exit
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            public void run() {
-                try {
-                    Files.delete(path);
-                } catch (IOException e) {
-                    throw new RuntimeIOException(e);
-                }
+        Runtime.getRuntime().addShutdownHook(new DeletePathThread(path));
+    }
+
+    /**
+     * WARNING: visible for testing. Do not use.
+     *
+     * Class for delete a path, used in a shutdown hook for delete on exit.
+     *
+     * @see #deleteOnExit(Path)
+     */
+    protected static final class DeletePathThread extends Thread {
+
+        private final Path path;
+
+        protected DeletePathThread(Path path) {this.path = path;}
+
+        @Override
+        public void run() {
+            try {
+                Files.delete(path);
+            } catch (IOException e) {
+                throw new RuntimeIOException(e);
             }
-        });
+        }
     }
 
     /** Returns the name of the file minus the extension (i.e. text after the last "." in the filename). */

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -245,7 +245,7 @@ public class IOUtil {
         for (final Path p : paths) {
             boolean deleted;
             try {
-                deleted = Files.delete(p);
+                Files.delete(p);
             } catch (IOException e) {
                 deleted = false;
             }

--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -230,7 +230,7 @@ public class SortingCollection<T> implements Iterable<T> {
 
                 os.flush();
             } catch (RuntimeIOException ex) {
-                throw new RuntimeIOException("Problem writing temporary file " + f.toUri().toString() +
+                throw new RuntimeIOException("Problem writing temporary file " + f.toUri() +
                         ".  Try setting TMP_DIR to a file system with lots of space.", ex);
             } finally {
                 if (os != null) {

--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -26,14 +26,14 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.Defaults;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Array;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -96,7 +96,7 @@ public class SortingCollection<T> implements Iterable<T> {
     }
 
     /** Directories where files of sorted records go. */
-    private final File[] tmpDirs;
+    private final Path[] tmpDirs;
 
     /** The minimum amount of space free on a temp filesystem to write a file there. */
     private final long TMP_SPACE_FREE = IOUtil.FIVE_GBS;
@@ -124,7 +124,7 @@ public class SortingCollection<T> implements Iterable<T> {
     /**
      * List of files in tmpDir containing sorted records
      */
-    private final List<File> files = new ArrayList<File>();
+    private final List<Path> files = new ArrayList<>();
 
     private boolean destructiveIteration = true;
 
@@ -139,7 +139,7 @@ public class SortingCollection<T> implements Iterable<T> {
      * @param tmpDir Where to write files of records that will not fit in RAM
      */
     private SortingCollection(final Class<T> componentType, final SortingCollection.Codec<T> codec,
-                             final Comparator<T> comparator, final int maxRecordsInRam, final File... tmpDir) {
+                             final Comparator<T> comparator, final int maxRecordsInRam, final Path... tmpDir) {
         if (maxRecordsInRam <= 0) {
             throw new IllegalArgumentException("maxRecordsInRam must be > 0");
         }
@@ -217,10 +217,10 @@ public class SortingCollection<T> implements Iterable<T> {
     private void spillToDisk() {
         try {
             Arrays.sort(this.ramRecords, 0, this.numRecordsInRam, this.comparator);
-            final File f = newTempFile();
+            final Path f = newTempFile();
             OutputStream os = null;
             try {
-                os = tempStreamFactory.wrapTempOutputStream(new FileOutputStream(f), Defaults.BUFFER_SIZE);
+                os = tempStreamFactory.wrapTempOutputStream(Files.newOutputStream(f), Defaults.BUFFER_SIZE);
                 this.codec.setOutputStream(os);
                 for (int i = 0; i < this.numRecordsInRam; ++i) {
                     this.codec.encode(ramRecords[i]);
@@ -230,7 +230,7 @@ public class SortingCollection<T> implements Iterable<T> {
 
                 os.flush();
             } catch (RuntimeIOException ex) {
-                throw new RuntimeIOException("Problem writing temporary file " + f.getAbsolutePath() +
+                throw new RuntimeIOException("Problem writing temporary file " + f.toUri().toString() +
                         ".  Try setting TMP_DIR to a file system with lots of space.", ex);
             } finally {
                 if (os != null) {
@@ -251,8 +251,8 @@ public class SortingCollection<T> implements Iterable<T> {
      * Creates a new tmp file on one of the available temp filesystems, registers it for deletion
      * on JVM exit and then returns it.
      */
-    private File newTempFile() throws IOException {
-        return IOUtil.newTempFile("sortingcollection.", ".tmp", this.tmpDirs, TMP_SPACE_FREE);
+    private Path newTempFile() throws IOException {
+        return IOUtil.newTempPath("sortingcollection.", ".tmp", this.tmpDirs, TMP_SPACE_FREE);
     }
 
     /**
@@ -281,7 +281,7 @@ public class SortingCollection<T> implements Iterable<T> {
         this.iterationStarted = true;
         this.cleanedUp = true;
 
-        IOUtil.deleteFiles(this.files);
+        IOUtil.deletePaths(this.files);
     }
 
     /**
@@ -298,7 +298,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM,
                                                        final File... tmpDir) {
-        return new SortingCollection<T>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
+        return new SortingCollection<T>(componentType, codec, comparator, maxRecordsInRAM, Arrays.stream(tmpDir).map(File::toPath).toArray(Path[]::new));
 
     }
 
@@ -320,7 +320,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                         codec,
                                         comparator,
                                         maxRecordsInRAM,
-                                        tmpDirs.toArray(new File[tmpDirs.size()]));
+                                        tmpDirs.stream().map(File::toPath).toArray(Path[]::new));
 
     }
 
@@ -338,8 +338,48 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM) {
 
-        final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+        final Path tmpDir = IOUtil.getDefaultTmpDirPath();
         return new SortingCollection<T>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
+    }
+
+    /**
+     * Syntactic sugar around the ctor, to save some typing of type parameters
+     *
+     * @param componentType Class of the record to be sorted.  Necessary because of Java generic lameness.
+     * @param codec For writing records to file and reading them back into RAM
+     * @param comparator Defines output sort order
+     * @param maxRecordsInRAM how many records to accumulate in memory before spilling to disk
+     * @param tmpDir Where to write files of records that will not fit in RAM
+     */
+    public static <T> SortingCollection<T> newInstance(final Class<T> componentType,
+            final SortingCollection.Codec<T> codec,
+            final Comparator<T> comparator,
+            final int maxRecordsInRAM,
+            final Path... tmpDir) {
+        return new SortingCollection<T>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
+
+    }
+
+    /**
+     * Syntactic sugar around the ctor, to save some typing of type parameters
+     *
+     * @param componentType Class of the record to be sorted.  Necessary because of Java generic lameness.
+     * @param codec For writing records to file and reading them back into RAM
+     * @param comparator Defines output sort order
+     * @param maxRecordsInRAM how many records to accumulate in memory before spilling to disk
+     * @param tmpDirs Where to write files of records that will not fit in RAM
+     */
+    public static <T> SortingCollection<T> newInstanceFromPaths(final Class<T> componentType,
+            final SortingCollection.Codec<T> codec,
+            final Comparator<T> comparator,
+            final int maxRecordsInRAM,
+            final Collection<Path> tmpDirs) {
+        return new SortingCollection<T>(componentType,
+                codec,
+                comparator,
+                maxRecordsInRAM,
+                tmpDirs.toArray(new Path[tmpDirs.size()]));
+
     }
 
     /**
@@ -403,7 +443,7 @@ public class SortingCollection<T> implements Iterable<T> {
         MergingIterator() {
             this.queue = new TreeSet<PeekFileRecordIterator>(new PeekFileRecordIteratorComparator());
             int n = 0;
-            for (final File f : SortingCollection.this.files) {
+            for (final Path f : SortingCollection.this.files) {
                 final FileRecordIterator it = new FileRecordIterator(f);
                 if (it.hasNext()) {
                     this.queue.add(new PeekFileRecordIterator(it, n++));
@@ -455,20 +495,20 @@ public class SortingCollection<T> implements Iterable<T> {
      * Read a file of records in format defined by the codec
      */
     class FileRecordIterator implements CloseableIterator<T> {
-        private final File file;
-        private final FileInputStream is;
+        private final Path file;
+        private final InputStream is;
         private final Codec<T> codec;
         private T currentRecord = null;
 
-        FileRecordIterator(final File file) {
+        FileRecordIterator(final Path file) {
             this.file = file;
             try {
-                this.is = new FileInputStream(file);
+                this.is = Files.newInputStream(file);
                 this.codec = SortingCollection.this.codec.clone();
                 this.codec.setInputStream(tempStreamFactory.wrapTempInputStream(this.is, Defaults.BUFFER_SIZE));
                 advance();
             }
-            catch (FileNotFoundException e) {
+            catch (IOException e) {
                 throw new RuntimeIOException(e);
             }
         }

--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -292,7 +292,10 @@ public class SortingCollection<T> implements Iterable<T> {
      * @param comparator Defines output sort order
      * @param maxRecordsInRAM how many records to accumulate in memory before spilling to disk
      * @param tmpDir Where to write files of records that will not fit in RAM
+     *
+     * @deprecated since 2017-09. Use {@link #newInstance(Class, Codec, Comparator, int, Path...)} instead
      */
+    @Deprecated
     public static <T> SortingCollection<T> newInstance(final Class<T> componentType,
                                                        final SortingCollection.Codec<T> codec,
                                                        final Comparator<T> comparator,
@@ -310,7 +313,10 @@ public class SortingCollection<T> implements Iterable<T> {
      * @param comparator Defines output sort order
      * @param maxRecordsInRAM how many records to accumulate in memory before spilling to disk
      * @param tmpDirs Where to write files of records that will not fit in RAM
+     *
+     * @deprecated since 2017-09. Use {@link #newInstanceFromPaths(Class, Codec, Comparator, int, Collection)} instead
      */
+    @Deprecated
     public static <T> SortingCollection<T> newInstance(final Class<T> componentType,
                                                        final SortingCollection.Codec<T> codec,
                                                        final Comparator<T> comparator,

--- a/src/test/java/htsjdk/samtools/util/IoUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IoUtilTest.java
@@ -230,7 +230,6 @@ public class IoUtilTest extends HtsjdkTest {
         };
     }
 
-
     @DataProvider(name = "fileNamesForDelete")
     public Object[][] fileNamesForDelete() {
         return new Object[][] {
@@ -241,12 +240,11 @@ public class IoUtilTest extends HtsjdkTest {
     }
 
     @Test
-    public void testHetDefaultTmpDirPath() throws Exception {
+    public void testGetDefaultTmpDirPath() throws Exception {
         final Path tmpPath = IOUtil.getDefaultTmpDirPath();
         final String user = System.getProperty("user.name");
         Assert.assertEquals(tmpPath.toFile().getAbsolutePath(), new File(systemTempDir).getAbsolutePath() + "/" + user);
     }
-
 
     @Test(dataProvider = "fileNamesForDelete")
     public void testDeletePathLocal(final List<String> fileNames) throws Exception {
@@ -349,7 +347,6 @@ public class IoUtilTest extends HtsjdkTest {
         }
     }
 
-
     @DataProvider
     public Object[][] filesForWritableDirectory() throws Exception {
         final File nonWritableFile = new File(systemTempDir, "testAssertDirectoryIsWritable_non_writable_dir");
@@ -378,5 +375,4 @@ public class IoUtilTest extends HtsjdkTest {
             }
         }
     }
-
 }

--- a/src/test/java/htsjdk/samtools/util/IoUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IoUtilTest.java
@@ -66,7 +66,7 @@ public class IoUtilTest extends HtsjdkTest {
     private String systemUser;
     private String systemTempDir;
 
-    private FileSystem inMemmoryfileSystem;
+    private FileSystem inMemoryfileSystem;
 
     @BeforeClass
     public void setUp() throws IOException {
@@ -74,7 +74,7 @@ public class IoUtilTest extends HtsjdkTest {
         existingTempFile.deleteOnExit();
         systemTempDir = System.getProperty("java.io.tmpdir");
         final File tmpDir = new File(systemTempDir);
-        inMemmoryfileSystem = Jimfs.newFileSystem(Configuration.unix());;
+        inMemoryfileSystem = Jimfs.newFileSystem(Configuration.unix());;
         if (!tmpDir.isDirectory()) tmpDir.mkdir();
         if (!tmpDir.isDirectory())
             throw new RuntimeException("java.io.tmpdir (" + systemTempDir + ") is not a directory");
@@ -86,7 +86,7 @@ public class IoUtilTest extends HtsjdkTest {
         // reset java properties to original
         System.setProperty("java.io.tmpdir", systemTempDir);
         System.setProperty("user.name", systemUser);
-        inMemmoryfileSystem.close();
+        inMemoryfileSystem.close();
     }
 
     @Test
@@ -315,11 +315,11 @@ public class IoUtilTest extends HtsjdkTest {
 
     private List<Path> createJimsFiles(final String folderName, final List<String> fileNames) throws Exception {
         final List<Path> paths = new ArrayList<>(fileNames.size());
-        final Path folder = inMemmoryfileSystem.getPath(folderName);
+        final Path folder = inMemoryfileSystem.getPath(folderName);
         if (Files.notExists(folder)) Files.createDirectory(folder);
 
         for (final String f: fileNames) {
-            final Path p = inMemmoryfileSystem.getPath(folderName, f);
+            final Path p = inMemoryfileSystem.getPath(folderName, f);
             Files.createFile(p);
             paths.add(p);
         }
@@ -331,7 +331,7 @@ public class IoUtilTest extends HtsjdkTest {
     public Object[][] pathsForDeletePathThread() throws Exception {
         return new Object[][] {
                 {File.createTempFile("testDeletePathThread", "file").toPath()},
-                {Files.createFile(inMemmoryfileSystem.getPath("testDeletePathThread"))}
+                {Files.createFile(inMemoryfileSystem.getPath("testDeletePathThread"))}
         };
     }
 
@@ -346,12 +346,12 @@ public class IoUtilTest extends HtsjdkTest {
     public Object[][] pathsForWritableDirectory() throws Exception {
         return new Object[][] {
                 // non existent
-                {inMemmoryfileSystem.getPath("no_exists"), false},
+                {inMemoryfileSystem.getPath("no_exists"), false},
                 // non directory
-                {Files.createFile(inMemmoryfileSystem.getPath("testAssertDirectoryIsWritable_file")), false},
+                {Files.createFile(inMemoryfileSystem.getPath("testAssertDirectoryIsWritable_file")), false},
                 // TODO - how to do in inMemmoryFileSystem a non-writable directory?
                 // writable directory
-                {Files.createDirectory(inMemmoryfileSystem.getPath("testAssertDirectoryIsWritable_directory")), true}
+                {Files.createDirectory(inMemoryfileSystem.getPath("testAssertDirectoryIsWritable_directory")), true}
         };
     }
 


### PR DESCRIPTION
### Description

- New methods in IOUtil to support Paths
- Change DiskBackedQueue to use Paths
- Change SortingCollection to use Paths
- Change SortingLongCollection to use Paths

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

