### PR TITLE
adding new method IOUtil.toPath(File)

### DIFF
--- a/src/main/java/htsjdk/samtools/BinaryBAMIndexWriter.java
+++ b/src/main/java/htsjdk/samtools/BinaryBAMIndexWriter.java
@@ -25,6 +25,7 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.BinaryCodec;
+import htsjdk.samtools.util.IOUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +48,7 @@ class BinaryBAMIndexWriter implements BAMIndexWriter {
      * @param output  BAM Index output file
      */
     public BinaryBAMIndexWriter(final int nRef, final File output) {
-        this(nRef, null == output ? null : output.toPath());
+        this(nRef, IOUtil.toPath(output));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -452,7 +452,7 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      */
     public SAMFileWriter makeWriter(final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
-        return makeWriter(header, presorted, null == outputFile ? null : outputFile.toPath(), null == referenceFasta ? null : referenceFasta.toPath());
+        return makeWriter(header, presorted, IOUtil.toPath( outputFile ), null == referenceFasta ? null : referenceFasta.toPath());
     }
 
     /**
@@ -468,7 +468,7 @@ public class SAMFileWriterFactory implements Cloneable {
      */
     @Deprecated
     public SAMFileWriter makeWriter(final SAMFileHeader header, final boolean presorted, final Path outputPath, final File referenceFasta) {
-        return makeWriter(header, presorted, outputPath, null == referenceFasta ? null : referenceFasta.toPath());
+        return makeWriter(header, presorted, outputPath, IOUtil.toPath( referenceFasta ));
     }
 
     /**
@@ -503,7 +503,7 @@ public class SAMFileWriterFactory implements Cloneable {
      * @return CRAMFileWriter
      */
     public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final OutputStream stream, final File referenceFasta) {
-        return makeCRAMWriter(header, stream, null == referenceFasta ? null : referenceFasta.toPath());
+        return makeCRAMWriter(header, stream, IOUtil.toPath( referenceFasta ));
     }
 
     /**
@@ -537,7 +537,7 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      */
     public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final File outputFile, final File referenceFasta) {
-        return createCRAMWriterWithSettings(header, true, outputFile.toPath(), null == referenceFasta ? null : referenceFasta.toPath());
+        return createCRAMWriterWithSettings(header, true, outputFile.toPath(), IOUtil.toPath( referenceFasta ));
     }
 
     /**
@@ -556,7 +556,7 @@ public class SAMFileWriterFactory implements Cloneable {
      */
     @Deprecated
     public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final Path outputPath, final File referenceFasta) {
-        return makeCRAMWriter(header, true, outputPath, null == referenceFasta ? null : referenceFasta.toPath());
+        return makeCRAMWriter(header, true, outputPath, IOUtil.toPath( referenceFasta ));
     }
 
     /**
@@ -593,7 +593,7 @@ public class SAMFileWriterFactory implements Cloneable {
      */
     @Deprecated
     public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final boolean presorted, final Path output, final File referenceFasta) {
-        return makeCRAMWriter(header, presorted, output, null == referenceFasta ? null : referenceFasta.toPath());
+        return makeCRAMWriter(header, presorted, output, IOUtil.toPath( referenceFasta ));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -452,7 +452,7 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      */
     public SAMFileWriter makeWriter(final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
-        return makeWriter(header, presorted, IOUtil.toPath( outputFile ), null == referenceFasta ? null : referenceFasta.toPath());
+        return makeWriter(header, presorted, IOUtil.toPath( outputFile ), IOUtil.toPath(referenceFasta));
     }
 
     /**
@@ -572,7 +572,7 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      */
     public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
-        return makeCRAMWriter(header, presorted, outputFile.toPath(),  null == referenceFasta ? null : referenceFasta.toPath());
+        return makeCRAMWriter(header, presorted, outputFile.toPath(),  IOUtil.toPath(referenceFasta));
     }
 
 

--- a/src/main/java/htsjdk/samtools/SamFiles.java
+++ b/src/main/java/htsjdk/samtools/SamFiles.java
@@ -3,6 +3,7 @@ package htsjdk.samtools;
 import htsjdk.samtools.cram.CRAIIndex;
 import htsjdk.samtools.cram.build.CramIO;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import java.io.File;
 import java.io.IOException;
@@ -24,7 +25,7 @@ public class SamFiles {
      * @return The index for the provided SAM, or null if one was not found.
      */
     public static File findIndex(final File samFile) {
-        Path path = findIndex(samFile.toPath());
+        final Path path = findIndex(IOUtil.toPath(samFile));
         return path == null ? null : path.toFile();
     }
 

--- a/src/main/java/htsjdk/samtools/SamInputResource.java
+++ b/src/main/java/htsjdk/samtools/SamInputResource.java
@@ -271,7 +271,7 @@ class FileInputResource extends InputResource {
 
     @Override
     public Path asPath() {
-        return fileResource.toPath();
+        return IOUtil.toPath(fileResource);
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -20,12 +20,11 @@ package htsjdk.samtools.cram.ref;
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMSequenceRecord;
-import htsjdk.samtools.SAMUtils;
-import htsjdk.samtools.cram.build.Utils;
 import htsjdk.samtools.cram.io.InputStreamUtils;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
@@ -60,7 +59,7 @@ public class ReferenceSource implements CRAMReferenceSource {
     private final Map<String, WeakReference<byte[]>> cacheW = new HashMap<>();
 
     public ReferenceSource(final File file) {
-        this(file == null ? null : file.toPath());
+        this(IOUtil.toPath(file));
     }
 
     public ReferenceSource(final Path path) {

--- a/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -50,7 +50,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
      * @param file Fasta file to read.  Also acts as a prefix for supporting files.
      */
     AbstractFastaSequenceFile(final File file) {
-        this(file == null ? null : file.toPath());
+        this(IOUtil.toPath(file));
     }
 
     /**
@@ -86,10 +86,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     }
 
     protected static File findSequenceDictionary(final File file) {
-        if (file == null) {
-            return null;
-        }
-        Path dictionary = findSequenceDictionary(file.toPath());
+        final Path dictionary = findSequenceDictionary(IOUtil.toPath(file));
         if (dictionary == null) {
             return null;
         }

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceFile.java
@@ -53,7 +53,7 @@ public class FastaSequenceFile extends AbstractFastaSequenceFile {
 
     /** Constructs a FastaSequenceFile that reads from the specified file. */
     public FastaSequenceFile(final File file, final boolean truncateNamesAtWhitespace) {
-        this(file == null ? null : file.toPath(), truncateNamesAtWhitespace);
+        this(IOUtil.toPath(file), truncateNamesAtWhitespace);
     }
 
     /** Constructs a FastaSequenceFile that reads from the specified file. */

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
@@ -57,7 +57,7 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
      * @throws FileNotFoundException if the index file cannot be found.
      */
     public FastaSequenceIndex( File indexFile ) {
-        this(indexFile == null ? null : indexFile.toPath());
+        this(IOUtil.toPath(indexFile));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
@@ -59,7 +59,7 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
      * @throws FileNotFoundException If the fasta or any of its supporting files cannot be found.
      */
     public IndexedFastaSequenceFile(final File file, final FastaSequenceIndex index) {
-        this(file == null ? null : file.toPath(), index);
+        this(IOUtil.toPath(file), index);
     }
 
     /**
@@ -68,7 +68,7 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
      * @throws FileNotFoundException If the fasta or any of its supporting files cannot be found.
      */
     public IndexedFastaSequenceFile(final File file) throws FileNotFoundException {
-        this(file, new FastaSequenceIndex((findRequiredFastaIndexFile(file == null ? null : file.toPath()))));
+        this(file, new FastaSequenceIndex((findRequiredFastaIndexFile(IOUtil.toPath(file)))));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
@@ -93,7 +93,7 @@ public class ReferenceSequenceFileFactory {
      * @param preferIndexed if true attempt to return an indexed reader that supports non-linear traversal, else return the non-indexed reader
      */
     public static ReferenceSequenceFile getReferenceSequenceFile(final File file, final boolean truncateNamesAtWhitespace, final boolean preferIndexed) {
-        return getReferenceSequenceFile(file.toPath(), truncateNamesAtWhitespace, preferIndexed);
+        return getReferenceSequenceFile(IOUtil.toPath(file), truncateNamesAtWhitespace, preferIndexed);
     }
 
     /**
@@ -206,7 +206,7 @@ public class ReferenceSequenceFileFactory {
      * @param file the reference sequence file on disk.
      */
     public static File getDefaultDictionaryForReferenceSequence(final File file) {
-        return getDefaultDictionaryForReferenceSequence(file.toPath()).toFile();
+        return getDefaultDictionaryForReferenceSequence(IOUtil.toPath(file)).toFile();
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/main/java/htsjdk/samtools/util/BinaryCodec.java
@@ -123,7 +123,7 @@ public class BinaryCodec implements Closeable {
      * @param writing whether the file is being written to
      */
     public BinaryCodec(final File file, final boolean writing) {
-        this(null == file ? null : file.toPath(), writing);
+        this(IOUtil.toPath(file), writing);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -414,7 +414,7 @@ public class IOUtil {
      * @param file the file to check for readability
      */
     public static void assertFileIsReadable(final File file) {
-        assertFileIsReadable(file == null ? null : file.toPath());
+        assertFileIsReadable(toPath(file));
     }
 
     /**
@@ -521,7 +521,7 @@ public class IOUtil {
      * @param dir the dir to check for writability
      */
     public static void assertDirectoryIsWritable(final File dir) {
-        final Path asPath = (dir == null) ? null : dir.toPath();
+        final Path asPath = IOUtil.toPath(dir);
         assertDirectoryIsWritable(asPath);
     }
 
@@ -613,7 +613,7 @@ public class IOUtil {
      * @return the input stream to read from
      */
     public static InputStream openFileForReading(final File file) {
-        return openFileForReading(file.toPath());
+        return openFileForReading(toPath(file));
     }
 
     /**
@@ -646,7 +646,7 @@ public class IOUtil {
      * @return the input stream to read from
      */
     public static InputStream openGzipFileForReading(final File file) {
-        return openGzipFileForReading(file.toPath());
+        return openGzipFileForReading(toPath(file));
     }
 
     /**
@@ -886,7 +886,7 @@ public class IOUtil {
 
     /** Checks that a file exists and is readable, and then returns a buffered reader for it. */
     public static BufferedReader openFileForBufferedReading(final File file) {
-        return openFileForBufferedReading(file.toPath());
+        return openFileForBufferedReading(toPath(file));
     }
 
     /** Checks that a path exists and is readable, and then returns a buffered reader for it. */
@@ -1267,5 +1267,13 @@ public class IOUtil {
             }
         }
         return path;
+    }
+
+    /*
+     * @param file
+     * @return if file == null return null otherwise return file.toPath()
+     */
+    public static Path toPath(File file) {
+        return file == null ? null : file.toPath();
     }
 }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1268,12 +1268,4 @@ public class IOUtil {
         }
         return path;
     }
-
-    /*
-     * @param file
-     * @return if file == null return null otherwise return file.toPath()
-     */
-    public static Path toPath(File file) {
-        return file == null ? null : file.toPath();
-    }
 }

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -396,7 +396,7 @@ public class IntervalList implements Iterable<Interval> {
      * @return an IntervalList object that contains the headers and intervals from the file
      */
     public static IntervalList fromFile(final File file) {
-        return fromPath(file.toPath());
+        return fromPath(IOUtil.toPath(file));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/Md5CalculatingOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/Md5CalculatingOutputStream.java
@@ -27,7 +27,6 @@ import htsjdk.samtools.SAMException;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
@@ -68,7 +67,7 @@ public class Md5CalculatingOutputStream extends OutputStream {
     }
 
     public Md5CalculatingOutputStream(OutputStream os, File digestFile) {
-        this(os, digestFile == null ? (Path) null : digestFile.toPath());
+        this(os, IOUtil.toPath(digestFile));
     }
 
     @Override

--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -173,7 +173,7 @@ public abstract class AbstractIndex implements MutableIndex {
     }
 
     public AbstractIndex(final File featureFile) {
-        this(featureFile.toPath());
+        this(IOUtil.toPath(featureFile));
     }
 
     public AbstractIndex(final Path featurePath) {

--- a/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
@@ -24,6 +24,7 @@
 
 package htsjdk.tribble.index;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.index.interval.IntervalIndexCreator;
@@ -65,7 +66,7 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
     }
 
     public DynamicIndexCreator(final File inputFile, final IndexFactory.IndexBalanceApproach iba) {
-        this(inputFile.toPath(), iba);
+        this(IOUtil.toPath(inputFile), iba);
     }
 
     @Override

--- a/src/main/java/htsjdk/tribble/index/Index.java
+++ b/src/main/java/htsjdk/tribble/index/Index.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.tribble.index;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.util.LittleEndianOutputStream;
 
 import java.io.File;
@@ -79,7 +80,7 @@ public interface Index {
      * @throws IOException if the index is unable to write to the specified file
      */
     public default void write(final File idxFile) throws IOException {
-        write(idxFile.toPath());
+        write(IOUtil.toPath(idxFile));
     }
 
     /**
@@ -99,7 +100,7 @@ public interface Index {
      * @throws IOException if featureFile is not a normal file.
      */
     public default void writeBasedOnFeatureFile(File featureFile) throws IOException {
-        writeBasedOnFeaturePath(featureFile.toPath());
+        writeBasedOnFeaturePath(IOUtil.toPath(featureFile));
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
@@ -18,6 +18,7 @@
 
 package htsjdk.tribble.index.interval;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
@@ -60,11 +61,11 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
     }
 
     public IntervalIndexCreator(final File inputFile, final int featuresPerInterval) {
-        this(inputFile.toPath(), featuresPerInterval);
+        this(IOUtil.toPath(inputFile), featuresPerInterval);
     }
 
     public IntervalIndexCreator(final File inputFile) {
-        this(inputFile.toPath());
+        this(IOUtil.toPath(inputFile));
     }
 
     public IntervalIndexCreator(final Path inputPath) {

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -18,6 +18,7 @@
 
 package htsjdk.tribble.index.linear;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.index.AbstractIndex;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
@@ -84,7 +85,7 @@ public class LinearIndex extends AbstractIndex {
      * @param featureFile
      */
     public LinearIndex(final List<ChrIndex> indices, final File featureFile) {
-        this(indices, featureFile.toPath());
+        this(indices, IOUtil.toPath(featureFile));
     }
 
     private LinearIndex(final LinearIndex parent, final List<ChrIndex> indices) {

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.tribble.index.linear;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
@@ -57,11 +58,11 @@ public class LinearIndexCreator  extends TribbleIndexCreator {
     }
 
     public LinearIndexCreator(final File inputFile, final int binSize) {
-        this(inputFile.toPath(), binSize);
+        this(IOUtil.toPath(inputFile), binSize);
     }
 
     public LinearIndexCreator(final File inputFile) {
-        this(inputFile.toPath());
+        this(IOUtil.toPath(inputFile));
     }
 
     public LinearIndexCreator(final Path inputPath) {

--- a/src/test/java/htsjdk/samtools/SamFilesTest.java
+++ b/src/test/java/htsjdk/samtools/SamFilesTest.java
@@ -3,6 +3,7 @@ package htsjdk.samtools;
 import java.nio.file.Path;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.IOUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -88,6 +89,6 @@ public class SamFilesTest extends HtsjdkTest {
     @Test(dataProvider ="filesAndIndicies")
     public void testIndexSymlinking(File bam, File expected_index) {
         Assert.assertEquals(SamFiles.findIndex(bam), expected_index);
-        Assert.assertEquals(SamFiles.findIndex(bam.toPath()), expected_index == null ? null : expected_index.toPath());
+        Assert.assertEquals(SamFiles.findIndex(bam.toPath()), IOUtil.toPath(expected_index));
     }
 }

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -44,6 +44,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.lang.IllegalArgumentException;
+import java.nio.file.Path;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -265,6 +267,22 @@ public class IOUtilTest extends HtsjdkTest {
                 {"/non/existent/file", Boolean.TRUE},
         };
     }
+
+
+    @DataProvider
+    public Object[][] getFiles(){
+        final File file = new File("someFile");
+        return new Object[][] {
+                {null, null},
+                {file, file.toPath()}
+        };
+    }
+
+    @Test(dataProvider = "getFiles")
+    public void testToPath(final File file, final Path expected){
+        Assert.assertEquals(IOUtil.toPath(file), expected);
+    }
+
 
     @DataProvider(name = "fileNamesForDelete")
     public Object[][] fileNamesForDelete() {


### PR DESCRIPTION
### Description

this method converts a `File` to a `Path`, but passes a null through unchanged instead of crashing with an NPE
it is useful when adapting existing code that takes `File`s into code that takes `Path`s and should help avoid introducing new NPEs when converting code

updated existing uses of `file.toPath()` to `IOUtil.toPath(file)`

### Checklist

- [ x ] Code compiles correctly
- [ X ] New tests covering changes and new functionality
- [ x ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

