### PR TITLE
Proposal to evolve to HTSJDK version 3 (DO NOT MERGE)

### DIFF
--- a/htsjdk3-dev/htsjdk-core/README.md
+++ b/htsjdk3-dev/htsjdk-core/README.md
@@ -1,0 +1,7 @@
+# HTSJDK-CORE
+
+Contains common code and interface/api definitions.
+
+Includes SAM/BAM, VCF and tribble support.
+
+Should not include significant dependencies.

--- a/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/samtools/package-info.java
+++ b/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/samtools/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Contains SAM support.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+package htsjdk.samtools;

--- a/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/tribble/Feature.java
+++ b/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/tribble/Feature.java
@@ -1,7 +1,7 @@
 /*
- * The MIT License
+ * The MIT License (MIT)
  *
- * Copyright (c) 2013 The Broad Institute
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -10,37 +10,26 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 package htsjdk.tribble;
 
 
-import htsjdk.Htsjdk3;
-import htsjdk.samtools.util.Locatable;
+import htsjdk.util.Locatable;
 
 /**
  * Marker interface for Locatables with Tribble support. A Feature represents a record in a tribble-supported file format.
  * As {@link Locatable}, represents a locus on a reference sequence and is expected to return 1-based closed-ended intervals.
  */
-@Htsjdk3(newPackage = "", backwardsCompatible = false)
 public interface Feature extends Locatable {
-
-    /**
-     * Return the features reference sequence name, e.g chromosome or contig
-     * @deprecated on 03/2015. Use getContig() instead.
-     */
-    @Deprecated
-    default public String getChr() {
-        return getContig();
-    }
 
 }

--- a/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/tribble/package-info.java
+++ b/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/tribble/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Support for indexed and query-able genomic file formats.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+package htsjdk.tribble;

--- a/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/util/Locatable.java
+++ b/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/util/Locatable.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.util;
+
+/**
+ * Any class that has a single logical mapping onto the genome should implement Locatable
+ * positions should be reported as 1-based and closed at both ends.
+ */
+public interface Locatable {
+
+    /**
+     * Gets the contig name for the contig this is mapped to.  May return null if there is no unique mapping.
+     * @return name of the contig this is mapped to, potentially null
+     */
+    String getContig();
+
+    /**
+     * @return 1-based start position, undefined if getContig() == null
+     */
+    int getStart();
+
+    /**
+     * @return 1-based closed-ended position, undefined if getContig() == null
+     */
+    int getEnd();
+}

--- a/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/util/package-info.java
+++ b/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/util/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Common utilies.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+package htsjdk.util;

--- a/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/variant/package-info.java
+++ b/htsjdk3-dev/htsjdk-core/src/main/java/htsjdk/variant/package-info.java
@@ -1,0 +1,6 @@
+/**
+ *
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+package htsjdk.variant;

--- a/htsjdk3-dev/htsjdk-cram/README.md
+++ b/htsjdk3-dev/htsjdk-cram/README.md
@@ -1,0 +1,3 @@
+# HTSJDK-CRAM
+
+Includes support for CRAM format.

--- a/htsjdk3-dev/htsjdk-cram/src/main/java/htsjdk/samtools/cram/package-info.java
+++ b/htsjdk3-dev/htsjdk-cram/src/main/java/htsjdk/samtools/cram/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Support for CRAM format.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+package htsjdk.samtools.cram;

--- a/htsjdk3-dev/htsjdk-jexl/README.md
+++ b/htsjdk3-dev/htsjdk-jexl/README.md
@@ -1,0 +1,3 @@
+# HTSJDK-JEXL
+
+Includes support for JEXL expressions in VariantContext.

--- a/htsjdk3-dev/htsjdk-sra/README.md
+++ b/htsjdk3-dev/htsjdk-sra/README.md
@@ -1,0 +1,3 @@
+# HTSJDK-SRA
+
+Includes support for SRA format.

--- a/htsjdk3-dev/htsjdk-sra/src/main/java/htsjdk/samtools/sra/package-info.java
+++ b/htsjdk3-dev/htsjdk-sra/src/main/java/htsjdk/samtools/sra/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * SRA support.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+package htsjdk.samtools.sra;

--- a/src/main/java/htsjdk/Htsjdk3.java
+++ b/src/main/java/htsjdk/Htsjdk3.java
@@ -1,0 +1,31 @@
+package htsjdk;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker interface to indicate the status of the class in the HTSJDK3 development.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({
+        ElementType.ANNOTATION_TYPE,
+        ElementType.CONSTRUCTOR,
+        ElementType.FIELD,
+        ElementType.METHOD,
+        ElementType.TYPE
+})
+@Documented
+public @interface Htsjdk3 {
+
+    /** Indicates the name of the new package if changed; if not changed, returns the empty String. */
+    public String newPackage();
+
+    /** Returns {@code true} if the port is backwards compatible; {@code false} otherwise. */
+    public boolean backwardsCompatible();
+
+}

--- a/src/main/java/htsjdk/samtools/util/Locatable.java
+++ b/src/main/java/htsjdk/samtools/util/Locatable.java
@@ -1,10 +1,13 @@
 package htsjdk.samtools.util;
 
+import htsjdk.Htsjdk3;
+
 /**
  * Any class that has a single logical mapping onto the genome should implement Locatable
  * positions should be reported as 1-based and closed at both ends
  *
  */
+@Htsjdk3(newPackage = "", backwardsCompatible = true)
 public interface Locatable {
 
     /**


### PR DESCRIPTION
### Description

Because the governance model is gonna change soon (#871), I would like to revive the discussion about several issues about the API and proposing to evolve to HTSJDK in a join effort by the community. The related issues are the following:

* Non-backwards compatible API (https://github.com/samtools/htsjdk/issues/520), called in the proposal HTSJDK3. This includes implementing new interfaces as a public API independent of the implementation (see https://github.com/samtools/htsjdk/pull/868 for a discussion about the read interface).
* Evolving API (https://github.com/samtools/htsjdk/issues/378). By moving to HTSJDK-3 we can remove deprecated code and start from scratch. In addition, annotations for beta features could be implemented for the HTSJDK-3 release, marking as beta features that may change.
* Sub-module structure to reduce dependencies in the core functionality (https://github.com/samtools/htsjdk/issues/896). This also includes the issue swith the SRA support (e.g., https://github.com/samtools/htsjdk/issues/414 and https://github.com/samtools/htsjdk/issues/894), which can be moved to a different package.
* Mixing license (https://github.com/samtools/htsjdk/issues/917). By moving to HTSJDK-3, we can ask for porting the code to the new implementation using a common license.

### Proposal

The main idea is to create a folder structure as the one in `htsjdk3-dev` in the root folder of the project and move the current version of htsjdk to a sub-module called htsjdk-2 (not done in the PR for reduce the number of changes). Tasks in gradle to build the current version should be modified to keep the same behavior, and a new task to build the developmental version 3 should be included too.

In addition, I drafted a new annotation for mark the status of the classes with respect to version 3 (`@Htsjdk3`). As an example, I ported the `Locatable` and `Feature` interfaces to the new package. This will allow to see the progress of the new version and keep in sync fixes between versions.

I know that this is a huge proposal, but I expect that most of the code will require just copy-paste and/or repackage (and maybe adding a `@Beta` annotation for some code that may be changed in the future). I think that the community will benefit from this change to create a more consistent API for NGS data processing. In addition, some [dev issues](https://github.com/samtools/htsjdk/issues?q=is%3Aissue+is%3Aopen+label%3Adev) could be solved on the port to HTSJDK-3.

Bringing the attention to the maintainers of the project: @tfenne, @lbergelson, @jacarey

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

