### PR TITLE
Some refactoring of the Strand enum adding encoding (string and char)…

### DIFF
--- a/src/main/java/htsjdk/tribble/annotation/Strand.java
+++ b/src/main/java/htsjdk/tribble/annotation/Strand.java
@@ -24,29 +24,113 @@
 package htsjdk.tribble.annotation;
 
 /**
- * Enum for strand, which can be encoded as string
+ * Enum for strand, which can be encoded as a string
  */
 public enum Strand {
-    POSITIVE("+"), NEGATIVE("-"), NONE("!");  // not really sure what we should do for the NONE Enum
 
     /**
-     * How we represent the strand information as text
+     * Represents the positive or forward strand.
      */
-    private String encoding;
-    Strand(String str) {
-        encoding = str;
+    POSITIVE('+'),
+
+    /**
+     * Represents the negative or reverse strand.
+     */
+    NEGATIVE('-'),
+
+    /**
+     * Denotes that a strand designation is not applicable
+     * or is unknown.
+     */
+    NONE('.');  // not really sure what we should do for the NONE Enum
+
+    /**
+     * Common alias for the {@link #POSITIVE} strand.
+     */
+    public static final Strand FORWARD = POSITIVE;
+
+    /**
+     * Common alias for the {@link #NEGATIVE} strand.
+     */
+    public static final Strand REVERSE = NEGATIVE;
+
+    /**
+     * Cached array of instances.
+     */
+    private final static Strand[] VALUES = values();
+
+    /**
+     * How we represent the strand as a single {@code char}.
+     */
+    private final char charEncoding;
+
+    /**
+     * How we represent the strand as a {@link String}.
+     */
+    private final String stringEncoding;
+
+    Strand(final char ch) {
+        charEncoding = ch;
+        stringEncoding = String.valueOf(charEncoding);
     }
 
     /**
      * provide a way to take an encoding string, and produce a Strand
      * @param encoding the encoding string
      * @return a Strand object, if an appropriate one cannot be located an IllegalArg exception
+     * @deprecated please use {@link #decode} instead.
      */
-    public static Strand toStrand(String encoding) {
-        for (Strand st : Strand.values())
-            if (st.encoding.equals(encoding))
-                return st;
-        throw new IllegalArgumentException("Unable to match encoding to Strand enum for encoding string " + encoding);
+    @Deprecated
+    public static Strand toStrand(final String encoding) {
+        return decode(encoding);
     }
 
+    /**
+     * Returns the {@link Strand} that a {@code char} value represents.
+     * @param ch the char encoding for a Strand.
+     * @return never {@code null}, a value so that {@code decode(c).encodeAsChar() == c} or {@link #NONE} if
+     *   the encoding char is not recognized.
+     */
+    public static Strand decode(final char ch) {
+        for(final Strand value : VALUES) {
+            if (value.charEncoding == ch) {
+                return value;
+            }
+        }
+        return NONE;
+    }
+
+    /**
+     * Returns the {@link Strand} that a {@link String} encodes for.
+     * @param encoding the strand string representation.
+     * @return never {@code null}, a value so that {@code decode(s).encode().equals(s)}, or {@link #NONE} if
+     * the encoding string is not recognized.
+     */
+    public static Strand decode(final String encoding) {
+        if (encoding != null && encoding.length() == 1) {
+            return decode(encoding.charAt(0));
+        }
+        return NONE;
+    }
+
+    /**
+     * Returns a string representation of this {@link Strand}
+     * @return never {@code null}, a value so that {@code decode(encode(X)) == X}.
+     */
+    public String encode() {
+        return stringEncoding;
+    }
+
+    /**
+     * Returns a single char encoding of this {@link Strand}.
+     * @return a value so that {@code decode(encodeAsChar(X)) == X}.
+     */
+    public char encodeAsChar() {
+        return charEncoding;
+    }
+
+    @Override
+    public String toString() {
+        return stringEncoding;
+    }
 }

--- a/src/test/java/htsjdk/tribble/annotation/StrandTest.java
+++ b/src/test/java/htsjdk/tribble/annotation/StrandTest.java
@@ -1,0 +1,124 @@
+package htsjdk.tribble.annotation;
+
+import htsjdk.HtsjdkTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Unit tests for {@link Strand}.
+ * <p>
+ *     Makes sure that {@link Strand} will behave according to contract in run-time.
+ * </p>
+ */
+public class StrandTest extends HtsjdkTest {
+
+    @Test
+    public void testEncodeReturnNoNulls() {
+        for (final Strand subject : Strand.values()) {
+            Assert.assertNotNull(subject.encode());
+        }
+    }
+
+    @Test
+    public void testEncodeDecode() {
+        for (final Strand subject : Strand.values()) {
+            final String encode = subject.encode();
+            final Strand back = Strand.decode(encode);
+            Assert.assertSame(back, subject);
+        }
+    }
+
+    @Test
+    public void testEncodeDecodeAsChar() {
+        for (final Strand subject : Strand.values()) {
+            final char encode = subject.encodeAsChar();
+            final Strand back = Strand.decode(encode);
+            Assert.assertSame(back, subject);
+        }
+    }
+
+    @Test
+    public void testEncodeUniqueness() {
+        Assert.assertEquals(Stream.of(Strand.values())
+                .map(Strand::encode)
+                .collect(Collectors.toSet()).size(), Strand.values().length);
+    }
+
+    @Test
+    public void testEncodeAsCharUniqueness() {
+        Assert.assertEquals(Stream.of(Strand.values())
+                .map(Strand::encodeAsChar)
+                .collect(Collectors.toSet()).size(), Strand.values().length);
+    }
+
+    @Test
+    public void testEncodeAsStringAndCharAreEquivalent() {
+        for (final Strand subject : Strand.values()) {
+            final String str = subject.encode();
+            final char ch = subject.encodeAsChar();
+            Assert.assertEquals(str, String.valueOf(ch));
+        }
+    }
+
+    @Test
+    public void testAliases() {
+        Assert.assertSame(Strand.FORWARD, Strand.POSITIVE);
+        Assert.assertSame(Strand.REVERSE, Strand.NEGATIVE);
+    }
+
+    @Test
+    public void testToStrandMatchesDecode() {
+        for (final Strand value : Strand.values()) {
+            Assert.assertSame(Strand.toStrand(value.encode()), Strand.decode(value.encode()));
+        }
+    }
+
+    @Test
+    public void testToStringMatchesEncode() {
+        for (final Strand value : Strand.values()) {
+            Assert.assertEquals(value.toString(), value.encode());
+        }
+    }
+
+    @Test
+    public void testCurrentEncodings() {
+        Assert.assertSame(Strand.decode('+'), Strand.POSITIVE);
+        Assert.assertSame(Strand.decode('-'), Strand.NEGATIVE);
+        Assert.assertSame(Strand.decode('.'), Strand.NONE);
+
+        Assert.assertSame(Strand.decode("+"), Strand.POSITIVE);
+        Assert.assertSame(Strand.decode("-"), Strand.NEGATIVE);
+        Assert.assertSame(Strand.decode("."), Strand.NONE);
+    }
+
+    @Test(dataProvider = "invalidEncodingStringsData")
+    public void testDecodeOfInvalidEncodingStrings(final String encoding) {
+        Assert.assertSame(Strand.decode(encoding), Strand.NONE);
+    }
+
+    @Test(dataProvider = "invalidEncodingCharsData")
+    public void testDecodeOfInvalidEncodingChars(final char encoding) {
+        Assert.assertSame(Strand.decode(encoding), Strand.NONE);
+    }
+
+    @DataProvider(name = "invalidEncodingStringsData")
+    public Object[][] invalidEncodingStringsData() {
+        return Stream.of("", null, "+++", "---", "POSITIVE",
+                "NEGATIVE", "NONE",
+                "FORWARD", "REVERSE",
+                " +", "- ", "p", "m", "x", "!")
+                .map(s -> new Object[] { s}).toArray(Object[][]::new);
+    }
+
+    @DataProvider(name = "invalidEncodingCharsData")
+    public Object[][] invalidEncodingCharsData() {
+        final Character[] testCases = new Character[] {(char) 0, 'c', '\t', '\n', (char) -1, 'p', 'n', 'x', '!'};
+        return Stream.of(testCases)
+                .map(c -> new Object[] { c })
+                .toArray(Object[][]::new);
+    }
+}


### PR DESCRIPTION
… functionality.

### Description

Some refactoring of the Strand enum adding encoding (string and char) functionality.

Strand is lacking encoding methods it only had a decoding one (toStrand(String)) and an attempt to use toString or name would return POSITIVE, NEGATIVE... when in practice one wants '+', '-'... 

It also deprecates 'toStrand(String)' for 'decode(String)' for name consistency sake (encode/decode) and 'Strand' in toStrand is kinda redundant... ideally one would like to name it valueOf but is impossible (nor desirable) to override valueOf(String). 

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

