### PR TITLE
Fix no running tests due to lack of HtsjdkTest marker

### DIFF
--- a/src/test/java/htsjdk/samtools/BAMFileSpanTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileSpanTest.java
@@ -1,11 +1,13 @@
 package htsjdk.samtools;
 
 import java.util.Arrays;
+
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class BAMFileSpanTest {
+public class BAMFileSpanTest extends HtsjdkTest {
   @Test(dataProvider = "testRemoveContentsBeforeProvider")
   public void testRemoveContentsBefore(BAMFileSpan originalSpan, BAMFileSpan cutoff,
       BAMFileSpan expectedSpan) {

--- a/src/test/java/htsjdk/samtools/DuplicateScoringStrategyTest.java
+++ b/src/test/java/htsjdk/samtools/DuplicateScoringStrategyTest.java
@@ -1,10 +1,11 @@
 package htsjdk.samtools;
 
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class DuplicateScoringStrategyTest {
+public class DuplicateScoringStrategyTest extends HtsjdkTest {
 
     @DataProvider
     public Object [][] compareData() {

--- a/src/test/java/htsjdk/samtools/PathInputResourceTest.java
+++ b/src/test/java/htsjdk/samtools/PathInputResourceTest.java
@@ -5,10 +5,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.function.Function;
+
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class PathInputResourceTest {
+public class PathInputResourceTest extends HtsjdkTest {
   final String localBam = "src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam";
 
   @Test

--- a/src/test/java/htsjdk/samtools/SAMProgramRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMProgramRecordTest.java
@@ -23,13 +23,14 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
  * Test for SAMReadGroupRecordTest
  */
-public class SAMProgramRecordTest {
+public class SAMProgramRecordTest extends HtsjdkTest {
 
     @Test
     public void testGetSAMString() {

--- a/src/test/java/htsjdk/samtools/SAMReadGroupRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMReadGroupRecordTest.java
@@ -23,13 +23,14 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
  * Test for SAMReadGroupRecordTest
  */
-public class SAMReadGroupRecordTest {
+public class SAMReadGroupRecordTest extends HtsjdkTest {
 
     @Test
     public void testGetSAMString() {

--- a/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.Arrays;
 /**
  * Test for SAMReadGroupRecordTest
  */
-public class SAMSequenceRecordTest {
+public class SAMSequenceRecordTest extends HtsjdkTest {
 
     @Test
     public void testGetSAMString() {

--- a/src/test/java/htsjdk/samtools/fastq/FastqEncoderTest.java
+++ b/src/test/java/htsjdk/samtools/fastq/FastqEncoderTest.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools.fastq;
 
+import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordSetBuilder;
 import org.testng.Assert;
@@ -31,7 +32,7 @@ import org.testng.annotations.Test;
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class FastqEncoderTest {
+public class FastqEncoderTest extends HtsjdkTest {
 
     @Test
     public void testAsFastqRecord() throws Exception {

--- a/src/test/java/htsjdk/samtools/util/CigarElementUnitTest.java
+++ b/src/test/java/htsjdk/samtools/util/CigarElementUnitTest.java
@@ -1,11 +1,12 @@
 package htsjdk.samtools.util;
 
 
+import htsjdk.HtsjdkTest;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import org.testng.annotations.Test;
 
-public class CigarElementUnitTest {
+public class CigarElementUnitTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNegativeLengthCheck(){


### PR DESCRIPTION
### Description

Some tests were not running because they lack the HtsjdkTest marker. This PR adds the missing marker to these classes, which now are executed by the test task.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

