### PR TITLE
Write vcf to stdout

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -366,7 +366,7 @@ public class IOUtil {
      * and if it is a file then not a directory and is readable.  If any
      * condition is false then a runtime exception is thrown.
      *
-     * @param files the list of files to check for readability
+     * @param inputs the list of files to check for readability
      */
     public static void assertInputsAreValid(final List<String> inputs) {
         for (final String input : inputs) assertInputIsValid(input);
@@ -465,7 +465,7 @@ public class IOUtil {
     public static void assertFilesEqual(final File f1, final File f2) {
         try {
             if (f1.length() != f2.length()) {
-                throw new SAMException("Files " + f1 + " and " + f2 + " are different lengths.");
+                throw new SAMException("File " + f1 + " is " + f1.length() + " bytes but file " + f2 + " is " + f2.length() + " bytes.");
             }
             final FileInputStream s1 = new FileInputStream(f1);
             final FileInputStream s2 = new FileInputStream(f2);

--- a/src/main/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
@@ -60,6 +60,8 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
         this.refDict = refDict;
     }
 
+    static String DEFAULT_READER_NAME = "Reader Name";
+
     /**
      * Create a VariantContextWriter with an associated index using the default index creator
      *
@@ -178,6 +180,6 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
      * @return
      */
     protected static final String writerName(final File location, final OutputStream stream) {
-        return location == null ? stream.toString() : location.getAbsolutePath();
+        return location == null ? stream == null ? DEFAULT_READER_NAME : stream.toString() : location.getAbsolutePath();
     }
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -406,8 +406,9 @@ public class VariantContextWriterBuilder {
                 typeToBuild = OutputType.BCF_STREAM;
         }
 
+        // If we are writing to a file, or a special file type (ex. pipe) where the stream is not yet open.
         OutputStream outStreamFromFile = this.outStream;
-        if (FILE_TYPES.contains(this.outType)) {
+        if (FILE_TYPES.contains(this.outType) || (STREAM_TYPES.contains(this.outType) && this.outStream == null)) {
             try {
                 outStreamFromFile = IOUtil.maybeBufferOutputStream(new FileOutputStream(outFile), bufferSize);
             } catch (final FileNotFoundException e) {
@@ -445,7 +446,7 @@ public class VariantContextWriterBuilder {
                 if (options.contains(Options.INDEX_ON_THE_FLY))
                     throw new IllegalArgumentException("VCF index creation not supported for stream output.");
 
-                writer = createVCFWriter(null, outStream);
+                writer = createVCFWriter(null, outStreamFromFile);
                 break;
             case BCF_STREAM:
                 if (options.contains(Options.INDEX_ON_THE_FLY))

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -396,4 +396,12 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
             Assert.assertFalse(builder.isOptionSet(option)); // has been unset
         }
     }
+
+    @Test
+    public void testStdOut() {
+        final VariantContextWriter writer = new VariantContextWriterBuilder().setOutputFile("/dev/stdout").clearOptions().build();
+        OutputStream s = ((VCFWriter) writer).getOutputStream();
+        Assert.assertNotNull(((VCFWriter) writer).getOutputStream());
+        Assert.assertNotEquals(((VCFWriter) writer).getStreamName(), IndexingVariantContextWriter.DEFAULT_READER_NAME);
+    }
 }


### PR DESCRIPTION
Related to: https://github.com/broadinstitute/picard/issues/863

If we call `.setOutputFile` with `"/dev/stdout"`, then `this.outputStream` is `null`, this.outFile` is `File("/dev/stdout")`, and `this.outType` is `OutputType.VCF_STREAM`.  When calling `build()`, it will throw a NPE!