### PR TITLE
Ability to opt-out of logging all failed intervals for LiftOver

### DIFF
--- a/src/main/java/htsjdk/samtools/liftover/LiftOver.java
+++ b/src/main/java/htsjdk/samtools/liftover/LiftOver.java
@@ -69,7 +69,7 @@ public class LiftOver {
     /**
      * Resets the internal counter that tracks intervals that failed liftover due to insufficient intersection length
      */
-    public void resetFailedIntervalCounter(){
+    public void resetFailedIntervalCounter() {
         this.totalFailedIntervalsBelowThreshold = 0L;
     }
 
@@ -77,7 +77,7 @@ public class LiftOver {
      *
      * @return The total number of intervals that have failed liftover due to insufficient intersection length
      */
-    public long getFailedIntervalCounter(){
+    public long getFailedIntervalCounter() {
         return totalFailedIntervalsBelowThreshold;
     }
 
@@ -154,7 +154,7 @@ public class LiftOver {
                 targetIntersection = candidateIntersection;
             } else if (candidateIntersection != null) {
                 hasOverlapBelowThreshold = true;
-                if (logFailedIntervals){
+                if (logFailedIntervals) {
                     LOG.info("Interval " + interval.getName() + " failed to match chain " + chain.id +
                             " because intersection length " + candidateIntersection.intersectionLength + " < minMatchSize "
                             + minMatchSize +
@@ -163,7 +163,7 @@ public class LiftOver {
             }
         }
         if (chainHit == null) {
-            if (hasOverlapBelowThreshold){
+            if (hasOverlapBelowThreshold) {
                 totalFailedIntervalsBelowThreshold++;
             }
 

--- a/src/main/java/htsjdk/samtools/liftover/LiftOver.java
+++ b/src/main/java/htsjdk/samtools/liftover/LiftOver.java
@@ -62,14 +62,14 @@ public class LiftOver {
      * will be logged.  Set this to false to prevent logging.
      * @param logFailedIntervals
      */
-    public void setLogFailedIntervals(boolean logFailedIntervals) {
+    public void setShouldLogFailedIntervalsBelowThreshold(boolean logFailedIntervals) {
         this.logFailedIntervals = logFailedIntervals;
     }
 
     /**
      * Resets the internal counter that tracks intervals that failed liftover due to insufficient intersection length
      */
-    public void resetFailedIntervalCounter() {
+    public void resetFailedIntervalsBelowThresholdCounter() {
         this.totalFailedIntervalsBelowThreshold = 0L;
     }
 
@@ -77,7 +77,7 @@ public class LiftOver {
      *
      * @return The total number of intervals that have failed liftover due to insufficient intersection length
      */
-    public long getFailedIntervalCounter() {
+    public long getFailedIntervalsBelowThreshold() {
         return totalFailedIntervalsBelowThreshold;
     }
 

--- a/src/main/java/htsjdk/samtools/liftover/LiftOver.java
+++ b/src/main/java/htsjdk/samtools/liftover/LiftOver.java
@@ -57,7 +57,7 @@ public class LiftOver {
     private boolean logFailedIntervals = true;
 
     /**
-     * By default any lifted interval that falls below DEFAULT_LIFTOVER_MINMATCH
+     * By default any lifted interval that falls below liftOverMinMatch
      * will be logged.  Set this to false to prevent logging.
      * @param logFailedIntervals
      */

--- a/src/main/java/htsjdk/samtools/liftover/LiftOver.java
+++ b/src/main/java/htsjdk/samtools/liftover/LiftOver.java
@@ -54,6 +54,17 @@ public class LiftOver {
     private final OverlapDetector<Chain> chains;
     private final Map<String, Set<String>> contigMap = new HashMap<>();
 
+    private boolean logFailedIntervals = true;
+
+    /**
+     * By default any lifted interval that falls below DEFAULT_LIFTOVER_MINMATCH
+     * will be logged.  Set this to false to prevent logging.
+     * @param logFailedIntervals
+     */
+    public void setLogFailedIntervals(boolean logFailedIntervals) {
+        this.logFailedIntervals = logFailedIntervals;
+    }
+
     /**
      * Load UCSC chain file in order to lift over Intervals.
      */
@@ -125,10 +136,12 @@ public class LiftOver {
                 chainHit = chain;
                 targetIntersection = candidateIntersection;
             } else if (candidateIntersection != null) {
-                LOG.info("Interval " + interval.getName() + " failed to match chain " + chain.id +
-                " because intersection length " + candidateIntersection.intersectionLength + " < minMatchSize "
-                + minMatchSize +
-                " (" + (candidateIntersection.intersectionLength/(float)interval.length()) + " < " + liftOverMinMatch + ")");
+                if (logFailedIntervals){
+                    LOG.info("Interval " + interval.getName() + " failed to match chain " + chain.id +
+                            " because intersection length " + candidateIntersection.intersectionLength + " < minMatchSize "
+                            + minMatchSize +
+                            " (" + (candidateIntersection.intersectionLength/(float)interval.length()) + " < " + liftOverMinMatch + ")");
+                }
             }
         }
         if (chainHit == null) {

--- a/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
+++ b/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
@@ -59,11 +59,11 @@ public class LiftOverTest extends HtsjdkTest {
 
     @Test(dataProvider = "testIntervalsSubset")
     public void testLiftoverCounter(final Interval in, final Interval expected) {
-        liftOver.resetFailedIntervalCounter();
+        liftOver.resetFailedIntervalsBelowThresholdCounter();
         final Interval out = liftOver.liftOver(in);
         Assert.assertEquals(out, expected);
 
-        Assert.assertEquals(liftOver.getFailedIntervalCounter(), expected == null ? 1 : 0);
+        Assert.assertEquals(liftOver.getFailedIntervalsBelowThreshold(), expected == null ? 1 : 0);
 
     }
 

--- a/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
+++ b/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
@@ -33,10 +33,8 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.PrintWriter;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * @author alecw@broadinstitute.org
@@ -56,6 +54,11 @@ public class LiftOverTest extends HtsjdkTest {
 
     @Test(dataProvider = "testIntervals")
     public void testBasic(final Interval in, final Interval expected) {
+        Assert.assertEquals(liftOver.liftOver(in), expected);
+    }
+
+    @Test(dataProvider = "testIntervalsSubset")
+    public void testLiftoverCounter(final Interval in, final Interval expected) {
         liftOver.resetFailedIntervalCounter();
         final Interval out = liftOver.liftOver(in);
         Assert.assertEquals(out, expected);
@@ -64,9 +67,9 @@ public class LiftOverTest extends HtsjdkTest {
 
     }
 
-    @DataProvider(name = "testIntervals")
-    public Object[][] makeTestIntervals() {
-        return new Object[][] {
+    @DataProvider(name = "testIntervalsSubset")
+    public Object[][] makeTestIntervalsSubset() {
+        return new Object[][]{
                 {new Interval("chr3", 50911035, 50911051), null},
                 {new Interval("chr1", 16776377, 16776452),    new Interval("chr1", 16903790, 16903865)},
                 {new Interval("chr2", 30575990, 30576065),    new Interval("chr2", 30722486, 30722561)},
@@ -279,7 +282,15 @@ public class LiftOverTest extends HtsjdkTest {
                 {new Interval("chrX", 128442357, 128442474),	new Interval("chrX", 128614676, 128614793)},
                 {new Interval("chrX", 152701873, 152701902),	new Interval("chrX", 153048679, 153048708)},
                 {new Interval("chrY", 2715028, 2715646),	new Interval("chrY", 2655028, 2655646)},
-                {new Interval("chrY", 26179988, 26180064),	new Interval("chrY", 27770600, 27770676)},
+                {new Interval("chrY", 26179988, 26180064),	new Interval("chrY", 27770600, 27770676)}
+        };
+    }
+
+    @DataProvider(name = "testIntervals")
+    public Object[][] makeTestIntervals() {
+        Object[][] arr1 = makeTestIntervalsSubset();
+
+        Object[][] arr2 = new Object[][] {
                 // Some intervals that are flipped in the new genome
                 {new Interval("chr1", 2479704, 2479833, false, "target_549"),        new Interval("chr1", 2494585, 2494714, true, "target_549")},
                 {new Interval("chr1", 2480081, 2480116, false, "target_550"),        new Interval("chr1", 2494302, 2494337, true, "target_550")},
@@ -387,6 +398,8 @@ public class LiftOverTest extends HtsjdkTest {
                 {new Interval("chrX", 48774611, 48775058), null},
 
         };
+
+        return Stream.concat(Arrays.stream(arr1), Arrays.stream(arr2)).toArray(Object[][]::new);
     }
 
     @Test(dataProvider = "failingIntervals")

--- a/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
+++ b/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
@@ -56,8 +56,11 @@ public class LiftOverTest extends HtsjdkTest {
 
     @Test(dataProvider = "testIntervals")
     public void testBasic(final Interval in, final Interval expected) {
+        liftOver.resetFailedIntervalCounter();
         final Interval out = liftOver.liftOver(in);
         Assert.assertEquals(out, expected);
+
+        Assert.assertEquals(liftOver.getFailedIntervalCounter(), expected == null ? 1 : 0);
 
     }
 


### PR DESCRIPTION
### Description

Liftover currently logs each time an interval fails liftOverMinMatch.  This can result in a lot of logging, and callers cannot current control this behavior.  This adds a setLogFailedIntervals(), so callers can optionally turn off this logging.  It's opt-in and will not change current behavior for any callers.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

