### PR TITLE
Add ability to log to file

### DIFF
--- a/src/main/java/htsjdk/samtools/util/Log.java
+++ b/src/main/java/htsjdk/samtools/util/Log.java
@@ -47,7 +47,7 @@ public final class Log {
 
     private final Class<?> clazz;
     private final String className;
-    private final PrintStream out = System.err;
+    private static PrintStream out = System.err;
 
     /**
      * Private constructor
@@ -70,6 +70,8 @@ public final class Log {
     public static void setGlobalLogLevel(final LogLevel logLevel) {
         globalLogLevel = logLevel;
     }
+
+    public static void setGlobalPrintStream(final PrintStream stream) { out = stream; }
 
     /** Returns true if the specified log level is enabled otherwise false. */
     public static final boolean isEnabled(final LogLevel level) {

--- a/src/main/java/htsjdk/samtools/util/Log.java
+++ b/src/main/java/htsjdk/samtools/util/Log.java
@@ -41,13 +41,13 @@ import java.util.Date;
  */
 public final class Log {
     /** Enumeration for setting log levels. */
-    public static enum LogLevel { ERROR, WARNING, INFO, DEBUG }
+    public enum LogLevel { ERROR, WARNING, INFO, DEBUG }
 
     private static LogLevel globalLogLevel = LogLevel.INFO;
+    private static PrintStream out = System.err;
 
     private final Class<?> clazz;
     private final String className;
-    private static PrintStream out = System.err;
 
     /**
      * Private constructor
@@ -67,11 +67,40 @@ public final class Log {
         return new Log(clazz);
     }
 
+    /**
+     * Set the log level.
+     *
+     * @param logLevel  The log level enumeration
+     */
     public static void setGlobalLogLevel(final LogLevel logLevel) {
         globalLogLevel = logLevel;
     }
 
+    /**
+     * Get the log level.
+     *
+     * @return The enumeration for setting log levels.
+     */
+    public static LogLevel getGlobalLogLevel() {
+        return globalLogLevel;
+    }
+
+    /**
+     * Set the {@link PrintStream} for writing.
+     *
+     * @param stream    {@link PrintStream} to write to.
+     */
     public static void setGlobalPrintStream(final PrintStream stream) { out = stream; }
+
+    /**
+     * Get the {@link PrintStream} for writing.
+     *
+     * @return  {@link PrintStream} to write to.
+     */
+    public static PrintStream getGlobalPrintStream() {
+        return out;
+    }
+
 
     /** Returns true if the specified log level is enabled otherwise false. */
     public static final boolean isEnabled(final LogLevel level) {

--- a/src/test/java/htsjdk/samtools/util/LogTest.java
+++ b/src/test/java/htsjdk/samtools/util/LogTest.java
@@ -20,12 +20,22 @@ public class LogTest extends HtsjdkTest {
     public void testLogToFile() throws IOException {
         final File logFile = File.createTempFile(getClass().getSimpleName(), ".tmp");
         logFile.deleteOnExit();
-        Log.setGlobalPrintStream(new PrintStream(new FileOutputStream(logFile.getPath(), true)));
 
-        final String words = "Hello World";
-        log.info(words);
-        final List<String> list = Files.readAllLines(logFile.toPath());
-        Assert.assertEquals(list.size(), 1);
-        Assert.assertTrue(list.get(0).contains(words));
+        final Log.LogLevel originalLogLevel = Log.getGlobalLogLevel();
+        final PrintStream originalStream = Log.getGlobalPrintStream();
+
+        try (final PrintStream stream = new PrintStream(new FileOutputStream(logFile.getPath(), true))) {
+            Log.setGlobalPrintStream(stream);
+            Log.setGlobalLogLevel(Log.LogLevel.DEBUG);
+            final String words = "Hello World";
+            log.info(words);
+            final List<String> list = Files.readAllLines(logFile.toPath());
+            Assert.assertEquals(Log.getGlobalLogLevel(), Log.LogLevel.DEBUG);
+            Assert.assertEquals(list.size(), 1);
+            Assert.assertTrue(list.get(0).contains(words));
+        } finally {
+            Log.setGlobalLogLevel(originalLogLevel);
+            Log.setGlobalPrintStream(originalStream);
+        }
     }
 }

--- a/src/test/java/htsjdk/samtools/util/LogTest.java
+++ b/src/test/java/htsjdk/samtools/util/LogTest.java
@@ -1,0 +1,31 @@
+package htsjdk.samtools.util;
+
+import htsjdk.HtsjdkTest;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.util.List;
+
+public class LogTest extends HtsjdkTest {
+
+    private final Log log = Log.getInstance(getClass());
+
+    @Test
+    public void testLogToFile() throws IOException {
+        final File logFile = File.createTempFile(getClass().getSimpleName(), ".tmp");
+        logFile.deleteOnExit();
+        Log.setGlobalPrintStream(new PrintStream(new FileOutputStream(logFile.getPath(), true)));
+
+        final String words = "Hello World";
+        log.info(words);
+        final List<String> list = Files.readAllLines(logFile.toPath());
+        Assert.assertEquals(list.size(), 1);
+        Assert.assertTrue(list.get(0).contains(words));
+    }
+}


### PR DESCRIPTION
### Description

Clients, such as GATK, want to capture the htsjdk output log data to a file. This capability is required for fully implementing https://github.com/broadinstitute/gatk/pull/2751.

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

