### PR TITLE
Deprecate 'not-primary' in favor of secondary along HTSJDK

### DIFF
--- a/src/main/java/htsjdk/samtools/NotPrimarySkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/NotPrimarySkippingIterator.java
@@ -24,39 +24,17 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.PeekIterator;
 
 /**
  * Wrapper around SAMRecord iterator that skips over non-primary elements.
  * This iterator conflates a filtering iterator and a peekable iterator.  It would be cleaner to
  * handle those concerns separately.
+ * @deprecated use {@link SecondarySkippingIterator} instead.
  */
-public class NotPrimarySkippingIterator {
-    private final PeekIterator<SAMRecord> it;
+@Deprecated
+public class NotPrimarySkippingIterator extends SecondarySkippingIterator {
 
-    public NotPrimarySkippingIterator(final CloseableIterator<SAMRecord> underlyingIt) {
-        it = new PeekIterator<SAMRecord>(underlyingIt);
-        skipAnyNotprimary();
-    }
-
-    public boolean hasCurrent() {
-        return it.hasNext();
-    }
-
-    public SAMRecord getCurrent() {
-        assert(hasCurrent());
-        return it.peek();
-    }
-
-    public boolean advance() {
-        it.next();
-        skipAnyNotprimary();
-        return hasCurrent();
-    }
-
-    private void skipAnyNotprimary() {
-        while (it.hasNext() && it.peek().getNotPrimaryAlignmentFlag()) {
-            it.next();
-        }
+    public NotPrimarySkippingIterator(CloseableIterator<SAMRecord> underlyingIt) {
+        super(underlyingIt);
     }
 }

--- a/src/main/java/htsjdk/samtools/NotPrimarySkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/NotPrimarySkippingIterator.java
@@ -29,10 +29,10 @@ import htsjdk.samtools.util.CloseableIterator;
  * Wrapper around SAMRecord iterator that skips over non-primary elements.
  * This iterator conflates a filtering iterator and a peekable iterator.  It would be cleaner to
  * handle those concerns separately.
- * @deprecated use {@link SecondarySkippingIterator} instead.
+ * @deprecated use {@link SecondaryAlignmentSkippingIterator} instead.
  */
 @Deprecated
-public class NotPrimarySkippingIterator extends SecondarySkippingIterator {
+public class NotPrimarySkippingIterator extends SecondaryAlignmentSkippingIterator {
 
     public NotPrimarySkippingIterator(CloseableIterator<SAMRecord> underlyingIt) {
         super(underlyingIt);

--- a/src/main/java/htsjdk/samtools/SAMFlag.java
+++ b/src/main/java/htsjdk/samtools/SAMFlag.java
@@ -39,6 +39,9 @@ public enum SAMFlag {
     MATE_REVERSE_STRAND(            0x20,   "SEQ of the next segment in the template being reverse complemented"),
     FIRST_OF_PAIR(                  0x40,   "The first segment in the template"),
     SECOND_OF_PAIR(                 0x80,   "The last segment in the template"),
+    SECONDARY_ALIGNMENT(            0x100,  "Secondary alignment"),
+    /** @deprecated use {@link #SECONDARY_ALIGNMENT} instead. */
+    @Deprecated
     NOT_PRIMARY_ALIGNMENT(          0x100,  "Secondary alignment"),
     READ_FAILS_VENDOR_QUALITY_CHECK(0x200,  "Not passing quality controls"),
     DUPLICATE_READ(                 0x400,  "PCR or optical duplicate"), 

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -967,20 +967,19 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 
     /**
      * the alignment is not primary (a read having split hits may have multiple primary alignment records).
-     * @deprecated use {@link #getSecondaryAlignmentFlag()} instead.
+     * @deprecated use {@link #isSecondaryAlignment()} instead.
      */
     @Deprecated
     public boolean getNotPrimaryAlignmentFlag() {
-        return getSecondaryAlignmentFlag();
+        return isSecondaryAlignment();
     }
 
     /**
      * the alignment is secondary (a read having slipt hits have multiple alignment records).
      */
-    public boolean getSecondaryAlignmentFlag() {
+    public boolean isSecondaryAlignment() {
         return (mFlags & SAMFlag.SECONDARY_ALIGNMENT.flag) != 0;
     }
-
 
     /**
      * the alignment is supplementary (TODO: further explanation?).
@@ -1073,17 +1072,17 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 
     /**
      * the alignment is not primary (a read having split hits may have multiple primary alignment records).
-     * @deprecated use {@link #setSecondaryAlignmentFlag(boolean)} instead.
+     * @deprecated use {@link #setSecondaryAlignment(boolean)} instead.
      */
     @Deprecated
     public void setNotPrimaryAlignmentFlag(final boolean flag) {
-        setSecondaryAlignmentFlag(flag);
+        setSecondaryAlignment(flag);
     }
 
     /**
      * the alignment is secondary (a read having slipt hits have multiple alignment records).
      */
-    public void setSecondaryAlignmentFlag(final boolean flag) {
+    public void setSecondaryAlignment(final boolean flag) {
         setFlag(flag, SAMFlag.SECONDARY_ALIGNMENT.flag);
     }
 
@@ -1113,7 +1112,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * equivalent to {@code (getNotPrimaryAlignmentFlag() || getSupplementaryAlignmentFlag())}.
      */
     public boolean isSecondaryOrSupplementary() {
-        return getSecondaryAlignmentFlag() || getSupplementaryAlignmentFlag();
+        return isSecondaryAlignment() || getSupplementaryAlignmentFlag();
     }
 
     private void setFlag(final boolean flag, final int bit) {
@@ -1973,7 +1972,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             if (firstOnly) return ret;
         }
         if (getReadUnmappedFlag()) {
-            if (getSecondaryAlignmentFlag()) {
+            if (isSecondaryAlignment()) {
                 if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_NOT_PRIM_ALIGNMENT, "Secondary alignment flag should not be set for unmapped read.", getReadName()));
                 if (firstOnly) return ret;
@@ -2049,7 +2048,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             if (firstOnly) return ret;
         }
         // TODO(mccowan): Is this asking "is this the primary alignment"?
-        if (this.getReadLength() == 0 && !this.getSecondaryAlignmentFlag()) {
+        if (this.getReadLength() == 0 && !this.isSecondaryAlignment()) {
             final Object fz = getAttribute(SAMTagUtil.getSingleton().FZ);
             if (fz == null) {
                 final String cq = (String)getAttribute(SAMTagUtil.getSingleton().CQ);

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -967,10 +967,20 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 
     /**
      * the alignment is not primary (a read having split hits may have multiple primary alignment records).
+     * @deprecated use {@link #getSecondaryAlignmentFlag()} instead.
      */
+    @Deprecated
     public boolean getNotPrimaryAlignmentFlag() {
-        return (mFlags & SAMFlag.NOT_PRIMARY_ALIGNMENT.flag) != 0;
+        return getSecondaryAlignmentFlag();
     }
+
+    /**
+     * the alignment is secondary (a read having slipt hits have multiple alignment records).
+     */
+    public boolean getSecondaryAlignmentFlag() {
+        return (mFlags & SAMFlag.SECONDARY_ALIGNMENT.flag) != 0;
+    }
+
 
     /**
      * the alignment is supplementary (TODO: further explanation?).
@@ -1063,9 +1073,18 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 
     /**
      * the alignment is not primary (a read having split hits may have multiple primary alignment records).
+     * @deprecated use {@link #setSecondaryAlignmentFlag(boolean)} instead.
      */
+    @Deprecated
     public void setNotPrimaryAlignmentFlag(final boolean flag) {
-        setFlag(flag, SAMFlag.NOT_PRIMARY_ALIGNMENT.flag);
+        setSecondaryAlignmentFlag(flag);
+    }
+
+    /**
+     * the alignment is secondary (a read having slipt hits have multiple alignment records).
+     */
+    public void setSecondaryAlignmentFlag(final boolean flag) {
+        setFlag(flag, SAMFlag.SECONDARY_ALIGNMENT.flag);
     }
 
     /**
@@ -1094,7 +1113,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * equivalent to {@code (getNotPrimaryAlignmentFlag() || getSupplementaryAlignmentFlag())}.
      */
     public boolean isSecondaryOrSupplementary() {
-        return getNotPrimaryAlignmentFlag() || getSupplementaryAlignmentFlag();
+        return getSecondaryAlignmentFlag() || getSupplementaryAlignmentFlag();
     }
 
     private void setFlag(final boolean flag, final int bit) {
@@ -1954,9 +1973,9 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             if (firstOnly) return ret;
         }
         if (getReadUnmappedFlag()) {
-            if (getNotPrimaryAlignmentFlag()) {
+            if (getSecondaryAlignmentFlag()) {
                 if (ret == null) ret = new ArrayList<>();
-                ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_NOT_PRIM_ALIGNMENT, "Not primary alignment flag should not be set for unmapped read.", getReadName()));
+                ret.add(new SAMValidationError(SAMValidationError.Type.INVALID_FLAG_NOT_PRIM_ALIGNMENT, "Secondary alignment flag should not be set for unmapped read.", getReadName()));
                 if (firstOnly) return ret;
             }
             if (getSupplementaryAlignmentFlag()) {
@@ -2030,7 +2049,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             if (firstOnly) return ret;
         }
         // TODO(mccowan): Is this asking "is this the primary alignment"?
-        if (this.getReadLength() == 0 && !this.getNotPrimaryAlignmentFlag()) {
+        if (this.getReadLength() == 0 && !this.getSecondaryAlignmentFlag()) {
             final Object fz = getAttribute(SAMTagUtil.getSingleton().FZ);
             if (fz == null) {
                 final String cq = (String)getAttribute(SAMTagUtil.getSingleton().CQ);

--- a/src/main/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
@@ -51,8 +51,8 @@ public class SAMRecordQueryNameComparator implements SAMRecordComparator, Serial
         if (samRecord1.getReadNegativeStrandFlag() != samRecord2.getReadNegativeStrandFlag()) {
             return (samRecord1.getReadNegativeStrandFlag()? 1: -1);
         }
-        if (samRecord1.getSecondaryAlignmentFlag() != samRecord2.getSecondaryAlignmentFlag()) {
-            return samRecord2.getSecondaryAlignmentFlag()? -1: 1;
+        if (samRecord1.isSecondaryAlignment() != samRecord2.isSecondaryAlignment()) {
+            return samRecord2.isSecondaryAlignment()? -1: 1;
         }
         if (samRecord1.getSupplementaryAlignmentFlag() != samRecord2.getSupplementaryAlignmentFlag()) {
             return samRecord2.getSupplementaryAlignmentFlag() ? -1 : 1;

--- a/src/main/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
@@ -51,8 +51,8 @@ public class SAMRecordQueryNameComparator implements SAMRecordComparator, Serial
         if (samRecord1.getReadNegativeStrandFlag() != samRecord2.getReadNegativeStrandFlag()) {
             return (samRecord1.getReadNegativeStrandFlag()? 1: -1);
         }
-        if (samRecord1.getNotPrimaryAlignmentFlag() != samRecord2.getNotPrimaryAlignmentFlag()) {
-            return samRecord2.getNotPrimaryAlignmentFlag()? -1: 1;
+        if (samRecord1.getSecondaryAlignmentFlag() != samRecord2.getSecondaryAlignmentFlag()) {
+            return samRecord2.getSecondaryAlignmentFlag()? -1: 1;
         }
         if (samRecord1.getSupplementaryAlignmentFlag() != samRecord2.getSupplementaryAlignmentFlag()) {
             return samRecord2.getSupplementaryAlignmentFlag() ? -1 : 1;

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -25,7 +25,6 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
 import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.SequenceUtil;
 
@@ -287,7 +286,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
                              final boolean recordUnmapped, final String cigar, final String qualityString,
                              final int defaultQuality, final boolean isSecondary) throws SAMException {
         final htsjdk.samtools.SAMRecord rec = createReadNoFlag(name, contig, start, negativeStrand, recordUnmapped, cigar, qualityString, defaultQuality);
-        if (isSecondary) rec.setSecondaryAlignmentFlag(true);
+        if (isSecondary) rec.setSecondaryAlignment(true);
         this.records.add(rec);
         return rec;
     }
@@ -300,7 +299,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
                              final boolean recordUnmapped, final String cigar, final String qualityString,
                              final int defaultQuality, final boolean isSecondary, final boolean isSupplementary) throws SAMException {
         final htsjdk.samtools.SAMRecord rec = createReadNoFlag(name, contig, start, negativeStrand, recordUnmapped, cigar, qualityString, defaultQuality);
-        if (isSecondary) rec.setSecondaryAlignmentFlag(true);
+        if (isSecondary) rec.setSecondaryAlignment(true);
         if (isSupplementary) rec.setSupplementaryAlignmentFlag(true);
         this.records.add(rec);
         return rec;
@@ -434,11 +433,11 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         end2.setReadPairedFlag(true);
         end2.setSecondOfPairFlag(true);
 
-        if (record1NonPrimary) end1.setSecondaryAlignmentFlag(true);
-        if (record2NonPrimary) end2.setSecondaryAlignmentFlag(true);
+        if (record1NonPrimary) end1.setSecondaryAlignment(true);
+        if (record2NonPrimary) end2.setSecondaryAlignment(true);
 
-        if (record1NonPrimary) end1.setSecondaryAlignmentFlag(true);
-        if (record2NonPrimary) end2.setSecondaryAlignmentFlag(true);
+        if (record1NonPrimary) end1.setSecondaryAlignment(true);
+        if (record2NonPrimary) end2.setSecondaryAlignment(true);
 
         // set mate info
         SamPairUtil.setMateInfo(end1, end2, true);

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -287,7 +287,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
                              final boolean recordUnmapped, final String cigar, final String qualityString,
                              final int defaultQuality, final boolean isSecondary) throws SAMException {
         final htsjdk.samtools.SAMRecord rec = createReadNoFlag(name, contig, start, negativeStrand, recordUnmapped, cigar, qualityString, defaultQuality);
-        if (isSecondary) rec.setNotPrimaryAlignmentFlag(true);
+        if (isSecondary) rec.setSecondaryAlignmentFlag(true);
         this.records.add(rec);
         return rec;
     }
@@ -300,7 +300,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
                              final boolean recordUnmapped, final String cigar, final String qualityString,
                              final int defaultQuality, final boolean isSecondary, final boolean isSupplementary) throws SAMException {
         final htsjdk.samtools.SAMRecord rec = createReadNoFlag(name, contig, start, negativeStrand, recordUnmapped, cigar, qualityString, defaultQuality);
-        if (isSecondary) rec.setNotPrimaryAlignmentFlag(true);
+        if (isSecondary) rec.setSecondaryAlignmentFlag(true);
         if (isSupplementary) rec.setSupplementaryAlignmentFlag(true);
         this.records.add(rec);
         return rec;
@@ -434,11 +434,11 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         end2.setReadPairedFlag(true);
         end2.setSecondOfPairFlag(true);
 
-        if (record1NonPrimary) end1.setNotPrimaryAlignmentFlag(true);
-        if (record2NonPrimary) end2.setNotPrimaryAlignmentFlag(true);
+        if (record1NonPrimary) end1.setSecondaryAlignmentFlag(true);
+        if (record2NonPrimary) end2.setSecondaryAlignmentFlag(true);
 
-        if (record1NonPrimary) end1.setNotPrimaryAlignmentFlag(true);
-        if (record2NonPrimary) end2.setNotPrimaryAlignmentFlag(true);
+        if (record1NonPrimary) end1.setSecondaryAlignmentFlag(true);
+        if (record2NonPrimary) end2.setSecondaryAlignmentFlag(true);
 
         // set mate info
         SamPairUtil.setMateInfo(end1, end2, true);

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -580,7 +580,7 @@ public final class SAMUtils {
         rec.setCigarString(SAMRecord.NO_ALIGNMENT_CIGAR);
         rec.setMappingQuality(SAMRecord.NO_MAPPING_QUALITY);
         rec.setInferredInsertSize(0);
-        rec.setSecondaryAlignmentFlag(false);
+        rec.setSecondaryAlignment(false);
         rec.setSupplementaryAlignmentFlag(false);
         rec.setProperPairFlag(false);
         rec.setReadUnmappedFlag(true);

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -580,7 +580,7 @@ public final class SAMUtils {
         rec.setCigarString(SAMRecord.NO_ALIGNMENT_CIGAR);
         rec.setMappingQuality(SAMRecord.NO_MAPPING_QUALITY);
         rec.setInferredInsertSize(0);
-        rec.setNotPrimaryAlignmentFlag(false);
+        rec.setSecondaryAlignmentFlag(false);
         rec.setSupplementaryAlignmentFlag(false);
         rec.setProperPairFlag(false);
         rec.setReadUnmappedFlag(true);

--- a/src/main/java/htsjdk/samtools/SamFlagField.java
+++ b/src/main/java/htsjdk/samtools/SamFlagField.java
@@ -111,7 +111,7 @@ public enum SamFlagField {
             if ((flag & SAMFlag.FIRST_OF_PAIR.flag) != 0)                   value.append('1');
             if ((flag & SAMFlag.SECOND_OF_PAIR.flag) != 0)                  value.append('2');
 
-            if ((flag & SAMFlag.NOT_PRIMARY_ALIGNMENT.flag) != 0)           value.append('s');
+            if ((flag & SAMFlag.SECONDARY_ALIGNMENT.flag) != 0)           value.append('s');
             if ((flag & SAMFlag.SUPPLEMENTARY_ALIGNMENT.flag) != 0)         value.append('S');
             if ((flag & SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK.flag) != 0) value.append('x');
             if ((flag & SAMFlag.DUPLICATE_READ.flag) != 0)                  value.append('d');
@@ -138,7 +138,7 @@ public enum SamFlagField {
                     case 'R':  value |= SAMFlag.MATE_REVERSE_STRAND.flag;  break;
                     case '1':  value |= SAMFlag.FIRST_OF_PAIR.flag;  break;
                     case '2':  value |= SAMFlag.SECOND_OF_PAIR.flag;  break;
-                    case 's':  value |= SAMFlag.NOT_PRIMARY_ALIGNMENT.flag;  break;
+                    case 's':  value |= SAMFlag.SECONDARY_ALIGNMENT.flag;  break;
                     case 'x':  value |= SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK.flag;  break;
                     case 'd':  value |= SAMFlag.DUPLICATE_READ.flag;  break;
                     case 'S':  value |= SAMFlag.SUPPLEMENTARY_ALIGNMENT.flag;  break;

--- a/src/main/java/htsjdk/samtools/SecondaryAlignmentSkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/SecondaryAlignmentSkippingIterator.java
@@ -55,7 +55,7 @@ public class SecondaryAlignmentSkippingIterator {
     }
 
     private void skipAnySecondary() {
-        while (it.hasNext() && it.peek().getSecondaryAlignmentFlag()) {
+        while (it.hasNext() && it.peek().isSecondaryAlignment()) {
             it.next();
         }
     }

--- a/src/main/java/htsjdk/samtools/SecondaryAlignmentSkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/SecondaryAlignmentSkippingIterator.java
@@ -31,10 +31,10 @@ import htsjdk.samtools.util.PeekIterator;
  * This iterator conflates a filtering iterator and a peekable iterator.  It would be cleaner to
  * handle those concerns separately.
  */
-public class SecondarySkippingIterator {
+public class SecondaryAlignmentSkippingIterator {
     private final PeekIterator<SAMRecord> it;
 
-    public SecondarySkippingIterator(final CloseableIterator<SAMRecord> underlyingIt) {
+    public SecondaryAlignmentSkippingIterator(final CloseableIterator<SAMRecord> underlyingIt) {
         it = new PeekIterator<>(underlyingIt);
         skipAnySecondary();
     }

--- a/src/main/java/htsjdk/samtools/SecondaryOrSupplementarySkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/SecondaryOrSupplementarySkippingIterator.java
@@ -6,7 +6,7 @@ import htsjdk.samtools.util.PeekIterator;
 /**
  * Wrapper around SAMRecord iterator that skips over secondary and supplementary elements.
  * This iterator conflates a filtering iterator and a peekable iterator.  It would be cleaner to
- * handle those concerns separately. This class should be viewed as a replacement for SecondarySkippingIterator,
+ * handle those concerns separately. This class should be viewed as a replacement for SecondaryAlignmentSkippingIterator,
  * in that we did not want to change the functionality of NPSI to no longer match its name
  */
 public class SecondaryOrSupplementarySkippingIterator {

--- a/src/main/java/htsjdk/samtools/SecondaryOrSupplementarySkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/SecondaryOrSupplementarySkippingIterator.java
@@ -6,7 +6,7 @@ import htsjdk.samtools.util.PeekIterator;
 /**
  * Wrapper around SAMRecord iterator that skips over secondary and supplementary elements.
  * This iterator conflates a filtering iterator and a peekable iterator.  It would be cleaner to
- * handle those concerns separately. This class should be viewed as a replacement for NotPrimarySkippingIterator,
+ * handle those concerns separately. This class should be viewed as a replacement for SecondarySkippingIterator,
  * in that we did not want to change the functionality of NPSI to no longer match its name
  */
 public class SecondaryOrSupplementarySkippingIterator {

--- a/src/main/java/htsjdk/samtools/SecondarySkippingIterator.java
+++ b/src/main/java/htsjdk/samtools/SecondarySkippingIterator.java
@@ -21,15 +21,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package htsjdk.samtools.filter;
+package htsjdk.samtools;
+
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.PeekIterator;
 
 /**
- * Filter out SAMRecords with NotPrimaryAlignment flag set
- *
- * $Id$
- * @deprecated use {@link SecondaryAlignmentFilter} instead.
+ * Wrapper around SAMRecord iterator that skips over secondary elements.
+ * This iterator conflates a filtering iterator and a peekable iterator.  It would be cleaner to
+ * handle those concerns separately.
  */
-@Deprecated
-public class NotPrimaryAlignmentFilter extends SecondaryAlignmentFilter {
+public class SecondarySkippingIterator {
+    private final PeekIterator<SAMRecord> it;
 
+    public SecondarySkippingIterator(final CloseableIterator<SAMRecord> underlyingIt) {
+        it = new PeekIterator<>(underlyingIt);
+        skipAnySecondary();
+    }
+
+    public boolean hasCurrent() {
+        return it.hasNext();
+    }
+
+    public SAMRecord getCurrent() {
+        assert(hasCurrent());
+        return it.peek();
+    }
+
+    public boolean advance() {
+        it.next();
+        skipAnySecondary();
+        return hasCurrent();
+    }
+
+    private void skipAnySecondary() {
+        while (it.hasNext() && it.peek().getSecondaryAlignmentFlag()) {
+            it.next();
+        }
+    }
 }

--- a/src/main/java/htsjdk/samtools/cram/build/Cram2SamRecordFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/Cram2SamRecordFactory.java
@@ -108,7 +108,7 @@ public class Cram2SamRecordFactory {
         samRecord.setReadNegativeStrandFlag(cramRecord.isNegativeStrand());
         samRecord.setFirstOfPairFlag(cramRecord.isFirstSegment());
         samRecord.setSecondOfPairFlag(cramRecord.isLastSegment());
-        samRecord.setSecondaryAlignmentFlag(cramRecord.isSecondaryAlignment());
+        samRecord.setSecondaryAlignment(cramRecord.isSecondaryAlignment());
         samRecord.setReadFailsVendorQualityCheckFlag(cramRecord.isVendorFiltered());
         samRecord.setDuplicateReadFlag(cramRecord.isDuplicate());
         samRecord.setSupplementaryAlignmentFlag(cramRecord.isSupplementary());

--- a/src/main/java/htsjdk/samtools/cram/build/Cram2SamRecordFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/Cram2SamRecordFactory.java
@@ -108,7 +108,7 @@ public class Cram2SamRecordFactory {
         samRecord.setReadNegativeStrandFlag(cramRecord.isNegativeStrand());
         samRecord.setFirstOfPairFlag(cramRecord.isFirstSegment());
         samRecord.setSecondOfPairFlag(cramRecord.isLastSegment());
-        samRecord.setNotPrimaryAlignmentFlag(cramRecord.isSecondaryAlignment());
+        samRecord.setSecondaryAlignmentFlag(cramRecord.isSecondaryAlignment());
         samRecord.setReadFailsVendorQualityCheckFlag(cramRecord.isVendorFiltered());
         samRecord.setDuplicateReadFlag(cramRecord.isDuplicate());
         samRecord.setSupplementaryAlignmentFlag(cramRecord.isSupplementary());

--- a/src/main/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
@@ -93,7 +93,7 @@ public class Sam2CramRecordFactory {
         cramRecord.setNegativeStrand(record.getReadNegativeStrandFlag());
         cramRecord.setFirstSegment(record.getReadPairedFlag() && record.getFirstOfPairFlag());
         cramRecord.setLastSegment(record.getReadPairedFlag() && record.getSecondOfPairFlag());
-        cramRecord.setSecondaryAlignment(record.getNotPrimaryAlignmentFlag());
+        cramRecord.setSecondaryAlignment(record.getSecondaryAlignmentFlag());
         cramRecord.setVendorFiltered(record.getReadFailsVendorQualityCheckFlag());
         cramRecord.setDuplicate(record.getDuplicateReadFlag());
         cramRecord.setSupplementary(record.getSupplementaryAlignmentFlag());

--- a/src/main/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/Sam2CramRecordFactory.java
@@ -93,7 +93,7 @@ public class Sam2CramRecordFactory {
         cramRecord.setNegativeStrand(record.getReadNegativeStrandFlag());
         cramRecord.setFirstSegment(record.getReadPairedFlag() && record.getFirstOfPairFlag());
         cramRecord.setLastSegment(record.getReadPairedFlag() && record.getSecondOfPairFlag());
-        cramRecord.setSecondaryAlignment(record.getSecondaryAlignmentFlag());
+        cramRecord.setSecondaryAlignment(record.isSecondaryAlignment());
         cramRecord.setVendorFiltered(record.getReadFailsVendorQualityCheckFlag());
         cramRecord.setDuplicate(record.getDuplicateReadFlag());
         cramRecord.setSupplementary(record.getSupplementaryAlignmentFlag());

--- a/src/main/java/htsjdk/samtools/filter/SecondaryAlignmentFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/SecondaryAlignmentFilter.java
@@ -10,13 +10,13 @@ public class SecondaryAlignmentFilter implements SamRecordFilter {
      * Returns true if the read is marked as secondary.
      */
     @Override
-    public boolean filterOut(final SAMRecord record) { return record.getNotPrimaryAlignmentFlag(); }
+    public boolean filterOut(final SAMRecord record) { return record.getSecondaryAlignmentFlag(); }
 
     /**
      * Returns true if either read is marked as secondary.
      */
     @Override
     public boolean filterOut(final SAMRecord first, final SAMRecord second) {
-        return first.getNotPrimaryAlignmentFlag() || second.getNotPrimaryAlignmentFlag();
+        return first.getSecondaryAlignmentFlag() || second.getSecondaryAlignmentFlag();
     }
 }

--- a/src/main/java/htsjdk/samtools/filter/SecondaryAlignmentFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/SecondaryAlignmentFilter.java
@@ -10,13 +10,13 @@ public class SecondaryAlignmentFilter implements SamRecordFilter {
      * Returns true if the read is marked as secondary.
      */
     @Override
-    public boolean filterOut(final SAMRecord record) { return record.getSecondaryAlignmentFlag(); }
+    public boolean filterOut(final SAMRecord record) { return record.isSecondaryAlignment(); }
 
     /**
      * Returns true if either read is marked as secondary.
      */
     @Override
     public boolean filterOut(final SAMRecord first, final SAMRecord second) {
-        return first.getSecondaryAlignmentFlag() || second.getSecondaryAlignmentFlag();
+        return first.isSecondaryAlignment() || second.isSecondaryAlignment();
     }
 }

--- a/src/main/java/htsjdk/samtools/filter/SecondaryOrSupplementaryFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/SecondaryOrSupplementaryFilter.java
@@ -3,8 +3,8 @@ package htsjdk.samtools.filter;
 import htsjdk.samtools.SAMRecord;
 
 /**
- * Filter out SAMRecords with NotPrimaryAlignment or Supplementary flag set
- * This class should be viewed as a replacement for NotPrimarySkippingIterator,
+ * Filter out SAMRecords with Secondary or Supplementary flag set
+ * This class should be viewed as a replacement for {@link htsjdk.samtools.NotPrimarySkippingIterator},
  * in that we did not want to change the functionality of NPSI to no longer match its name
  * $Id$
  */

--- a/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
+++ b/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
@@ -43,15 +43,11 @@ import ngs.Read;
 import ngs.Fragment;
 import ngs.ErrorMsg;
 
-import java.io.IOException;
 import java.util.EnumSet;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 /**
  * Extends SAMRecord so that any of the fields will be loaded only when needed.
@@ -157,10 +153,10 @@ public class SRALazyRecord extends SAMRecord {
                 return self.getProperPairFlag();
             }
         },
-        NOT_PRIMARY_ALIGNMENT(true) {
+        SECONDARY_ALIGNMENT(true) {
             @Override
             public boolean getFlag(SRALazyRecord self) {
-                return self.getNotPrimaryAlignmentFlag();
+                return self.getSecondaryAlignmentFlag();
             }
         },
         MATE_NEGATIVE_STRAND(false) {
@@ -533,19 +529,19 @@ public class SRALazyRecord extends SAMRecord {
     }
 
     @Override
-    public boolean getNotPrimaryAlignmentFlag() {
-        if (!initializedFlags.contains(LazyFlag.NOT_PRIMARY_ALIGNMENT)) {
-            setNotPrimaryAlignmentFlag(getNotPrimaryAlignmentFlagImpl());
+    public boolean getSecondaryAlignmentFlag() {
+        if (!initializedFlags.contains(LazyFlag.SECONDARY_ALIGNMENT)) {
+            setSecondaryAlignmentFlag(getSecondaryAlignmentFlagImpl());
         }
-        return super.getNotPrimaryAlignmentFlag();
+        return super.getSecondaryAlignmentFlag();
     }
 
     @Override
-    public void setNotPrimaryAlignmentFlag(final boolean flag) {
-        if (!initializedFlags.contains(LazyFlag.NOT_PRIMARY_ALIGNMENT)) {
-            initializedFlags.add(LazyFlag.NOT_PRIMARY_ALIGNMENT);
+    public void setSecondaryAlignmentFlag(final boolean flag) {
+        if (!initializedFlags.contains(LazyFlag.SECONDARY_ALIGNMENT)) {
+            initializedFlags.add(LazyFlag.SECONDARY_ALIGNMENT);
         }
-        super.setNotPrimaryAlignmentFlag(flag);
+        super.setSecondaryAlignmentFlag(flag);
     }
 
     @Override
@@ -951,7 +947,7 @@ public class SRALazyRecord extends SAMRecord {
         return isAligned && getReadPairedFlag() && !getMateUnmappedFlag();
     }
 
-    private boolean getNotPrimaryAlignmentFlagImpl() {
+    private boolean getSecondaryAlignmentFlagImpl() {
         try {
             if (isAligned) {
                 return getCurrentAlignment().getAlignmentCategory() == Alignment.secondaryAlignment;

--- a/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
+++ b/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
@@ -156,7 +156,7 @@ public class SRALazyRecord extends SAMRecord {
         SECONDARY_ALIGNMENT(true) {
             @Override
             public boolean getFlag(SRALazyRecord self) {
-                return self.getSecondaryAlignmentFlag();
+                return self.isSecondaryAlignment();
             }
         },
         MATE_NEGATIVE_STRAND(false) {
@@ -529,19 +529,19 @@ public class SRALazyRecord extends SAMRecord {
     }
 
     @Override
-    public boolean getSecondaryAlignmentFlag() {
+    public boolean isSecondaryAlignment() {
         if (!initializedFlags.contains(LazyFlag.SECONDARY_ALIGNMENT)) {
-            setSecondaryAlignmentFlag(getSecondaryAlignmentFlagImpl());
+            setSecondaryAlignment(getSecondaryAlignmentFlagImpl());
         }
-        return super.getSecondaryAlignmentFlag();
+        return super.isSecondaryAlignment();
     }
 
     @Override
-    public void setSecondaryAlignmentFlag(final boolean flag) {
+    public void setSecondaryAlignment(final boolean flag) {
         if (!initializedFlags.contains(LazyFlag.SECONDARY_ALIGNMENT)) {
             initializedFlags.add(LazyFlag.SECONDARY_ALIGNMENT);
         }
-        super.setSecondaryAlignmentFlag(flag);
+        super.setSecondaryAlignment(flag);
     }
 
     @Override

--- a/src/test/java/htsjdk/samtools/SAMFlagTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFlagTest.java
@@ -38,6 +38,7 @@ public class SAMFlagTest extends HtsjdkTest {
         Assert.assertFalse(SAMFlag.getFlags(83).contains(SAMFlag.READ_UNMAPPED));
         Assert.assertFalse(SAMFlag.getFlags(83).contains(SAMFlag.MATE_UNMAPPED));
         Assert.assertTrue(SAMFlag.getFlags(0).isEmpty());
-        Assert.assertEquals(SAMFlag.getFlags(4095).size(),12);
+        // TODO: this test should be modified once the deprecated NOT_PRIMARY_ALIGNMENT is removed
+        Assert.assertEquals(SAMFlag.getFlags(4095).size(), 13);
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMRecordQueryNameComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordQueryNameComparatorTest.java
@@ -71,7 +71,7 @@ public class SAMRecordQueryNameComparatorTest extends HtsjdkTest {
         record.setFirstOfPairFlag(false);
         record.setSecondOfPairFlag(false);
         // primary/secondary/supplementary alignments
-        record.setSecondaryAlignmentFlag(false);
+        record.setSecondaryAlignment(false);
         record.setSupplementaryAlignmentFlag(false);
 
         // record1, record2, comparison value
@@ -94,8 +94,8 @@ public class SAMRecordQueryNameComparatorTest extends HtsjdkTest {
                 {record, copyAndSet(record, r -> r.setReadNegativeStrandFlag(true)), -1},
 
                 // primary alignment is first compared to not primary
-                {record, copyAndSet(record, r -> r.setSecondaryAlignmentFlag(true)), -1},
-                {copyAndSet(record, r -> r.setSecondaryAlignmentFlag(true)), record, 1},
+                {record, copyAndSet(record, r -> r.setSecondaryAlignment(true)), -1},
+                {copyAndSet(record, r -> r.setSecondaryAlignment(true)), record, 1},
                 // secondary alignment is last compared to primary
                 {record, copyAndSet(record, r -> r.setSupplementaryAlignmentFlag(true)), -1},
                 {copyAndSet(record, r -> r.setSupplementaryAlignmentFlag(true)), record, 1},

--- a/src/test/java/htsjdk/samtools/SAMRecordQueryNameComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordQueryNameComparatorTest.java
@@ -71,7 +71,7 @@ public class SAMRecordQueryNameComparatorTest extends HtsjdkTest {
         record.setFirstOfPairFlag(false);
         record.setSecondOfPairFlag(false);
         // primary/secondary/supplementary alignments
-        record.setNotPrimaryAlignmentFlag(false);
+        record.setSecondaryAlignmentFlag(false);
         record.setSupplementaryAlignmentFlag(false);
 
         // record1, record2, comparison value
@@ -94,8 +94,8 @@ public class SAMRecordQueryNameComparatorTest extends HtsjdkTest {
                 {record, copyAndSet(record, r -> r.setReadNegativeStrandFlag(true)), -1},
 
                 // primary alignment is first compared to not primary
-                {record, copyAndSet(record, r -> r.setNotPrimaryAlignmentFlag(true)), -1},
-                {copyAndSet(record, r -> r.setNotPrimaryAlignmentFlag(true)), record, 1},
+                {record, copyAndSet(record, r -> r.setSecondaryAlignmentFlag(true)), -1},
+                {copyAndSet(record, r -> r.setSecondaryAlignmentFlag(true)), record, 1},
                 // secondary alignment is last compared to primary
                 {record, copyAndSet(record, r -> r.setSupplementaryAlignmentFlag(true)), -1},
                 {copyAndSet(record, r -> r.setSupplementaryAlignmentFlag(true)), record, 1},

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -208,7 +208,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
         }
         final Iterator<SAMRecord> records = samBuilder.iterator();
         records.next().setReadNegativeStrandFlag(true);
-        records.next().setNotPrimaryAlignmentFlag(true);
+        records.next().setSecondaryAlignmentFlag(true);
         records.next().setMappingQuality(10);
         records.next().setCigarString("36M");
 

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -208,7 +208,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
         }
         final Iterator<SAMRecord> records = samBuilder.iterator();
         records.next().setReadNegativeStrandFlag(true);
-        records.next().setSecondaryAlignmentFlag(true);
+        records.next().setSecondaryAlignment(true);
         records.next().setMappingQuality(10);
         records.next().setCigarString("36M");
 

--- a/src/test/java/htsjdk/samtools/filter/IntervalKeepPairFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/IntervalKeepPairFilterTest.java
@@ -91,7 +91,7 @@ public class IntervalKeepPairFilterTest extends HtsjdkTest {
 
         boolean notPrimary = StreamSupport.stream(builder.spliterator(), false)
                 .filter(rec -> !filter.filterOut(rec))
-                .anyMatch(rec -> rec.getNotPrimaryAlignmentFlag() || rec.getSupplementaryAlignmentFlag());
+                .anyMatch(rec -> rec.getSecondaryAlignmentFlag() || rec.getSupplementaryAlignmentFlag());
 
         Assert.assertFalse(notPrimary);
     }

--- a/src/test/java/htsjdk/samtools/filter/IntervalKeepPairFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/IntervalKeepPairFilterTest.java
@@ -91,7 +91,7 @@ public class IntervalKeepPairFilterTest extends HtsjdkTest {
 
         boolean notPrimary = StreamSupport.stream(builder.spliterator(), false)
                 .filter(rec -> !filter.filterOut(rec))
-                .anyMatch(rec -> rec.getSecondaryAlignmentFlag() || rec.getSupplementaryAlignmentFlag());
+                .anyMatch(rec -> rec.isSecondaryAlignment() || rec.getSupplementaryAlignmentFlag());
 
         Assert.assertFalse(notPrimary);
     }

--- a/src/test/java/htsjdk/samtools/filter/SecondaryAlignmentFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/SecondaryAlignmentFilterTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
 /**
  * Created by farjoun on 5/27/17.
  */
-public class NotPrimaryAlignmentFilterTest extends HtsjdkTest {
+public class SecondaryAlignmentFilterTest extends HtsjdkTest {
 
     @Test
     public void testSecondaryRecords() {
@@ -36,7 +36,7 @@ public class NotPrimaryAlignmentFilterTest extends HtsjdkTest {
         }
 
         FilteringSamIterator filteringSamIterator = new FilteringSamIterator(builder.getRecords().iterator(),
-                new NotPrimaryAlignmentFilter());
+                new SecondaryAlignmentFilter());
 
         Assert.assertEquals(filteringSamIterator.hasNext(), false);
     }
@@ -67,7 +67,7 @@ public class NotPrimaryAlignmentFilterTest extends HtsjdkTest {
         }
 
         FilteringSamIterator filteringSamIterator = new FilteringSamIterator(builder.getRecords().iterator(),
-                new NotPrimaryAlignmentFilter());
+                new SecondaryAlignmentFilter());
 
         // i is incremented once for each 3 records that are added (a pair and a fragment)
         Assert.assertEquals(filteringSamIterator.stream().count(), i * 3);
@@ -100,7 +100,7 @@ public class NotPrimaryAlignmentFilterTest extends HtsjdkTest {
         builder.forEach(r -> r.setSupplementaryAlignmentFlag(true));
 
         FilteringSamIterator filteringSamIterator = new FilteringSamIterator(builder.getRecords().iterator(),
-                new NotPrimaryAlignmentFilter());
+                new SecondaryAlignmentFilter());
 
         // i is incremented once for each 3 records that are added (a pair and a fragment)
         Assert.assertEquals(filteringSamIterator.stream().count(), i * 3);

--- a/src/test/java/htsjdk/samtools/sra/SRATest.java
+++ b/src/test/java/htsjdk/samtools/sra/SRATest.java
@@ -45,7 +45,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -363,7 +362,7 @@ public class SRATest extends AbstractSRATest {
             }
 
             if (currentRecord.getReadName().equals(readName)
-                    && currentRecord.getSecondaryAlignmentFlag() == isSecondaryAlignment
+                    && currentRecord.isSecondaryAlignment() == isSecondaryAlignment
                     && (!hasMate || currentRecord.getSecondOfPairFlag() == isSecondOfPair)) {
                 record = currentRecord;
                 break;
@@ -412,7 +411,7 @@ public class SRATest extends AbstractSRATest {
         Assert.assertEquals(record.getBaseQualityString(), quals);
         Assert.assertEquals(record.getReadPairedFlag(), hasMate);
         Assert.assertEquals(record.getFlags(), flags);
-        Assert.assertEquals(record.getSecondaryAlignmentFlag(), isSecondaryAlignment);
+        Assert.assertEquals(record.isSecondaryAlignment(), isSecondaryAlignment);
         if (hasMate) {
             Assert.assertEquals(record.getSecondOfPairFlag(), isSecondOfPair);
         }

--- a/src/test/java/htsjdk/samtools/sra/SRATest.java
+++ b/src/test/java/htsjdk/samtools/sra/SRATest.java
@@ -363,7 +363,7 @@ public class SRATest extends AbstractSRATest {
             }
 
             if (currentRecord.getReadName().equals(readName)
-                    && currentRecord.getNotPrimaryAlignmentFlag() == isSecondaryAlignment
+                    && currentRecord.getSecondaryAlignmentFlag() == isSecondaryAlignment
                     && (!hasMate || currentRecord.getSecondOfPairFlag() == isSecondOfPair)) {
                 record = currentRecord;
                 break;
@@ -412,7 +412,7 @@ public class SRATest extends AbstractSRATest {
         Assert.assertEquals(record.getBaseQualityString(), quals);
         Assert.assertEquals(record.getReadPairedFlag(), hasMate);
         Assert.assertEquals(record.getFlags(), flags);
-        Assert.assertEquals(record.getNotPrimaryAlignmentFlag(), isSecondaryAlignment);
+        Assert.assertEquals(record.getSecondaryAlignmentFlag(), isSecondaryAlignment);
         if (hasMate) {
             Assert.assertEquals(record.getSecondOfPairFlag(), isSecondOfPair);
         }


### PR DESCRIPTION
### Description

The term "not-primary alignment" used in HTSJDK is confusing, because it refers only to "secondary alignment" but not "supplementary alignments". This commit deprecate classes/methdos using "not-primary" in favor of the "secondary" option (implemented if not already included).

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

