### PR TITLE
One possible solution to cigarLen>65535 (DON'T MERGE; for discussion only)

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMRecordCodec.java
+++ b/src/main/java/htsjdk/samtools/BAMRecordCodec.java
@@ -208,11 +208,13 @@ public class BAMRecordCodec implements SortingCollection.Codec<SAMRecord> {
         final short readNameLength = this.binaryCodec.readUByte();
         final short mappingQuality = this.binaryCodec.readUByte();
         int bin, cigarLen, flags;
+        boolean isLongCigarLen = false;
         final int preBin = this.binaryCodec.readUShort();
         final int preCigarLen = this.binaryCodec.readUShort();
         final int preFlags = this.binaryCodec.readUShort();
-        if (preFlags & 0x8000) { // cigarLen has more than 16 bits
-            bin = null; // the true `bin` is not available
+        if (0x8000 == (preFlags & 0x8000)) { // cigarLen has more than 16 bits
+            isLongCigarLen = true;
+            bin = 0; // the true `bin` is not available
             cigarLen = preBin << 16 | preCigarLen; // the real cigarLen
             flags = preFlags & ~0x8000; // clear the highest bit
         } else { // cigarLen fits 16 bits
@@ -230,8 +232,8 @@ public class BAMRecordCodec implements SortingCollection.Codec<SAMRecord> {
                 header, referenceID, coordinate, readNameLength, mappingQuality,
                 bin, cigarLen, flags, readLen, mateReferenceID, mateCoordinate, insertSize, restOfRecord);
 
-        if (null == bin) {
-            //ret.setIndexingBin(ret.computeIndexingBin()); // update mIndexingBin to the correct value. Is it necessary?
+        if (isLongCigarLen) {
+            ret.setIndexingBin(ret.computeIndexingBin()); // update mIndexingBin to the correct value. Is it necessary?
         }
         if (null != header) {
             // don't reset a null header as this will clobber the reference and mate reference indices

--- a/src/main/java/htsjdk/samtools/BAMRecordCodec.java
+++ b/src/main/java/htsjdk/samtools/BAMRecordCodec.java
@@ -231,7 +231,7 @@ public class BAMRecordCodec implements SortingCollection.Codec<SAMRecord> {
                 bin, cigarLen, flags, readLen, mateReferenceID, mateCoordinate, insertSize, restOfRecord);
 
         if (null == bin) {
-            ret.setIndexingBin(ret.computeIndexingBin()); // update mIndexingBin to the correct value. Is it necessary?
+            //ret.setIndexingBin(ret.computeIndexingBin()); // update mIndexingBin to the correct value. Is it necessary?
         }
         if (null != header) {
             // don't reset a null header as this will clobber the reference and mate reference indices


### PR DESCRIPTION
### Description

First of all, this PR is not intended to be merged. It is only meant to show code changes for a solution to CIGARs with >65535 operations. The solution was first [proposed here](https://sourceforge.net/p/samtools/mailman/message/30672431/) (solution 1). It is not the solution @yfarjoun and I have agreed on, but it probably requires the least code change. The other solution needs to add a few hundred lines of code to htsjdk across multiple files.

You can see how the approach works from the change to BAMRecordCodec.encode(). When cigarLen is too large, we write indexingBin, cigarLen and flags differently. The decoder sets the correct values for these fields once the BAMRecord is read to memory. `./gradlew test` reported "all tests passed" in the end, but this doesn't tell us whether/how my changes work with a new BAM with long cigars.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

