### PR TITLE
Discussion: implement Read interface

### DIFF
--- a/src/main/java/htsjdk/samtools/read/Read.java
+++ b/src/main/java/htsjdk/samtools/read/Read.java
@@ -233,7 +233,7 @@ public interface Read extends Locatable {
     String getContig();
 
     /**
-     * Gets the 1-based inclusive leftmost position of the sequence remaining after clipping.
+     * Gets the 1-based leftmost mapping POSition of the first CIGAR operation that “consumes” a reference base.
      *
      * <p>Equivalent to <b>POS</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
@@ -243,7 +243,7 @@ public interface Read extends Locatable {
     int getStart();
 
     /**
-     * Gets the 1-based inclusive rightmost position of the sequence remaining after clipping.
+     * Gets the 1-based inclusive rightmost mapping POSition of the first CIGAR operation that “consumes” a reference base.
      *
      * @return 1-based closed-ended position; {@link ReadConstants#NO_ALIGNMENT_START} if there is no position (e.g. for unmapped read).
      */
@@ -285,7 +285,7 @@ public interface Read extends Locatable {
      *
      * <p>Note: this is not necessarily the same as the number of reference bases the read is aligned to.
      *
-     * @return The number of bases in the read
+     * @return The number of bases in the read-sequence.
      */
     int getLength();
 
@@ -301,7 +301,7 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Gets the PHERD scaled mapping quality.
+     * Gets the phred scaled mapping quality.
      *
      * <p>The {@link ReadConstants#UNKNOWN_MAPPING_QUALITY} implies valid mapping, but hard to compute quality.
      *
@@ -312,7 +312,7 @@ public interface Read extends Locatable {
     int getMappingQuality();
 
     /**
-     * Sets the PHRED scaled mapping quality.
+     * Sets the phred scaled mapping quality.
      *
      * <p>Equivalent to <b>MAPQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
@@ -323,6 +323,8 @@ public interface Read extends Locatable {
     /**
      * Gets the {@link Cigar} object describing how the read aligns to the reference.
      *
+     * <p>Equivalent to <b>CIGAR</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
      * <p>This method should make a defensive copy of the {@link Cigar} before returning it to allow
      * modification of the returned {@link Cigar} without effects on the {@link Read}.
      *
@@ -332,6 +334,8 @@ public interface Read extends Locatable {
 
     /**
      * Gets the number of cigar elements (number + operator) in the cigar string.
+     *
+     * <p>Equivalent to <b>CIGAR</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
      * <p>Default implementation returns {@code getCigar().numCigarElements()}.
      * Subclasses may override to provide more efficient implementations.
@@ -344,6 +348,8 @@ public interface Read extends Locatable {
 
     /**
      * Sets the {@link Cigar} object describing how the read aligns to the reference.
+     *
+     * <p>Equivalent to <b>CIGAR</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
      * @param cigar Cigar object for the read; empty Cigar if there is none.
      *
@@ -397,27 +403,33 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Gets the insert size (difference between the 5' end of the read and the 5' end of the mate).
-     * The insert size is negative if the mate maps to lower position than the read.
+     * Gets the signed observed template length. If  all  segments  are  mapped  to  the  same  reference,
+     * the unsigned observed template length equals the number of bases from the leftmost mapped base to the
+     * rightmost mapped base.  The leftmost segment has a plus sign and the rightmost has a minus sign.
+     * The sign of segments in the middle is undefined. It is set as 0 for single-segment template or when the
+     * information is unavailable.
      *
      * <p>Equivalent to <b>TLEN</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * @return insert size if possible; {@code 0} otherwise.
+     * @return insert size if possible to compute; {@code 0} otherwise.
      */
     int getInferredInsertSize();
 
     /**
-     * Sets the insert size (difference between the 5' end of the read and the 5' end of the mate).
-     * The insert size is negative if the mate maps to lower position than the read.
+     * Sets the signed observed template length. If  all  segments  are  mapped  to  the  same  reference,
+     * the unsigned observed template length equals the number of bases from the leftmost mapped base to the
+     * rightmost mapped base.  The leftmost segment has a plus sign and the rightmost has a minus sign.
+     * The sign of segments in the middle is undefined. It is set as 0 for single-segment template or when the
+     * information is unavailable.
      *
      * <p>Equivalent to <b>TLEN</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * @param insertSize insert size (negative if mate mapts to lower position than the read) if possible; {@code 0} otherwise.
+     * @param insertSize insert size if possible to compute; {@code 0} otherwise.
      */
     void setInsertSize(final int insertSize);
 
     /**
-     * Gets the read sequence as ASCII bytes ACGTN=
+     * Gets the read sequence as ASCII bytes.
      *
      * <p>Equivalent to <b>SEQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
@@ -436,7 +448,7 @@ public interface Read extends Locatable {
      * <p>Default implementation returns {@code getBases()[i]}.
      * Subclasses may override to provide a more efficient implementation.
      *
-     * @return base at index i.
+     * @return base at index i (0-based).
      *
      * @throws IndexOutOfBoundsException if i is negative or of i is not smaller than the number
      * of bases (as reported by {@link #getLength()}. In particular, if no sequence is present.
@@ -446,7 +458,7 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Gets all the bases in the read as a String of ACGTN=
+     * Gets all the bases in the read as an ASCII String.
      *
      * <p>Equivalent to <b>SEQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
@@ -464,14 +476,14 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to <b>SEQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * @param bases read sequence as ASCII bytes ACGTN=; {@link ReadConstants#NULL_SEQUENCE} if no sequence is present.
+     * @param bases read sequence as ASCII bytes; {@link ReadConstants#NULL_SEQUENCE} if no sequence is present.
      *
      * @throws IllegalArgumentException if the bases are null.
      */
     void setBases(final byte[] bases);
 
     /**
-     * Gets the base qualities, as binary PHRED scores (not ASCII).
+     * Gets the base qualities, as binary phred scores (not ASCII).
      *
      * <p>Equivalent to <b>QUAL</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
@@ -513,7 +525,7 @@ public interface Read extends Locatable {
      * <p>Default implementation returns {@code getBaseQualities()[i]}.
      * Subclasses may override to provide a more efficient implementation.
      *
-     * @return The base quality at index i.
+     * @return The base quality at index i (0-based).
      *
      * @throws IndexOutOfBoundsException if i is negative or of i is not smaller than the number
      * of base qualities (as reported by {@link #getBaseQualityLength()}.
@@ -549,7 +561,7 @@ public interface Read extends Locatable {
     ///////////////////////////////////////////////////////////
 
     /**
-     * Gets the list of optional fields for the read. This are encoded as tag/value pairs, where
+     * Gets the list of optional fields for the read. These are encoded as tag/value pairs, where
      * the tag is a 2-character String and the value is from a concrete type.
      *
      * @return immutable list of attributes.
@@ -563,7 +575,7 @@ public interface Read extends Locatable {
      * and returns the first one matching the tag.
      * Subclasses may override to provide more efficient implementations.
      *
-     * @param tag attribute tag.
+     * @param tag attribute tag (two character string).
      *
      * @return optional value associated with the tag; may be empty if the attribute is not present.
      *
@@ -583,7 +595,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation returns {@code getAttribute(tag).isPresent()}.
      *
-     * @param tag attribute tag.
+     * @param tag attribute tag (two character string).
      * @return {@code true} if the attribute was set; {@code false} otherwise.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -597,7 +609,7 @@ public interface Read extends Locatable {
      *
      * <p>Note: it is preferable to use setters for typed objects.
      *
-     * @param tag attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value object value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -613,7 +625,7 @@ public interface Read extends Locatable {
     /**
      * Clear an individual attribute on the read.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
      */
@@ -691,6 +703,7 @@ public interface Read extends Locatable {
      *
      * @return {@code true} if this read is unmapped; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default boolean isUnmapped() {
         return isSet(SAMFlag.READ_UNMAPPED);
     }
@@ -704,6 +717,7 @@ public interface Read extends Locatable {
      *
      * @param unmapped {@code true} if this read is unmapped; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default void setUnmapped(final boolean unmapped) {
         addFlag(SAMFlag.READ_UNMAPPED, unmapped);
     }
@@ -717,6 +731,7 @@ public interface Read extends Locatable {
      *
      * @return {@code true} if this read's mate is unmapped; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default boolean isMateUnmapped() {
         return isSet(SAMFlag.MATE_UNMAPPED);
     }
@@ -730,6 +745,7 @@ public interface Read extends Locatable {
      *
      * @param mateUnmapped {@code true} if this read's mate is unmapped; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default void setMateUnmapped(final boolean mateUnmapped) {
         addFlag(SAMFlag.MATE_UNMAPPED, mateUnmapped);
     }
@@ -743,6 +759,7 @@ public interface Read extends Locatable {
      *
      * @return {@code true} if the read is in the reverse strand; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default boolean isReverseStrand() {
         return isSet(SAMFlag.READ_REVERSE_STRAND);
     }
@@ -756,6 +773,7 @@ public interface Read extends Locatable {
      *
      * @param reverseStrand {@code true} if the read is in the reverse strand; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default void setReverseStrand(final boolean reverseStrand) {
         addFlag(SAMFlag.READ_REVERSE_STRAND, reverseStrand);
     }
@@ -769,6 +787,7 @@ public interface Read extends Locatable {
      *
      * @return {@code true} if the read's mate is in the reverse strand; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default boolean isMateReverseStrand() {
         return isSet(SAMFlag.MATE_REVERSE_STRAND);
     }
@@ -782,6 +801,7 @@ public interface Read extends Locatable {
      *
      * @param mateReverseStrand {@code true} if the read's mate is in the reverse strand; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default void setMateReverseStrand(final boolean mateReverseStrand) {
         addFlag(SAMFlag.MATE_REVERSE_STRAND, mateReverseStrand);
     }
@@ -873,6 +893,7 @@ public interface Read extends Locatable {
      *
      * @return {@code true} if the read fails the quality vendor check; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default boolean failsQualityVendorCheck() {
         return isSet(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK);
     }
@@ -886,6 +907,7 @@ public interface Read extends Locatable {
      *
      * @param failsQualityVendorCheck {@code true} if the read fails the quality vendor check; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get/set the reverse
     default void setFailsQualityVendorCheck(final boolean failsQualityVendorCheck) {
         addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityVendorCheck);
     }
@@ -938,10 +960,23 @@ public interface Read extends Locatable {
      *
      * @param supplementaryAlignment {@code true} if the read is a supplementary alignment; {@code false} otherwise.
      */
+    // TODO (before merging) - add method for get the reverse
     default void setSupplementaryAlignment(final boolean supplementaryAlignment) {
         addFlag(SAMFlag.SUPPLEMENTARY_ALIGNMENT, supplementaryAlignment);
     }
 
+    /**
+     * Checks if the read is a secondary or supplementary alignment.
+     *
+     * <p>Equivalent to the 0x100 or 0x800 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@code isSecondaryAlignment() || isSupplementaryAlignment()}.
+     *
+     * @return {@code true} if the read is secondary or supplementary; {@code false} otherwise.
+     */
+    default boolean isSecondaryOrSupplementary() {
+        return isSecondaryAlignment() || isSupplementaryAlignment();
+    }
 
     ///////////////////////////////////////////////////////////
     // OPTIONAL FIELDS - typed getters/setters
@@ -954,7 +989,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@link Character}.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
      * @return the character value.
      *
@@ -975,18 +1010,18 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Gets the singed integer value associated with the tag.
+     * Gets the signed Integer value associated with the tag.
      *
-     * <p>Equivalent to an attribute with <b>TYPE i</b> or any <b>TYPE B</b> integer (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     * <p>Equivalent to an attribute with <b>TYPE i</b> (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
      * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a numeric value within the integer range.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
-     * @return the integer value.
+     * @return the Integer value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
-     * @throws SAMException if the attribute value is not an integer.
+     * @throws SAMException if the attribute value is not an Integer.
      */
     default Optional<Integer> getIntegerAttribute(final String tag) {
         final Optional<Object> attr = getAttribute(tag);
@@ -1006,18 +1041,18 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Gets the float value associated with the tag.
+     * Gets the Float value associated with the tag.
      *
-     * <p>Equivalent to an attribute with <b>TYPE f</b> or <b>TYPE B</b> float in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     * <p>Equivalent to an attribute with <b>TYPE f</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
      * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@link Float}.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
-     * @return the float value.
+     * @return the Float value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
-     * @throws SAMException if the attribute is not a float.
+     * @throws SAMException if the attribute is not a Float.
      */
     default Optional<Float> getFloatAttribute(final String tag) {
         final Optional<Object> attr = getAttribute(tag);
@@ -1032,18 +1067,18 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Gets the string associated with the tag.
+     * Gets the String associated with the tag.
      *
      * <p>Equivalent to an attribute with <b>TYPE Z</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
      * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@link String}.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
-     * @return the string value.
+     * @return the String value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
-     * @throws SAMException if the attribute is not a string.
+     * @throws SAMException if the attribute is not a String.
      */
     default Optional<String> getStringAttribute(final String tag) {
         final Optional<Object> attr = getAttribute(tag);
@@ -1058,18 +1093,18 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Gets the short associated with the tag.
+     * Gets the Byte associated with the tag.
      *
      * <p>Equivalent to an attribute with <b>TYPE B</b> byte (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a numeric within the byte range.
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a numeric within the Byte range.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
-     * @return the byte array value.
+     * @return the Byte value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
-     * @throws SAMException if the attribute is not a float.
+     * @throws SAMException if the attribute is not a Byte.
      */
     default Optional<Byte> getByteAttribute(final String tag) {
         final Optional<Object> attr = getAttribute(tag);
@@ -1091,18 +1126,18 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Gets the short associated with the tag.
+     * Gets the Short associated with the tag.
      *
      * <p>Equivalent to an attribute with <b>TYPE B</b> short (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a numeric within the short range.
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a numeric within the Short range.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
-     * @return the byte array value.
+     * @return the Short value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
-     * @throws SAMException if the attribute is not a float.
+     * @throws SAMException if the attribute is not a Short.
      */
     default Optional<Short> getShortAttribute(final String tag) {
         final Optional<Object> attr = getAttribute(tag);
@@ -1130,7 +1165,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@code int[]}.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
      * @return the int array value.
      *
@@ -1152,11 +1187,11 @@ public interface Read extends Locatable {
     /**
      * Gets the float array associated with the tag.
      *
-     * <p>Equivalent to an attribute with <b>TYPE B</b> float array (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     * <p>Equivalent to an attribute with <b>TYPE B</b> float array in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
      * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@code float[]}.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
      * @return the float array value.
      *
@@ -1172,7 +1207,7 @@ public interface Read extends Locatable {
         if (val instanceof float[]) {
             return Optional.of((float[])val);
         }
-        throw new SAMException("Value for tag " + tag + " is not a byte[]: " + val.getClass());
+        throw new SAMException("Value for tag " + tag + " is not a float[]: " + val.getClass());
     }
 
     /**
@@ -1182,7 +1217,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@code byte[]}.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
      * @return the byte array value.
      *
@@ -1208,7 +1243,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@code short[]}.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      *
      * @return the short array value.
      *
@@ -1232,7 +1267,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the character value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1246,7 +1281,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the integer value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1260,7 +1295,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the float value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1274,7 +1309,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the string value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1288,7 +1323,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the byte value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1302,7 +1337,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the short value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1316,7 +1351,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the integer value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1330,7 +1365,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the float array value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1344,7 +1379,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the byte array value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
@@ -1358,7 +1393,7 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
      *
-     * @param tag the attribute tag.
+     * @param tag attribute tag (two character string).
      * @param value the short array value.
      *
      * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.

--- a/src/main/java/htsjdk/samtools/read/Read.java
+++ b/src/main/java/htsjdk/samtools/read/Read.java
@@ -411,9 +411,9 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to <b>TLEN</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * @return insert size if possible to compute; {@code 0} otherwise.
+     * @return template length if available; {@code 0} otherwise.
      */
-    int getInferredInsertSize();
+    int getTemplateLength();
 
     /**
      * Sets the signed observed template length. If  all  segments  are  mapped  to  the  same  reference,
@@ -424,9 +424,9 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to <b>TLEN</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * @param insertSize insert size if possible to compute; {@code 0} otherwise.
+     * @param templateLength template length if available; {@code 0} otherwise.
      */
-    void setInsertSize(final int insertSize);
+    void setTemplateLength(final int templateLength);
 
     /**
      * Gets the read sequence as ASCII bytes.

--- a/src/main/java/htsjdk/samtools/read/Read.java
+++ b/src/main/java/htsjdk/samtools/read/Read.java
@@ -1,0 +1,1438 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools.read;
+
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.SAMException;
+import htsjdk.samtools.SAMFlag;
+import htsjdk.samtools.SAMUtils;
+import htsjdk.samtools.util.Locatable;
+import htsjdk.samtools.util.StringUtil;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Interface for read, which is a sequence of bases aligned to a reference.
+ *
+ * <p>This interface is based on the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public interface Read extends Locatable {
+
+    ///////////////////////////////////////////////////////////
+    // MANDATORY FIELDS - getters/setters
+    ///////////////////////////////////////////////////////////
+
+    /**
+     * Gets the name of the read.
+     *
+     * <p>Equivalent to <b>QNAME</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @return the read name or {@code null} if the read has no name.
+     */
+    String getName();
+
+    /**
+     * Sets the name of the read.
+     *
+     * <p>Equivalent to <b>QNAME</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @param name new name for the read; {@code null} if the read has no name.
+     */
+    void setName(final String name);
+
+    /**
+     * Gets the bitwise flag.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Note: it is preferable to use the methods for testing if specific flags are set (using {@link #isSet(SAMFlag)} or {@link #isUnset(SAMFlag)}),
+     * get all the set flags with {@link #getSetFlags()} or testing specific flags with the shortcuts.
+     *
+     * @return the bitwise flag as an integer.
+     */
+    int getFlag();
+
+    /**
+     * Gets the {@link SAMFlag} that are set.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@code SAMFlag.getFlags(getFlag())}.
+     *
+     * @return a set of the flags that are set for the read.
+     */
+    default Set<SAMFlag> getSetFlags() {
+        return SAMFlag.getFlags(getFlag());
+    }
+
+    /**
+     * Checks if the flag is set.
+     *
+     * <p>Default implementation calls {@code flag.isSet(getFlag())}.
+     *
+     * @param flag the flag to test.
+     * @return {@code true} if the flag is set; {@code false} otherwise.
+     *
+     * @throws IllegalArgumentException if the flag is {@code null}.
+     */
+    default boolean isSet(final SAMFlag flag) {
+        return flag.isSet(getFlag());
+    }
+
+    /**
+     * Checks if the flag is unset.
+     *
+     * <p>Default implementation calls {@code flag.isUnset(getFlag())}.
+     *
+     * @param flag the flag to test.
+     * @return {@code true} if the flag is unset; {@code false} otherwise.
+     *
+     * @throws IllegalArgumentException if the flag is {@code null}.
+     */
+    default boolean isUnset(final SAMFlag flag) {
+        return flag.isUnset(getFlag());
+    }
+
+    /**
+     * Sets the bitwise flag.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Note: it is preferable to use the methods for set/unset specific flags are set (using {@link #setFlag(SAMFlag)} or {@link #unsetFlag(SAMFlag)}),
+     * clear the flags using {@link #clearFlag()}, set/unset the specific flags (using {@link #setFlags(Set) and {@link #unsetFlags(Set)}},
+     * or use the shortcuts.
+     *
+     * @param flag bitwise flag to assign to the read.
+     */
+    void setFlag(final int flag);
+
+    /**
+     * Clears the bitwise flag, un-setting all the bits.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@code setFlag(0)}.
+     */
+    default void clearFlag() {
+        setFlag(0);
+    }
+
+    /**
+     * Adds the flag, either setting it or unsetting it.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Deafault implementation modifies the {@link SAMFlag} bit of the {@link #getFlag()}, setting it afterwards with {@link #setFlag(int)} .
+     *
+     * @param flag flag to be set or unset.
+     * @param set {@code true} if the flag should be set; {@code false} otherwise.
+     *
+     * @throws IllegalArgumentException if the flag is {@code null}.
+     */
+    default void addFlag(final SAMFlag flag, final boolean set) {
+        if (flag == null) {
+            throw new IllegalArgumentException("null flag");
+        }
+        int bitwiseFlag = getFlag();
+        if (set) {
+            bitwiseFlag |= flag.intValue();
+        } else {
+            bitwiseFlag &= ~flag.intValue();
+        }
+        setFlag(bitwiseFlag);
+    }
+
+    /**
+     * Sets the bit of the provided flag.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@code addFlag(flag, true)}.
+     *
+     * @param flag flag to be set.
+     *
+     * @throws IllegalArgumentException if the flag is {@code null}.
+     */
+    default void setFlag(final SAMFlag flag) {
+        addFlag(flag, true);
+    }
+
+    /**
+     * Unsets the bit of the provided flag.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@code addFlag(flag, false)}.
+     *
+     * @param flag flag to be unset.
+     */
+    default void unsetFlag(final SAMFlag flag) {
+        addFlag(flag, false);
+    }
+
+    /**
+     * Sets all the provided flags.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #setFlag(SAMFlag)} for each of the elements in the set.
+     *
+     * @param flags flags to be set.
+     */
+    default void setFlags(final Set<SAMFlag> flags) {
+        flags.forEach(this::setFlag);
+    }
+
+    /**
+     * Unsets all the provided flags.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #unsetFlag(SAMFlag)}} for each of the elements in the set.
+     *
+     * @param flags flags to be unset.
+     */
+    default void unsetFlags(final Set<SAMFlag> flags) {
+        flags.forEach(this::unsetFlag);
+    }
+
+    /**
+     * Gets the contig name where the read is mapped to. May return null if there is no unique mapping.
+     *
+     * <p>Equivalent to <b>RNAME</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @return name of the contig this read is mapped to; {@link ReadConstants#NO_ALIGNMENT_REFERENCE_NAME} if unset (e.g. for unmapped reads).
+     */
+    @Override
+    String getContig();
+
+    /**
+     * Gets the 1-based inclusive leftmost position of the sequence remaining after clipping.
+     *
+     * <p>Equivalent to <b>POS</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @return 1-based start position; {@link ReadConstants#NO_ALIGNMENT_START} if there is no position (e.g. for unmapped read).
+     */
+    @Override
+    int getStart();
+
+    /**
+     * Gets the 1-based inclusive rightmost position of the sequence remaining after clipping.
+     *
+     * @return 1-based closed-ended position; {@link ReadConstants#NO_ALIGNMENT_START} if there is no position (e.g. for unmapped read).
+     */
+    @Override
+    int getEnd();
+
+    /**
+     * Sets the alignment position.
+     *
+     * <p>Equivalent to <b>RNAME</b> and <b>POS</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @param contig name of the contig this read is mapped to; {@link ReadConstants#NO_ALIGNMENT_REFERENCE_NAME} if unset (e.g. for unmapped reads).
+     * @param start 1-based start position; {@link ReadConstants#NO_ALIGNMENT_START} if there is no position (e.g. for unmapped read).
+     *
+     * @throws IllegalArgumentException if the contig is {@code null}.
+     */
+    void setAlignmentPosition(final String contig, final int start);
+
+    /**
+     * Sets the alignment position.
+     *
+     * <p>Equivalent to <b>POS</b> and <b>POS</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation uses the {@link #setAlignmentPosition(String, int)}, ignoring the {@link Locatable#getEnd()}.
+     *
+     * @param position location this read is mapped to.
+     *
+     * @throws IllegalArgumentException if the locatable is {@code null}.
+     */
+    default void setAlignmentPosition(final Locatable position) {
+        if (position == null) {
+            throw new IllegalArgumentException("null position");
+        }
+        setAlignmentPosition(position.getContig(), position.getStart());
+    }
+
+    /**
+     * Gets the read length.
+     *
+     * <p>Note: this is not necessarily the same as the number of reference bases the read is aligned to.
+     *
+     * @return The number of bases in the read
+     */
+    int getLength();
+
+    /**
+     * Checks if the read has bases.
+     *
+     * <p>Default implementation returns {@code getLength() == 0}.
+     *
+     * @return {@code true} if the read has no bases; {@code false} otherwise.
+     */
+    default boolean isEmpty() {
+        return getLength() == 0;
+    }
+
+    /**
+     * Gets the PHERD scaled mapping quality.
+     *
+     * <p>The {@link ReadConstants#UNKNOWN_MAPPING_QUALITY} implies valid mapping, but hard to compute quality.
+     *
+     * <p>Equivalent to <b>MAPQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @return mapping quality.
+     */
+    int getMappingQuality();
+
+    /**
+     * Sets the PHRED scaled mapping quality.
+     *
+     * <p>Equivalent to <b>MAPQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @param mapq mapping quality.
+     */
+    void setMappingQuality(final int mapq);
+
+    /**
+     * Gets the {@link Cigar} object describing how the read aligns to the reference.
+     *
+     * <p>This method should make a defensive copy of the {@link Cigar} before returning it to allow
+     * modification of the returned {@link Cigar} without effects on the {@link Read}.
+     *
+     * @return Cigar object for the read; empty cigar if there is none.
+     */
+    Cigar getCigar();
+
+    /**
+     * Gets the number of cigar elements (number + operator) in the cigar string.
+     *
+     * <p>Default implementation returns {@code getCigar().numCigarElements()}.
+     * Subclasses may override to provide more efficient implementations.
+     *
+     * @return number of cigar elements (number + operator) in the cigar string.
+     */
+    default int getCigarLength() {
+        return getCigar().numCigarElements();
+    }
+
+    /**
+     * Sets the {@link Cigar} object describing how the read aligns to the reference.
+     *
+     * @param cigar Cigar object for the read; empty Cigar if there is none.
+     *
+     * @throws IllegalArgumentException if the cigar is {@code null}.
+     */
+    void setCigar(final Cigar cigar);
+
+    /**
+     * Gets the contig name where the read's mate is mapped to. May return null if there is no unique mapping.
+     *
+     * <p>Equivalent to <b>RNEXT</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @return name of the contig the read's mate is mapped to; {@link ReadConstants#NO_ALIGNMENT_REFERENCE_NAME} if unset (e.g. for unmapped reads).
+     */
+    String getMateContig();
+
+    /**
+     * Gets the 1-based inclusive leftmost position of the sequence remaining after clipping for the read's mate.
+     *
+     * <p>Equivalent to <b>PNEXT</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @return 1-based start position; {@link ReadConstants#NO_ALIGNMENT_START} if there is no position (e.g. for unmapped read).
+     */
+    int getMateStart();
+
+    /**
+     * Sets the alignment position for the read's mate.
+     *
+     * <p>Equivalent to <b>RNEXT</b> and <b>PNEXT</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @param contig name of the contig the read's mate is mapped to; {@link ReadConstants#NO_ALIGNMENT_REFERENCE_NAME} if unset (e.g. for unmapped reads).
+     * @param start 1-based start position; {@link ReadConstants#NO_ALIGNMENT_START} if there is no position (e.g. for unmapped read).
+     *
+     * @throws IllegalArgumentException if the contig is {@code null}.
+     */
+    void setMateAlignmentPosition(final String contig, int start);
+
+    /**
+     * Sets the alignment position for the read's mate.
+     *
+     * <p>Equivalent to <b>RNEXT</b> and <b>PNEXT</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation uses the {@link #setMateAlignmentPosition(String, int)}, ignoring the {@link Locatable#getEnd()}.
+     *
+     * @param position location the read's mate is mapped to.
+     *
+     * @throws IllegalArgumentException if the locatable is {@code null}.
+     */
+    default void setMateAlignmentPosition(final Locatable position) {
+        setMateAlignmentPosition(position.getContig(), position.getStart());
+    }
+
+    /**
+     * Gets the insert size (difference between the 5' end of the read and the 5' end of the mate).
+     * The insert size is negative if the mate maps to lower position than the read.
+     *
+     * <p>Equivalent to <b>TLEN</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @return insert size if possible; {@code 0} otherwise.
+     */
+    int getInferredInsertSize();
+
+    /**
+     * Sets the insert size (difference between the 5' end of the read and the 5' end of the mate).
+     * The insert size is negative if the mate maps to lower position than the read.
+     *
+     * <p>Equivalent to <b>TLEN</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @param insertSize insert size (negative if mate mapts to lower position than the read) if possible; {@code 0} otherwise.
+     */
+    void setInsertSize(final int insertSize);
+
+    /**
+     * Gets the read sequence as ASCII bytes ACGTN=
+     *
+     * <p>Equivalent to <b>SEQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>This method should make a defensive copy of the bases array before returning it to allow
+     * modification of the returned array without effects on the {@link Read}.
+     *
+     * @return the read sequence; {@link ReadConstants#NULL_SEQUENCE} if no sequence is present.
+     */
+    byte[] getBases();
+
+    /**
+     * Gets the base at position i.
+     *
+     * <p>Equivalent to <b>SEQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation returns {@code getBases()[i]}.
+     * Subclasses may override to provide a more efficient implementation.
+     *
+     * @return base at index i.
+     *
+     * @throws IndexOutOfBoundsException if i is negative or of i is not smaller than the number
+     * of bases (as reported by {@link #getLength()}. In particular, if no sequence is present.
+     */
+    default byte getBase(final int i){
+        return getBases()[i];
+    }
+
+    /**
+     * Gets all the bases in the read as a String of ACGTN=
+     *
+     * <p>Equivalent to <b>SEQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation uses {@code getBases()}.
+     * Subclasses may override to provide a more efficient implementation.
+     *
+     * @return read sequence as a string ; {@link ReadConstants#NULL_SEQUENCE_STRING} if the read is empty.
+     */
+    default String getBasesString() {
+        return isEmpty() ? ReadConstants.NULL_SEQUENCE_STRING : StringUtil.bytesToString(getBases());
+    }
+
+    /**
+     * Sets the sequence bases.
+     *
+     * <p>Equivalent to <b>SEQ</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @param bases read sequence as ASCII bytes ACGTN=; {@link ReadConstants#NULL_SEQUENCE} if no sequence is present.
+     *
+     * @throws IllegalArgumentException if the bases are null.
+     */
+    void setBases(final byte[] bases);
+
+    /**
+     * Gets the base qualities, as binary PHRED scores (not ASCII).
+     *
+     * <p>Equivalent to <b>QUAL</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>This method should make a defensive copy of the bases array before returning it to allow
+     * modification of the returned array without effects on the {@link Read}.
+     *
+     * @return base qualities; {@link ReadConstants#NULL_QUALS} if base qualities are not present.
+     */
+    byte[] getBaseQualities();
+
+    /**
+     * Gets the number of base qualities in the read sequence.
+     *
+     * <p>Equivalent to <b>QUAL</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@code getBaseQualities().length}.
+     * Subclasses may override to provide a more efficient implementation.
+     *
+     * @return number of base qualities in the read sequence.
+     */
+    default int getBaseQualityLength(){
+        return getBaseQualities().length;
+    }
+
+    /**
+     * Checks if the read has qualities.
+     *
+     * <p>Default implementation returns {@code getBaseQualityLength() != 0}.
+     *
+     * @return {@code true} if the read has qualities; {@code false} otherwise.
+     */
+    default boolean hasQualities() {
+        return getBaseQualityLength() != 0;
+    }
+
+    /**
+     * Gets the base quality at position i.
+     *
+     * <p>Default implementation returns {@code getBaseQualities()[i]}.
+     * Subclasses may override to provide a more efficient implementation.
+     *
+     * @return The base quality at index i.
+     *
+     * @throws IndexOutOfBoundsException if i is negative or of i is not smaller than the number
+     * of base qualities (as reported by {@link #getBaseQualityLength()}.
+     */
+    default byte getBaseQuality(final int i){
+        return getBaseQualities()[i];
+    }
+
+    /**
+     * Gets all the base qualities in the read as an ASCII String.
+     *
+     * <p>Equivalent to <b>QUAL</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @return base qualities as a string ; {@link ReadConstants#NULL_QUALS_STRING} if the read does not have qualities.
+     */
+    default String getBaseQualityString() {
+        return hasQualities() ? SAMUtils.phredToFastq(getBaseQualities()) : ReadConstants.NULL_QUALS_STRING;
+    }
+
+    /**
+     * Set the base qualities.
+     *
+     * <p>Equivalent to <b>QUAL</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * @param baseQualities base qualities as binary phred scores (not ASCII); {@link ReadConstants#NULL_QUALS} if no base qualities are present.
+     *
+     * @throws IllegalArgumentException if the base qualities are null or an invalid (negative) base quality is provided.
+     */
+    void setBaseQualities(final byte[] baseQualities);
+
+    ///////////////////////////////////////////////////////////
+    // OPTIONAL FIELDS - untyped getters/setters
+    ///////////////////////////////////////////////////////////
+
+    /**
+     * Gets the list of optional fields for the read. This are encoded as tag/value pairs, where
+     * the tag is a 2-character String and the value is from a concrete type.
+     *
+     * @return immutable list of attributes.
+     */
+    List<ReadAttribute<?>> getAttributes();
+
+    /**
+     * Gets the attribute value associated with the attribute tag provided.
+     *
+     * <p>Default implementation search for the tag value is the {@link #getAttributes()} list
+     * and returns the first one matching the tag.
+     * Subclasses may override to provide more efficient implementations.
+     *
+     * @param tag attribute tag.
+     *
+     * @return optional value associated with the tag; may be empty if the attribute is not present.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default Optional<Object> getAttribute(final String tag) {
+        if (ReadAttribute.isValidTag(tag)) {
+            throw new SAMException("String tag does not have length() == 2: " + tag);
+        }
+        return getAttributes().stream().filter(attr -> attr.getTag().equals(tag))
+                .map(attr -> (Object) attr.getValue())
+                .findFirst();
+    }
+
+    /**
+     * Checks if the read has set the attribute tag provided.
+     *
+     * <p>Default implementation returns {@code getAttribute(tag).isPresent()}.
+     *
+     * @param tag attribute tag.
+     * @return {@code true} if the attribute was set; {@code false} otherwise.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default boolean hasAttribute(final String tag) {
+        return getAttribute(tag).isPresent();
+    }
+
+    /**
+     * Sets the attribute value associated with the attribute tag.
+     *
+     * <p>Note: it is preferable to use setters for typed objects.
+     *
+     * @param tag attribute tag.
+     * @param value object value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     *
+     * @throws IllegalArgumentException if the value is {@code null}. For clear an attribute value,
+     * use {@link #clearAttribute(String)} instead.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the value is invalid following the contract of {@link ReadAttribute#isAllowedAttributeValue(Object)}.
+     */
+    void setAttribute(final String tag, final Object value);
+
+    /**
+     * Clear an individual attribute on the read.
+     *
+     * @param tag the attribute tag.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    void clearAttribute(final String tag);
+
+    /**
+     * Clear all attributes on the read.
+     */
+    void clearAttributes();
+
+
+    ///////////////////////////////////////////////////////////
+    // FLAG SHORTCUT METHODS
+    ///////////////////////////////////////////////////////////
+
+
+    /**
+     * Checks if the read is paired.
+     *
+     * <p>Equivalent to the 0x1 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#READ_PAIRED}.
+     *
+     * @return {@code true} if this read is paired (e.g. has a mate); {@code false} otherwise.
+     */
+    default boolean isPaired() {
+        return isSet(SAMFlag.READ_PAIRED);
+    }
+
+    /**
+     * Mark the read as paired (having a mate) or not paired.
+     *
+     * <p>Equivalent to the 0x1 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_PAIRED, paired)}.
+     *
+     * @param paired {@code true} if the read is paired; {@code false} otherwise.
+     */
+    default void setPaired(final boolean paired) {
+        addFlag(SAMFlag.READ_PAIRED, paired);
+    }
+
+    /**
+     * Checks if the read is mapped in a proper pair (depends on the protocol, normally inferred during alignment).
+     *
+     * <p>Equivalent to the 0x2 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#PROPER_PAIR}.
+     *
+     * @return {@code true} if this read is properly paired ; {@code false} otherwise.
+     */
+    default boolean isProperlyPaired() {
+        return isSet(SAMFlag.PROPER_PAIR);
+    }
+
+    /**
+     * Mark the read as properly paired or not.
+     *
+     * <p>Equivalent to the 0x2 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.PROPER_PAIR, properlyPaired)}.
+     *
+     * @param properlyPaired {@code true} if the read is properly paired; {@code false} otherwise.
+     */
+    default void setProperlyPaired(final boolean properlyPaired) {
+        addFlag(SAMFlag.PROPER_PAIR, properlyPaired);
+    }
+
+    /**
+     * Checks if the read is unmapped.
+     *
+     * <p>Equivalent to the 0x4 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#READ_UNMAPPED}.
+     *
+     * @return {@code true} if this read is unmapped; {@code false} otherwise.
+     */
+    default boolean isUnmapped() {
+        return isSet(SAMFlag.READ_UNMAPPED);
+    }
+
+    /**
+     * Mark the read as unmapped or not.
+     *
+     * <p>Equivalent to the 0x4 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_UNMAPPED, unmapped)}.
+     *
+     * @param unmapped {@code true} if this read is unmapped; {@code false} otherwise.
+     */
+    default void setUnmapped(final boolean unmapped) {
+        addFlag(SAMFlag.READ_UNMAPPED, unmapped);
+    }
+
+    /**
+     * Checks if the read's mate is unmapped.
+     *
+     * <p>Equivalent to the 0x8 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#MATE_UNMAPPED}.
+     *
+     * @return {@code true} if this read's mate is unmapped; {@code false} otherwise.
+     */
+    default boolean isMateUnmapped() {
+        return isSet(SAMFlag.MATE_UNMAPPED);
+    }
+
+    /**
+     * Mark the read's mate as unmapped or not.
+     *
+     * <p>Equivalent to the 0x8 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.MATE_UNMAPPED, mateUnmapped)}.
+     *
+     * @param mateUnmapped {@code true} if this read's mate is unmapped; {@code false} otherwise.
+     */
+    default void setMateUnmapped(final boolean mateUnmapped) {
+        addFlag(SAMFlag.MATE_UNMAPPED, mateUnmapped);
+    }
+
+    /**
+     * Checks if the read is in the reverse strand.
+     *
+     * <p>Equivalent to the 0x10 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#READ_REVERSE_STRAND}.
+     *
+     * @return {@code true} if the read is in the reverse strand; {@code false} otherwise.
+     */
+    default boolean isReverseStrand() {
+        return isSet(SAMFlag.READ_REVERSE_STRAND);
+    }
+
+    /**
+     * Marks the read as being in the reverse strand or not.
+     *
+     * <p>Equivalent to the 0x10 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_REVERSE_STRAND, reverseStrand)}.
+     *
+     * @param reverseStrand {@code true} if the read is in the reverse strand; {@code false} otherwise.
+     */
+    default void setReverseStrand(final boolean reverseStrand) {
+        addFlag(SAMFlag.READ_REVERSE_STRAND, reverseStrand);
+    }
+
+    /**
+     * Checks if the read's mate is in the reverse strand.
+     *
+     * <p>Equivalent to the 0x20 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#MATE_REVERSE_STRAND}.
+     *
+     * @return {@code true} if the read's mate is in the reverse strand; {@code false} otherwise.
+     */
+    default boolean isMateReverseStrand() {
+        return isSet(SAMFlag.MATE_REVERSE_STRAND);
+    }
+
+    /**
+     * Marks the read's mate as being in the reverse strand or not.
+     *
+     * <p>Equivalent to the 0x20 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.MATE_REVERSE_STRAND, mateReverseStrand)}.
+     *
+     * @param mateReverseStrand {@code true} if the read's mate is in the reverse strand; {@code false} otherwise.
+     */
+    default void setMateReverseStrand(final boolean mateReverseStrand) {
+        addFlag(SAMFlag.MATE_REVERSE_STRAND, mateReverseStrand);
+    }
+
+    /**
+     * Checks if the read is the first of a pair.
+     *
+     * <p>Equivalent to the 0x40 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#FIRST_OF_PAIR}.
+     *
+     * @return {@code true} if the read is in the first of a pair; {@code false} otherwise.
+     */
+    default boolean isFirstOfPair() {
+        return isSet(SAMFlag.FIRST_OF_PAIR);
+    }
+
+    /**
+     * Marks the read as being the first of the pair or not.
+     *
+     * <p>Equivalent to the 0x40 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.FIRST_OF_PAIR, firstOfPair)}.
+     *
+     * @param firstOfPair {@code true} if the read is in the first of a pair; {@code false} otherwise.
+     */
+    default void setFirstOfPair(final boolean firstOfPair) {
+        addFlag(SAMFlag.FIRST_OF_PAIR, firstOfPair);
+    }
+
+    /**
+     * Checks if the read is the second of a pair.
+     *
+     * <p>Equivalent to the 0x80 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#SECOND_OF_PAIR}.
+     *
+     * @return {@code true} if the read is in the second of a pair; {@code false} otherwise.
+     */
+    default boolean isSecondOfPair() {
+        return isSet(SAMFlag.SECOND_OF_PAIR);
+    }
+
+    /**
+     * Marks the read as being the second of a pair or not.
+     *
+     * <p>Equivalent to the 0x80 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.SECOND_OF_PAIR, secondOfPair)}.
+     *
+     * @param secondOfPair {@code true} if the read is in the second of a pair; {@code false} otherwise.
+     */
+    default void setSecondOfPair(final boolean secondOfPair) {
+        addFlag(SAMFlag.SECOND_OF_PAIR, secondOfPair);
+    }
+
+    /**
+     * Checks if the read is a secondary alignment.
+     *
+     * <p>Equivalent to the 0x100 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#NOT_PRIMARY_ALIGNMENT}.
+     *
+     * @return {@code true} if the read is a secondary alignment; {@code false} otherwise.
+     */
+    default boolean isSecondaryAlignment() {
+        return isSet(SAMFlag.NOT_PRIMARY_ALIGNMENT);
+    }
+
+    /**
+     * Marks the read as being a secondary alignment or not.
+     *
+     * <p>Equivalent to the 0x100 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.NOT_PRIMARY_ALIGNMENT, secondaryAlignment)}.
+     *
+     * @param secondaryAlignment {@code true} if the read is a secondary alignment; {@code false} otherwise.
+     */
+    default void setSecondaryAlignment(final boolean secondaryAlignment) {
+        addFlag(SAMFlag.NOT_PRIMARY_ALIGNMENT, secondaryAlignment);
+    }
+
+    /**
+     * Checks if the read fails the quality vendor check.
+     *
+     * <p>Equivalent to the 0x200 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#READ_FAILS_VENDOR_QUALITY_CHECK}.
+     *
+     * @return {@code true} if the read fails the quality vendor check; {@code false} otherwise.
+     */
+    default boolean failsQualityVendorCheck() {
+        return isSet(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK);
+    }
+
+    /**
+     * Marks the read as failing the quality vendor check or not.
+     *
+     * <p>Equivalent to the 0x200 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityVendorCheck)}.
+     *
+     * @param failsQualityVendorCheck {@code true} if the read fails the quality vendor check; {@code false} otherwise.
+     */
+    default void setFailsQualityVendorCheck(final boolean failsQualityVendorCheck) {
+        addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityVendorCheck);
+    }
+
+    /**
+     * Checks if the read is a duplicate.
+     *
+     * <p>Equivalent to the 0x400 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#DUPLICATE_READ}.
+     *
+     * @return {@code true} if the read is a duplicate; {@code false} otherwise.
+     */
+    default boolean isDuplicate() {
+        return isSet(SAMFlag.DUPLICATE_READ);
+    }
+
+    /**
+     * Marks the read as a duplicate or not.
+     *
+     * <p>Equivalent to the 0x400 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.DUPLICATE_READ, duplicate)}.
+     *
+     * @param duplicate {@code true} if the read is a duplicate; {@code false} otherwise.
+     */
+    default void setDuplicate(final boolean duplicate) {
+        addFlag(SAMFlag.DUPLICATE_READ, duplicate);
+    }
+
+    /**
+     * Checks if the read is a supplementary alignment.
+     *
+     * <p>Equivalent to the 0x800 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@link #isSet(SAMFlag)} for {@link SAMFlag#SUPPLEMENTARY_ALIGNMENT}.
+     *
+     * @return {@code true} if the read is a supplementary alignment; {@code false} otherwise.
+     */
+    default boolean isSupplementaryAlignment() {
+        return isSet(SAMFlag.SUPPLEMENTARY_ALIGNMENT);
+    }
+
+    /**
+     * Marks the read as being a supplementary alignment.
+     *
+     * <p>Equivalent to the 0x800 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.SUPPLEMENTARY_ALIGNMENT, supplementaryAlignment)}.
+     *
+     * @param supplementaryAlignment {@code true} if the read is a supplementary alignment; {@code false} otherwise.
+     */
+    default void setSupplementaryAlignment(final boolean supplementaryAlignment) {
+        addFlag(SAMFlag.SUPPLEMENTARY_ALIGNMENT, supplementaryAlignment);
+    }
+
+
+    ///////////////////////////////////////////////////////////
+    // OPTIONAL FIELDS - typed getters/setters
+    ///////////////////////////////////////////////////////////
+
+    /**
+     * Gets the character value associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE A</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@link Character}.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the character value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute value is not a character.
+     */
+    default Optional<Character> getCharacterAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+
+        if (val instanceof Character) {
+            return Optional.of((Character)val);
+        }
+        throw new SAMException("Value for tag " + tag + " is not a Character: " + val.getClass());
+    }
+
+    /**
+     * Gets the singed integer value associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE i</b> or any <b>TYPE B</b> integer (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a numeric value within the integer range.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the integer value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute value is not an integer.
+     */
+    default Optional<Integer> getIntegerAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+
+        if (!(val instanceof Number)) {
+            throw new SAMException("Value for tag " + tag + " is not Number: " + val.getClass());
+        }
+        final long longVal = ((Number)val).longValue();
+        if (longVal < Integer.MIN_VALUE || longVal > Integer.MAX_VALUE) {
+            throw new SAMException("Value for tag " + tag + " is not in Integer range: " + longVal);
+        }
+        return Optional.of((int) longVal);
+    }
+
+    /**
+     * Gets the float value associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE f</b> or <b>TYPE B</b> float in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@link Float}.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the float value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute is not a float.
+     */
+    default Optional<Float> getFloatAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+        if (val instanceof Float) {
+            return Optional.of((Float) val);
+        }
+        throw new SAMException("Value for tag " + tag + " is not a Float: " + val.getClass());
+    }
+
+    /**
+     * Gets the string associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE Z</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@link String}.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the string value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute is not a string.
+     */
+    default Optional<String> getStringAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+        if (val instanceof String) {
+            return Optional.of((String) val);
+        }
+        throw new SAMException("Value for tag " + tag + " is not a String: " + val.getClass());
+    }
+
+    /**
+     * Gets the short associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE B</b> byte (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a numeric within the byte range.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the byte array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute is not a float.
+     */
+    default Optional<Byte> getByteAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+        if (val instanceof Byte) {
+            return Optional.of((Byte)val);
+        }
+        if (!(val instanceof Number)) {
+            throw new SAMException("Value for tag " + tag + " is not Number: " + val.getClass());
+        }
+        final long longVal = ((Number)val).longValue();
+        if (longVal < Byte.MIN_VALUE || longVal > Byte.MAX_VALUE) {
+            throw new SAMException("Value for tag " + tag + " is not in Short range: " + longVal);
+        }
+        return Optional.of((byte)longVal);
+    }
+
+    /**
+     * Gets the short associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE B</b> short (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a numeric within the short range.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the byte array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute is not a float.
+     */
+    default Optional<Short> getShortAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+        if (val instanceof Short) {
+            return Optional.of((Short) val);
+        }
+        if (!(val instanceof Number)) {
+            throw new SAMException("Value for tag " + tag + " is not Number: " + val.getClass());
+        }
+        final long longVal = ((Number) val).longValue();
+        if (longVal < Short.MIN_VALUE || longVal > Short.MAX_VALUE) {
+            throw new SAMException("Value for tag " + tag + " is not in Short range: " + longVal);
+        }
+        return Optional.of((short) longVal);
+    }
+
+    /**
+     * Gets the integer array associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE B</b> integer array (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@code int[]}.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the int array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute is not a {@code int[]}.
+     */
+    default Optional<int[]> getIntegerArrayAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+        if (val instanceof int[]) {
+            return Optional.of((int[])val);
+        }
+        throw new SAMException("Value for tag " + tag + " is not a int[]: " + val.getClass());
+    }
+
+    /**
+     * Gets the float array associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE B</b> float array (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@code float[]}.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the float array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute is not a {@code float[]}.
+     */
+    default Optional<float[]> getFloatArrayAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+        if (val instanceof float[]) {
+            return Optional.of((float[])val);
+        }
+        throw new SAMException("Value for tag " + tag + " is not a byte[]: " + val.getClass());
+    }
+
+    /**
+     * Gets the byte array associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE H</b> and any <b>TYPE B</b> byte array (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@code byte[]}.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the byte array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute is not a {@code byte[]}.
+     */
+    default Optional<byte[]> getByteArrayAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+        if (val instanceof byte[]) {
+            return Optional.of((byte[])val);
+        }
+        throw new SAMException("Value for tag " + tag + " is not a byte[]: " + val.getClass());
+    }
+
+    /**
+     * Gets the short array associated with the tag.
+     *
+     * <p>Equivalent to an attribute with <b>TYPE B</b> short array (signed or unsigned) in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation gets the attribute with {@link #getAttribute(String)}, checking if it is a {@code short[]}.
+     *
+     * @param tag the attribute tag.
+     *
+     * @return the short array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     * @throws SAMException if the attribute is not a {@code short[]}.
+     */
+    default Optional<short[]> getShortArrayAttribute(final String tag) {
+        final Optional<Object> attr = getAttribute(tag);
+        if (!attr.isPresent()) {
+            return Optional.empty();
+        }
+        final Object val = attr.get();
+        if (val instanceof short[]) {
+            return Optional.of((short[])val);
+        }
+        throw new SAMException("Value for tag " + tag + " is not a short[]: " + val.getClass());
+    }
+
+    /**
+     * Sets a character attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the character value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final char value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets an integer attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the integer value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final int value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets a float attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the float value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final float value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets a String attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the string value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final String value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets a byte attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the byte value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final byte value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets a short attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the short value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final short value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets a integer array attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the integer value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final int[] value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets a float array attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the float array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final float[] value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets a byte array attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the byte array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final byte[] value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    /**
+     * Sets a short array attribute.
+     *
+     * <p>Default implementation calls {@link #setAttribute(String, Object)} casting the value.
+     *
+     * @param tag the attribute tag.
+     * @param value the short array value.
+     *
+     * @throws SAMException if the tag is invalid following the contract of {@link ReadAttribute#isValidTag(String)}.
+     */
+    default void setAttribute(final String tag, final short[] value) {
+        setAttribute(tag, (Object) value);
+    }
+
+    ///////////////////////////////////////////////////////////
+    // OTHER METHODS
+    ///////////////////////////////////////////////////////////
+
+    /**
+     * Returns the record in the SAM line-based text format. Fields are separated by '\t' characters,
+     * and the String is terminated by '\n'.
+     *
+     * @return SAM-formatted String
+     */
+    // TODO: add default implementation - requires SAMTestWriter to handle reads
+    String getSAMString();
+
+    /**
+     * Return a copy of this read.
+     *
+     * <p>Note: the copy will not necessarily be a true deep copy. The fields encapsulated by the read
+     * itself may be shallow copied. It should be safe to use in general if the return objects are
+     * defensive copies of the read.
+     *
+     * @return a copy of this read.
+     */
+    Read copy();
+
+    /**
+     * Return a deep copy of this read, where any downstream modification would not be applied to this object.
+     *
+     * @return a true deep copy of this read.
+     */
+    Read deepCopy();
+
+    ///////////////////////////////////////////////////////////
+    // HELPER METHODS FOR SUBCLASSES
+    ///////////////////////////////////////////////////////////
+
+    /**
+     * Generates a common String to use in {@link #toString()} for subclasses.
+     *
+     * <p>Note: this method should be used only for developer consumption.
+     *
+     * @return a common String representation or the read.
+     */
+    default String commonToString() {
+        final StringBuilder builder = new StringBuilder(64);
+        builder.append(getName());
+        if (isPaired()) {
+            if (isFirstOfPair()) {
+                builder.append(" 1/2");
+            }
+            else {
+                builder.append(" 2/2");
+            }
+        }
+
+        builder.append(' ')
+                .append(String.valueOf(getLength()))
+                .append('b');
+
+        if (isUnmapped()) {
+            builder.append(" unmapped read.");
+        }
+        else {
+            builder.append(" aligned read.");
+        }
+
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/htsjdk/samtools/read/Read.java
+++ b/src/main/java/htsjdk/samtools/read/Read.java
@@ -72,52 +72,11 @@ public interface Read extends Locatable {
      * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
      * <p>Note: it is preferable to use the methods for testing if specific flags are set (using {@link #isSet(SAMFlag)} or {@link #isUnset(SAMFlag)}),
-     * get all the set flags with {@link #getSetFlags()} or testing specific flags with the shortcuts.
+     * get all the set flags with {@link #getTrueFlags()} or testing specific flags with the shortcuts.
      *
      * @return the bitwise flag as an integer.
      */
-    int getFlag();
-
-    /**
-     * Gets the {@link SAMFlag} that are set.
-     *
-     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
-     *
-     * <p>Default implementation calls {@code SAMFlag.getFlags(getFlag())}.
-     *
-     * @return a set of the flags that are set for the read.
-     */
-    default Set<SAMFlag> getSetFlags() {
-        return SAMFlag.getFlags(getFlag());
-    }
-
-    /**
-     * Checks if the flag is set.
-     *
-     * <p>Default implementation calls {@code flag.isSet(getFlag())}.
-     *
-     * @param flag the flag to test.
-     * @return {@code true} if the flag is set; {@code false} otherwise.
-     *
-     * @throws IllegalArgumentException if the flag is {@code null}.
-     */
-    default boolean isSet(final SAMFlag flag) {
-        return flag.isSet(getFlag());
-    }
-
-    /**
-     * Checks if the flag is unset.
-     *
-     * <p>Default implementation calls {@code flag.isUnset(getFlag())}.
-     *
-     * @param flag the flag to test.
-     * @return {@code true} if the flag is unset; {@code false} otherwise.
-     *
-     * @throws IllegalArgumentException if the flag is {@code null}.
-     */
-    default boolean isUnset(final SAMFlag flag) {
-        return flag.isUnset(getFlag());
-    }
+    int getFlags();
 
     /**
      * Sets the bitwise flag.
@@ -125,12 +84,12 @@ public interface Read extends Locatable {
      * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
      * <p>Note: it is preferable to use the methods for set/unset specific flags are set (using {@link #setFlag(SAMFlag)} or {@link #unsetFlag(SAMFlag)}),
-     * clear the flags using {@link #clearFlag()}, set/unset the specific flags (using {@link #setFlags(Set) and {@link #unsetFlags(Set)}},
+     * clear the flags using {@link #clearFlags()}, set/unset the specific flags (using {@link #setTrueFlags(Set) and {@link #unsetFlags(Set)}},
      * or use the shortcuts.
      *
      * @param flag bitwise flag to assign to the read.
      */
-    void setFlag(final int flag);
+    void setFlags(final int flag);
 
     /**
      * Clears the bitwise flag, un-setting all the bits.
@@ -139,8 +98,36 @@ public interface Read extends Locatable {
      *
      * <p>Default implementation calls {@code setFlag(0)}.
      */
-    default void clearFlag() {
-        setFlag(0);
+    default void clearFlags() {
+        setFlags(0);
+    }
+
+    /**
+     * Checks if the flag is set.
+     *
+     * <p>Default implementation calls {@code flag.isSet(getFlags())}.
+     *
+     * @param flag the flag to test.
+     * @return {@code true} if the flag is set; {@code false} otherwise.
+     *
+     * @throws IllegalArgumentException if the flag is {@code null}.
+     */
+    default boolean isSet(final SAMFlag flag) {
+        return flag.isSet(getFlags());
+    }
+
+    /**
+     * Checks if the flag is unset.
+     *
+     * <p>Default implementation calls {@code flag.isUnset(getFlags())}.
+     *
+     * @param flag the flag to test.
+     * @return {@code true} if the flag is unset; {@code false} otherwise.
+     *
+     * @throws IllegalArgumentException if the flag is {@code null}.
+     */
+    default boolean isUnset(final SAMFlag flag) {
+        return flag.isUnset(getFlags());
     }
 
     /**
@@ -148,24 +135,24 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Deafault implementation modifies the {@link SAMFlag} bit of the {@link #getFlag()}, setting it afterwards with {@link #setFlag(int)} .
+     * <p>Deafault implementation modifies the {@link SAMFlag} bit of the {@link #getFlags()}, setting it afterwards with {@link #setFlags(int)} .
      *
      * @param flag flag to be set or unset.
      * @param set {@code true} if the flag should be set; {@code false} otherwise.
      *
      * @throws IllegalArgumentException if the flag is {@code null}.
      */
-    default void addFlag(final SAMFlag flag, final boolean set) {
+    default void setFlag(final SAMFlag flag, final boolean set) {
         if (flag == null) {
             throw new IllegalArgumentException("null flag");
         }
-        int bitwiseFlag = getFlag();
+        int bitwiseFlag = getFlags();
         if (set) {
             bitwiseFlag |= flag.intValue();
         } else {
             bitwiseFlag &= ~flag.intValue();
         }
-        setFlag(bitwiseFlag);
+        setFlags(bitwiseFlag);
     }
 
     /**
@@ -173,14 +160,14 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls {@code addFlag(flag, true)}.
+     * <p>Default implementation calls {@code setFlag(flag, true)}.
      *
      * @param flag flag to be set.
      *
      * @throws IllegalArgumentException if the flag is {@code null}.
      */
     default void setFlag(final SAMFlag flag) {
-        addFlag(flag, true);
+        setFlag(flag, true);
     }
 
     /**
@@ -188,12 +175,25 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls {@code addFlag(flag, false)}.
+     * <p>Default implementation calls {@code setFlag(flag, false)}.
      *
      * @param flag flag to be unset.
      */
     default void unsetFlag(final SAMFlag flag) {
-        addFlag(flag, false);
+        setFlag(flag, false);
+    }
+
+    /**
+     * Gets the {@link SAMFlag} that are set.
+     *
+     * <p>Equivalent to <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
+     *
+     * <p>Default implementation calls {@code SAMFlag.getFlags(getFlags())}.
+     *
+     * @return a set of the flags that are set for the read.
+     */
+    default Set<SAMFlag> getTrueFlags() {
+        return SAMFlag.getFlags(getFlags());
     }
 
     /**
@@ -205,7 +205,7 @@ public interface Read extends Locatable {
      *
      * @param flags flags to be set.
      */
-    default void setFlags(final Set<SAMFlag> flags) {
+    default void setTrueFlags(final Set<SAMFlag> flags) {
         flags.forEach(this::setFlag);
     }
 
@@ -660,12 +660,12 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x1 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_PAIRED, paired)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.READ_PAIRED, paired)}.
      *
      * @param paired {@code true} if the read is paired; {@code false} otherwise.
      */
     default void setPaired(final boolean paired) {
-        addFlag(SAMFlag.READ_PAIRED, paired);
+        setFlag(SAMFlag.READ_PAIRED, paired);
     }
 
     /**
@@ -686,12 +686,12 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x2 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.PROPER_PAIR, properlyPaired)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.PROPER_PAIR, properlyPaired)}.
      *
      * @param properlyPaired {@code true} if the read is properly paired; {@code false} otherwise.
      */
     default void setProperlyPaired(final boolean properlyPaired) {
-        addFlag(SAMFlag.PROPER_PAIR, properlyPaired);
+        setFlag(SAMFlag.PROPER_PAIR, properlyPaired);
     }
 
     /**
@@ -713,13 +713,13 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x4 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_UNMAPPED, unmapped)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.READ_UNMAPPED, unmapped)}.
      *
      * @param unmapped {@code true} if this read is unmapped; {@code false} otherwise.
      */
     // TODO (before merging) - add method for get/set the reverse
     default void setUnmapped(final boolean unmapped) {
-        addFlag(SAMFlag.READ_UNMAPPED, unmapped);
+        setFlag(SAMFlag.READ_UNMAPPED, unmapped);
     }
 
     /**
@@ -741,13 +741,13 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x8 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.MATE_UNMAPPED, mateUnmapped)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.MATE_UNMAPPED, mateUnmapped)}.
      *
      * @param mateUnmapped {@code true} if this read's mate is unmapped; {@code false} otherwise.
      */
     // TODO (before merging) - add method for get/set the reverse
     default void setMateUnmapped(final boolean mateUnmapped) {
-        addFlag(SAMFlag.MATE_UNMAPPED, mateUnmapped);
+        setFlag(SAMFlag.MATE_UNMAPPED, mateUnmapped);
     }
 
     /**
@@ -769,13 +769,13 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x10 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_REVERSE_STRAND, reverseStrand)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.READ_REVERSE_STRAND, reverseStrand)}.
      *
      * @param reverseStrand {@code true} if the read is in the reverse strand; {@code false} otherwise.
      */
     // TODO (before merging) - add method for get/set the reverse
     default void setReverseStrand(final boolean reverseStrand) {
-        addFlag(SAMFlag.READ_REVERSE_STRAND, reverseStrand);
+        setFlag(SAMFlag.READ_REVERSE_STRAND, reverseStrand);
     }
 
     /**
@@ -797,13 +797,13 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x20 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.MATE_REVERSE_STRAND, mateReverseStrand)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.MATE_REVERSE_STRAND, mateReverseStrand)}.
      *
      * @param mateReverseStrand {@code true} if the read's mate is in the reverse strand; {@code false} otherwise.
      */
     // TODO (before merging) - add method for get/set the reverse
     default void setMateReverseStrand(final boolean mateReverseStrand) {
-        addFlag(SAMFlag.MATE_REVERSE_STRAND, mateReverseStrand);
+        setFlag(SAMFlag.MATE_REVERSE_STRAND, mateReverseStrand);
     }
 
     /**
@@ -824,12 +824,12 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x40 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.FIRST_OF_PAIR, firstOfPair)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.FIRST_OF_PAIR, firstOfPair)}.
      *
      * @param firstOfPair {@code true} if the read is in the first of a pair; {@code false} otherwise.
      */
     default void setFirstOfPair(final boolean firstOfPair) {
-        addFlag(SAMFlag.FIRST_OF_PAIR, firstOfPair);
+        setFlag(SAMFlag.FIRST_OF_PAIR, firstOfPair);
     }
 
     /**
@@ -850,12 +850,12 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x80 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.SECOND_OF_PAIR, secondOfPair)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.SECOND_OF_PAIR, secondOfPair)}.
      *
      * @param secondOfPair {@code true} if the read is in the second of a pair; {@code false} otherwise.
      */
     default void setSecondOfPair(final boolean secondOfPair) {
-        addFlag(SAMFlag.SECOND_OF_PAIR, secondOfPair);
+        setFlag(SAMFlag.SECOND_OF_PAIR, secondOfPair);
     }
 
     /**
@@ -876,12 +876,12 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x100 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.NOT_PRIMARY_ALIGNMENT, secondaryAlignment)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.NOT_PRIMARY_ALIGNMENT, secondaryAlignment)}.
      *
      * @param secondaryAlignment {@code true} if the read is a secondary alignment; {@code false} otherwise.
      */
     default void setSecondaryAlignment(final boolean secondaryAlignment) {
-        addFlag(SAMFlag.NOT_PRIMARY_ALIGNMENT, secondaryAlignment);
+        setFlag(SAMFlag.NOT_PRIMARY_ALIGNMENT, secondaryAlignment);
     }
 
     /**
@@ -903,13 +903,13 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x200 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityFilters)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityFilters)}.
      *
      * @param failsQualityFilters {@code true} if the read fails the quality filters; {@code false} otherwise.
      */
     // TODO (before merging) - add method for get/set the reverse
     default void setFailsQualityFilters(final boolean failsQualityFilters) {
-        addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityFilters);
+        setFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityFilters);
     }
 
     /**
@@ -930,12 +930,12 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x400 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.DUPLICATE_READ, duplicate)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.DUPLICATE_READ, duplicate)}.
      *
      * @param duplicate {@code true} if the read is a duplicate; {@code false} otherwise.
      */
     default void setDuplicate(final boolean duplicate) {
-        addFlag(SAMFlag.DUPLICATE_READ, duplicate);
+        setFlag(SAMFlag.DUPLICATE_READ, duplicate);
     }
 
     /**
@@ -956,13 +956,13 @@ public interface Read extends Locatable {
      *
      * <p>Equivalent to the 0x800 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.SUPPLEMENTARY_ALIGNMENT, supplementaryAlignment)}.
+     * <p>Default implementation calls the {@code setFlag(SAMFlag.SUPPLEMENTARY_ALIGNMENT, supplementaryAlignment)}.
      *
      * @param supplementaryAlignment {@code true} if the read is a supplementary alignment; {@code false} otherwise.
      */
     // TODO (before merging) - add method for get the reverse
     default void setSupplementaryAlignment(final boolean supplementaryAlignment) {
-        addFlag(SAMFlag.SUPPLEMENTARY_ALIGNMENT, supplementaryAlignment);
+        setFlag(SAMFlag.SUPPLEMENTARY_ALIGNMENT, supplementaryAlignment);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/read/Read.java
+++ b/src/main/java/htsjdk/samtools/read/Read.java
@@ -885,7 +885,7 @@ public interface Read extends Locatable {
     }
 
     /**
-     * Checks if the read fails the quality vendor check.
+     * Checks if the read fails quality filters, such as platform/vendor quality controls.
      *
      * <p>Equivalent to the 0x200 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
@@ -894,22 +894,22 @@ public interface Read extends Locatable {
      * @return {@code true} if the read fails the quality vendor check; {@code false} otherwise.
      */
     // TODO (before merging) - add method for get/set the reverse
-    default boolean failsQualityVendorCheck() {
+    default boolean failsQualityFilters() {
         return isSet(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK);
     }
 
     /**
-     * Marks the read as failing the quality vendor check or not.
+     * Marks the read as failing quality filters, such as platform/vendor quality controls.
      *
      * <p>Equivalent to the 0x200 <b>FLAG</b> in the <a href="http://samtools.github.io/hts-specs/SAMv1.pdf">SAM specifications</a>.
      *
-     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityVendorCheck)}.
+     * <p>Default implementation calls the {@code addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityFilters)}.
      *
-     * @param failsQualityVendorCheck {@code true} if the read fails the quality vendor check; {@code false} otherwise.
+     * @param failsQualityFilters {@code true} if the read fails the quality filters; {@code false} otherwise.
      */
     // TODO (before merging) - add method for get/set the reverse
-    default void setFailsQualityVendorCheck(final boolean failsQualityVendorCheck) {
-        addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityVendorCheck);
+    default void setFailsQualityFilters(final boolean failsQualityFilters) {
+        addFlag(SAMFlag.READ_FAILS_VENDOR_QUALITY_CHECK, failsQualityFilters);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/read/ReadAttribute.java
+++ b/src/main/java/htsjdk/samtools/read/ReadAttribute.java
@@ -45,8 +45,7 @@ public interface ReadAttribute<T> {
     /**
      * Gets the read attribute value.
      *
-     * <p>Subclasses should return a value that returns {@code true} by {@link
-     * #isAllowedAttributeValue(Object)}.
+     * <p>Subclasses should return a value on which {@link #isAllowedAttributeValue(Object)} returns {@code true}.
      *
      * @return the value associated with the tag. Never {@code null}.
      */

--- a/src/main/java/htsjdk/samtools/read/ReadAttribute.java
+++ b/src/main/java/htsjdk/samtools/read/ReadAttribute.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools.read;
+
+import htsjdk.samtools.SAMUtils;
+
+/**
+ * Attribute for a {@link Read}.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public interface ReadAttribute<T> {
+
+    /**
+     * Gets the read attribute tag.
+     *
+     * <p>Subclasses should return a value that returns {@code true} by {@link #isValidTag(String)}.
+     *
+     * @return the tag.
+     */
+    String getTag();
+
+    /**
+     * Gets the read attribute value.
+     *
+     * <p>Subclasses should return a value that returns {@code true} by {@link
+     * #isAllowedAttributeValue(Object)}.
+     *
+     * @return the value associated with the tag. Never {@code null}.
+     */
+    T getValue();
+
+
+    /**
+     * Checks if the tag value is valid. A valid tag should have exactly 2-characters.
+     *
+     * @param tag the tag to check.
+     *
+     * @return {@code true} if the tag is valid; {@code false} otherwise.
+     */
+    public static boolean isValidTag(final String tag) {
+        return tag != null && tag.length() == 2;
+    }
+
+    /**
+     * Checks if the value is allowed as an attribute value.
+     *
+     * @param value the value to be checked.
+     *
+     * @return {@code true} if the value is valid; {@code false} otherwise.
+     */
+    // TODO: SAMBinaryTagAndValue.isAllowedAttributeValue should be deprecated in favor of this method
+    public static boolean isAllowedAttributeValue(final Object value) {
+        if (value instanceof Byte ||
+                value instanceof Short ||
+                value instanceof Integer ||
+                value instanceof String ||
+                value instanceof Character ||
+                value instanceof Float ||
+                value instanceof byte[] ||
+                value instanceof short[] ||
+                value instanceof int[] ||
+                value instanceof float[]) {
+            return true;
+        }
+
+        // A special case for Longs: we require Long values to fit into either a uint32_t or an int32_t,
+        // as that is what the BAM spec allows.
+        if (value instanceof Long) {
+            return SAMUtils.isValidUnsignedIntegerAttribute((Long) value)
+                    || ((Long) value >= Integer.MIN_VALUE && (Long) value <= Integer.MAX_VALUE);
+        }
+        return false;
+    }
+}

--- a/src/main/java/htsjdk/samtools/read/ReadConstants.java
+++ b/src/main/java/htsjdk/samtools/read/ReadConstants.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools.read;
+
+import htsjdk.samtools.GenomicIndexUtil;
+
+/**
+ * Constants for implementations of the {@link Read} interface.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public final class ReadConstants {
+
+    // cannot be instantiated
+    private ReadConstants() {}
+
+    /**
+     * Alignment score for a good alignment, but where computing a Phred-score is not feasible.
+     */
+    public static final int UNKNOWN_MAPPING_QUALITY = 255;
+
+    /**
+     * Alignment score for an unaligned read.
+     */
+    public static final int NO_MAPPING_QUALITY = 0;
+
+    /**
+     * Unset reference name for unaligned reads.
+     *
+     * <p>Note: not all unaligned reads have this reference name.
+     */
+    public static final String NO_ALIGNMENT_REFERENCE_NAME = "*";
+
+    /**
+     * Unset reference index for unaligned reads.
+     *
+     * <p>Note: not all unaligned reads have this reference index.
+     */
+    public static final int NO_ALIGNMENT_REFERENCE_INDEX = -1;
+
+    /**
+     * Cigar string for an unaligned read.
+     */
+    public static final String NO_ALIGNMENT_CIGAR = "*";
+
+    /**
+     * Unaligned position.
+     *
+     * <p>If a read has {@link #NO_ALIGNMENT_REFERENCE_NAME}, it will have this value for position.
+     */
+    public static final int NO_ALIGNMENT_START = GenomicIndexUtil.UNSET_GENOMIC_LOCATION;
+
+    /**
+     * Unset value for the read sequence.
+     *
+     * <p>This should rarely be used, since a read with no sequence doesn't make much sense.
+     */
+    public static final byte[] NULL_SEQUENCE = new byte[0];
+
+    /**
+     * Unset value for the read sequence.
+     *
+     * <p>This should rarely be used, since a read with no sequence doesn't make much sense.
+     */
+    public static final String NULL_SEQUENCE_STRING = "*";
+
+    /**
+     * Unset value for the read quality.
+     */
+    public static final byte[] NULL_QUALS = new byte[0];
+
+    /**
+     * Unset value for the read quality.
+     */
+    public static final String NULL_QUALS_STRING = "*";
+}

--- a/src/main/java/htsjdk/samtools/read/ReadUtils.java
+++ b/src/main/java/htsjdk/samtools/read/ReadUtils.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools.read;
+
+import htsjdk.samtools.SAMUtils;
+
+/**
+ * Static utilities for working with {@link Read}.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public final class ReadUtils {
+
+    // cannot be instantiated - utility class
+    private ReadUtils() {}
+
+    /**
+     * Gets the alignment start (1-based, inclusive) adjusted for clipped bases.
+     * Invalid to call on an unmapped read.
+     *
+     * <p>For example if the read has an alignment start of 100 but the first 4 bases were clipped
+     * (hard or soft clipped) then this method will return 96.
+     *
+     * @return the un-clipped alignment start (1-based, inclusive).
+     */
+    public static int getUnclippedStart(final Read read) {
+        return SAMUtils.getUnclippedStart(read.getStart(), read.getCigar());
+    }
+
+    /**
+     * Gets the alignment end (1-based, inclusive) adjusted for clipped bases.
+     * Invalid to call on an unmapped read.
+     *
+     * <p>For example if the read has an alignment end of 100 but the last 7 bases were clipped
+     * (hard or soft clipped) then this method will return 107.
+     *
+     * @return the un-clipped alignment end (1-based, inclusive).
+     */
+    public static int getUnclippedEnd(final Read read) {
+        return SAMUtils.getUnclippedEnd(read.getEnd(), read.getCigar());
+    }
+}


### PR DESCRIPTION
### Description
Create common Read interface to move to a interface-based API in htsjdk.
The new Read interface is packed in  `htsjdk.samtools.read` to add more
structure to the API. The interface is based in the current SAMRecord
and in the GATK's read interface, keeping some ideas from both.

In addition to the new interface, some more classes were added:

* ReadConstants: include constants for the Read interface. Correspond to some constants in the SAMRecord
* ReadAttribute: another API interface to allow different representations of the read attributes.
* ReadUtils: utility class for working with the read interface in a implementation-independent way. Include few examples of no-API methods for getting un-clipped start/end.

Once the interface is stable, I propose to implement a `SAMRecord`class in the `htsjdk.samtools.read` to substitute the `htsjdk.samtools.SAMRecord`, which would be a deprecated extension of that one. This proposal may help to keep the classes better organized in the htsjdk library and move towards the new interface-based API in the library deprecating the old code.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

