### PR TITLE
Don't generate interrupt on close in AbstractAsyncWriter.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AbstractAsyncWriter.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractAsyncWriter.java
@@ -72,7 +72,6 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
 
         if (!this.isClosed.getAndSet(true)) {
             try {
-                if (this.queue.isEmpty()) this.writer.interrupt(); // signal to writer clean up
             	this.writer.join();
             } catch (final InterruptedException ie) {
             	throw new RuntimeException("Interrupted waiting on writer thread.", ie);
@@ -120,7 +119,7 @@ public abstract class AbstractAsyncWriter<T> implements Closeable {
                 //the two operations are effectively atomic if isClosed returns true
                 while (!isClosed.get() || !queue.isEmpty()) {
                     try {
-                        final T item = queue.poll(2, TimeUnit.SECONDS);
+                        final T item = queue.poll(50, TimeUnit.MILLISECONDS);
                         if (item != null) synchronouslyWrite(item);
                     }
                     catch (final InterruptedException ie) {


### PR DESCRIPTION
### Description

This removes the explicit thread.interrupt() call from AbstractAsyncWriter close method. We're seeing this failure with GATK: if the close method is called while the writer thread is still executing code that is inside a try block that has a catch Exception clause (like [this block](https://github.com/samtools/htsjdk/blob/1ade6c921628e540f1cab0dfadfbdc536f702d73/src/main/java/htsjdk/samtools/BAMFileWriter.java#L133)), and that code is using NIO, an InterruptedException is thrown on the writer thread, and ultimately re-thrown as a SAMException, which causes the calling code to fail.

It looks like this can only happen if the queue is empty at the time the close method checks, but the writer thread is still processing the last item in the queue. Removing the interrupt call (and shortening the polling period, though that isn't necessary to fix the underlying issue) addresses this. Longer term we might want to rewrite the queueing part of this using some other mechanism, but this is a short-term fix.

### Checklist

- [ X] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [X ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

