### PR TITLE
Add option to use the maximum overlap for LiftOver

### DIFF
--- a/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
+++ b/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
@@ -58,7 +58,20 @@ public class LiftOverTest extends HtsjdkTest {
     public void testBasic(final Interval in, final Interval expected) {
         final Interval out = liftOver.liftOver(in);
         Assert.assertEquals(out, expected);
+    }
 
+    @Test(dataProvider = "testMaxOverlapIntervals")
+    public void testBasicMaxOverlapMultipleChains(final Interval in, final boolean useMaxOverlap, Interval expected) {
+        final Interval out = liftOver.liftOver(in, 0.10, useMaxOverlap);
+        Assert.assertEquals(out, expected);
+    }
+
+    @DataProvider(name = "testMaxOverlapIntervals")
+    public Object[][] makeTestaxOverlapIntervals() {
+        return new Object[][]{
+                {new Interval("chr2", 97446334, 97446434), true, new Interval("chr2", 98080300, 98080324)},
+                {new Interval("chr2", 97446334, 97446434), false, null}
+        };
     }
 
     @DataProvider(name = "testIntervals")


### PR DESCRIPTION
### Description

Implements #924. 
LiftOver uses the first chain overlapping the an interval that satisfies the "minimum fraction of bases that must remap" criteria. This makes it sensitive to the the order of items in the chain file. It should have the option of choosing the remapping that has the highest number of bases that overlap.

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

