### PR TITLE
ParallelBlockCompressedOutputStream

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -23,8 +23,10 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.samtools.util.AbstractBlockCompressedOutputStream;
 import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.ParallelBlockCompressedOutputStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 
@@ -42,35 +44,50 @@ class BAMFileWriter extends SAMFileWriterImpl {
 
     private final BinaryCodec outputBinaryCodec;
     private BAMRecordCodec bamRecordCodec = null;
-    private final BlockCompressedOutputStream blockCompressedOutputStream;
+    private final AbstractBlockCompressedOutputStream blockCompressedOutputStream;
     private BAMIndexer bamIndexer = null;
 
-    protected BAMFileWriter(final File path) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(path);
+    protected BAMFileWriter(final File path, boolean createIndex) {
+        blockCompressedOutputStream = Defaults.ZIP_THREADS > 0 && !createIndex ?
+                new ParallelBlockCompressedOutputStream(path) :
+                new BlockCompressedOutputStream(path);
+
         outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
         outputBinaryCodec.setOutputFileName(path.getAbsolutePath());
     }
 
-    protected BAMFileWriter(final File path, final int compressionLevel) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(path, compressionLevel);
+    protected BAMFileWriter(final File path, final int compressionLevel, boolean createIndex) {
+        blockCompressedOutputStream = Defaults.ZIP_THREADS > 0 && !createIndex ?
+                new ParallelBlockCompressedOutputStream(path, compressionLevel) :
+                new BlockCompressedOutputStream(path, compressionLevel);
+
         outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
         outputBinaryCodec.setOutputFileName(path.getAbsolutePath());
     }
 
-    protected BAMFileWriter(final OutputStream os, final File file) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file);
+    protected BAMFileWriter(final OutputStream os, final File file, boolean createIndex) {
+        blockCompressedOutputStream = Defaults.ZIP_THREADS > 0 && !createIndex ?
+                new ParallelBlockCompressedOutputStream(os, file) :
+                new BlockCompressedOutputStream(os, file);
+
         outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }
 
-    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file, compressionLevel);
+    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel, boolean createIndex) {
+        blockCompressedOutputStream = Defaults.ZIP_THREADS > 0 && !createIndex ?
+                new ParallelBlockCompressedOutputStream(os, file, compressionLevel) :
+                new BlockCompressedOutputStream(os, file, compressionLevel);
+
         outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }
 
-    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file, compressionLevel, deflaterFactory);
+    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel,
+                            final DeflaterFactory deflaterFactory, boolean createIndex) {
+        blockCompressedOutputStream = Defaults.ZIP_THREADS > 0 && !createIndex ?
+                new ParallelBlockCompressedOutputStream(os, file, compressionLevel, deflaterFactory) :
+                new BlockCompressedOutputStream(os, file, compressionLevel, deflaterFactory);
         outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }

--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -15,7 +15,7 @@ import java.util.TreeMap;
  */
 public class Defaults {
     private static Log log = Log.getInstance(Defaults.class);
-    
+
     /** Should BAM index files be created when writing out coordinate sorted BAM files?  Default = false. */
     public static final boolean CREATE_INDEX;
 
@@ -84,6 +84,7 @@ public class Defaults {
      */
     public static final boolean SRA_LIBRARIES_DOWNLOAD;
 
+    public static final int ZIP_THREADS;
 
     static {
         CREATE_INDEX = getBooleanProperty("create_index", false);
@@ -104,6 +105,7 @@ public class Defaults {
         CUSTOM_READER_FACTORY = getStringProperty("custom_reader", "");
         SAM_FLAG_FIELD_FORMAT = SamFlagField.valueOf(getStringProperty("sam_flag_field_format", SamFlagField.DECIMAL.name()));
         SRA_LIBRARIES_DOWNLOAD = getBooleanProperty("sra_libraries_download", false);
+        ZIP_THREADS = getIntProperty("zip_threads", 0);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -264,7 +264,7 @@ public class SAMFileWriterFactory implements Cloneable {
             }
             OutputStream os = IOUtil.maybeBufferOutputStream(new FileOutputStream(outputFile, false), bufferSize);
             if (createMd5File) os = new Md5CalculatingOutputStream(os, new File(outputFile.getAbsolutePath() + ".md5"));
-            final BAMFileWriter ret = new BAMFileWriter(os, outputFile, compressionLevel, deflaterFactory);
+            final BAMFileWriter ret = new BAMFileWriter(os, outputFile, compressionLevel, deflaterFactory, createIndex);
             final boolean createIndex = this.createIndex && IOUtil.isRegularPath(outputFile);
             if (this.createIndex && !createIndex) {
                 log.warn("Cannot create index for BAM because output file is not a regular file: " + outputFile.getAbsolutePath());
@@ -347,7 +347,7 @@ public class SAMFileWriterFactory implements Cloneable {
      */
 
     public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final OutputStream stream) {
-        return initWriter(header, presorted, new BAMFileWriter(stream, null, this.getCompressionLevel(), this.deflaterFactory));
+        return initWriter(header, presorted, new BAMFileWriter(stream, null, this.getCompressionLevel(), this.deflaterFactory, false));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/AbstractBlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractBlockCompressedOutputStream.java
@@ -1,0 +1,288 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package htsjdk.samtools.util;
+
+import htsjdk.samtools.Defaults;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.zip.Deflater;
+
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.DEFAULT_COMPRESSION_LEVEL;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.GZIP_ID1;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.GZIP_ID2;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.GZIP_XLEN;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.GZIP_XFL;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.GZIP_FLG;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.BLOCK_HEADER_LENGTH;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.GZIP_CM_DEFLATE;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.GZIP_OS_UNKNOWN;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.BGZF_ID1;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.BGZF_ID2;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.BGZF_LEN;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.BLOCK_FOOTER_LENGTH;
+import static htsjdk.samtools.util.BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK;
+
+/**
+ * Writer for a file that is a series of gzip blocks (BGZF format).  The caller just treats it as an
+ * OutputStream, and under the covers a gzip block is written when the amount of uncompressed as-yet-unwritten
+ * bytes reaches a threshold.
+ *
+ * The advantage of BGZF over conventional gzip is that BGZF allows for seeking without having to scan through
+ * the entire file up to the position being sought.
+ *
+ * Note that the flush() method should not be called by client
+ * unless you know what you're doing, because it forces a gzip block to be written even if the
+ * number of buffered bytes has not reached threshold.  close(), on the other hand, must be called
+ * when done writing in order to force the last gzip block to be written.
+ *
+ * c.f. http://samtools.sourceforge.net/SAM1.pdf for details of BGZF file format.
+ */
+public abstract class AbstractBlockCompressedOutputStream extends OutputStream implements LocationAware {
+
+    protected static DeflaterFactory defaultDeflaterFactory = new DeflaterFactory();
+    protected static int defaultCompressionLevel = DEFAULT_COMPRESSION_LEVEL;
+
+    protected final BinaryCodec codec;
+    protected final byte[] uncompressedBuffer = new byte[DEFAULT_UNCOMPRESSED_BLOCK_SIZE];
+    protected int numUncompressedBytes = 0;
+    protected long mBlockAddress = 0;
+    protected File file = null;
+
+    // Really a local variable, but allocate once to reduce GC burden.
+    protected final byte[] singleByteArray = new byte[1];
+
+
+    /**
+     * Sets the default {@link DeflaterFactory} that will be used for all instances unless specified otherwise in the constructor.
+     * If this method is not called the default is a factory that will create the JDK {@link Deflater}.
+     * @param deflaterFactory non-null default factory.
+     */
+    public static void setDefaultDeflaterFactory(final DeflaterFactory deflaterFactory) {
+        if (deflaterFactory == null) {
+            throw new IllegalArgumentException("null deflaterFactory");
+        }
+        defaultDeflaterFactory = deflaterFactory;
+    }
+
+    public static DeflaterFactory getDefaultDeflaterFactory() {
+        return defaultDeflaterFactory;
+    }
+
+    /**
+     * Sets the GZip compression level for subsequent BlockCompressedOutputStream object creation
+     * that do not specify the compression level.
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     */
+    public static void setDefaultCompressionLevel(final int compressionLevel) {
+        if (compressionLevel < Deflater.NO_COMPRESSION || compressionLevel > Deflater.BEST_COMPRESSION) {
+            throw new IllegalArgumentException("Invalid compression level: " + compressionLevel);
+        }
+        defaultCompressionLevel = compressionLevel;
+    }
+
+    public static int getDefaultCompressionLevel() {
+        return defaultCompressionLevel;
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     * @param file file to output
+     */
+    public AbstractBlockCompressedOutputStream(final File file) {
+        this.file = file;
+        codec = new BinaryCodec(file, true);
+    }
+
+
+    /**
+     * Prepare to compress at the given compression level
+     * @param os output stream opened on the file
+     * @param file file to output
+     */
+    public AbstractBlockCompressedOutputStream(final OutputStream os, final File file) {
+        this.file = file;
+        codec = new BinaryCodec(os);
+        if (file != null) {
+            codec.setOutputFileName(file.getAbsolutePath());
+        }
+    }
+
+    /**
+     * Create new {@link AbstractBlockCompressedOutputStream} or return exactly the same if it already the {@link AbstractBlockCompressedOutputStream}
+     * @param location May be null.  Used for error messages, and for checking file termination.
+     * @param output May or not already be a BlockCompressedOutputStream.
+     * @return A BlockCompressedOutputStream, either by wrapping the given OutputStream, or by casting if it already
+     *         is a BCOS.
+     */
+    public static AbstractBlockCompressedOutputStream maybeBgzfWrapOutputStream(final File location, OutputStream output) {
+        if (!(output instanceof AbstractBlockCompressedOutputStream)) {
+                return Defaults.ZIP_THREADS > 0
+                        ? new ParallelBlockCompressedOutputStream(output, location)
+                        : new BlockCompressedOutputStream(output, location);
+        } else {
+        return (AbstractBlockCompressedOutputStream)output;
+        }
+    }
+
+    /**
+     * Writes b.length bytes from the specified byte array to this output stream. The general contract for write(b)
+     * is that it should have exactly the same effect as the call write(b, 0, b.length).
+     * @param bytes the data
+     */
+    @Override
+    public void write(final byte[] bytes) throws IOException {
+        write(bytes, 0, bytes.length);
+    }
+
+    /**
+     * Writes len bytes from the specified byte array starting at offset off to this output stream. The general
+     * contract for write(b, off, len) is that some of the bytes in the array b are written to the output stream in order;
+     * element b[off] is the first byte written and b[off+len-1] is the last byte written by this operation.
+     *
+     * @param bytes the data
+     * @param startIndex the start offset in the data
+     * @param numBytes the number of bytes to write
+     */
+    @Override
+    public void write(final byte[] bytes, int startIndex, int numBytes) throws IOException {
+        assert(numUncompressedBytes < uncompressedBuffer.length);
+        while (numBytes > 0) {
+            final int bytesToWrite = Math.min(uncompressedBuffer.length - numUncompressedBytes, numBytes);
+            System.arraycopy(bytes, startIndex, uncompressedBuffer, numUncompressedBytes, bytesToWrite);
+            numUncompressedBytes += bytesToWrite;
+            startIndex += bytesToWrite;
+            numBytes -= bytesToWrite;
+            assert(numBytes >= 0);
+            if (numUncompressedBytes == uncompressedBuffer.length) {
+                deflateBlock();
+            }
+        }
+    }
+
+    /**
+     * WARNING: flush() affects the output format, because it causes the current contents of uncompressedBuffer
+     * to be compressed and written, even if it isn't full.  Unless you know what you're doing, don't call flush().
+     * Instead, call close(), which will flush any unwritten data before closing the underlying stream.
+     *
+     */
+    @Override
+    public void flush() throws IOException {
+        while (numUncompressedBytes > 0) {
+            deflateBlock();
+        }
+        codec.getOutputStream().flush();
+    }
+
+    /**
+     * close() must be called in order to flush any remaining buffered bytes.  An unclosed file will likely be
+     * defective.
+     *
+     */
+    @Override
+    public void close() throws IOException {
+        flush();
+        // For debugging...
+        // if (numberOfThrottleBacks > 0) {
+        //     System.err.println("In BlockCompressedOutputStream, had to throttle back " + numberOfThrottleBacks +
+        //                        " times for file " + codec.getOutputFileName());
+        // }
+        codec.writeBytes(EMPTY_GZIP_BLOCK);
+        codec.close();
+        // Can't re-open something that is not a regular file, e.g. a named pipe or an output stream
+        if (this.file == null || !this.file.isFile() || !Files.isRegularFile(this.file.toPath())) return;
+        if (BlockCompressedInputStream.checkTermination(this.file) !=
+                BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) {
+            throw new IOException("Terminator block not found after closing BGZF file " + this.file);
+        }
+    }
+
+    /**
+     * Writes the specified byte to this output stream. The general contract for write is that one byte is written
+     * to the output stream. The byte to be written is the eight low-order bits of the argument b.
+     * The 24 high-order bits of b are ignored.
+     * @param bite
+     * @throws IOException
+     */
+    @Override
+    public void write(final int bite) throws IOException {
+        singleByteArray[0] = (byte)bite;
+        write(singleByteArray);
+    }
+
+    /** Encode virtual file pointer
+     * Upper 48 bits is the byte offset into the compressed stream of a block.
+     * Lower 16 bits is the byte offset into the uncompressed stream inside the block.
+     */
+    public long getFilePointer(){
+        return BlockCompressedFilePointerUtil.makeFilePointer(mBlockAddress, numUncompressedBytes);
+    }
+
+    @Override
+    public long getPosition() {
+        return getFilePointer();
+    }
+
+    /**
+     * Attempt to write the data in uncompressedBuffer to the underlying file in a gzip block.
+     * If the entire uncompressedBuffer does not fit in the maximum allowed size, reduce the amount
+     * of data to be compressed, and slide the excess down in uncompressedBuffer so it can be picked
+     * up in the next deflate event.
+     * @return size of gzip block that was written.
+     */
+    protected abstract int deflateBlock();
+
+    /**
+     * Writes the entire gzip block, assuming the compressed data is stored in uncompressedBuffer
+     * @return  size of gzip block that was written.
+     */
+    protected int writeGzipBlock(final byte[] compressedBuffer, final int compressedSize, final int uncompressedSize, final long crc) {
+        // Init gzip header
+        codec.writeByte(GZIP_ID1);
+        codec.writeByte(GZIP_ID2);
+        codec.writeByte(GZIP_CM_DEFLATE);
+        codec.writeByte(GZIP_FLG);
+        codec.writeInt(0); // Modification time
+        codec.writeByte(GZIP_XFL);
+        codec.writeByte(GZIP_OS_UNKNOWN);
+        codec.writeShort(GZIP_XLEN);
+        codec.writeByte(BGZF_ID1);
+        codec.writeByte(BGZF_ID2);
+        codec.writeShort(BGZF_LEN);
+        final int totalBlockSize = compressedSize + BLOCK_HEADER_LENGTH +
+                BLOCK_FOOTER_LENGTH;
+
+        // I don't know why we store block size - 1, but that is what the spec says
+        codec.writeShort((short)(totalBlockSize - 1));
+        codec.writeBytes(compressedBuffer, 0, compressedSize);
+        codec.writeInt((int)crc);
+        codec.writeInt(uncompressedSize);
+        return totalBlockSize;
+    }
+}

--- a/src/main/java/htsjdk/samtools/util/AsyncBufferedIterator.java
+++ b/src/main/java/htsjdk/samtools/util/AsyncBufferedIterator.java
@@ -228,13 +228,13 @@ public class AsyncBufferedIterator<T> implements CloseableIterator<T> {
         }
     }
     /**
-     * Block of records from the underlying iterator 
+     * Block of records from the underlying iterator
      */
     private static class IteratorBuffer<U> implements Iterator<U> {
         private final Throwable exception;
         private final Iterator<U> it;
         public IteratorBuffer(Iterable<U> it) {
-            this.it = it != null ? it.iterator() : null;;
+            this.it = it != null ? it.iterator() : null;
             this.exception = null;
         }
 

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -26,72 +26,19 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 
 /**
- * Writer for a file that is a series of gzip blocks (BGZF format).  The caller just treats it as an
- * OutputStream, and under the covers a gzip block is written when the amount of uncompressed as-yet-unwritten
- * bytes reaches a threshold.
+ * Single threaded realisation of {@link AbstractBlockCompressedOutputStream}
+ * Each block compressed one-by-one synchronously.
  *
- * The advantage of BGZF over conventional gzip is that BGZF allows for seeking without having to scan through
- * the entire file up to the position being sought.
- *
- * Note that the flush() method should not be called by client
- * unless you know what you're doing, because it forces a gzip block to be written even if the
- * number of buffered bytes has not reached threshold.  close(), on the other hand, must be called
- * when done writing in order to force the last gzip block to be written.
- *
- * c.f. http://samtools.sourceforge.net/SAM1.pdf for details of BGZF file format.
+ * @see AbstractBlockCompressedOutputStream
  */
 public class BlockCompressedOutputStream
-        extends OutputStream
-        implements LocationAware
-{
+        extends AbstractBlockCompressedOutputStream {
 
-    private static final Log log = Log.getInstance(BlockCompressedOutputStream.class);
-
-    private static int defaultCompressionLevel = BlockCompressedStreamConstants.DEFAULT_COMPRESSION_LEVEL;
-    private static DeflaterFactory defaultDeflaterFactory = new DeflaterFactory();
-
-    /**
-     * Sets the GZip compression level for subsequent BlockCompressedOutputStream object creation
-     * that do not specify the compression level.
-     * @param compressionLevel 1 <= compressionLevel <= 9
-     */
-    public static void setDefaultCompressionLevel(final int compressionLevel) {
-        if (compressionLevel < Deflater.NO_COMPRESSION || compressionLevel > Deflater.BEST_COMPRESSION) {
-            throw new IllegalArgumentException("Invalid compression level: " + compressionLevel);
-        }
-        defaultCompressionLevel = compressionLevel;
-    }
-
-    public static int getDefaultCompressionLevel() {
-        return defaultCompressionLevel;
-    }
-
-    /**
-     * Sets the default {@link DeflaterFactory} that will be used for all instances unless specified otherwise in the constructor.
-     * If this method is not called the default is a factory that will create the JDK {@link Deflater}.
-     * @param deflaterFactory non-null default factory.
-     */
-    public static void setDefaultDeflaterFactory(final DeflaterFactory deflaterFactory) {
-        if (deflaterFactory == null) {
-            throw new IllegalArgumentException("null deflaterFactory");
-        }
-        defaultDeflaterFactory = deflaterFactory;
-    }
-
-    public static DeflaterFactory getDefaultDeflaterFactory() {
-        return defaultDeflaterFactory;
-    }
-
-    private final BinaryCodec codec;
-    private final byte[] uncompressedBuffer = new byte[BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE];
-    private int numUncompressedBytes = 0;
     private final byte[] compressedBuffer =
             new byte[BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE -
                     BlockCompressedStreamConstants.BLOCK_HEADER_LENGTH];
@@ -111,12 +58,6 @@ public class BlockCompressedOutputStream
     // so just use JDK standard.
     private final Deflater noCompressionDeflater = new Deflater(Deflater.NO_COMPRESSION, true);
     private final CRC32 crc32 = new CRC32();
-    private File file = null;
-    private long mBlockAddress = 0;
-
-
-    // Really a local variable, but allocate once to reduce GC burden.
-    private final byte[] singleByteArray = new byte[1];
 
     /**
      * Uses default compression level, which is 5 unless changed by setCompressionLevel
@@ -161,10 +102,8 @@ public class BlockCompressedOutputStream
      * @param deflaterFactory custom factory to create deflaters (overrides the default)
      */
     public BlockCompressedOutputStream(final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        this.file = file;
-        codec = new BinaryCodec(file, true);
+       super(file);
         deflater = deflaterFactory.makeDeflater(compressionLevel, true);
-        log.debug("Using deflater: " + deflater.getClass().getSimpleName());
     }
 
     /**
@@ -194,136 +133,12 @@ public class BlockCompressedOutputStream
      * @param deflaterFactory custom factory to create deflaters (overrides the default)
      */
     public BlockCompressedOutputStream(final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        this.file = file;
-        codec = new BinaryCodec(os);
-        if (file != null) {
-            codec.setOutputFileName(file.getAbsolutePath());
-        }
+        super(os, file);
         deflater = deflaterFactory.makeDeflater(compressionLevel, true);
-        log.debug("Using deflater: " + deflater.getClass().getSimpleName());
-    }
-
-    /**
-     *
-     * @param location May be null.  Used for error messages, and for checking file termination.
-     * @param output May or not already be a BlockCompressedOutputStream.
-     * @return A BlockCompressedOutputStream, either by wrapping the given OutputStream, or by casting if it already
-     *         is a BCOS.
-     */
-    public static BlockCompressedOutputStream maybeBgzfWrapOutputStream(final File location, OutputStream output) {
-        if (!(output instanceof BlockCompressedOutputStream)) {
-           return new BlockCompressedOutputStream(output, location);
-        } else {
-           return (BlockCompressedOutputStream)output;
-        }
-    }
-
-    /**
-     * Writes b.length bytes from the specified byte array to this output stream. The general contract for write(b)
-     * is that it should have exactly the same effect as the call write(b, 0, b.length).
-     * @param bytes the data
-     */
-    @Override
-    public void write(final byte[] bytes) throws IOException {
-        write(bytes, 0, bytes.length);
-    }
-
-    /**
-     * Writes len bytes from the specified byte array starting at offset off to this output stream. The general
-     * contract for write(b, off, len) is that some of the bytes in the array b are written to the output stream in order;
-     * element b[off] is the first byte written and b[off+len-1] is the last byte written by this operation.
-     *
-     * @param bytes the data
-     * @param startIndex the start offset in the data
-     * @param numBytes the number of bytes to write
-     */
-    @Override
-    public void write(final byte[] bytes, int startIndex, int numBytes) throws IOException {
-        assert(numUncompressedBytes < uncompressedBuffer.length);
-        while (numBytes > 0) {
-            final int bytesToWrite = Math.min(uncompressedBuffer.length - numUncompressedBytes, numBytes);
-            System.arraycopy(bytes, startIndex, uncompressedBuffer, numUncompressedBytes, bytesToWrite);
-            numUncompressedBytes += bytesToWrite;
-            startIndex += bytesToWrite;
-            numBytes -= bytesToWrite;
-            assert(numBytes >= 0);
-            if (numUncompressedBytes == uncompressedBuffer.length) {
-                deflateBlock();
-            }
-        }
-    }
-
-    /**
-     * WARNING: flush() affects the output format, because it causes the current contents of uncompressedBuffer
-     * to be compressed and written, even if it isn't full.  Unless you know what you're doing, don't call flush().
-     * Instead, call close(), which will flush any unwritten data before closing the underlying stream.
-     *
-     */
-    @Override
-    public void flush() throws IOException {
-        while (numUncompressedBytes > 0) {
-            deflateBlock();
-        }
-        codec.getOutputStream().flush();
-    }
-
-    /**
-     * close() must be called in order to flush any remaining buffered bytes.  An unclosed file will likely be
-     * defective.
-     *
-     */
-    @Override
-    public void close() throws IOException {
-        flush();
-        // For debugging...
-        // if (numberOfThrottleBacks > 0) {
-        //     System.err.println("In BlockCompressedOutputStream, had to throttle back " + numberOfThrottleBacks +
-        //                        " times for file " + codec.getOutputFileName());
-        // }
-        codec.writeBytes(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK);
-        codec.close();
-        // Can't re-open something that is not a regular file, e.g. a named pipe or an output stream
-        if (this.file == null || !this.file.isFile() || !Files.isRegularFile(this.file.toPath())) return;
-        if (BlockCompressedInputStream.checkTermination(this.file) !=
-                BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) {
-            throw new IOException("Terminator block not found after closing BGZF file " + this.file);
-        }
-    }
-
-    /**
-     * Writes the specified byte to this output stream. The general contract for write is that one byte is written
-     * to the output stream. The byte to be written is the eight low-order bits of the argument b.
-     * The 24 high-order bits of b are ignored.
-     * @param bite
-     * @throws IOException
-     */
-    @Override
-    public void write(final int bite) throws IOException {
-        singleByteArray[0] = (byte)bite;
-        write(singleByteArray);
-    }
-
-    /** Encode virtual file pointer
-     * Upper 48 bits is the byte offset into the compressed stream of a block.
-     * Lower 16 bits is the byte offset into the uncompressed stream inside the block.
-     */
-    public long getFilePointer(){
-        return BlockCompressedFilePointerUtil.makeFilePointer(mBlockAddress, numUncompressedBytes);
     }
 
     @Override
-    public long getPosition() {
-        return getFilePointer();
-    }
-
-    /**
-     * Attempt to write the data in uncompressedBuffer to the underlying file in a gzip block.
-     * If the entire uncompressedBuffer does not fit in the maximum allowed size, reduce the amount
-     * of data to be compressed, and slide the excess down in uncompressedBuffer so it can be picked
-     * up in the next deflate event.
-     * @return size of gzip block that was written.
-     */
-    private int deflateBlock() {
+    protected int deflateBlock() {
         if (numUncompressedBytes == 0) {
             return 0;
         }
@@ -349,8 +164,8 @@ public class BlockCompressedOutputStream
         crc32.reset();
         crc32.update(uncompressedBuffer, 0, bytesToCompress);
 
-        final int totalBlockSize = writeGzipBlock(compressedSize, bytesToCompress, crc32.getValue());
-        assert(bytesToCompress <= numUncompressedBytes);
+        final int totalBlockSize = writeGzipBlock(this.compressedBuffer, compressedSize, bytesToCompress, crc32.getValue());
+        assert (bytesToCompress <= numUncompressedBytes);
 
         // Clear out from uncompressedBuffer the data that was written
         if (bytesToCompress == numUncompressedBytes) {
@@ -364,31 +179,4 @@ public class BlockCompressedOutputStream
         return totalBlockSize;
     }
 
-    /**
-     * Writes the entire gzip block, assuming the compressed data is stored in compressedBuffer
-     * @return  size of gzip block that was written.
-     */
-    private int writeGzipBlock(final int compressedSize, final int uncompressedSize, final long crc) {
-        // Init gzip header
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_ID1);
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_ID2);
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_CM_DEFLATE);
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_FLG);
-        codec.writeInt(0); // Modification time
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_XFL);
-        codec.writeByte(BlockCompressedStreamConstants.GZIP_OS_UNKNOWN);
-        codec.writeShort(BlockCompressedStreamConstants.GZIP_XLEN);
-        codec.writeByte(BlockCompressedStreamConstants.BGZF_ID1);
-        codec.writeByte(BlockCompressedStreamConstants.BGZF_ID2);
-        codec.writeShort(BlockCompressedStreamConstants.BGZF_LEN);
-        final int totalBlockSize = compressedSize + BlockCompressedStreamConstants.BLOCK_HEADER_LENGTH +
-                BlockCompressedStreamConstants.BLOCK_FOOTER_LENGTH;
-
-        // I don't know why we store block size - 1, but that is what the spec says
-        codec.writeShort((short)(totalBlockSize - 1));
-        codec.writeBytes(compressedBuffer, 0, compressedSize);
-        codec.writeInt((int)crc);
-        codec.writeInt(uncompressedSize);
-        return totalBlockSize;
-    }
 }

--- a/src/main/java/htsjdk/samtools/util/ParallelBlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/ParallelBlockCompressedOutputStream.java
@@ -1,0 +1,312 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.util;
+
+import htsjdk.samtools.Defaults;
+import htsjdk.samtools.util.zip.DeflaterFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+
+/**
+ * Parallel implementation of BAM file compression.
+ * <p>
+ * The main idea is to compress blocks of a BAM file asynchronously. After a next 64K block filled,
+ * it sends to the first available processor core, put future result into the buffer and continues to fill a next 64K block of data.
+ * When buffer of futures with compressed block is full next writing task will be submitted.
+ * <p>
+ *
+ * @see AbstractBlockCompressedOutputStream
+ */
+public class ParallelBlockCompressedOutputStream extends AbstractBlockCompressedOutputStream {
+
+    private static final ExecutorService gzipExecutorService = Executors.newFixedThreadPool(
+            Defaults.ZIP_THREADS,
+            r -> {
+                Thread t = Executors.defaultThreadFactory().newThread(r);
+                t.setDaemon(true);
+                return t;
+            }
+    );
+
+    private static final Void NOTHING = null;
+    private static final int BLOCKS_PACK_SIZE = 16 * Defaults.ZIP_THREADS;
+
+    private DeflaterFactory deflaterFactory;
+    private final int compressionLevel;
+
+    List<Future<CompressedBlock>> compressedBlocksInFuture = new ArrayList<>(BLOCKS_PACK_SIZE);
+    private CompletableFuture<Void> writeBlocksTask = CompletableFuture.completedFuture(NOTHING);
+
+
+    public ParallelBlockCompressedOutputStream(final String filename) {
+        this(filename, defaultCompressionLevel);
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     */
+    public ParallelBlockCompressedOutputStream(final String filename, final int compressionLevel) {
+        this(new File(filename), compressionLevel);
+    }
+
+    /**
+     * Uses default compression level, which is 5 unless changed by setCompressionLevel
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #ParallelBlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public ParallelBlockCompressedOutputStream(final File file) {
+        this(file, defaultCompressionLevel);
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #ParallelBlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public ParallelBlockCompressedOutputStream(final File file, final int compressionLevel) {
+        this(file, compressionLevel, defaultDeflaterFactory);
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     * @param compressionLevel 1 <= compressionLevel <= 9
+     * @param deflaterFactory custom factory to create deflaters (overrides the default)
+     */
+    public ParallelBlockCompressedOutputStream(final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
+        super(file);
+        this.deflaterFactory = deflaterFactory;
+        this.compressionLevel = compressionLevel;
+    }
+
+    /**
+     * Uses default compression level, which is 5 unless changed by setCompressionLevel
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #ParallelBlockCompressedOutputStream(OutputStream, File, int, DeflaterFactory)} to specify a custom factory.
+     *
+     * @param file may be null
+     */
+    public ParallelBlockCompressedOutputStream(final OutputStream os, final File file) {
+        this(os, file, defaultCompressionLevel);
+    }
+
+    /**
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #ParallelBlockCompressedOutputStream(OutputStream, File, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public ParallelBlockCompressedOutputStream(final OutputStream os, final File file, final int compressionLevel) {
+        this(os, file, compressionLevel, defaultDeflaterFactory);
+    }
+
+    /**
+     * Creates the output stream.
+     * @param os output stream to create a BlockCompressedOutputStream from
+     * @param file file to which to write the output or null if not available
+     * @param compressionLevel the compression level (0-9)
+     * @param deflaterFactory custom factory to create deflaters (overrides the default)
+     */
+    public ParallelBlockCompressedOutputStream(final OutputStream os, final File file, final int compressionLevel,
+                                               DeflaterFactory deflaterFactory) {
+        super(os, file);
+        this.deflaterFactory = deflaterFactory;
+        this.compressionLevel = compressionLevel;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        while (numUncompressedBytes > 0) {
+            deflateBlock();
+        }
+        submitSpillTask();
+        writeBlocksTask.join();
+        // gzipDeflatingWorkers must be empty then flushing
+        codec.getOutputStream().flush();
+    }
+
+    /**
+     * @see AbstractBlockCompressedOutputStream#getFilePointer();
+     * This implementation of get file pointer is blocking, because we have to wait to the end
+     * of writing all provided data for getting right pointer.
+     */
+    @Override
+    public long getFilePointer() {
+        // we have to wait all writing tasks in other case we risk to get wrong mBlockAddress
+        submitSpillTask();
+        writeBlocksTask.join();
+        return super.getFilePointer();
+    }
+
+    /**
+     * Submit new deflate task of the current uncompressed byte buffer.
+     */
+    @Override
+    protected int deflateBlock() {
+        if (numUncompressedBytes == 0) {
+            return 0;
+        }
+        submitDeflateTask();
+        numUncompressedBytes = 0;
+
+        if (compressedBlocksInFuture.size() == BLOCKS_PACK_SIZE) {
+            submitSpillTask();
+        }
+
+        return 0;
+    }
+
+    void submitDeflateTask() {
+        UncompressedBlock uncompressedBlock = new UncompressedBlock(
+                Arrays.copyOf(this.uncompressedBuffer, numUncompressedBytes),
+                numUncompressedBytes
+        );
+        compressedBlocksInFuture.add(
+                CompletableFuture.supplyAsync(new BlockZipper(uncompressedBlock), gzipExecutorService)
+        );
+    }
+
+    void submitSpillTask() {
+        writeBlocksTask.join();
+        writeBlocksTask = CompletableFuture.runAsync(new BlocksSpiller(compressedBlocksInFuture), gzipExecutorService);
+        compressedBlocksInFuture = new ArrayList<>(BLOCKS_PACK_SIZE);
+    }
+
+    /**
+     * Inner class which represent task for spilling block which was passed
+     * */
+    private class BlocksSpiller implements Runnable {
+
+        private List<Future<CompressedBlock>> compressedBlocks;
+
+        BlocksSpiller(List<Future<CompressedBlock>> compressedBlocks) {
+            this.compressedBlocks = compressedBlocks;
+        }
+
+        @Override
+        public void run() {
+            for (Future<CompressedBlock> compressedBlockFuture : compressedBlocks) {
+                try {
+                    CompressedBlock compressedBlock = compressedBlockFuture.get();
+                    mBlockAddress += writeGzipBlock(
+                            compressedBlock.compressedBuffer,
+                            compressedBlock.compressedSize,
+                            compressedBlock.bytesToCompress,
+                            compressedBlock.crc32Value
+                    );
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeIOException("Enable to write Gzip block", e);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Inner class which represent task for zipping block which was passed
+     * */
+    private class BlockZipper implements Supplier<CompressedBlock> {
+
+        private UncompressedBlock block;
+
+        BlockZipper(UncompressedBlock block) {
+            this.block = block;
+        }
+
+        @Override
+        public CompressedBlock get() {
+            return compressBlock(block);
+
+        }
+
+        private CompressedBlock compressBlock(UncompressedBlock uncompressedBlock) {
+            final CRC32 crc32 = new CRC32();
+            final Deflater deflater = deflaterFactory.makeDeflater(compressionLevel, true);
+
+            final byte[] compressedBuffer = new byte[BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE -
+                    BlockCompressedStreamConstants.BLOCK_HEADER_LENGTH];
+            // Compress the input
+            deflater.setInput(uncompressedBlock.uncompressedBuffer, 0, uncompressedBlock.bytesToCompress);
+            deflater.finish();
+            int compressedSize = deflater.deflate(compressedBuffer, 0, compressedBuffer.length);
+
+            // If it didn't all fit in uncompressedBuffer.length, set compression level to NO_COMPRESSION
+            // and try again.  This should always fit.
+            if (!deflater.finished()) {
+                final Deflater noCompressionDeflater = deflaterFactory.makeDeflater(Deflater.NO_COMPRESSION, true);
+                noCompressionDeflater.setInput(uncompressedBlock.uncompressedBuffer, 0, uncompressedBlock.bytesToCompress);
+                noCompressionDeflater.finish();
+                compressedSize = noCompressionDeflater.deflate(compressedBuffer, 0, compressedBuffer.length);
+                if (!noCompressionDeflater.finished()) {
+                    throw new IllegalStateException("unpossible");
+                }
+            }
+
+            // Data compressed small enough, so write it out.
+            crc32.update(uncompressedBlock.uncompressedBuffer, 0, uncompressedBlock.bytesToCompress);
+            return new CompressedBlock(compressedBuffer, compressedSize, uncompressedBlock.bytesToCompress, crc32.getValue());
+        }
+
+    }
+
+    static class UncompressedBlock {
+
+        byte[] uncompressedBuffer;
+        int bytesToCompress;
+
+        UncompressedBlock(byte[] uncompressedBuffer, int bytesToCompress) {
+            this.uncompressedBuffer = uncompressedBuffer;
+            this.bytesToCompress = bytesToCompress;
+        }
+
+    }
+    static class CompressedBlock {
+
+        byte[] compressedBuffer;
+        int compressedSize;
+        int bytesToCompress;
+        long crc32Value;
+
+        CompressedBlock(byte[] compressedBuffer, int compressedSize, int bytesToCompress, long crc32Value) {
+            this.compressedBuffer = compressedBuffer;
+            this.compressedSize = compressedSize;
+            this.bytesToCompress = bytesToCompress;
+            this.crc32Value = crc32Value;
+        }
+
+    }
+}

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
@@ -24,6 +24,7 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.Defaults;
 import htsjdk.samtools.FileTruncatedException;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 import org.testng.Assert;
@@ -50,7 +51,7 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
         f.deleteOnExit();
         final List<String> linesWritten = new ArrayList<>();
         System.out.println("Creating file " + f);
-        final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(f);
+        final AbstractBlockCompressedOutputStream bcos = create(f);
         String s = "Hi, Mom!\n";
         bcos.write(s.getBytes());
         linesWritten.add(s);
@@ -132,7 +133,7 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
         f.deleteOnExit();
         final List<String> linesWritten = new ArrayList<>();
         System.out.println("Creating file " + f);
-        final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(f);
+        final AbstractBlockCompressedOutputStream bcos = create(f);
         Random r = new Random(15555);
         final int INPUT_SIZE = 64 * 1024;
         byte[] input = new byte[INPUT_SIZE];
@@ -157,7 +158,7 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
     // I don't think this will work on Windows, because /dev/null doesn't work
     @Test(groups = "broken")
     public void testDevNull() throws Exception {
-        final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream("/dev/null");
+        final AbstractBlockCompressedOutputStream bcos = create("/dev/null");
         bcos.write("Hi, Mom!".getBytes());
         bcos.close();
     }
@@ -188,7 +189,7 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
             }
         };
         final List<String> linesWritten = new ArrayList<>();
-        final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(f, 5, myDeflaterFactory);
+        final AbstractBlockCompressedOutputStream bcos = create(f, 5, myDeflaterFactory);
         String s = "Hi, Mom!\n";
         bcos.write(s.getBytes()); //Call 1
         linesWritten.add(s);
@@ -212,5 +213,23 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
         }
         bcis.close();
         Assert.assertEquals(deflateCalls[0], 3, "deflate calls");
+    }
+
+    static AbstractBlockCompressedOutputStream create(File f) {
+        return Defaults.ZIP_THREADS > 0
+                ? new ParallelBlockCompressedOutputStream(f)
+                : new BlockCompressedOutputStream(f);
+    }
+
+    static AbstractBlockCompressedOutputStream create(String name) {
+        return Defaults.ZIP_THREADS > 0
+                ? new ParallelBlockCompressedOutputStream(name)
+                : new BlockCompressedOutputStream(name);
+    }
+
+    static AbstractBlockCompressedOutputStream create(File f, int compLevel, DeflaterFactory df) {
+        return Defaults.ZIP_THREADS > 0
+                ? new ParallelBlockCompressedOutputStream(f, compLevel, df)
+                : new BlockCompressedOutputStream(f, compLevel, df);
     }
 }

--- a/src/test/java/htsjdk/samtools/util/ParallelBlockCompressedOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/ParallelBlockCompressedOutputStreamTest.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.util;
+
+import htsjdk.samtools.Defaults;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class ParallelBlockCompressedOutputStreamTest extends BlockCompressedOutputStreamTest {
+
+    @BeforeClass
+    public void setup() throws NoSuchFieldException, IllegalAccessException {
+        changeDefaultsParam(Defaults.class, "ZIP_THREADS", 2);
+    }
+
+    @AfterClass
+    public void tearDown() throws NoSuchFieldException, IllegalAccessException {
+        changeDefaultsParam(Defaults.class, "ZIP_THREADS", 0);
+    }
+
+    @Test(expectedExceptions = CompletionException.class)
+    public void pbcosShouldRethrowExceptionFromDeflateTasksOnFlush() throws IOException {
+        final byte[] data = new byte[65536];
+        File tmp = File.createTempFile("pbcos", "tmp");
+        AbstractBlockCompressedOutputStream stream = new ParallelBlockCompressedOutputStreamForTests(tmp);
+        stream.write(data);
+        stream.flush();
+    }
+
+    @Test(expectedExceptions = CompletionException.class)
+    public void pbcosShouldRethrowExceptionFromDeflateTasksOnClose() throws IOException {
+        final byte[] data = new byte[65536];
+        File tmp = File.createTempFile("pbcos", "tmp");
+        AbstractBlockCompressedOutputStream stream = new ParallelBlockCompressedOutputStreamForTests(tmp);
+        stream.write(data);
+        stream.close();
+    }
+
+    private static class ParallelBlockCompressedOutputStreamForTests extends ParallelBlockCompressedOutputStream {
+
+        public ParallelBlockCompressedOutputStreamForTests(File file) {
+            super(file);
+        }
+
+        @Override
+        void submitDeflateTask() {
+            compressedBlocksInFuture.add(
+                    CompletableFuture.supplyAsync(() -> {
+                        throw new RuntimeIOException("Bang!");
+                    })
+            );
+        }
+    }
+
+    // for changing Defaults.ZIP_THREADS
+    private static void changeDefaultsParam(Class clazz, String fieldName, Object newValue)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Field modifiers = field.getClass().getDeclaredField("modifiers");
+        modifiers.setAccessible(true);
+        modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, newValue);
+    }
+
+}


### PR DESCRIPTION
We would like to represent new multithreading implementation of BlockCompressedOutptuStream.
`ParallelBlockCompressedOutptuStream` provides parallel zipping of GZ-blocks, which leads to performance gain by utilizing CPU cores.
Base `AbstractBlockCompressedOutptuStream` class was extracted. `AbstractBlockCompressedOutptuStream` was then extended by singlethread `BlockCompressedOutptuStream` and by `ParallelBlockCompressedOutptuStream` implementation. 

![uml classes](https://user-images.githubusercontent.com/14291943/27473993-920b9cf8-5809-11e7-92cb-751c16efcc8a.png)

`ParallelBlockCompressedOutptuStream` implements `deflateBlock` method, which is called at the moment the buffer is full and GZ-block should be compressed and be written. The ParallelBCOS `deflateBlock` implementation submits the task of zipping the GZ-block to the ThreadPoolExecutor, so it will be processed in another thread in parallel. The number of threads in ThreadPoolExecutor (number of blocks are processed in parallel) is controlled by setting `-Dsamjdk.zip_threads` property. If the property is equal to 0 (by default), single thread implementation is used.
After enough (64 * ZIP_THREADS) deflating tasks are submitted, the writing task will be submitted. Writing task will join all previous deflating tasks and write them in the original order.

![parallel](https://user-images.githubusercontent.com/14291943/27474014-a5145b82-5809-11e7-9782-a1d6a428da40.png)

Here are benchmarks for comparing performance results of BlockCompressedOutputStream and ParallelBlockCompressedOutputStream:

```
Benchmark                               (blocks)  Mode  Cnt      Score      Error  Units
BCOSBenchmark.BCOSBenchmark                    2  avgt    5      4.206 ±    0.803  ms/op
BCOSBenchmark.BCOSBenchmark                 1024  avgt    5   1838.131 ±   58.076  ms/op
BCOSBenchmark.BCOSBenchmark                 4096  avgt    5   7791.901 ±  282.288  ms/op
BCOSBenchmark.BCOSBenchmark                16384  avgt    5  29659.399 ±  643.186  ms/op
BCOSBenchmark.parallelBCOSBenchmark4th         2  avgt    5      5.259 ±    6.846  ms/op
BCOSBenchmark.parallelBCOSBenchmark4th      1024  avgt    5    616.716 ±   46.377  ms/op
BCOSBenchmark.parallelBCOSBenchmark4th      4096  avgt    5   3037.837 ±  932.181  ms/op
BCOSBenchmark.parallelBCOSBenchmark4th     16384  avgt    5  10798.186 ± 1611.957  ms/op
```
We just generate random block of data and write it to the output stream. 
 
Here are also results of second part of SortSam where BlockCompressedOutputStream is used:

```
master branch realization:
INFO	2017-06-28 13:23:55	SortSam	Wrote    10,000,000 records from a sorting collection.  Elapsed time: 00:20:45s.  Time for last 10,000,000:  118s.  Last read position: 21:24,587,673
INFO	2017-06-28 13:25:49	SortSam	Wrote    20,000,000 records from a sorting collection.  Elapsed time: 00:22:38s.  Time for last 10,000,000:  113s.  Last read position: 7:23,286,339
INFO	2017-06-28 13:27:40	SortSam	Wrote    30,000,000 records from a sorting collection.  Elapsed time: 00:24:30s.  Time for last 10,000,000:  111s.  Last read position: 16:11,025,537
INFO	2017-06-28 13:29:33	SortSam	Wrote    40,000,000 records from a sorting collection.  Elapsed time: 00:26:22s.  Time for last 10,000,000:  112s.  Last read position: 6:143,105,022
INFO	2017-06-28 13:31:27	SortSam	Wrote    50,000,000 records from a sorting collection.  Elapsed time: 00:28:16s.  Time for last 10,000,000:  114s.  Last read position: 1:186,643,572
INFO	2017-06-28 13:33:21	SortSam	Wrote    60,000,000 records from a sorting collection.  Elapsed time: 00:30:10s.  Time for last 10,000,000:  114s.  Last read position: 1:196,714,975
INFO	2017-06-28 13:35:13	SortSam	Wrote    70,000,000 records from a sorting collection.  Elapsed time: 00:32:03s.  Time for last 10,000,000:  112s.  Last read position: 16:49,983,724
INFO	2017-06-28 13:37:06	SortSam	Wrote    80,000,000 records from a sorting collection.  Elapsed time: 00:33:55s.  Time for last 10,000,000:  112s.  Last read position: 1:197,704,968
INFO	2017-06-28 13:38:59	SortSam	Wrote    90,000,000 records from a sorting collection.  Elapsed time: 00:35:48s.  Time for last 10,000,000:  113s.  Last read position: 9:125,905,256
INFO	2017-06-28 13:40:54	SortSam	Wrote   100,000,000 records from a sorting collection.  Elapsed time: 00:37:43s.  Time for last 10,000,000:  114s.  Last read position: 6:140,620,132
INFO	2017-06-28 13:42:46	SortSam	Wrote   110,000,000 records from a sorting collection.  Elapsed time: 00:39:35s.  Time for last 10,000,000:  111s.  Last read position: 9:104,433,180
INFO	2017-06-28 13:44:36	SortSam	Wrote   120,000,000 records from a sorting collection.  Elapsed time: 00:41:25s.  Time for last 10,000,000:  110s.  Last read position: 1:143,767,447
INFO	2017-06-28 13:46:26	SortSam	Wrote   130,000,000 records from a sorting collection.  Elapsed time: 00:43:16s.  Time for last 10,000,000:  110s.  Last read position: 5:168,250,174
INFO	2017-06-28 13:48:20	SortSam	Wrote   140,000,000 records from a sorting collection.  Elapsed time: 00:45:09s.  Time for last 10,000,000:  113s.  Last read position: 17:8,159,993
INFO	2017-06-28 13:50:12	SortSam	Wrote   150,000,000 records from a sorting collection.  Elapsed time: 00:47:01s.  Time for last 10,000,000:  112s.  Last read position: 6:70,942,372
INFO	2017-06-28 13:52:04	SortSam	Wrote   160,000,000 records from a sorting collection.  Elapsed time: 00:48:53s.  Time for last 10,000,000:  112s.  Last read position: 22:50,433,075
INFO	2017-06-28 13:53:56	SortSam	Wrote   170,000,000 records from a sorting collection.  Elapsed time: 00:50:45s.  Time for last 10,000,000:  111s.  Last read position: 6:16,823,069
INFO	2017-06-28 13:55:48	SortSam	Wrote   180,000,000 records from a sorting collection.  Elapsed time: 00:52:38s.  Time for last 10,000,000:  112s.  Last read position: 16:20,636,901
INFO	2017-06-28 13:57:40	SortSam	Wrote   190,000,000 records from a sorting collection.  Elapsed time: 00:54:29s.  Time for last 10,000,000:  111s.  Last read position: 4:180,667,149
INFO	2017-06-28 13:59:33	SortSam	Wrote   200,000,000 records from a sorting collection.  Elapsed time: 00:56:22s.  Time for last 10,000,000:  112s.  Last read position: X:7,434,779
INFO	2017-06-28 14:01:25	SortSam	Wrote   210,000,000 records from a sorting collection.  Elapsed time: 00:58:14s.  Time for last 10,000,000:  112s.  Last read position: 2:60,740,053

With 2 threads for zipping:
INFO	2017-06-28 14:21:05	SortSam	Wrote    10,000,000 records from a sorting collection.  Elapsed time: 00:19:10s.  Time for last 10,000,000:   76s.  Last read position: 21:24,587,673
INFO	2017-06-28 14:22:18	SortSam	Wrote    20,000,000 records from a sorting collection.  Elapsed time: 00:20:23s.  Time for last 10,000,000:   73s.  Last read position: 7:23,286,339
INFO	2017-06-28 14:23:32	SortSam	Wrote    30,000,000 records from a sorting collection.  Elapsed time: 00:21:36s.  Time for last 10,000,000:   73s.  Last read position: 16:11,025,537
INFO	2017-06-28 14:24:45	SortSam	Wrote    40,000,000 records from a sorting collection.  Elapsed time: 00:22:50s.  Time for last 10,000,000:   73s.  Last read position: 6:143,105,022
INFO	2017-06-28 14:25:59	SortSam	Wrote    50,000,000 records from a sorting collection.  Elapsed time: 00:24:03s.  Time for last 10,000,000:   73s.  Last read position: 1:186,643,572
INFO	2017-06-28 14:27:08	SortSam	Wrote    60,000,000 records from a sorting collection.  Elapsed time: 00:25:12s.  Time for last 10,000,000:   69s.  Last read position: 1:196,714,975
INFO	2017-06-28 14:28:21	SortSam	Wrote    70,000,000 records from a sorting collection.  Elapsed time: 00:26:25s.  Time for last 10,000,000:   73s.  Last read position: 16:49,983,724
INFO	2017-06-28 14:29:35	SortSam	Wrote    80,000,000 records from a sorting collection.  Elapsed time: 00:27:40s.  Time for last 10,000,000:   74s.  Last read position: 1:197,704,968
INFO	2017-06-28 14:30:47	SortSam	Wrote    90,000,000 records from a sorting collection.  Elapsed time: 00:28:52s.  Time for last 10,000,000:   71s.  Last read position: 9:125,905,256
INFO	2017-06-28 14:32:01	SortSam	Wrote   100,000,000 records from a sorting collection.  Elapsed time: 00:30:06s.  Time for last 10,000,000:   74s.  Last read position: 6:140,620,132
INFO	2017-06-28 14:33:15	SortSam	Wrote   110,000,000 records from a sorting collection.  Elapsed time: 00:31:20s.  Time for last 10,000,000:   74s.  Last read position: 9:104,433,180
INFO	2017-06-28 14:34:29	SortSam	Wrote   120,000,000 records from a sorting collection.  Elapsed time: 00:32:34s.  Time for last 10,000,000:   73s.  Last read position: 1:143,767,447
INFO	2017-06-28 14:35:42	SortSam	Wrote   130,000,000 records from a sorting collection.  Elapsed time: 00:33:47s.  Time for last 10,000,000:   72s.  Last read position: 5:168,250,174
INFO	2017-06-28 14:36:56	SortSam	Wrote   140,000,000 records from a sorting collection.  Elapsed time: 00:35:01s.  Time for last 10,000,000:   74s.  Last read position: 17:8,159,993
INFO	2017-06-28 14:38:16	SortSam	Wrote   150,000,000 records from a sorting collection.  Elapsed time: 00:36:21s.  Time for last 10,000,000:   79s.  Last read position: 6:70,942,372
INFO	2017-06-28 14:39:35	SortSam	Wrote   160,000,000 records from a sorting collection.  Elapsed time: 00:37:40s.  Time for last 10,000,000:   78s.  Last read position: 22:50,433,075
INFO	2017-06-28 14:40:48	SortSam	Wrote   170,000,000 records from a sorting collection.  Elapsed time: 00:38:53s.  Time for last 10,000,000:   73s.  Last read position: 6:16,823,069
INFO	2017-06-28 14:42:02	SortSam	Wrote   180,000,000 records from a sorting collection.  Elapsed time: 00:40:06s.  Time for last 10,000,000:   73s.  Last read position: 16:20,636,901
INFO	2017-06-28 14:43:18	SortSam	Wrote   190,000,000 records from a sorting collection.  Elapsed time: 00:41:22s.  Time for last 10,000,000:   76s.  Last read position: 4:180,667,149
INFO	2017-06-28 14:44:34	SortSam	Wrote   200,000,000 records from a sorting collection.  Elapsed time: 00:42:39s.  Time for last 10,000,000:   76s.  Last read position: X:7,434,779
INFO	2017-06-28 14:45:56	SortSam	Wrote   210,000,000 records from a sorting collection.  Elapsed time: 00:44:01s.  Time for last 10,000,000:   81s.  Last read position: 2:60,740,053

```
NOTE:
write(), close() and flush() methods can block the current thread because we have to wait until all tasks for zipping and writing will be completed.
ThreadPoolExecutor is static, for the reason to restrict the number of threads globally (in case several PBCOS are created).
