### PR TITLE
Add support for SQ-AN in SAMSequenceDictionary

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
@@ -86,6 +86,8 @@ public class SAMSequenceDictionary implements Serializable {
             if (mSequenceMap.put(record.getSequenceName(), record) != null) {
                 throw new IllegalArgumentException("Cannot add sequence that already exists in SAMSequenceDictionary: " +
                         record.getSequenceName());
+            } else {
+                record.getAlternativeSequeneNames().forEach(an -> addSequenceAlias(record.getSequenceName(), an));
             }
         }
     }
@@ -98,6 +100,7 @@ public class SAMSequenceDictionary implements Serializable {
         sequenceRecord.setSequenceIndex(mSequences.size());
         mSequences.add(sequenceRecord);
         mSequenceMap.put(sequenceRecord.getSequenceName(), sequenceRecord);
+        sequenceRecord.getAlternativeSequeneNames().forEach(an -> addSequenceAlias(sequenceRecord.getSequenceName(), an));
     }
 
     /**
@@ -220,6 +223,9 @@ public class SAMSequenceDictionary implements Serializable {
      * <code>1,chr1,chr01,01,CM000663,NC_000001.10</code> e.g:
      * <code>MT,chrM</code>
      *
+     * NOTE: this method does not add the alias to the alternative sequence name tag (AN) in the SAMSequenceRecord.
+     * If you would like to add it to the AN tag, use {@link #setAlternativeSequenceName(String, String)} instead.
+     *
      * @param originalName
      *            existing contig name
      * @param altName
@@ -244,6 +250,27 @@ public class SAMSequenceDictionary implements Serializable {
         }
         mSequenceMap.put(altName, originalSeqRecord);
         return originalSeqRecord;
+    }
+
+    /**
+     * Add an alternative sequence name (AN tag) to a SAMSequenceRecord, including it into the aliases
+     * to retrieve the contigs (as with {@link #addSequenceAlias(String, String)}.
+     *
+     * <p>This can be use to provide some alternate names fo a given contig. e.g:
+     * <code>1,chr1,chr01,01,CM000663,NC_000001.10</code> or
+     * <code>MT,chrM</code>.
+     *
+     * @param originalName
+     *            existing contig name
+     * @param altName
+     *            new contig name
+     * @return the contig associated to the 'originalName/altName', with the AN tag including the altName
+     */
+    public SAMSequenceRecord addAlternativeSequenceName(final String originalName,
+            final String altName) {
+        final SAMSequenceRecord record = addSequenceAlias(originalName, altName);
+        record.addAlternativeSequenceName(altName);
+        return record;
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
@@ -224,7 +224,7 @@ public class SAMSequenceDictionary implements Serializable {
      * <code>MT,chrM</code>
      *
      * NOTE: this method does not add the alias to the alternative sequence name tag (AN) in the SAMSequenceRecord.
-     * If you would like to add it to the AN tag, use {@link #setAlternativeSequenceName(String, String)} instead.
+     * If you would like to add it to the AN tag, use {@link #addAlternativeSequenceName(String, String)} instead.
      *
      * @param originalName
      *            existing contig name

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
@@ -87,7 +87,7 @@ public class SAMSequenceDictionary implements Serializable {
                 throw new IllegalArgumentException("Cannot add sequence that already exists in SAMSequenceDictionary: " +
                         record.getSequenceName());
             } else {
-                record.getAlternativeSequeneNames().forEach(an -> addSequenceAlias(record.getSequenceName(), an));
+                record.getAlternativeSequenceNames().forEach(an -> addSequenceAlias(record.getSequenceName(), an));
             }
         }
     }
@@ -100,7 +100,7 @@ public class SAMSequenceDictionary implements Serializable {
         sequenceRecord.setSequenceIndex(mSequences.size());
         mSequences.add(sequenceRecord);
         mSequenceMap.put(sequenceRecord.getSequenceName(), sequenceRecord);
-        sequenceRecord.getAlternativeSequeneNames().forEach(an -> addSequenceAlias(sequenceRecord.getSequenceName(), an));
+        sequenceRecord.getAlternativeSequenceNames().forEach(an -> addSequenceAlias(sequenceRecord.getSequenceName(), an));
     }
 
     /**
@@ -206,7 +206,11 @@ public class SAMSequenceDictionary implements Serializable {
         return !thatSequences.hasNext();
     }
 
-    /** returns true if the two dictionaries are the same, aliases are NOT considered */
+    /**
+     * Returns {@code true} if the two dictionaries are the same.
+     *
+     * <p>NOTE: Aliases are NOT considered, but alternative sequence names (AN tag) names ARE.
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -223,13 +227,11 @@ public class SAMSequenceDictionary implements Serializable {
      * <code>1,chr1,chr01,01,CM000663,NC_000001.10</code> e.g:
      * <code>MT,chrM</code>
      *
-     * NOTE: this method does not add the alias to the alternative sequence name tag (AN) in the SAMSequenceRecord.
+     * <p>NOTE: this method does not add the alias to the alternative sequence name tag (AN) in the SAMSequenceRecord.
      * If you would like to add it to the AN tag, use {@link #addAlternativeSequenceName(String, String)} instead.
      *
-     * @param originalName
-     *            existing contig name
-     * @param altName
-     *            new contig name
+     * @param originalName  existing contig name
+     * @param altName       new contig name
      * @return the contig associated to the 'originalName/altName'
      */
     public SAMSequenceRecord addSequenceAlias(final String originalName,
@@ -257,13 +259,11 @@ public class SAMSequenceDictionary implements Serializable {
      * to retrieve the contigs (as with {@link #addSequenceAlias(String, String)}.
      *
      * <p>This can be use to provide some alternate names fo a given contig. e.g:
-     * <code>1,chr1,chr01,01,CM000663,NC_000001.10</code> or
+     * <code>1,chr1,chr01,01,CM000663</code> or
      * <code>MT,chrM</code>.
      *
-     * @param originalName
-     *            existing contig name
-     * @param altName
-     *            new contig name
+     * @param originalName  existing contig name
+     * @param altName       new contig name
      * @return the contig associated to the 'originalName/altName', with the AN tag including the altName
      */
     public SAMSequenceRecord addAlternativeSequenceName(final String originalName,

--- a/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlValue;
 import java.math.BigInteger;
 import java.net.URI;
@@ -48,6 +49,7 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
 {
     public static final long serialVersionUID = 1L; // AbstractSAMHeaderRecord implements Serializable
     private String mSequenceName = null; // Value must be interned() if it's ever set/modified
+    @XmlAttribute(name = "alternative_sequece_names")
     private Set<String> mAlternativeSequenceName = new LinkedHashSet<>();
     private int mSequenceIndex = -1;
     private int mSequenceLength = 0;
@@ -147,7 +149,7 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
     public void setSequenceIndex(final int value) { mSequenceIndex = value; }
 
     /** Returns unmodifiable set with alternative sequence names. */
-    @XmlAttribute(name = "alternative_sequece_names")
+    @XmlTransient //we use the field instead of getter/setter
     public Set<String> getAlternativeSequeneNames() {
         return Collections.unmodifiableSet(mAlternativeSequenceName);
     }

--- a/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -85,7 +85,7 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
     private static char[] WHITESPACE_CHARS = {' ', '\t', '\n', '\013', '\f', '\r'}; // \013 is vertical tab
 
     // alternative sequence name regexp
-    private static final Pattern ALTERNATIVE_SEQUENCE_NAME_REGEXP = Pattern.compile("[0-9A-Za-z][0-9A-Za-z*+.@-]*");
+    private static final Pattern ALTERNATIVE_SEQUENCE_NAME_REGEXP = Pattern.compile("[0-9A-Za-z][0-9A-Za-z*+.@_|-]*");
     private static final String ALTERNATIVE_SEQUENCE_NAME_SEPARATOR = ",";
 
     /** a (private) empty constructor is required for JAXB.XML-serialisation */

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -505,7 +505,7 @@ public class SAMTextHeaderCodec {
         fields[1] = SAMSequenceRecord.SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + sequenceRecord.getSequenceName();
         fields[2] = SAMSequenceRecord.SEQUENCE_LENGTH_TAG + TAG_KEY_VALUE_SEPARATOR + Integer.toString(sequenceRecord.getSequenceLength());
         encodeTags(sequenceRecord, fields, 3);
-        if (sequenceRecord.hasAlternativeSequenceNames()) fields[fields.length - 1] = SAMSequenceRecord.ALTERNATIVE_SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + String.join(",", sequenceRecord.getAlternativeSequeneNames());
+        if (sequenceRecord.hasAlternativeSequenceNames()) fields[fields.length - 1] = SAMSequenceRecord.ALTERNATIVE_SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + String.join(",", sequenceRecord.getAlternativeSequenceNames());
         return StringUtil.join(FIELD_SEPARATOR, fields);
     }
 

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -498,12 +498,14 @@ public class SAMTextHeaderCodec {
     }
 
     protected String getSQLine(final SAMSequenceRecord sequenceRecord) {
-        final int numAttributes = sequenceRecord.getAttributes() != null ? sequenceRecord.getAttributes().size() : 0;
+        int numAttributes = sequenceRecord.getAttributes() != null ? sequenceRecord.getAttributes().size() : 0;
+        if (sequenceRecord.hasAlternativeSequenceNames()) numAttributes++;
         final String[] fields = new String[3 + numAttributes];
         fields[0] = HEADER_LINE_START + HeaderRecordType.SQ;
         fields[1] = SAMSequenceRecord.SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + sequenceRecord.getSequenceName();
         fields[2] = SAMSequenceRecord.SEQUENCE_LENGTH_TAG + TAG_KEY_VALUE_SEPARATOR + Integer.toString(sequenceRecord.getSequenceLength());
         encodeTags(sequenceRecord, fields, 3);
+        if (sequenceRecord.hasAlternativeSequenceNames()) fields[fields.length - 1] = SAMSequenceRecord.ALTERNATIVE_SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + String.join(",", sequenceRecord.getAlternativeSequeneNames());
         return StringUtil.join(FIELD_SEPARATOR, fields);
     }
 

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -498,14 +498,12 @@ public class SAMTextHeaderCodec {
     }
 
     protected String getSQLine(final SAMSequenceRecord sequenceRecord) {
-        int numAttributes = sequenceRecord.getAttributes() != null ? sequenceRecord.getAttributes().size() : 0;
-        if (sequenceRecord.hasAlternativeSequenceNames()) numAttributes++;
+        final int numAttributes = sequenceRecord.getAttributes() != null ? sequenceRecord.getAttributes().size() : 0;
         final String[] fields = new String[3 + numAttributes];
         fields[0] = HEADER_LINE_START + HeaderRecordType.SQ;
         fields[1] = SAMSequenceRecord.SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + sequenceRecord.getSequenceName();
         fields[2] = SAMSequenceRecord.SEQUENCE_LENGTH_TAG + TAG_KEY_VALUE_SEPARATOR + Integer.toString(sequenceRecord.getSequenceLength());
         encodeTags(sequenceRecord, fields, 3);
-        if (sequenceRecord.hasAlternativeSequenceNames()) fields[fields.length - 1] = SAMSequenceRecord.ALTERNATIVE_SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + String.join(",", sequenceRecord.getAlternativeSequenceNames());
         return StringUtil.join(FIELD_SEPARATOR, fields);
     }
 

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
@@ -59,6 +59,24 @@ public class SAMSequenceDictionaryTest extends HtsjdkTest {
         Assert.assertNull(dict.getSequence("chr2"));
     }
 
+    @Test
+    public void testAlternativeSequences() {
+        final SAMSequenceRecord ssr1 = new SAMSequenceRecord("1", 1);
+        final SAMSequenceRecord ssr2 = new SAMSequenceRecord("2", 1);
+
+        final SAMSequenceDictionary dict = new SAMSequenceDictionary(
+                Arrays.asList(ssr1, ssr2));
+        Assert.assertEquals(dict.size(), 2);
+        dict.addAlternativeSequenceName("1", "chr1");
+        dict.addAlternativeSequenceName("1", "01");
+        dict.addAlternativeSequenceName("1", "1");
+        dict.addAlternativeSequenceName("01", "chr01");
+        Assert.assertEquals(dict.size(), 2);
+        Assert.assertTrue(dict.getSequence("chr1").hasAlternativeSequenceNames());
+        Assert.assertEquals(dict.getSequence("1").getAlternativeSequeneNames().size(), 3);
+        Assert.assertNull(dict.getSequence("chr2"));
+    }
+
     /**
      * should be saved as XML
      * 

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
@@ -73,7 +73,7 @@ public class SAMSequenceDictionaryTest extends HtsjdkTest {
         dict.addAlternativeSequenceName("01", "chr01");
         Assert.assertEquals(dict.size(), 2);
         Assert.assertTrue(dict.getSequence("chr1").hasAlternativeSequenceNames());
-        Assert.assertEquals(dict.getSequence("1").getAlternativeSequeneNames().size(), 3);
+        Assert.assertEquals(dict.getSequence("1").getAlternativeSequenceNames().size(), 3);
         Assert.assertNull(dict.getSequence("chr2"));
     }
 

--- a/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
@@ -29,6 +29,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Test for SAMReadGroupRecordTest
@@ -82,5 +84,29 @@ public class SAMSequenceRecordTest extends HtsjdkTest {
             rec1.setSequenceIndex(index1);
             Assert.assertEquals(rec1.isSameSequence(rec2), isSame);
         }
+    }
+
+    @Test
+    public void testAlternativeSequences() {
+        final SAMSequenceRecord chr1 = new SAMSequenceRecord("1", 100);
+
+        // no AN tag yet
+        Assert.assertFalse(chr1.hasAlternativeSequenceNames());
+        Assert.assertTrue(chr1.getAlternativeSequeneNames().isEmpty());
+
+        // set to a random alias
+        chr1.addAlternativeSequenceName("my_chromosome");
+        // TODO: if equals is changed, the two objects shouldn't be equals
+        Assert.assertEquals(chr1, new SAMSequenceRecord(chr1.getSequenceName(), chr1.getSequenceLength()));
+        Assert.assertTrue(chr1.hasAlternativeSequenceNames());
+        Assert.assertEquals(chr1.getAlternativeSequeneNames(), Collections.singleton("my_chromosome"));
+        Assert.assertEquals("@SQ\tSN:1\tLN:100\tAN:my_chromosome", chr1.getSAMString());
+
+        // set to new chromosome aliases (removing previous)
+        final List<String> chr1AltNames = Arrays.asList("chr1","chr01","01","CM000663","NC_000001.10");
+        chr1.setAlternativeSequenceName(chr1AltNames);
+        Assert.assertTrue(chr1.hasAlternativeSequenceNames());
+        Assert.assertEquals(chr1.getAlternativeSequeneNames(),  chr1AltNames);
+        Assert.assertEquals("@SQ\tSN:1\tLN:100\tAN:chr1,chr01,01,CM000663,NC_000001.10", chr1.getSAMString());
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
@@ -92,21 +92,39 @@ public class SAMSequenceRecordTest extends HtsjdkTest {
 
         // no AN tag yet
         Assert.assertFalse(chr1.hasAlternativeSequenceNames());
-        Assert.assertTrue(chr1.getAlternativeSequeneNames().isEmpty());
+        Assert.assertTrue(chr1.getAlternativeSequenceNames().isEmpty());
 
         // set to a random alias
-        chr1.addAlternativeSequenceName("my_chromosome");
-        // TODO: if equals is changed, the two objects shouldn't be equals
-        Assert.assertEquals(chr1, new SAMSequenceRecord(chr1.getSequenceName(), chr1.getSequenceLength()));
+        chr1.addAlternativeSequenceName("my-chromosome");
+        Assert.assertNotEquals(chr1, new SAMSequenceRecord(chr1.getSequenceName(), chr1.getSequenceLength()));
         Assert.assertTrue(chr1.hasAlternativeSequenceNames());
-        Assert.assertEquals(chr1.getAlternativeSequeneNames(), Collections.singleton("my_chromosome"));
-        Assert.assertEquals("@SQ\tSN:1\tLN:100\tAN:my_chromosome", chr1.getSAMString());
+        Assert.assertEquals(chr1.getAlternativeSequenceNames(), Collections.singleton("my-chromosome"));
+        Assert.assertEquals("@SQ\tSN:1\tLN:100\tAN:my-chromosome", chr1.getSAMString());
 
         // set to new chromosome aliases (removing previous)
-        final List<String> chr1AltNames = Arrays.asList("chr1","chr01","01","CM000663","NC_000001.10");
+        final List<String> chr1AltNames = Arrays.asList("chr1","chr01","01","CM000663");
         chr1.setAlternativeSequenceName(chr1AltNames);
         Assert.assertTrue(chr1.hasAlternativeSequenceNames());
-        Assert.assertEquals(chr1.getAlternativeSequeneNames(),  chr1AltNames);
-        Assert.assertEquals("@SQ\tSN:1\tLN:100\tAN:chr1,chr01,01,CM000663,NC_000001.10", chr1.getSAMString());
+        Assert.assertEquals(chr1.getAlternativeSequenceNames(),  chr1AltNames);
+        Assert.assertEquals("@SQ\tSN:1\tLN:100\tAN:chr1,chr01,01,CM000663", chr1.getSAMString());
+    }
+
+    @DataProvider
+    public Object[][] invalidAlternativeSequences() {
+        return new Object[][] {
+                // invalid start
+                {"@chr1"}, {",chr1"},
+                // comma-separated
+                {"chr1,alt"},
+                // coordinate-like
+                {"chr1:1000"}, {"chr1:100-200"}
+        };
+    }
+
+    @Test(dataProvider = "invalidAlternativeSequences")
+    public void testInvalidAlternativeSequences(final String altName) {
+        final SAMSequenceRecord chr1 = new SAMSequenceRecord("1", 100);
+        Assert.assertThrows(IllegalArgumentException.class, () -> chr1.addAlternativeSequenceName(altName));
+        Assert.assertThrows(IllegalArgumentException.class, () -> chr1.setAlternativeSequenceName(Collections.singleton(altName)));
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
@@ -110,6 +110,32 @@ public class SAMSequenceRecordTest extends HtsjdkTest {
     }
 
     @DataProvider
+    public Object[][] validAlternativeSequences() {
+        return new Object[][] {
+                // only characters
+                {"a"},
+                {"alias"},
+                // valid symbols after first character ('*', '+', '.', '@', '_', '|', '-')
+                {"my*contig"},
+                {"my+contig"},
+                {"my.contig"},
+                {"my@contig"},
+                {"my_contig"},
+                {"my|contig"},
+                {"my-contig"}
+        };
+    }
+
+    @Test(dataProvider = "validAlternativeSequences")
+    public void testValidAlternativeSequences(final String altName) {
+        final SAMSequenceRecord contig = new SAMSequenceRecord("contig", 100);
+        // should not throw
+        contig.setAlternativeSequenceName(Collections.singleton(altName));
+        Assert.assertTrue(contig.hasAlternativeSequenceNames());
+        Assert.assertEquals(contig.getAlternativeSequenceNames(), Collections.singleton(altName));
+    }
+
+    @DataProvider
     public Object[][] invalidAlternativeSequences() {
         return new Object[][] {
                 // invalid start


### PR DESCRIPTION
### Description

Adding the support for the new `@SQ` AN tag for alternative sequences (https://github.com/samtools/hts-specs/pull/220).

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

