### PR TITLE
renaming VariantContextWriter.setVCFHeader -> setHeader

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriter.java
@@ -55,8 +55,8 @@ public class AsyncVariantContextWriter extends AbstractAsyncWriter<VariantContex
     }
 
     @Override
-    public void setVCFHeader(final VCFHeader header) {
-        this.underlyingWriter.setVCFHeader(header);
+    public void setHeader(final VCFHeader header) {
+        this.underlyingWriter.setHeader(header);
     }
 
 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -149,7 +149,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
 
     @Override
     public void writeHeader(VCFHeader header) {
-        setVCFHeader(header);
+        setHeader(header);
 
         try {
             // write out the header into a byte stream, get its length, and write everything to the file
@@ -202,7 +202,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
     }
 
     @Override
-    public void setVCFHeader(final VCFHeader header) {
+    public void setHeader(final VCFHeader header) {
         if (outputHasBeenWritten) {
             throw new IllegalStateException("The header cannot be modified after the header or variants have been written to the output stream.");
         }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/SortingVariantContextWriterBase.java
@@ -137,8 +137,8 @@ abstract class SortingVariantContextWriterBase implements VariantContextWriter {
     }
 
     @Override
-    public void setVCFHeader(final VCFHeader header) {
-        innerWriter.setVCFHeader(header);
+    public void setHeader(final VCFHeader header) {
+        innerWriter.setHeader(header);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -134,7 +134,7 @@ class VCFWriter extends IndexingVariantContextWriter {
 
         // note we need to update the mHeader object after this call because they header
         // may have genotypes trimmed out of it, if doNotWriteGenotypes is true
-        setVCFHeader(header);
+        setHeader(header);
         try {
             writeHeader(this.mHeader, writer, getVersionLine(), getStreamName());
             writeAndResetBuffer();
@@ -232,7 +232,7 @@ class VCFWriter extends IndexingVariantContextWriter {
     }
 
     @Override
-    public void setVCFHeader(final VCFHeader header) {
+    public void setHeader(final VCFHeader header) {
         if (outputHasBeenWritten) {
             throw new IllegalStateException("The header cannot be modified after the header or variants have been written to the output stream.");
         }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriter.java
@@ -59,11 +59,11 @@ public interface VariantContextWriter extends Closeable {
     /**
      * Sets the VCF header so that data blocks can be written without writing the header
      *
-     * Exactly one of writeHeader() or setVCFHeader() should be called when using a writer
+     * Exactly one of writeHeader() or setHeader() should be called when using a writer
      *
      * @param header VCF header
      * @throws IllegalStateException if header or body is already written
 
      */
-    void setVCFHeader(VCFHeader header);
+    void setHeader(VCFHeader header);
 }

--- a/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
@@ -180,7 +180,7 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
                 .setOutputFile(bcfOutputHeaderlessFile).setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
-            fakeBCFBodyFileWriter.setVCFHeader(header); // does not write header
+            fakeBCFBodyFileWriter.setHeader(header); // does not write header
             fakeBCFBodyFileWriter.add(createVC(header));
             fakeBCFBodyFileWriter.add(createVC(header));
         }
@@ -232,7 +232,7 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
             writer.writeHeader(header);
-            writer.setVCFHeader(header);
+            writer.setHeader(header);
         }
     }
 
@@ -247,9 +247,9 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
                 .setOutputFile(bcfOutputFile).setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
-            writer.setVCFHeader(header);
+            writer.setHeader(header);
             writer.add(createVC(header));
-            writer.setVCFHeader(header);
+            writer.setHeader(header);
         }
     }
 

--- a/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
@@ -86,7 +86,7 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
                 .setOutputFile(fakeVCFFile).setReferenceDictionary(sequenceDict)
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY, Options.USE_ASYNC_IO))
                 .build()) {
-            writer.setVCFHeader(header);
+            writer.setHeader(header);
             writer.add(createVC(header));
             writer.add(createVC(header));
         }

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -148,7 +148,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
                 .setOutputFile(fakeVCFFile).setReferenceDictionary(sequenceDict)
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build()) {
-            writer.setVCFHeader(header);
+            writer.setHeader(header);
             writer.add(createVC(header));
             writer.add(createVC(header));
         }
@@ -198,7 +198,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
                 .setReferenceDictionary(sequenceDict)
                 .build()) {
             writer2.writeHeader(header);
-            writer2.setVCFHeader(header);
+            writer2.setHeader(header);
         }
     }
 
@@ -213,9 +213,9 @@ public class VCFWriterUnitTest extends VariantBaseTest {
                 .setOutputFile(fakeVCFFile)
                 .setReferenceDictionary(sequenceDict)
                 .build()) {
-            writer3.setVCFHeader(header);
+            writer3.setHeader(header);
             writer3.add(createVC(header));
-            writer3.setVCFHeader(header);
+            writer3.setHeader(header);
         }
     }
 


### PR DESCRIPTION
this seems cleaner, since we've never released this change it should be
ok to change the name without a deprecation process

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

