### PR TITLE
SAMFileWriterImpl improvements for subclasses

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileWriter.java
@@ -116,8 +116,12 @@ public class CRAMFileWriter extends SAMFileWriterImpl {
 
     @Override
     protected void writeHeader(final String textHeader) {
-        cramContainerStream.writeHeader(
-                new SAMTextHeaderCodec().decode(BufferedLineReader.fromString(textHeader),fileName != null ? fileName : null));
+        writeHeader(new SAMTextHeaderCodec().decode(BufferedLineReader.fromString(textHeader),fileName != null ? fileName : null));
+    }
+
+    @Override
+    protected void writeHeader(final SAMFileHeader header) {
+        cramContainerStream.writeHeader(header);
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -105,14 +105,14 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
      * before spilling to disk.  Must be called before setHeader().
      * @param maxRecordsInRam
      */
-    void setMaxRecordsInRam(final int maxRecordsInRam) {
+    protected void setMaxRecordsInRam(final int maxRecordsInRam) {
         if (this.header != null) {
             throw new IllegalStateException("setMaxRecordsInRam must be called before setHeader()");
         }
         this.maxRecordsInRam = maxRecordsInRam;
     }
 
-    int getMaxRecordsInRam() {
+    protected int getMaxRecordsInRam() {
         return maxRecordsInRam;
     }
 
@@ -121,13 +121,13 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
      * for spilling to disk.  Must be called before setHeader().
      * @param tmpDir path to the temporary directory
      */
-    void setTempDirectory(final File tmpDir) {
+    protected void setTempDirectory(final File tmpDir) {
         if (tmpDir!=null) {
             this.tmpDir = tmpDir;
         }
     }
 
-    File getTempDirectory() {
+    protected File getTempDirectory() {
         return tmpDir;
     }
 

--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -146,11 +146,7 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
         }
         header.setSortOrder(sortOrder);
 
-        writeHeader(() -> {
-            final StringWriter headerTextBuffer = new StringWriter();
-            new SAMTextHeaderCodec().encode(headerTextBuffer, header);
-            return headerTextBuffer.toString();
-        });
+        writeHeader(header);
 
         if (presorted) {
             if (sortOrder.equals(SAMFileHeader.SortOrder.unsorted)) {
@@ -245,7 +241,7 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
     /**
      * Write the header to disk.  Header object is available via getHeader().
      * @param textHeader for convenience if the implementation needs it.
-     * @deprecated since 06/2017. {@link #writeHeader(Supplier)} is preferred for avoid String construction if not need it.
+     * @deprecated since 06/2018. {@link #writeHeader(SAMFileHeader)} is preferred for avoid String construction if not need it.
      */
     @Deprecated
     abstract protected void writeHeader(String textHeader);
@@ -253,12 +249,17 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
     /**
      * Write the header to disk. Header object is available via getHeader().
      *
-     * <p>Note: default implementation uses {@link #writeHeader(String)}.
+     * <p>IMPORTANT: this method will be abstract once {@link #writeHeader(String)} is removed.
      *
-     * @param textHeaderSupplier for convenience if the implementation needs it.
+     * <p>Note: default implementation uses {@link SAMTextHeaderCodec#encode} and calls
+     * {@link #writeHeader(String)}.
+     *
+     * @param header object to write.
      */
-    protected void writeHeader(Supplier<String> textHeaderSupplier) {
-        writeHeader(textHeaderSupplier.get());
+    protected void writeHeader(final SAMFileHeader header) {
+        final StringWriter headerTextBuffer = new StringWriter();
+        new SAMTextHeaderCodec().encode(headerTextBuffer, header);
+        writeHeader(headerTextBuffer.toString());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMTextWriter.java
+++ b/src/main/java/htsjdk/samtools/SAMTextWriter.java
@@ -198,6 +198,11 @@ public class SAMTextWriter extends SAMFileWriterImpl {
         }
     }
 
+    @Override
+    protected void writeHeader(final SAMFileHeader header) {
+        new SAMTextHeaderCodec().encode(out, header);
+    }
+
     /**
      * Do any required flushing here.
      */


### PR DESCRIPTION
### Description

This PR addresses two issues with `SAMFileWriterImpl`:

* When sub-classing, it is difficult to access to some important features unless the class lives in the same pacakge. Concretely, this are the maximum records in RAM and the temporary directory. This PR makes this methods and the getters protected.
* While adding a header to the writer the current implementation generates the text header always, even if it is not used. This is rather inefficient for writers where the header should not be written down for whatever reason. This PR deprecates the abstract method `writeHeader` for a `String`in favor of a new one with a `Supplier` (which defaults in the previous one).

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

