### PR TITLE
Updated javadocs for query method

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -137,7 +137,14 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
 		}
 	}
 
-    /** Queries for records within the region specified. */
+    /**
+     * Queries for records overlapping the region specified.
+     * Note that this method requires VCF files with an associated index.  If no index exists a TribbleException will be thrown.
+     * @param chrom the chomosome to query
+     * @param start query interval start
+     * @param end query interval end
+     * @return non-null iterator over VariantContexts
+     */
     public CloseableIterator<VariantContext> query(final String chrom, final int start, final int end) {
         try { return reader.query(chrom, start, end); }
         catch (final IOException ioe) {


### PR DESCRIPTION
### Description

Updated the javadocs so that it's clear that an error will be thrown without an index.
Based on recommendations from https://github.com/broadinstitute/picard/issues/814.
Note that this was implemented by @ben10wald who doesn't have push access to this repo.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

