### PR TITLE
Proposal: deprecate FixBAMFile.java

### DIFF
--- a/src/main/java/htsjdk/samtools/FixBAMFile.java
+++ b/src/main/java/htsjdk/samtools/FixBAMFile.java
@@ -27,6 +27,10 @@ import htsjdk.samtools.util.CloserUtil;
 
 import java.io.File;
 
+/**
+ * @deprecated since 07/2017. This tool is undocumented and untested.
+ */
+@Deprecated
 public class FixBAMFile {
     public static void main(String[] args) {
         File inputFile = new File(args[0]);


### PR DESCRIPTION
### Description

The `FixBAMFile` is an undocumented and untested feature that does not add anything to the HTSJDK as a library. I propose to deprecate this class and remove it eventually.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

