### PR TITLE
TabixReader : delete s.toCharArray()

### DIFF
--- a/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
@@ -160,4 +160,16 @@ public class TabixReaderTest extends HtsjdkTest {
         assertTrue(nRecords > 0);
 
     }
+    
+    /**
+     * Test TabixReader.readLine
+     *
+     * @throws java.io.IOException
+     */
+    @Test
+    public void testTabixReaderReadLine() throws IOException {
+        TabixReader tabixReader = new TabixReader(tabixFile);
+        Assert.assertNotNull(tabixReader.readLine());
+        tabixReader.close();
+    }
 }


### PR DESCRIPTION
### Description

the main motivation of this small PR was to remove the  line.toCharArray() in TabixReader https://github.com/samtools/htsjdk/blob/master/src/main/java/htsjdk/tribble/readers/TabixReader.java#L419

```
                    char[] str = s.toCharArray();
(...)
                    if (str.length == 0 || str[0] == mMeta) continue;
```

replaced with:

```
      if (s.isEmpty() || s.charAt(0) == mMeta) continue;
```

while I was here, I've added a few  `final`, fixed the name of some variables (e.g: 's' -> 'contig').

I've also added a variable `longestLineLength` that is used to allocate the capacity in the function:

```
    private static String readLine(final InputStream is,final int bufferCapacity) throws IOException {
```


### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

