### PR TITLE
deprecating SortingVariantContextWriter

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriter.java
@@ -29,7 +29,11 @@ import htsjdk.variant.variantcontext.VariantContext;
 
 /**
  * this class writes VCF files, allowing records to be passed in unsorted (up to a certain genomic distance away)
+ *
+ * @deprecated 9/2017, this class is completely untested and unsupported, there is no replacement at this time
+ * if you use this class please file an issue on github or it will be removed at some point in the future
  */
+@Deprecated
 public class SortingVariantContextWriter extends SortingVariantContextWriterBase {
 
     // the maximum START distance between records that we'll cache

--- a/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
@@ -38,7 +38,11 @@ import java.util.concurrent.PriorityBlockingQueue;
 /**
  * This class writes VCF files, allowing records to be passed in unsorted.
  * It also enforces that it is never passed records of the same chromosome with any other chromosome in between them.
+ *
+ * @deprecated 9/2017, this class is completely untested and unsupported, there is no replacement at this time
+ * if you use this class please file an issue on github or it will be removed at some point in the future
  */
+@Deprecated
 abstract class SortingVariantContextWriterBase implements VariantContextWriter {
 
     // The VCFWriter to which to actually write the sorted VCF records


### PR DESCRIPTION
### Description

* deprecating the classes `SortingVariantContextWriter` and `SortingVariantContextWriterBase`
* these classes are completely untested and unused in htsjdk, picard, and gatk, we should either deprecate them or add tests and support them, but unless anyone has any use case I'd recommend deprecating

### Checklist

- [ x ] Is not backward compatible (breaks binary or source compatibility)

