### PR TITLE
Fix BufferedLineReader peek() at end of line with Windows line endings.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
+++ b/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
@@ -25,7 +25,6 @@ package htsjdk.samtools.util;
 
 import htsjdk.samtools.Defaults;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -80,7 +79,7 @@ public class BufferedLineReader extends LineNumberReader implements LineReader {
     @Override
     public int peek() {
         try {
-            mark(1);
+            mark(2); // Two characters required here as the next read will collapse \r\n to a single \n
             final int ret = read();
             reset();
             return ret;

--- a/src/test/java/htsjdk/samtools/util/BufferedLineReaderTest.java
+++ b/src/test/java/htsjdk/samtools/util/BufferedLineReaderTest.java
@@ -71,10 +71,12 @@ public class BufferedLineReaderTest {
             input = "";
         }
         final BufferedLineReader blr = BufferedLineReader.fromString(input);
+        blr.peek();
         final String output = blr.readLine();
         if (lastLineTerminated) {
             Assert.assertEquals(output, "");
         }
+        blr.peek();
         Assert.assertNull(blr.readLine());
     }
 
@@ -105,12 +107,14 @@ public class BufferedLineReaderTest {
         }
         final BufferedLineReader blr = BufferedLineReader.fromString(input);
         for (int i = 0; i < lines.length - 1; ++i) {
+            blr.peek();
             final String s = blr.readLine();
             String expected = lines[i];
             Assert.assertEquals(s, expected);
         }
 
         // Last line may need to be handled specially
+        blr.peek();
         String s = blr.readLine();
         if (!lastLineTerminated
                 && emptyLineState == EmptyLineState.LAST_LINE) {
@@ -119,6 +123,7 @@ public class BufferedLineReaderTest {
             String expected = lines[lines.length - 1];
             Assert.assertEquals(s, expected);
         }
+        blr.peek();
         s = blr.readLine();
         Assert.assertNull(s);
     }


### PR DESCRIPTION
### Description

LineNumberReader.read() compresses multiple-character line terminators into a single \n character. Thus, a single-character mark is insufficient in the peek() method, resulting in "Mark invalid" exceptions being thrown when a Windows line ending is encountered. The existing unit tests have been extended to check that peek() does not throw, and these fail when using the original 1 character mark.

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

