### PR TITLE
Test that all the @DataProviders are successful 

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AbstractProgressLogger.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractProgressLogger.java
@@ -44,6 +44,8 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
      */
     abstract protected void log(String ... message);
 
+
+
     @Override
     public synchronized boolean record(final String chrom, final int pos) {
 	    if (this.lastStartTime == -1) this.lastStartTime = System.currentTimeMillis();
@@ -69,6 +71,8 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
             return false;
         }
     }
+
+
 
     /**
      * Records that a given record has been processed and triggers logging if necessary.

--- a/src/main/java/htsjdk/tribble/AsciiFeatureCodec.java
+++ b/src/main/java/htsjdk/tribble/AsciiFeatureCodec.java
@@ -18,7 +18,6 @@
 
 package htsjdk.tribble;
 
-import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.samtools.util.Log;

--- a/src/main/java/htsjdk/utils/ClassFinder.java
+++ b/src/main/java/htsjdk/utils/ClassFinder.java
@@ -28,13 +28,16 @@ import htsjdk.samtools.util.Log;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -74,7 +77,8 @@ public class ClassFinder {
     /** Convert a filename to a class name by removing '.class' and converting '/'s to '.'s. */
     public String toClassName(final String filename) {
         return filename.substring(0, filename.lastIndexOf(".class"))
-                .replace('/', '.').replace('\\', '.');
+                .replace('/', '.')
+                .replace('\\', '.');
     }
 
     /**
@@ -188,5 +192,27 @@ public class ClassFinder {
     /** Fetches the set of classes discovered so far. */
     public Set<Class<?>> getClasses() {
         return this.classes;
+    }
+
+
+    /**
+     * Fetches the set of classes discovered so far, subsetted down to concrete (non-abstract/interface) classes only
+     *
+     * @return subset of classes discovered so far including only concrete (non-abstract/interface) classes
+     */
+    public Set<Class<?>> getConcreteClasses() {
+        return getClasses().stream()
+                .filter(ClassFinder::isConcrete)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Determines whether or not the specified class is concrete (ie., non-abstract and non-interface)
+     *
+     * @param clazz class to check
+     * @return true if the class is neither abstract nor an interface, otherwise false
+     */
+    public static boolean isConcrete( final Class<?> clazz ) {
+        return ! Modifier.isAbstract(clazz.getModifiers()) && ! Modifier.isInterface(clazz.getModifiers());
     }
 }

--- a/src/main/java/htsjdk/utils/ClassFinder.java
+++ b/src/main/java/htsjdk/utils/ClassFinder.java
@@ -1,0 +1,192 @@
+package htsjdk.utils;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import htsjdk.samtools.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+
+/**
+ * Utility class that can scan for classes in the classpath and find all the ones
+ * annotated with a particular annotation.
+ *
+ * @author Tim Fennell
+ */
+public class ClassFinder {
+    private final Set<Class<?>> classes = new HashSet<Class<?>>();
+    private final ClassLoader loader;
+    private Class<?> parentType;
+    // If not null, only look for classes in this jar
+    private String jarPath = null;
+
+    private static final Log log = Log.getInstance(ClassFinder.class);
+
+    public ClassFinder() {
+        loader = Thread.currentThread().getContextClassLoader();
+    }
+
+    public ClassFinder(final ClassLoader loader) {
+        this.loader = loader;
+    }
+
+    public ClassFinder(final File jarFile) throws IOException {
+        // The class loader must have the context in order to load dependent classes when loading a class,
+        // but the jarPath is remembered so that the iteration over the classpath skips anything other than
+        // the jarPath.
+        jarPath = jarFile.getCanonicalPath();
+        final URL[] urls = {new File(jarPath).toURI().toURL()};
+        loader = new URLClassLoader(urls, Thread.currentThread().getContextClassLoader());
+    }
+
+    /** Convert a filename to a class name by removing '.class' and converting '/'s to '.'s. */
+    public String toClassName(final String filename) {
+        return filename.substring(0, filename.lastIndexOf(".class"))
+                .replace('/', '.').replace('\\', '.');
+    }
+
+    /**
+     * Scans the classpath for classes within the specified package and sub-packages that
+     * extend the parentType. This method can be called repeatedly
+     * with different packages. Classes are accumulated internally and
+     * can be accessed by calling {@link #getClasses()}.
+     */
+    public void find(String packageName, final Class<?> parentType) {
+        this.parentType = parentType;
+        packageName = packageName.replace('.', '/');
+        final Enumeration<URL> urls;
+
+        try {
+            urls = loader.getResources(packageName);
+        }
+        catch (IOException ioe) {
+            log.warn("Could not read package: " + packageName, ioe);
+            return;
+        }
+
+        while (urls.hasMoreElements()) {
+            try {
+                String urlPath = urls.nextElement().getFile();
+                // convert URL to URI
+                // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4466485
+                // using URLDecode does not work if urlPath has a '+' character
+                try {
+                    URI uri = new URI(urlPath);
+                    urlPath = uri.getPath();
+                } catch (URISyntaxException e) {
+                    log.warn("Cannot convert to URI the " + urlPath + " URL");
+                }
+                if (urlPath.indexOf('!') > 0) {
+                    urlPath = urlPath.substring(0, urlPath.indexOf('!'));
+                }
+                if (jarPath != null && !jarPath.equals(urlPath)) {
+                    continue;
+                }
+
+                //Log.info("Looking for classes in location: " + urlPath);
+                final File file = new File(urlPath);
+                if ( file.isDirectory() ) {
+                    scanDir(file, packageName);
+                }
+                else {
+                    scanJar(file, packageName);
+                }
+            }
+            catch (IOException ioe) {
+                log.warn("could not read entries", ioe);
+            }
+        }
+    }
+
+    /**
+     * Scans the entries in a ZIP/JAR file for classes under the parent package.
+     * @param file the jar file to be scanned
+     * @param packagePath the top level package to start from
+     */
+    protected void scanJar(final File file, final String packagePath) throws IOException {
+        final ZipFile zip = new ZipFile(file);
+        final Enumeration<? extends ZipEntry> entries = zip.entries();
+        while ( entries.hasMoreElements() ) {
+            final ZipEntry entry = entries.nextElement();
+            final String name = entry.getName();
+            if (name.startsWith(packagePath)) {
+                handleItem(name);
+            }
+        }
+    }
+
+    /**
+     * Scans a directory on the filesystem for classes.
+     * @param file the directory or file to examine
+     * @param path the package path acculmulated so far (e.g. edu/mit/broad)
+     */
+    protected void scanDir(final File file, final String path) {
+        for ( final File child: file.listFiles() ) {
+            final String newPath = (path==null ? child.getName() : path + '/' + child.getName() );
+            if ( child.isDirectory() ) {
+                scanDir(child, newPath);
+            }
+            else {
+                handleItem(newPath);
+            }
+        }
+    }
+
+    /**
+     * Checks an item to see if it is a class and is annotated with the specified
+     * annotation.  If so, adds it to the set, otherwise ignores it.
+     * @param name the path equivelant to the package + class/item name
+     */
+    protected void handleItem(final String name) {
+        if (name.endsWith(".class")) {
+            final String classname = toClassName(name);
+
+            try {
+                final Class<?> type = loader.loadClass(classname);
+                if (parentType.isAssignableFrom(type)) {
+                    this.classes.add(type);
+                }
+            }
+            catch (Throwable t) {
+                log.debug("could not load class: " + classname, t);
+            }
+        }
+    }
+
+    /** Fetches the set of classes discovered so far. */
+    public Set<Class<?>> getClasses() {
+        return this.classes;
+    }
+}

--- a/src/test/java/htsjdk/TestClassDependenceTest.java
+++ b/src/test/java/htsjdk/TestClassDependenceTest.java
@@ -1,0 +1,76 @@
+package htsjdk;
+
+import htsjdk.utils.ClassFinder;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.NoInjection;
+import org.testng.annotations.Test;
+import org.testng.collections.Sets;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+/**
+ * Created by farjoun on 10/2/17.
+ */
+public class TestClassDependenceTest extends HtsjdkTest {
+
+    @Test
+    public void independentTestOfDataProviderTest() throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        testAllTestsData();
+    }
+
+    @DataProvider(name = "Tests")
+    public Iterator<Object[]> testAllTestsData() throws IllegalAccessException, InstantiationException, InvocationTargetException {
+
+        List<Object[]> data = new ArrayList<>();
+        final ClassFinder classFinder = new ClassFinder();
+        classFinder.find("htsjdk", Object.class);
+
+        for (final Class<?> testClass : classFinder.getConcreteClasses()) {
+            // getDeclaredMethods will also include private methods
+            Set<Method> methodSet = Sets.newHashSet();
+            methodSet.addAll(Arrays.asList(testClass.getDeclaredMethods()));
+            methodSet.addAll(Arrays.asList(testClass.getMethods()));
+
+            for (final Method method : testClass.getDeclaredMethods()) {
+                if (method.isAnnotationPresent(Test.class)) {
+                    data.add(new Object[]{method, testClass});
+                }
+            }
+        }
+        Assert.assertTrue(data.size() > 1);
+
+        // make sure that this @DataProvider is in the list
+        Assert.assertEquals(data.stream().filter(c ->
+                ((Method) c[0]).getName().equals("testDependenceData") &&
+                ((Class)  c[1]).getName().equals(this.getClass().getName())).count(), 1L);
+
+        // Make sure that we found the private method declared below, and then remove it from the list so that
+        // the actual test doesn't fail.
+        Optional<Object[]> perhapsPrivateMethodAndClass = data.stream().filter(c ->
+                ((Method) c[0]).getName().equals("testForThePurposeOfTestingPrivateTests") &&
+                ((Class)  c[1]).getName().equals(this.getClass().getName())).findFirst();
+
+        Assert.assertTrue(perhapsPrivateMethodAndClass.isPresent());
+        data.remove(perhapsPrivateMethodAndClass.get());
+
+        return data.iterator();
+    }
+
+    // Make sure that all @Tests are public methods residing in classes that inherit from HtsjdkTest.
+    @Test(dataProvider = "Tests")
+    public void testDependenceData(@NoInjection final Method method, final Class clazz) throws IllegalAccessException, InstantiationException, InvocationTargetException {
+        Assert.assertTrue(HtsjdkTest.class.isAssignableFrom(clazz), "Test Classes must extend HtsJdkTest: " + clazz.getName());
+        Assert.assertTrue(Modifier.isPublic(method.getModifiers()),"Test methods must have public visibility: " + clazz.getName() + "::" + method.getName());
+    }
+
+    // This test is explicitly private and we test that we would have found it in the data-provider before removing it form the list (so that the test itself doesn't fail)
+    // It shouldn't be run since it's private, so the tests do not actually fail.
+    @Test
+    private void testForThePurposeOfTestingPrivateTests() {
+        Assert.assertTrue(false);
+    }
+}

--- a/src/test/java/htsjdk/TestClassDependenceTest.java
+++ b/src/test/java/htsjdk/TestClassDependenceTest.java
@@ -43,34 +43,21 @@ public class TestClassDependenceTest extends HtsjdkTest {
         }
         Assert.assertTrue(data.size() > 1);
 
-        // make sure that this @DataProvider is in the list
+        // make sure that the @Tests in this class are found:
+        Assert.assertEquals(data.stream().filter(c ->
+                ((Method) c[0]).getName().equals("independentTestOfDataProviderTest") &&
+                        ((Class)  c[1]).getName().equals(this.getClass().getName())).count(), 1L);
         Assert.assertEquals(data.stream().filter(c ->
                 ((Method) c[0]).getName().equals("testDependenceData") &&
-                ((Class)  c[1]).getName().equals(this.getClass().getName())).count(), 1L);
-
-        // Make sure that we found the private method declared below, and then remove it from the list so that
-        // the actual test doesn't fail.
-        Optional<Object[]> perhapsPrivateMethodAndClass = data.stream().filter(c ->
-                ((Method) c[0]).getName().equals("testForThePurposeOfTestingPrivateTests") &&
-                ((Class)  c[1]).getName().equals(this.getClass().getName())).findFirst();
-
-        Assert.assertTrue(perhapsPrivateMethodAndClass.isPresent());
-        data.remove(perhapsPrivateMethodAndClass.get());
+                        ((Class)  c[1]).getName().equals(this.getClass().getName())).count(), 1L);
 
         return data.iterator();
     }
 
-    // Make sure that all @Tests are public methods residing in classes that inherit from HtsjdkTest.
+    // Make sure that all @Tests are in classes that inherit from HtsjdkTest.
     @Test(dataProvider = "Tests")
     public void testDependenceData(@NoInjection final Method method, final Class clazz) throws IllegalAccessException, InstantiationException, InvocationTargetException {
         Assert.assertTrue(HtsjdkTest.class.isAssignableFrom(clazz), "Test Classes must extend HtsJdkTest: " + clazz.getName());
-        Assert.assertTrue(Modifier.isPublic(method.getModifiers()),"Test methods must have public visibility: " + clazz.getName() + "::" + method.getName());
     }
 
-    // This test is explicitly private and we test that we would have found it in the data-provider before removing it form the list (so that the test itself doesn't fail)
-    // It shouldn't be run since it's private, so the tests do not actually fail.
-    @Test
-    private void testForThePurposeOfTestingPrivateTests() {
-        Assert.assertTrue(false);
-    }
 }

--- a/src/test/java/htsjdk/TestClassDependenceTest.java
+++ b/src/test/java/htsjdk/TestClassDependenceTest.java
@@ -13,10 +13,19 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 
 /**
- * Created by farjoun on 10/2/17.
+ * Our testing framework assumes that all java tests extend HtsjdkTest (while Scala tests extend from UnitSpec)
+ *
+ * Tests that do not extend HtsjdkTest will not be run during testing leading to possible silent "passage" of broken tests.
+ * This test suite examines the all classes that contain methods that are annotated with the {@link Test} annotation,
+ * and checks that they extend HtsjdkTest.
  */
 public class TestClassDependenceTest extends HtsjdkTest {
 
+
+    // since there are assertions inside the dataprovider, this test check that the dataprovider completes succeessfully.
+    // This is needed since a failing data-provider will result in silently skipping the tests that rely on it.
+
+    // This idea led to the creation of {@link TestDataProviders}, which renders it no-longer needed....
     @Test
     public void independentTestOfDataProviderTest() throws IllegalAccessException, InvocationTargetException, InstantiationException {
         testAllTestsData();

--- a/src/test/java/htsjdk/TestDataProviders.java
+++ b/src/test/java/htsjdk/TestDataProviders.java
@@ -1,0 +1,89 @@
+package htsjdk;
+
+import htsjdk.utils.ClassFinder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * This test is a mechanism to check that none of the data-providers fail to run.
+ * It is needed because in the case that a data-provider fails (for some reason, perhaps a change in some other code
+ * causes it to throw an exception) the tests that rely on it will be sliently skipped.
+ * The only mention of this will be in test logs but since we normally avoid reading these logs and rely on the
+ * exit code, it will look like all the tests have passed.
+ *
+ * @author Yossi Farjoun
+ */
+public class TestDataProviders {
+
+    private static class Container {
+        public final Method method;
+        public final Class<?> clazz;
+
+        // Encapsulation (of the Method) is required due to what seems to be a bug in TestNG.
+
+        public Container(Method method, Class clazz) {
+            this.method = method;
+            this.clazz = clazz;
+        }
+
+        @Override
+        public String toString() {
+            return clazz.getName() + "::" + method.getName();
+        }
+    }
+
+    @Test
+    public void IndependentTestOfDataProviderTest() throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        testAllDataProvidersdata();
+    }
+
+    @DataProvider(name = "DataprovidersThatDontTestThemselves")
+    public Iterator<Object[]> testAllDataProvidersdata() throws IllegalAccessException, InstantiationException, InvocationTargetException {
+        int i = 0;
+        List<Object[]> data = new ArrayList<>();
+        final ClassFinder classFinder = new ClassFinder();
+        classFinder.find("htsjdk", Object.class);
+
+        for (final Class<?> testClass : classFinder.getClasses()) {
+            if (Modifier.isAbstract(testClass.getModifiers())) continue;
+            for (final Method method : testClass.getMethods()) {
+                if (method.isAnnotationPresent(DataProvider.class)) {
+                    data.add(new Object[]{new Container(method, testClass)});
+                }
+            }
+        }
+        Assert.assertTrue(data.size() > 1);
+
+        // make sure that this @DataProvider is in the list
+        Assert.assertEquals(data.stream().filter(c -> ((Container) c[0]).method.getName().equals("testAllDataProvidersdata")).count(), 1);
+
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "DataprovidersThatDontTestThemselves")
+    public void testDataProviderswithDP(final Container container) throws IllegalAccessException, InstantiationException, InvocationTargetException {
+        final Method method = container.method;
+        final Class clazz = container.clazz;
+        System.err.println("Method: " + method + " Class: " + clazz.getName());
+
+        Object instance = clazz.newInstance();
+
+        // Some tests assume that the @BeforeSuite methods will be called before the @DataProviders
+        for (final Method otherMethod : clazz.getMethods()) {
+            if (otherMethod.isAnnotationPresent(BeforeSuite.class)) {
+                otherMethod.invoke(instance);
+            }
+        }
+
+        method.invoke(instance);
+    }
+}

--- a/src/test/java/htsjdk/TestDataProviders.java
+++ b/src/test/java/htsjdk/TestDataProviders.java
@@ -1,6 +1,5 @@
 package htsjdk;
 
-import htsjdk.utils.ClassFinder;
 import htsjdk.utils.TestNGUtils;
 import org.testng.Assert;
 import org.testng.annotations.*;
@@ -8,9 +7,10 @@ import org.testng.collections.Sets;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.*;
-import java.util.stream.Stream;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Spliterators;
 import java.util.stream.StreamSupport;
 
 /**

--- a/src/test/java/htsjdk/TestDataProviders.java
+++ b/src/test/java/htsjdk/TestDataProviders.java
@@ -4,6 +4,7 @@ import htsjdk.utils.ClassFinder;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.NoInjection;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -16,7 +17,7 @@ import java.util.List;
 /**
  * This test is a mechanism to check that none of the data-providers fail to run.
  * It is needed because in the case that a data-provider fails (for some reason, perhaps a change in some other code
- * causes it to throw an exception) the tests that rely on it will be sliently skipped.
+ * causes it to throw an exception) the tests that rely on it will be silently skipped.
  * The only mention of this will be in test logs but since we normally avoid reading these logs and rely on the
  * exit code, it will look like all the tests have passed.
  *
@@ -24,22 +25,6 @@ import java.util.List;
  */
 public class TestDataProviders {
 
-    private static class Container {
-        public final Method method;
-        public final Class<?> clazz;
-
-        // Encapsulation (of the Method) is required due to what seems to be a bug in TestNG.
-
-        public Container(Method method, Class clazz) {
-            this.method = method;
-            this.clazz = clazz;
-        }
-
-        @Override
-        public String toString() {
-            return clazz.getName() + "::" + method.getName();
-        }
-    }
 
     @Test
     public void IndependentTestOfDataProviderTest() throws IllegalAccessException, InvocationTargetException, InstantiationException {
@@ -48,7 +33,7 @@ public class TestDataProviders {
 
     @DataProvider(name = "DataprovidersThatDontTestThemselves")
     public Iterator<Object[]> testAllDataProvidersdata() throws IllegalAccessException, InstantiationException, InvocationTargetException {
-        int i = 0;
+
         List<Object[]> data = new ArrayList<>();
         final ClassFinder classFinder = new ClassFinder();
         classFinder.find("htsjdk", Object.class);
@@ -57,22 +42,23 @@ public class TestDataProviders {
             if (Modifier.isAbstract(testClass.getModifiers())) continue;
             for (final Method method : testClass.getMethods()) {
                 if (method.isAnnotationPresent(DataProvider.class)) {
-                    data.add(new Object[]{new Container(method, testClass)});
+                    data.add(new Object[]{method, testClass});
                 }
             }
         }
         Assert.assertTrue(data.size() > 1);
 
         // make sure that this @DataProvider is in the list
-        Assert.assertEquals(data.stream().filter(c -> ((Container) c[0]).method.getName().equals("testAllDataProvidersdata")).count(), 1);
+        Assert.assertEquals(data.stream().filter(c -> ((Method) c[0]).getName().equals("testAllDataProvidersdata")).count(), 1);
 
         return data.iterator();
     }
 
+    // @NoInjection annotations required according to this test:
+    // https://github.com/cbeust/testng/blob/master/src/test/java/test/inject/NoInjectionTest.java
     @Test(dataProvider = "DataprovidersThatDontTestThemselves")
-    public void testDataProviderswithDP(final Container container) throws IllegalAccessException, InstantiationException, InvocationTargetException {
-        final Method method = container.method;
-        final Class clazz = container.clazz;
+    public void testDataProviderswithDP(@NoInjection final Method method, final Class clazz) throws IllegalAccessException, InstantiationException, InvocationTargetException {
+
         System.err.println("Method: " + method + " Class: " + clazz.getName());
 
         Object instance = clazz.newInstance();

--- a/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
+++ b/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
@@ -55,7 +55,7 @@ public class BAMRemoteFileTest extends HtsjdkTest {
 
 
     @Test
-    void testRemoteLocal()
+    public void testRemoteLocal()
             throws Exception {
         runLocalRemoteTest(bamURL, BAM_FILE, "chrM", 10400, 10600, false);
     }

--- a/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
+++ b/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
@@ -55,21 +55,18 @@ public class BAMRemoteFileTest extends HtsjdkTest {
 
 
     @Test
-    public void testRemoteLocal()
-            throws Exception {
+    public void testRemoteLocal() throws Exception {
         runLocalRemoteTest(bamURL, BAM_FILE, "chrM", 10400, 10600, false);
     }
 
     @Test
-    public void testSpecificQueries()
-            throws Exception {
+    public void testSpecificQueries() throws Exception {
         assertEquals(runQueryTest(bamURL, "chrM", 10400, 10600, true), 1);
         assertEquals(runQueryTest(bamURL, "chrM", 10400, 10600, false), 2);
     }
 
-    @Test(enabled = true)
-    public void testRandomQueries()
-            throws Exception {
+    @Test
+    public void testRandomQueries() throws Exception {
         runRandomTest(bamURL, 20, new Random());
     }
 
@@ -135,7 +132,6 @@ public class BAMRemoteFileTest extends HtsjdkTest {
 
     private List<String> getReferenceNames(final URL bamFile) throws IOException {
 
-
         final SamReader reader = SamReaderFactory.makeDefault().open(SamInputResource.of(bamFile.openStream()));
 
         final List<String> result = new ArrayList<String>();
@@ -176,8 +172,6 @@ public class BAMRemoteFileTest extends HtsjdkTest {
             //System.out.println(records1.get(i).format());
             assertEquals(records1.get(i).getSAMString(), records2.get(i).getSAMString());
         }
-
-
     }
 
     private int runQueryTest(final URL bamURL, final String sequence, final int startPos, final int endPos, final boolean contained) {
@@ -207,9 +201,6 @@ public class BAMRemoteFileTest extends HtsjdkTest {
                 record2 = iter2.next();
                 count2++;
             }
-            // System.out.println("Iteration:");
-            // System.out.println(" Record1 = " + ((record1 == null) ? "null" : record1.format()));
-            // System.out.println(" Record2 = " + ((record2 == null) ? "null" : record2.format()));
             if (record1 == null && record2 == null) {
                 break;
             }

--- a/src/test/java/htsjdk/samtools/CRAMIndexQueryTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMIndexQueryTest.java
@@ -686,7 +686,7 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "unmappedSliceTest")
-    private void testUnmappedMultiSlice(
+    public void testUnmappedMultiSlice(
             final File cramFileName,
             final File referenceFileName,
             final int expectedCount) throws IOException

--- a/src/test/java/htsjdk/samtools/CRAMSliceMD5Test.java
+++ b/src/test/java/htsjdk/samtools/CRAMSliceMD5Test.java
@@ -1,5 +1,6 @@
 package htsjdk.samtools;
 
+import htsjdk.HtsjdkTest;
 import htsjdk.samtools.cram.CRAMException;
 import htsjdk.samtools.cram.build.CramIO;
 import htsjdk.samtools.cram.ref.CRAMReferenceSource;
@@ -22,7 +23,7 @@ import java.util.Arrays;
 /**
  * Created by vadim on 03/07/2017.
  */
-public class CRAMSliceMD5Test {
+public class CRAMSliceMD5Test extends HtsjdkTest{
 
     @Test
     public void testSliceMD5() throws IOException {

--- a/src/test/java/htsjdk/samtools/QueryIntervalTest.java
+++ b/src/test/java/htsjdk/samtools/QueryIntervalTest.java
@@ -1,9 +1,10 @@
 package htsjdk.samtools;
 
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class QueryIntervalTest {
+public class QueryIntervalTest extends HtsjdkTest{
 
     @Test
     public void testOptimizeIntervals() throws Exception {

--- a/src/test/java/htsjdk/samtools/cram/build/Sam2CramRecordFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/Sam2CramRecordFactoryTest.java
@@ -1,5 +1,6 @@
 package htsjdk.samtools.cram.build;
 
+import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMUtils;
@@ -19,7 +20,7 @@ import java.util.List;
 /**
  * Created by vadim on 06/06/2017.
  */
-public class Sam2CramRecordFactoryTest {
+public class Sam2CramRecordFactoryTest extends HtsjdkTest{
 
     /**
      * This checks that all read bases returned in the record from {@link Sam2CramRecordFactory#createCramRecord(SAMRecord)}

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceSourceTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceSourceTest.java
@@ -1,5 +1,6 @@
 package htsjdk.samtools.cram.ref;
 
+import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
 import htsjdk.samtools.util.SequenceUtil;
@@ -11,7 +12,7 @@ import java.util.Arrays;
 /**
  * Created by vadim on 29/06/2017.
  */
-public class ReferenceSourceTest {
+public class ReferenceSourceTest extends HtsjdkTest{
 
     @Test
     public void testReferenceSourceUpperCasesBases() {

--- a/src/test/java/htsjdk/samtools/metrics/MetricBaseTest.java
+++ b/src/test/java/htsjdk/samtools/metrics/MetricBaseTest.java
@@ -67,7 +67,8 @@ public class MetricBaseTest extends HtsjdkTest {
         Assert.assertFalse(b.equals(a));
     }
 
-    @Test void testSelfEquality(){
+    @Test
+    public void testSelfEquality(){
         final A a = new A();
         final B b = new B();
         Assert.assertTrue(a.equals(a));

--- a/src/test/java/htsjdk/samtools/util/BufferedLineReaderTest.java
+++ b/src/test/java/htsjdk/samtools/util/BufferedLineReaderTest.java
@@ -24,13 +24,14 @@
 
 package htsjdk.samtools.util;
 
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
-public class BufferedLineReaderTest {
+public class BufferedLineReaderTest extends HtsjdkTest{
 
     private static final String[] TERMINATORS = {"\r", "\n", "\r\n"};
     private static final boolean[] LAST_LINE_TERMINATED = {false, true};

--- a/src/test/java/htsjdk/samtools/util/LocatableUnitTest.java
+++ b/src/test/java/htsjdk/samtools/util/LocatableUnitTest.java
@@ -1,10 +1,11 @@
 package htsjdk.samtools.util;
 
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class LocatableUnitTest {
+public class LocatableUnitTest extends HtsjdkTest{
 
     private static Locatable getLocatable(final String contig, final int start, final int end) {
         return new Locatable() {

--- a/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
@@ -132,7 +132,6 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
         Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(testURI), expected);
     }
 
-
     @DataProvider(name = "vcfFileAndWrapperCombinations")
     private static Object[][] vcfFileAndWrapperCombinations(){
         return new Object[][] {
@@ -151,6 +150,7 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
     public void testGetFeatureReaderWithPathAndWrappers(String file, String index,
                                                         Function<SeekableByteChannel, SeekableByteChannel> wrapper,
                                                         Function<SeekableByteChannel, SeekableByteChannel> indexWrapper) throws IOException, URISyntaxException {
+        Assert.assertTrue(false);
         try(FileSystem fs = Jimfs.newFileSystem("test", Configuration.unix());
             final AbstractFeatureReader<VariantContext, ?> featureReader = getFeatureReader(file, index, wrapper,
                                                                                             indexWrapper,
@@ -164,7 +164,7 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
     }
 
     @DataProvider(name = "failsWithoutWrappers")
-    private static Object[][] failsWithoutWrappers(){
+    public static Object[][] failsWithoutWrappers(){
         return new Object[][] {
                 {MANGLED_VCF, MANGLED_VCF_INDEX},
                 {VCF, CORRUPTED_VCF_INDEX},
@@ -269,5 +269,4 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
         Files.copy(idxPath, root.resolve(idxDestination.getFileName().toString()));
         return Files.copy(vcfPath, root.resolve(vcfPath.getFileName().toString()));
     }
-
 }

--- a/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
@@ -150,7 +150,6 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
     public void testGetFeatureReaderWithPathAndWrappers(String file, String index,
                                                         Function<SeekableByteChannel, SeekableByteChannel> wrapper,
                                                         Function<SeekableByteChannel, SeekableByteChannel> indexWrapper) throws IOException, URISyntaxException {
-        Assert.assertTrue(false);
         try(FileSystem fs = Jimfs.newFileSystem("test", Configuration.unix());
             final AbstractFeatureReader<VariantContext, ?> featureReader = getFeatureReader(file, index, wrapper,
                                                                                             indexWrapper,

--- a/src/test/java/htsjdk/tribble/AsciiFeatureCodecTest.java
+++ b/src/test/java/htsjdk/tribble/AsciiFeatureCodecTest.java
@@ -1,5 +1,6 @@
 package htsjdk.tribble;
 
+import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -8,7 +9,7 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 
-public class AsciiFeatureCodecTest {
+public class AsciiFeatureCodecTest extends HtsjdkTest{
 
     @Test
     public void testMakeIndexableSourceFromUnknownStream() {

--- a/src/test/java/htsjdk/utils/ClassFinderTest.java
+++ b/src/test/java/htsjdk/utils/ClassFinderTest.java
@@ -1,0 +1,31 @@
+package htsjdk.utils;
+
+import htsjdk.HtsjdkTest;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Created by farjoun on 9/28/17.
+ */
+public class ClassFinderTest extends HtsjdkTest {
+
+    @Test
+    public void testFindTestClass() {
+        ClassFinder finder = new ClassFinder();
+        finder.find("htsjdk", HtsjdkTest.class);
+        Assert.assertFalse(finder.getClasses().isEmpty());
+
+        Assert.assertEquals(finder.getClasses().stream()
+                .filter(c -> c.getName().equals("htsjdk.utils.ClassFinderTest")).count(), 1);
+    }
+
+    @Test
+    public void testFindClassFinder() {
+        ClassFinder finder = new ClassFinder();
+        finder.find("htsjdk", Object.class);
+
+        Assert.assertFalse(finder.getClasses().isEmpty());
+        Assert.assertEquals(finder.getClasses().stream()
+                .filter(c -> c.getName().equals("htsjdk.utils.ClassFinder")).count(), 1);
+    }
+}

--- a/src/test/java/htsjdk/utils/TestNGUtils.java
+++ b/src/test/java/htsjdk/utils/TestNGUtils.java
@@ -1,0 +1,43 @@
+package htsjdk.utils;
+
+import org.testng.annotations.DataProvider;
+import org.testng.collections.Sets;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+/**
+ * Small class implementing some utility functions that are useful for test and interfacing with the TestNG framework.
+ */
+public class TestNGUtils {
+
+    /** A Method that returns all the Methods that are annotated with @DataProvider
+     * in a given package.
+     *
+     * @param pakkage the package under hwich to look for classes and methods
+     * @return an iterator to collection of Object[]'s consisting of {Method method, Class clazz} pair.
+     * where method has the @DataProviderAnnotation and is a member of clazz.
+     */
+    public static Iterator<Object[]> getDataProviders(final String pakkage) {
+        List<Object[]> data = new ArrayList<>();
+        final ClassFinder classFinder = new ClassFinder();
+        classFinder.find(pakkage, Object.class);
+
+        for (final Class<?> testClass : classFinder.getClasses()) {
+            if (Modifier.isAbstract(testClass.getModifiers()) || Modifier.isInterface(testClass.getModifiers()))
+                continue;
+            Set<Method> methodSet = Sets.newHashSet();
+            methodSet.addAll(Arrays.asList(testClass.getDeclaredMethods()));
+            methodSet.addAll(Arrays.asList(testClass.getMethods()));
+
+            for (final Method method : methodSet) {
+                if (method.isAnnotationPresent(DataProvider.class)) {
+                    data.add(new Object[]{method, testClass});
+                }
+            }
+        }
+
+        return data.iterator();
+    }
+}

--- a/src/test/java/htsjdk/utils/TestNGUtils.java
+++ b/src/test/java/htsjdk/utils/TestNGUtils.java
@@ -15,14 +15,14 @@ public class TestNGUtils {
     /** A Method that returns all the Methods that are annotated with @DataProvider
      * in a given package.
      *
-     * @param pakkage the package under hwich to look for classes and methods
+     * @param packageName the package under which to look for classes and methods
      * @return an iterator to collection of Object[]'s consisting of {Method method, Class clazz} pair.
      * where method has the @DataProviderAnnotation and is a member of clazz.
      */
-    public static Iterator<Object[]> getDataProviders(final String pakkage) {
+    public static Iterator<Object[]> getDataProviders(final String packageName) {
         List<Object[]> data = new ArrayList<>();
         final ClassFinder classFinder = new ClassFinder();
-        classFinder.find(pakkage, Object.class);
+        classFinder.find(packageName, Object.class);
 
         for (final Class<?> testClass : classFinder.getClasses()) {
             if (Modifier.isAbstract(testClass.getModifiers()) || Modifier.isInterface(testClass.getModifiers()))


### PR DESCRIPTION
(otherwise the dependent tests will be silently skipped)


### Description
Adds a test that makes sure that the @DataProviders are not failing. This is important since A failing data-provider causes the dependent tests to fail **silently** which means that an api change could cause parts of the code to be untested even though we have tests for them...

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

