### PR TITLE
Remove redundant use of DataOutputStream when passing to BinaryCodec.

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -29,7 +29,6 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,7 +36,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Concrete implementation of SAMFileWriter for writing gzipped BAM files.
@@ -51,37 +49,37 @@ class BAMFileWriter extends SAMFileWriterImpl {
 
     protected BAMFileWriter(final File path) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(path);
-        outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
+        outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(path.getAbsolutePath());
     }
 
     protected BAMFileWriter(final File path, final int compressionLevel) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(path, compressionLevel);
-        outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
+        outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(path.getAbsolutePath());
     }
 
     protected BAMFileWriter(final OutputStream os, final File file) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(os, file);
-        outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
+        outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }
 
     protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(os, file, compressionLevel);
-        outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
+        outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }
 
     protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(os, file, compressionLevel, deflaterFactory);
-        outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
+        outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(getPathString(file));
     }
 
     protected BAMFileWriter(final OutputStream os, final String absoluteFilename, final int compressionLevel, final DeflaterFactory deflaterFactory) {
       blockCompressedOutputStream = new BlockCompressedOutputStream(os, null, compressionLevel, deflaterFactory);
-      outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
+      outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
       outputBinaryCodec.setOutputFileName(absoluteFilename);
     }
 
@@ -204,7 +202,7 @@ class BAMFileWriter extends SAMFileWriterImpl {
 
     protected static void writeHeader(final OutputStream outputStream, final SAMFileHeader samFileHeader) {
         final BlockCompressedOutputStream blockCompressedOutputStream = new BlockCompressedOutputStream(outputStream, null);
-        final BinaryCodec outputBinaryCodec = new BinaryCodec(new DataOutputStream(blockCompressedOutputStream));
+        final BinaryCodec outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         writeHeader(outputBinaryCodec, samFileHeader);
         try {
             blockCompressedOutputStream.flush();

--- a/src/test/java/htsjdk/samtools/util/BinaryCodecTest.java
+++ b/src/test/java/htsjdk/samtools/util/BinaryCodecTest.java
@@ -27,12 +27,12 @@ import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 
 /*
@@ -56,7 +56,7 @@ public class BinaryCodecTest extends HtsjdkTest {
         //Writing to file
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeBytes(value);
         codec.close();
@@ -66,7 +66,7 @@ public class BinaryCodecTest extends HtsjdkTest {
         valuesTwo[0] = 1;
         valuesTwo[1] = 2;
 
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
         final byte[] bytesFromBinaryFile = new byte[2];
         readCodec.readBytes(bytesFromBinaryFile);
@@ -82,13 +82,13 @@ public class BinaryCodecTest extends HtsjdkTest {
         //Writing to file
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeString(value, true, false);
         codec.close();
 
         //Reading from file
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
         final int stringLength = readCodec.readInt();
         Assert.assertEquals(value.length(), stringLength);
@@ -104,13 +104,13 @@ public class BinaryCodecTest extends HtsjdkTest {
         //Writing to file
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeInt(value);
         codec.close();
 
         //Reading from file
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
         Assert.assertEquals(value, readCodec.readInt());
         readCodec.close();
@@ -122,13 +122,13 @@ public class BinaryCodecTest extends HtsjdkTest {
 
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeDouble(value);
         codec.close();
 
         //Reading from file
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
         Assert.assertEquals(value, readCodec.readDouble());
         readCodec.close();
@@ -140,13 +140,13 @@ public class BinaryCodecTest extends HtsjdkTest {
 
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeLong(value);
         codec.close();
 
         //Reading from file
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
         Assert.assertEquals(value, readCodec.readLong());
         readCodec.close();
@@ -159,13 +159,13 @@ public class BinaryCodecTest extends HtsjdkTest {
 
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeFloat(value);
         codec.close();
 
         //Reading from file
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
         Assert.assertEquals(value, readCodec.readFloat());
         readCodec.close();
@@ -179,13 +179,13 @@ public class BinaryCodecTest extends HtsjdkTest {
         for (boolean value : values) {
             final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
             outputFile.deleteOnExit();
-            final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+            final OutputStream stream = new FileOutputStream(outputFile);
             final BinaryCodec codec = new BinaryCodec(stream);
             codec.writeBoolean(value);
             codec.close();
 
             //Reading from file
-            final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+            final InputStream instream = new FileInputStream(outputFile);
             final BinaryCodec readCodec = new BinaryCodec(instream);
             Assert.assertEquals(value, readCodec.readBoolean());
             readCodec.close();
@@ -199,14 +199,14 @@ public class BinaryCodecTest extends HtsjdkTest {
 
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         codec.writeFloat(fValue);
         codec.writeString(sValue, true, false);
         codec.close();
 
         //Reading from file
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
         Assert.assertEquals(fValue, readCodec.readFloat());
         final int stringLength = readCodec.readInt();
@@ -221,7 +221,7 @@ public class BinaryCodecTest extends HtsjdkTest {
 
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         while (i<100){
             codec.writeInt(i);
@@ -229,7 +229,7 @@ public class BinaryCodecTest extends HtsjdkTest {
         }
         codec.close();
 
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
 
         System.out.println((System.currentTimeMillis() - startTime) + "ms to write");
@@ -256,7 +256,7 @@ public class BinaryCodecTest extends HtsjdkTest {
 
         final File outputFile = File.createTempFile(TEST_BASENAME, ".bin");
         outputFile.deleteOnExit();
-        final DataOutputStream stream = new DataOutputStream(new FileOutputStream(outputFile));
+        final OutputStream stream = new FileOutputStream(outputFile);
         final BinaryCodec codec = new BinaryCodec(stream);
         while (i<100){
             codec.writeInt(i);
@@ -264,7 +264,7 @@ public class BinaryCodecTest extends HtsjdkTest {
         }
         codec.close();
 
-        final DataInputStream instream = new DataInputStream(new FileInputStream(outputFile));
+        final InputStream instream = new FileInputStream(outputFile);
         final BinaryCodec readCodec = new BinaryCodec(instream);
 
         System.out.println((System.currentTimeMillis() - startTime) + "ms to write");


### PR DESCRIPTION
### Description

These DataOutputStream objects are being created needlessly and
confusingly (I suspect they are vestigial). BinaryCodec states that it
is responsible for ensuring the endian-ness (which it does internally
via its ByteBuffer).

This PR is just a minor cleanup that removes the redundant and confusing calls.

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality (existing tests, no new functionality)
- [X] All tests passing
- [X] Extended the README / documentation, if necessary (N/A)
- [ ] Is not backward compatible (breaks binary or source compatibility)

