### PR TITLE
Change contract for getAnyAttribute to return null for missing values

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Genotype.java
@@ -529,33 +529,37 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
 
     /**
      * A totally generic getter, that allows you to get specific keys that correspond
-     * to even inline values (GQ, for example).  Can be very expensive.  Additionally,
-     * all <code>int[]</code> are converted inline into <code>List&lt;Integer&gt;</code> for convenience.
+     * to even inline values (GQ, for example). Can be very expensive.
+     *
+     * <p>Note: all {@code int[]} values are converted inline into {@code List<Integer>} for convenience.
+     *
+     * <p>Warning: values associated with missing fields returns always {@code null}. For example,
+     * {@code GQ == -1} may return {@code null}.
      *
      * @param key
-     * @return
+     * @return the value associated to the key; if not present, {@code null}.
      */
     public Object getAnyAttribute(final String key) {
         if (key.equals(VCFConstants.GENOTYPE_KEY)) {
-            return getAlleles();
+            return isAvailable() ? getAlleles() : null;
         } else if (key.equals(VCFConstants.GENOTYPE_QUALITY_KEY)) {
-            return getGQ();
+            return hasGQ() ? getGQ() : null;
         } else if (key.equals(VCFConstants.GENOTYPE_ALLELE_DEPTHS)) {
             if (hasAD()) {
                 final List<Integer> intList = new ArrayList<Integer>(getAD().length);
                 for(int i : getAD()) intList.add(i);
                 return intList;
             }
-            return Collections.EMPTY_LIST;
+            return null;
         } else if (key.equals(VCFConstants.GENOTYPE_PL_KEY)) {
             if (hasPL()) {
                 final List<Integer> intList = new ArrayList<Integer>(getPL().length);
                 for(int i : getPL()) intList.add(i);
                 return intList;
             }
-            return Collections.EMPTY_LIST;
+            return null;
         } else if (key.equals(VCFConstants.DEPTH_KEY)) {
-            return getDP();
+            return hasDP() ? getDP() : null;
         } else if (key.equals(VCFConstants.GENOTYPE_FILTER_KEY)) {
             return getFilters();
         } else {

--- a/src/test/java/htsjdk/variant/variantcontext/GenotypeUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/GenotypeUnitTest.java
@@ -35,6 +35,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 
 public class GenotypeUnitTest extends VariantBaseTest {
     Allele A, Aref, T;
@@ -69,6 +72,26 @@ public class GenotypeUnitTest extends VariantBaseTest {
         Assert.assertTrue(makeGB().make().hasAnyAttribute(VCFConstants.GENOTYPE_FILTER_KEY), "hasAnyAttribute(GENOTYPE_FILTER_KEY) should return true");
         Assert.assertFalse(makeGB().filter("").make().isFiltered(), "empty filters should count as unfiltered");
         Assert.assertEquals(makeGB().filter("").make().getFilters(), null, "empty filter string should result in null filters");
+    }
+
+    @Test
+    public void testGetAnyAttribute() {
+        // test unset values always return null
+        Assert.assertNull(makeGB().make().getAnyAttribute("GT"));
+        Assert.assertNull(makeGB().make().getAnyAttribute("GQ"));
+        Assert.assertNull(makeGB().make().getAnyAttribute("AD"));
+        Assert.assertNull(makeGB().make().getAnyAttribute("PL"));
+        Assert.assertNull(makeGB().make().getAnyAttribute("FT"));
+        Assert.assertNull(makeGB().make().getAnyAttribute("DP"));
+        Assert.assertNull(makeGB().make().getAnyAttribute("OTHER"));
+        // test set values
+        Assert.assertEquals(makeGB().alleles(Arrays.asList(Aref, T)).make().getAnyAttribute("GT"), Arrays.asList(Aref, T));
+        Assert.assertEquals(makeGB().GQ(10).make().getAnyAttribute("GQ"), 10);
+        Assert.assertEquals(makeGB().AD(new int[]{1, 2}).make().getAnyAttribute("AD"), Arrays.asList(1, 2));
+        Assert.assertEquals(makeGB().PL(new int[]{1, 2}).make().getAnyAttribute("PL"), Arrays.asList(1, 2));
+        Assert.assertEquals(makeGB().filter("LOWQUAL").make().getAnyAttribute("FT"), "LOWQUAL");
+        Assert.assertEquals(makeGB().DP(100).make().getAnyAttribute("DP"), 100);
+        Assert.assertEquals(makeGB().attribute("OTHER", 30).make().getAnyAttribute("OTHER"), 30);
     }
 
 //    public Genotype(String sampleName, List<Allele> alleles, double negLog10PError, Set<String> filters, Map<String, ?> attributes, boolean isPhased) {


### PR DESCRIPTION
### Description

Proposal to fix  #957, to have a consistent behaviour for missing values in `Genotype.getAnyAttribute()`.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

