### PR TITLE
Move bad coordinates check

### DIFF
--- a/src/main/java/htsjdk/tribble/readers/TabixReader.java
+++ b/src/main/java/htsjdk/tribble/readers/TabixReader.java
@@ -446,7 +446,7 @@ public class TabixReader {
     }
 
     /**
-     * Return
+     * Get an iterator for an interval specified by the sequence id and begin and end coordinates
      * @param tid Sequence id
      * @param beg beginning of interval, genomic coords
      * @param end end of interval, genomic coords
@@ -455,7 +455,7 @@ public class TabixReader {
     public Iterator query(final int tid, final int beg, final int end) {
         TPair64[] off, chunks;
         long min_off;
-        if(tid< 0 || tid>=this.mIndex.length) return EOF_ITERATOR;
+        if (tid < 0 || beg < 0 || end < 0 || tid >= this.mIndex.length) return EOF_ITERATOR;
         TIndex idx = mIndex[tid];
         int[] bins = new int[MAX_BIN];
         int i, l, n_off, n_bins = reg2bins(beg, end, bins);
@@ -514,7 +514,6 @@ public class TabixReader {
      */
     public Iterator query(final String reg) {
         int[] x = parseReg(reg);
-        if(x[0]<0) return EOF_ITERATOR;
         return query(x[0], x[1], x[2]);
     }
 
@@ -528,7 +527,6 @@ public class TabixReader {
     */
    public Iterator query(final String reg,int start,int end) {
        int tid=this.chr2tid(reg);
-       if(tid==-1) return EOF_ITERATOR;
        return query(tid, start, end);
    }
 

--- a/src/main/java/htsjdk/tribble/readers/TabixReader.java
+++ b/src/main/java/htsjdk/tribble/readers/TabixReader.java
@@ -447,15 +447,15 @@ public class TabixReader {
 
     /**
      * Get an iterator for an interval specified by the sequence id and begin and end coordinates
-     * @param tid Sequence id
-     * @param beg beginning of interval, genomic coords
-     * @param end end of interval, genomic coords
-     * @return an iterator over the lines within the specified interval
+     * @param tid Sequence id, if non-existent returns EOF_ITERATOR
+     * @param beg beginning of interval, genomic coords (0-based, closed-open)
+     * @param end end of interval, genomic coords (0-based, closed-open)
+     * @return an iterator over the specified interval
      */
     public Iterator query(final int tid, final int beg, final int end) {
         TPair64[] off, chunks;
         long min_off;
-        if (tid < 0 || beg < 0 || end < 0 || tid >= this.mIndex.length) return EOF_ITERATOR;
+        if (tid < 0 || beg < 0 || end <= 0 || tid >= this.mIndex.length) return EOF_ITERATOR;
         TIndex idx = mIndex[tid];
         int[] bins = new int[MAX_BIN];
         int i, l, n_off, n_bins = reg2bins(beg, end, bins);
@@ -510,7 +510,7 @@ public class TabixReader {
      *
      * @see #parseReg(String)
      * @param reg A region string of the form acceptable by {@link #parseReg(String)}
-     * @return
+     * @return an iterator over the specified interval
      */
     public Iterator query(final String reg) {
         int[] x = parseReg(reg);
@@ -518,15 +518,15 @@ public class TabixReader {
     }
 
     /**
-    *
+    * Get an iterator for an interval specified by the sequence id and begin and end coordinates
     * @see #parseReg(String)
     * @param reg a chromosome
     * @param start start interval
     * @param end end interval
-    * @return a tabix iterator
+    * @return a tabix iterator over the specified interval
     */
-   public Iterator query(final String reg,int start,int end) {
-       int tid=this.chr2tid(reg);
+   public Iterator query(final String reg, int start, int end) {
+       int tid = this.chr2tid(reg);
        return query(tid, start, end);
    }
 

--- a/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
@@ -96,16 +96,35 @@ public class TabixReaderTest extends HtsjdkTest {
         Assert.assertNotNull(iter);
         Assert.assertNull(iter.next());
 
-        iter=tabixReader.query("1",-1,Integer.MAX_VALUE);
+        iter = tabixReader.query("1", -1, Integer.MAX_VALUE);
         Assert.assertNotNull(iter);
         Assert.assertNull(iter.next());
 
-        iter=tabixReader.query("1",Integer.MAX_VALUE,-1);
+        iter = tabixReader.query("1", Integer.MAX_VALUE, -1);
         Assert.assertNotNull(iter);
+        Assert.assertNull(iter.next());
+
+        iter = tabixReader.query("1", Integer.MAX_VALUE, 0);
+        Assert.assertNotNull(iter);
+        Assert.assertNull(iter.next());
+
+        iter = tabixReader.query("1:100-1000");
+        Assert.assertNotNull(iter);
+        Assert.assertNotNull(iter.next());
         Assert.assertNull(iter.next());
 
         final int pos_snp_in_vcf_chr1=327;
-        
+
+        iter = tabixReader.query("1:" + pos_snp_in_vcf_chr1 + "-" + pos_snp_in_vcf_chr1);
+        Assert.assertNotNull(iter);
+        Assert.assertNotNull(iter.next());
+        Assert.assertNull(iter.next());
+
+        iter = tabixReader.query("1:" + pos_snp_in_vcf_chr1);
+        Assert.assertNotNull(iter);
+        Assert.assertNotNull(iter.next());
+        Assert.assertNull(iter.next());
+
         iter=tabixReader.query("1",pos_snp_in_vcf_chr1,pos_snp_in_vcf_chr1);
         Assert.assertNotNull(iter);
         Assert.assertNotNull(iter);
@@ -165,7 +184,6 @@ public class TabixReaderTest extends HtsjdkTest {
             nRecords++;
         }
         Assert.assertTrue(nRecords > 0);
-
     }
     
     /**

--- a/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
@@ -79,9 +79,12 @@ public class TabixReaderTest extends HtsjdkTest {
         iter=tabixReader.query("UN:1-100");
         Assert.assertNotNull(iter);
         Assert.assertNull(iter.next());
-       
-        
+
         iter=tabixReader.query("1:10-1");
+        Assert.assertNotNull(iter);
+        Assert.assertNull(iter.next());
+
+        iter=tabixReader.query("chr2:0-1");
         Assert.assertNotNull(iter);
         Assert.assertNull(iter.next());
  
@@ -92,7 +95,15 @@ public class TabixReaderTest extends HtsjdkTest {
         iter=tabixReader.query("1",Integer.MAX_VALUE-1,Integer.MAX_VALUE);
         Assert.assertNotNull(iter);
         Assert.assertNull(iter.next());
-        
+
+        iter=tabixReader.query("1",-1,Integer.MAX_VALUE);
+        Assert.assertNotNull(iter);
+        Assert.assertNull(iter.next());
+
+        iter=tabixReader.query("1",Integer.MAX_VALUE,-1);
+        Assert.assertNotNull(iter);
+        Assert.assertNull(iter.next());
+
         final int pos_snp_in_vcf_chr1=327;
         
         iter=tabixReader.query("1",pos_snp_in_vcf_chr1,pos_snp_in_vcf_chr1);
@@ -107,7 +118,6 @@ public class TabixReaderTest extends HtsjdkTest {
         iter=tabixReader.query("1",pos_snp_in_vcf_chr1+1,pos_snp_in_vcf_chr1+1);
         Assert.assertNotNull(iter);
         Assert.assertNull(iter.next());
-
     }
     
     


### PR DESCRIPTION
### Description

Follow up to #908.
Move the bad coordinates check to the root method, `public Iterator query(final String reg)`. If this public method is used by an application, the bad coordinates will return an `EOF_ITERATOR;`

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

