### PR TITLE
Optimize intervals falls to merge abutting intervals

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/BAMFileReader.java
@@ -879,7 +879,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
             if (prev.overlaps(thisInterval)) {
                 throw new IllegalArgumentException(String.format("List of intervals is not optimized: %s intersects %s", prev, thisInterval));
             }
-            if (prev.abuts(thisInterval)) {
+            if (prev.endsAtStartOf(thisInterval)) {
                 throw new IllegalArgumentException(String.format("List of intervals is not optimized: %s abuts %s", prev, thisInterval));
             }
         }

--- a/src/main/java/htsjdk/samtools/QueryInterval.java
+++ b/src/main/java/htsjdk/samtools/QueryInterval.java
@@ -44,7 +44,7 @@ public class QueryInterval implements Comparable<QueryInterval> {
     /**
      * @return true if both are on same reference, and other starts exactly before this ends.
      */
-    public boolean abuts(final QueryInterval other) {
+    public boolean endsAtStartOf(final QueryInterval other) {
         return this.referenceIndex == other.referenceIndex && this.end + 1 == other.start;
     }
 
@@ -81,7 +81,7 @@ public class QueryInterval implements Comparable<QueryInterval> {
 
         for (int i = 1; i < inputIntervals.length; ++i) {
             final QueryInterval next = inputIntervals[i];
-            if (previous.abuts(next) || previous.overlaps(next)) {
+            if (previous.endsAtStartOf(next) || previous.overlaps(next)) {
                 final int newEnd = ((previous.end == 0 || next.end == 0) ? 0 : Math.max(previous.end, next.end));
                 previous = new QueryInterval(previous.referenceIndex, previous.start, newEnd);
             } else {
@@ -102,9 +102,7 @@ public class QueryInterval implements Comparable<QueryInterval> {
 
         QueryInterval that = (QueryInterval) o;
 
-        if (referenceIndex != that.referenceIndex) return false;
-        if (start != that.start) return false;
-        return end == that.end;
+        return this.compareTo(that) == 0;
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/QueryInterval.java
+++ b/src/main/java/htsjdk/samtools/QueryInterval.java
@@ -42,10 +42,10 @@ public class QueryInterval implements Comparable<QueryInterval> {
     }
 
     /**
-     * @return true if both are on same reference, and other starts exactly where this ends.
+     * @return true if both are on same reference, and other starts exactly before this ends.
      */
     public boolean abuts(final QueryInterval other) {
-        return this.referenceIndex == other.referenceIndex && this.end == other.start;
+        return this.referenceIndex == other.referenceIndex && this.end + 1 == other.start;
     }
 
     /**
@@ -93,5 +93,25 @@ public class QueryInterval implements Comparable<QueryInterval> {
         if (previous != null) unique.add(previous);
 
         return unique.toArray(EMPTY_QUERY_INTERVAL_ARRAY);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        QueryInterval that = (QueryInterval) o;
+
+        if (referenceIndex != that.referenceIndex) return false;
+        if (start != that.start) return false;
+        return end == that.end;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = referenceIndex;
+        result = 31 * result + start;
+        result = 31 * result + end;
+        return result;
     }
 }

--- a/src/test/java/htsjdk/samtools/CRAMIndexQueryTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMIndexQueryTest.java
@@ -320,13 +320,13 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
     public Object[][] multipleIntervalOverlapping() {
         return new Object[][]{
             {cramQueryWithCRAI, cramQueryReference,
-                    new QueryInterval[]{new QueryInterval(0, 100010, 100010), new QueryInterval(0, 100011, 100011)},
+                    new QueryInterval[]{new QueryInterval(0, 100009, 100009), new QueryInterval(0, 100011, 100011)},
                     new String[]{"a", "b", "c", "d", "e"}},
             {cramQueryWithLocalCRAI, cramQueryReference,
-                    new QueryInterval[]{new QueryInterval(0, 100010, 100010), new QueryInterval(0, 100011, 100011)},
+                    new QueryInterval[]{new QueryInterval(0, 100009, 100009), new QueryInterval(0, 100011, 100011)},
                     new String[]{"a", "b", "c", "d", "e"}},
             {cramQueryWithBAI, cramQueryReference,
-                    new QueryInterval[]{new QueryInterval(0, 100010, 100010), new QueryInterval(0, 100011, 100011)},
+                    new QueryInterval[]{new QueryInterval(0, 100009, 100009), new QueryInterval(0, 100011, 100011)},
                     new String[]{"a", "b", "c", "d", "e"}},
             // no matching reads
             {cramQueryReadsWithBAI, cramQueryReadsReference,

--- a/src/test/java/htsjdk/samtools/QueryIntervalTest.java
+++ b/src/test/java/htsjdk/samtools/QueryIntervalTest.java
@@ -1,0 +1,42 @@
+package htsjdk.samtools;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class QueryIntervalTest {
+
+    @Test
+    public void testOptimizeIntervals() throws Exception {
+        final QueryInterval[] overlappingIntervals = new QueryInterval[] {
+                new QueryInterval(0, 1520, 1521),
+                new QueryInterval(0, 1521, 1525)
+        };
+
+        final QueryInterval[] optimizedOverlapping = QueryInterval.optimizeIntervals(overlappingIntervals);
+
+        final QueryInterval[] abuttingIntervals = new QueryInterval[]{
+                new QueryInterval(0, 1520, 1521),
+                new QueryInterval(0, 1522, 1525)
+        };
+
+        final QueryInterval[] optimizedAbutting = QueryInterval.optimizeIntervals(abuttingIntervals);
+
+        final QueryInterval[] expected = new QueryInterval[]{
+                new QueryInterval(0, 1520, 1525),
+        };
+
+        Assert.assertEquals(optimizedOverlapping, expected);
+        Assert.assertEquals(optimizedAbutting, expected);
+
+
+        final QueryInterval[]
+                nonOptimizableSeparatedIntervals = new QueryInterval[]{
+                new QueryInterval(0, 1520, 1521),
+                new QueryInterval(0, 1523, 1525)
+        };
+
+        final QueryInterval[] optimizedSeparated = QueryInterval.optimizeIntervals(nonOptimizableSeparatedIntervals);
+
+        Assert.assertEquals(optimizedSeparated, nonOptimizableSeparatedIntervals);
+    }
+}


### PR DESCRIPTION
### Description
Optimizing intervals in `QueryInterval` class works incorrectly: intervals are considered abutting only if they overlap each other by a single base.

### Prerequisites
Need bug fix for current implementation of abuts(): `QueryInterval[]` array still contains two initial intervals after invoking `optimizeIntervals()` method, even though they touch. [Github issue](https://github.com/samtools/htsjdk/issues/971).

### Solution
* `abuts()` method has been fixed. It used to return `true` only in case if one of them starts exactly where other ends. Now it returns `true` if one of the given intervals ends just before another one starts;
* `equals()` and `hashcode()` methods were overridden in `QueryInterval` class for using `assert` in TestNg;
* `testOptimizeIntervals()` was added to the `CRAMFileBAIIndexTest` class to test 3 options: abutting, overlapping and non-overlapping intervals.

### Checklist
- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)
