### PR TITLE
minor changes to snappy

### DIFF
--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -14,7 +14,7 @@ import java.util.TreeMap;
  * @author Tim Fennell
  */
 public class Defaults {
-    private static Log log = Log.getInstance(Defaults.class);
+      private static final Log log = Log.getInstance(Defaults.class);
     
     /** Should BAM index files be created when writing out coordinate sorted BAM files?  Default = false. */
     public static final boolean CREATE_INDEX;
@@ -85,6 +85,21 @@ public class Defaults {
     public static final boolean SRA_LIBRARIES_DOWNLOAD;
 
 
+    /**
+     * the name of the system property that disables snappy
+     */
+    public static final String DISABLE_SNAPPY_PROPERTY_NAME = "snappy.disable";
+
+    /**
+     * Disable use of the Snappy compressor
+     */
+    public static final boolean DISABLE_SNAPPY_COMPRESSOR;
+
+    /**
+     * determines if snappy should emit log messages when snappy is successfully loaded
+     */
+    public static final boolean SNAPPY_EXTRA_VERBOSE;
+
     static {
         CREATE_INDEX = getBooleanProperty("create_index", false);
         CREATE_MD5 = getBooleanProperty("create_md5", false);
@@ -104,6 +119,8 @@ public class Defaults {
         CUSTOM_READER_FACTORY = getStringProperty("custom_reader", "");
         SAM_FLAG_FIELD_FORMAT = SamFlagField.valueOf(getStringProperty("sam_flag_field_format", SamFlagField.DECIMAL.name()));
         SRA_LIBRARIES_DOWNLOAD = getBooleanProperty("sra_libraries_download", false);
+        SNAPPY_EXTRA_VERBOSE = getBooleanProperty("snappy.loader.verbosity", false);
+        DISABLE_SNAPPY_COMPRESSOR = getBooleanProperty(DISABLE_SNAPPY_PROPERTY_NAME, false);
     }
 
     /**
@@ -126,6 +143,8 @@ public class Defaults {
         result.put("EBI_REFERENCE_SERVICE_URL_MASK", EBI_REFERENCE_SERVICE_URL_MASK);
         result.put("CUSTOM_READER_FACTORY", CUSTOM_READER_FACTORY);
         result.put("SAM_FLAG_FIELD_FORMAT", SAM_FLAG_FIELD_FORMAT);
+        result.put("DISABLE_SNAPPY_COMPRESSOR", DISABLE_SNAPPY_COMPRESSOR);
+        result.put("SNAPPY_EXTRA_VERBOSE", SNAPPY_EXTRA_VERBOSE);
         return Collections.unmodifiableSortedMap(result);
     }
 

--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -95,11 +95,6 @@ public class Defaults {
      */
     public static final boolean DISABLE_SNAPPY_COMPRESSOR;
 
-    /**
-     * determines if snappy should emit log messages when snappy is successfully loaded
-     */
-    public static final boolean SNAPPY_EXTRA_VERBOSE;
-
     static {
         CREATE_INDEX = getBooleanProperty("create_index", false);
         CREATE_MD5 = getBooleanProperty("create_md5", false);
@@ -119,7 +114,6 @@ public class Defaults {
         CUSTOM_READER_FACTORY = getStringProperty("custom_reader", "");
         SAM_FLAG_FIELD_FORMAT = SamFlagField.valueOf(getStringProperty("sam_flag_field_format", SamFlagField.DECIMAL.name()));
         SRA_LIBRARIES_DOWNLOAD = getBooleanProperty("sra_libraries_download", false);
-        SNAPPY_EXTRA_VERBOSE = getBooleanProperty("snappy.loader.verbosity", false);
         DISABLE_SNAPPY_COMPRESSOR = getBooleanProperty(DISABLE_SNAPPY_PROPERTY_NAME, false);
     }
 
@@ -144,7 +138,6 @@ public class Defaults {
         result.put("CUSTOM_READER_FACTORY", CUSTOM_READER_FACTORY);
         result.put("SAM_FLAG_FIELD_FORMAT", SAM_FLAG_FIELD_FORMAT);
         result.put("DISABLE_SNAPPY_COMPRESSOR", DISABLE_SNAPPY_COMPRESSOR);
-        result.put("SNAPPY_EXTRA_VERBOSE", SNAPPY_EXTRA_VERBOSE);
         return Collections.unmodifiableSortedMap(result);
     }
 

--- a/src/main/java/htsjdk/samtools/util/SnappyLoader.java
+++ b/src/main/java/htsjdk/samtools/util/SnappyLoader.java
@@ -44,7 +44,11 @@ public class SnappyLoader {
     private final boolean snappyAvailable;
 
     public SnappyLoader() {
-        if (Defaults.DISABLE_SNAPPY_COMPRESSOR) {
+        this(Defaults.DISABLE_SNAPPY_COMPRESSOR);
+    }
+
+    public SnappyLoader(boolean disableSnappyCompressor) {
+        if (disableSnappyCompressor) {
             logger.debug("Snappy is disabled via system property.");
             snappyAvailable = false;
         }

--- a/src/main/java/htsjdk/samtools/util/SnappyLoader.java
+++ b/src/main/java/htsjdk/samtools/util/SnappyLoader.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools.util;
 
+import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMException;
 import org.xerial.snappy.SnappyError;
 import org.xerial.snappy.SnappyInputStream;
@@ -38,14 +39,12 @@ import java.io.OutputStream;
  */
 public class SnappyLoader {
     private static final int SNAPPY_BLOCK_SIZE = 32768;  // keep this as small as can be without hurting compression ratio.
-    private final boolean SnappyAvailable;
-    private final Log logger = Log.getInstance(this.getClass());
+    private static final Log logger = Log.getInstance(SnappyLoader.class);
 
-    private static final boolean DefaultVerbosity = Boolean.valueOf(System.getProperty("snappy.loader.verbosity", "false"));
-    public static final boolean Disabled = Boolean.valueOf(System.getProperty("snappy.disable", "false"));
+    private final boolean snappyAvailable;
 
     public SnappyLoader() {
-        this(DefaultVerbosity);
+        this(Defaults.SNAPPY_EXTRA_VERBOSE);
     }
 
     /**
@@ -53,16 +52,14 @@ public class SnappyLoader {
      * @param verbose if true output a small number of log messages
      */
     public SnappyLoader(final boolean verbose) {
-        if (Disabled) {
-            logger.info("Snappy is disabled via system property.");
-            SnappyAvailable = false;
+        if (Defaults.DISABLE_SNAPPY_COMPRESSOR) {
+            if(verbose) logger.info("Snappy is disabled via system property.");
+            snappyAvailable = false;
         }
         else {
             boolean tmpSnappyAvailable = false;
-            try {
-                final OutputStream test = new SnappyOutputStream(new ByteArrayOutputStream(1000));
+            try (final OutputStream test = new SnappyOutputStream(new ByteArrayOutputStream(1000))){
                 test.write("Hello World!".getBytes());
-                test.close();
                 tmpSnappyAvailable = true;
                 if (verbose) logger.info("Snappy successfully loaded.");
             }
@@ -72,39 +69,49 @@ public class SnappyLoader {
              * IOException: potentially thrown by the `test.write` and `test.close` calls.
              * SnappyError: potentially thrown for a variety of reasons by Snappy.
              */
-            catch (ExceptionInInitializerError|IllegalStateException|IOException|SnappyError e) {
+            catch (final ExceptionInInitializerError | IllegalStateException | IOException | SnappyError e) {
                 if (verbose) logger.warn("Snappy native library failed to load: " + e.getMessage());
             }
-            SnappyAvailable = tmpSnappyAvailable;
+            snappyAvailable = tmpSnappyAvailable;
         }
     }
 
     /** Returns true if Snappy is available, false otherwise. */
-    public boolean isSnappyAvailable() { return SnappyAvailable; }
+    public boolean isSnappyAvailable() { return snappyAvailable; }
 
-    /** Wrap an InputStream in a SnappyInputStream. If Snappy is not available will throw an exception. */
+    /**
+     * Wrap an InputStream in a SnappyInputStream.
+     * @throws SAMException if Snappy is not available will throw an exception.
+     */
     public InputStream wrapInputStream(final InputStream inputStream) {
+        return wrapWithSnappyOrThrow(inputStream, SnappyInputStream::new);
+    }
+
+    /**
+     * Wrap an OutputStream in a SnappyOutputStream.
+     * @throws SAMException if Snappy is not available
+     */
+    public OutputStream wrapOutputStream(final OutputStream outputStream) {
+        return wrapWithSnappyOrThrow(outputStream, (stream) -> new SnappyOutputStream(stream, SNAPPY_BLOCK_SIZE));
+    }
+
+    private interface IOFunction<T,R> {
+        R apply(T input) throws IOException;
+    }
+
+    private <T,R> R wrapWithSnappyOrThrow(T stream, IOFunction<T, R> wrapper){
         if (isSnappyAvailable()) {
             try {
-                return new SnappyInputStream(inputStream);
+                return wrapper.apply(stream);
             } catch (Exception e) {
                 throw new SAMException("Error instantiating SnappyInputStream", e);
             }
         } else {
-            throw new SAMException("Snappy not available");
-        }
-    }
-
-    /** Wrap an InputStream in a SnappyInputStream. If Snappy is not available will throw an exception. */
-    public OutputStream wrapOutputStream(final OutputStream outputStream) {
-        if (isSnappyAvailable()) {
-            try {
-                return new SnappyOutputStream(outputStream, SNAPPY_BLOCK_SIZE);
-            } catch (Exception e) {
-                throw new SAMException("Error instantiating SnappyOutputStream", e);
-            }
-        } else {
-            throw new SAMException("Snappy not available");
+            final String errorMessage = Defaults.DISABLE_SNAPPY_COMPRESSOR
+                    ? "Cannot wrap stream with snappy compressor because snappy was disabled via the "
+                    + Defaults.DISABLE_SNAPPY_PROPERTY_NAME + " system property."
+                    : "Cannot wrap stream with snappy compressor because we could not load the snappy library.";
+            throw new SAMException(errorMessage);
         }
     }
 }

--- a/src/main/java/htsjdk/samtools/util/SnappyLoader.java
+++ b/src/main/java/htsjdk/samtools/util/SnappyLoader.java
@@ -43,12 +43,13 @@ public class SnappyLoader {
 
     private final boolean snappyAvailable;
 
+
     public SnappyLoader() {
         this(Defaults.DISABLE_SNAPPY_COMPRESSOR);
     }
 
-    public SnappyLoader(boolean disableSnappyCompressor) {
-        if (disableSnappyCompressor) {
+    SnappyLoader(boolean disableSnappy) {
+        if (disableSnappy) {
             logger.debug("Snappy is disabled via system property.");
             snappyAvailable = false;
         }
@@ -100,7 +101,7 @@ public class SnappyLoader {
             try {
                 return wrapper.apply(stream);
             } catch (Exception e) {
-                throw new SAMException("Error instantiating SnappyInputStream", e);
+                throw new SAMException("Error wrapping stream with snappy", e);
             }
         } else {
             final String errorMessage = Defaults.DISABLE_SNAPPY_COMPRESSOR

--- a/src/main/java/htsjdk/samtools/util/SnappyLoader.java
+++ b/src/main/java/htsjdk/samtools/util/SnappyLoader.java
@@ -44,16 +44,8 @@ public class SnappyLoader {
     private final boolean snappyAvailable;
 
     public SnappyLoader() {
-        this(Defaults.SNAPPY_EXTRA_VERBOSE);
-    }
-
-    /**
-     * Constructs a new SnappyLoader which will check to see if snappy is available in the JVM/library path.
-     * @param verbose if true output a small number of log messages
-     */
-    public SnappyLoader(final boolean verbose) {
         if (Defaults.DISABLE_SNAPPY_COMPRESSOR) {
-            if(verbose) logger.info("Snappy is disabled via system property.");
+            logger.debug("Snappy is disabled via system property.");
             snappyAvailable = false;
         }
         else {
@@ -61,7 +53,7 @@ public class SnappyLoader {
             try (final OutputStream test = new SnappyOutputStream(new ByteArrayOutputStream(1000))){
                 test.write("Hello World!".getBytes());
                 tmpSnappyAvailable = true;
-                if (verbose) logger.info("Snappy successfully loaded.");
+                logger.debug("Snappy successfully loaded.");
             }
             /*
              * ExceptionInInitializerError: thrown by Snappy if native libs fail to load.
@@ -70,7 +62,7 @@ public class SnappyLoader {
              * SnappyError: potentially thrown for a variety of reasons by Snappy.
              */
             catch (final ExceptionInInitializerError | IllegalStateException | IOException | SnappyError e) {
-                if (verbose) logger.warn("Snappy native library failed to load: " + e.getMessage());
+                logger.warn(e, "Snappy native library failed to load.");
             }
             snappyAvailable = tmpSnappyAvailable;
         }

--- a/src/test/java/htsjdk/samtools/util/SnappyLoaderUnitTest.java
+++ b/src/test/java/htsjdk/samtools/util/SnappyLoaderUnitTest.java
@@ -1,0 +1,49 @@
+package htsjdk.samtools.util;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.SAMException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.*;
+
+public class SnappyLoaderUnitTest extends HtsjdkTest{
+
+    @Test
+    public void testCanLoadAndRoundTripWithSnappy() throws IOException {
+        final SnappyLoader snappyLoader = new SnappyLoader(false);
+        Assert.assertTrue(snappyLoader.isSnappyAvailable());
+        final File tempFile = File.createTempFile("snappyOutput", ".txt");
+        tempFile.deleteOnExit();
+
+        final String toWrite = "Hello Filesystem";
+        try(Writer out = new OutputStreamWriter(snappyLoader.wrapOutputStream(new FileOutputStream(tempFile)))) {
+            out.write(toWrite);
+        }
+        
+        try(LineReader in = new BufferedLineReader(snappyLoader.wrapInputStream(new FileInputStream(tempFile)))){
+            final String recoveredString = in.readLine();
+            Assert.assertEquals(recoveredString, toWrite);
+        }
+    }
+
+    @Test
+    public void testCanDisableSnappy(){
+        final SnappyLoader snappyLoader = new SnappyLoader(true);
+        Assert.assertFalse(snappyLoader.isSnappyAvailable());
+    }
+
+    @Test(expectedExceptions = SAMException.class)
+    public void disabledSnappyCantCreateInputWrappers(){
+        final SnappyLoader snappyLoader = new SnappyLoader(true);
+        Assert.assertFalse(snappyLoader.isSnappyAvailable());
+        snappyLoader.wrapInputStream(new ByteArrayInputStream(new byte[]{ 0,0,0}));
+    }
+
+    @Test(expectedExceptions = SAMException.class)
+    public void disabledSnappyCantCreateOutputWrappers(){
+        final SnappyLoader snappyLoader = new SnappyLoader(true);
+        Assert.assertFalse(snappyLoader.isSnappyAvailable());
+        snappyLoader.wrapOutputStream(new ByteArrayOutputStream(10));
+    }
+}


### PR DESCRIPTION
### Description
There were a few changes I wanted to make to the previous snappy pull request but it seemed better to get the main part of that merged in and then deal with them rather than sit in limbo forever.

There are a 2 commits, hopefully the first is uncontroversial:

 1st Commit: 
  * move the system properties to Defaults to be consistent with the rest of the htsjdk system properties
 * produce a more specific error message when failing to wrap a stream with snappy, and refactor to avoid duplicating the error message logic, the refactoring here might be overkill, but it seemed slightly cleaner to me than just duplicating the code, happy to roll that bit back though if it's too java8 for people's taste
* adding a few finals and try-with-resources to taste

 2nd commit:
 * removes the newly added verbosity argument and replaces it by making the log levels better tuned.  This seems to me like a reasonable tradeoff but @tfenne you were the one who wanted better control of the logging messages, so I'm not sure if it does what you need.  I think your initial logging changes may have gotten clobbered by the changes, so i'm not sure it's doing what you want anyway right now. 

### Checklist
- [X] Is not backward compatible (breaks binary or source compatibility)  this is not strictly compatible with the previous snappy pr, but that's never been released, so assuming we can get this in before a release it's not a breaking change


