### PR TITLE
Deprecate FastqRecord.toString to warn users for a future change in behaviour

### DIFF
--- a/src/main/java/htsjdk/samtools/fastq/FastqRecord.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqRecord.java
@@ -101,7 +101,7 @@ public class FastqRecord implements Serializable {
     /**
      * Get the read name
      *
-     * @return the read name
+     * @return the read name (may be {@code null}).
      */
     public String getReadName() {
         return readName;
@@ -110,7 +110,7 @@ public class FastqRecord implements Serializable {
     /**
      * Get the DNA sequence
      *
-     * @return read sequence as a string of ACGTN=.
+     * @return read sequence as a string of ACGTN= (may be {@code null}).
      */
     public String getReadString() {
         return readString;
@@ -128,7 +128,7 @@ public class FastqRecord implements Serializable {
     /**
      * Get the base qualities encoded as a FASTQ string
      *
-     * @return the quality string
+     * @return the quality string (may be {@code null}).
      */
     public String getBaseQualityString() {
         return baseQualityString;
@@ -155,7 +155,7 @@ public class FastqRecord implements Serializable {
     /**
      * Get the base quality header
      *
-     * @return the base quality header
+     * @return the base quality header (may be {@code null}).
      */
     public String getBaseQualityHeader() {
         return qualityHeader;
@@ -228,8 +228,13 @@ public class FastqRecord implements Serializable {
     }
 
     /**
-     * Returns {@link #toFastQString()}
+     * Returns {@link #toFastQString()}.
+     *
+     * @deprecated since 07/2017. This method will be deprecated until it is changed in the future
+     * for a simpler representation of the object. For code relying on the formatting as a FASTQ
+     * String, please refactor your code to use {@link #toFastQString()}.
      */
+    @Deprecated
     @Override
     public String toString() {
         // TODO: this should be change in the future for a simpler and more informative form such as

--- a/src/main/java/htsjdk/samtools/fastq/FastqRecord.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqRecord.java
@@ -230,11 +230,10 @@ public class FastqRecord implements Serializable {
     /**
      * Returns {@link #toFastQString()}.
      *
-     * @deprecated since 07/2017. This method will be deprecated until it is changed in the future
-     * for a simpler representation of the object. For code relying on the formatting as a FASTQ
-     * String, please refactor your code to use {@link #toFastQString()}.
+     * WARNING: This method will be changed in the future for a simpler representation of the object.
+     * For code relying on the formatting as a FASTQ String, please refactor your code to use
+     * {@link #toFastQString()}.
      */
-    @Deprecated
     @Override
     public String toString() {
         // TODO: this should be change in the future for a simpler and more informative form such as

--- a/src/test/java/htsjdk/samtools/fastq/FastqRecordTest.java
+++ b/src/test/java/htsjdk/samtools/fastq/FastqRecordTest.java
@@ -1,6 +1,7 @@
 package htsjdk.samtools.fastq;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -160,6 +161,22 @@ public final class FastqRecordTest extends HtsjdkTest {
         final String qualLine = "GATTACA";
         new FastqRecord(seqHeaderPrefix, "", "qualHeaderPrefix", qualLine);
         //Note: this does not blow up now but it will once we enforce non empty seqLine
+    }
+
+    @Test
+    public void testEmptyRecord() {
+        //Note: this does not blow up now but it will once we enforce non empty fields
+        final FastqRecord record = new FastqRecord(null, (String) null, null, null);
+        // assert how null is handled
+        Assert.assertNull(record.getReadName());
+        Assert.assertNull(record.getReadString());
+        Assert.assertNull(record.getBaseQualityString());
+        Assert.assertEquals(record.getReadBases(), SAMRecord.NULL_SEQUENCE);
+        Assert.assertEquals(record.getBaseQualities(), SAMRecord.NULL_QUALS);
+        // copy the FastqRecord to check that equals and hashCode is working for the null read without blow up
+        final FastqRecord copy = new FastqRecord(record);
+        Assert.assertEquals(record, copy);
+        Assert.assertEquals(record.hashCode(), copy.hashCode());
     }
 
     @Test


### PR DESCRIPTION
### Description

The current implementation of `FastqRecord.toString()` is using a FASTQ-formatted String. Usually, the `toString()` method should implement a description of the object that should be useful for the developer, but not for rely on it for usage on other parts of the code (such a writer). Because there is a TODO for changing the method for something more simple, this PR deprecates the current implementation to warn the users to use the `FastqRecord.toFastQString()` method instead, and change the behaviour in a future release.

In addition, this PR includes changes in the javadoc to point out where a null value could be returned and adds tests for a "null" record.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

