### PR TITLE
Support BAMs with >65535 CIGAR operations

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMRecord.java
+++ b/src/main/java/htsjdk/samtools/BAMRecord.java
@@ -97,7 +97,7 @@ public class BAMRecord extends SAMRecord {
 
         // Test if the real CIGAR is kept in the CG:B,I tag. If so, get its length and the offset in restOfData.
         int tagCigarLen = -1, tagCigarOffset = -1, newIndexingBin;
-        if (cigarLen >= 1 && referenceID >= 0 && restOfData.length - readNameLength >= 8 + cigarLen * 4) { // "CGBI"(4) + realCigarLen(4) + fakeCigar
+        if (restOfData != null && cigarLen >= 1 && referenceID >= 0 && restOfData.length - readNameLength >= 8 + cigarLen * 4) { // "CGBI"(4) + realCigarLen(4) + fakeCigar
             final ByteBuffer cigarReader = ByteBuffer.wrap(restOfData, readNameLength, 4);
             cigarReader.order(ByteOrder.LITTLE_ENDIAN);
             int cigar1 = cigarReader.getInt();

--- a/src/main/java/htsjdk/samtools/BAMRecord.java
+++ b/src/main/java/htsjdk/samtools/BAMRecord.java
@@ -116,6 +116,8 @@ public class BAMRecord extends SAMRecord {
                             break;
                         }
                         r.position(r.position() + typeLength(type2) * len);
+                    } else if (type1 == 'Z' || type1 == 'H') {
+                        while (r.getChar() != 0);
                     } else {
                         r.position(r.position() + typeLength(type1));
                     }

--- a/src/main/java/htsjdk/samtools/BAMRecord.java
+++ b/src/main/java/htsjdk/samtools/BAMRecord.java
@@ -23,7 +23,6 @@
  */
 package htsjdk.samtools;
 
-import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.StringUtil;
 
 import java.nio.ByteBuffer;

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -325,7 +325,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
      * Randomly fills in the bases for the given record.
      */
     private void fillInBases(final SAMRecord rec) {
-        final int length = this.readLength;
+        final int length = rec.getCigar() != null ? rec.getCigar().getReadLength() : readLength;
         final byte[] bases = new byte[length];
 
         for (int i = 0; i < length; ++i) {
@@ -521,7 +521,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
      * Relies on the alignment start and end having been set to get read length.
      */
     private void fillInBasesAndQualities(final SAMRecord rec, final int defaultQuality) {
-        final int length = this.readLength;
+        final int length = rec.getCigar() != null ? rec.getCigar().getReadLength() : readLength;
         final byte[] quals = new byte[length];
 
         if (-1 != defaultQuality) {

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.SequenceUtil;
+import htsjdk.samtools.util.TestUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -521,7 +522,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
      * Relies on the alignment start and end having been set to get read length.
      */
     private void fillInBasesAndQualities(final SAMRecord rec, final int defaultQuality) {
-        final int length = rec.getCigar() != null ? rec.getCigar().getReadLength() : readLength;
+        final int length = rec.getCigar() != null && rec.getCigar().getReadLength() != 0 ? rec.getCigar().getReadLength() : readLength;
         final byte[] quals = new byte[length];
 
         if (-1 != defaultQuality) {

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -324,6 +324,8 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
 
     /**
      * Randomly fills in the bases for the given record.
+     *
+     * If there's a cigar with read-length >0, will use that length for reads. Otherwise will use length = 36
      */
     private void fillInBases(final SAMRecord rec) {
         final int length = rec.getCigar() != null && rec.getCigar().getReadLength() != 0 ? rec.getCigar().getReadLength() : readLength;
@@ -519,7 +521,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
     /**
      * Fills in bases and qualities with a set default quality. If the defaultQuality is set to -1 quality scores will
      * be randomly generated.
-     * Relies on the alignment start and end having been set to get read length.
+     * If there's a cigar with read-length >0, will use that length for reads. Otherwise will use length = 36
      */
     private void fillInBasesAndQualities(final SAMRecord rec, final int defaultQuality) {
         final int length = rec.getCigar() != null && rec.getCigar().getReadLength() != 0 ? rec.getCigar().getReadLength() : readLength;

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -325,7 +325,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
      * Randomly fills in the bases for the given record.
      */
     private void fillInBases(final SAMRecord rec) {
-        final int length = rec.getCigar() != null ? rec.getCigar().getReadLength() : readLength;
+        final int length = rec.getCigar() != null && rec.getCigar().getReadLength() != 0 ? rec.getCigar().getReadLength() : readLength;
         final byte[] bases = new byte[length];
 
         for (int i = 0; i < length; ++i) {

--- a/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
@@ -25,7 +25,6 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.SequenceUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -35,6 +34,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Test that BAM writing doesn't blow up.  For presorted writing, the resulting BAM file is read and contents are
@@ -60,53 +61,55 @@ public class BAMFileWriterTest extends HtsjdkTest {
      * @param presorted           If true, samText is in the order specified by sortOrder
      */
     private void testHelper(final SAMRecordSetBuilder samRecordSetBuilder, final SAMFileHeader.SortOrder sortOrder, final boolean presorted) throws Exception {
-        final SamReader samReader = samRecordSetBuilder.getSamReader();
         final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
         bamFile.deleteOnExit();
-        samReader.getFileHeader().setSortOrder(sortOrder);
-        final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(samReader.getFileHeader(), presorted, bamFile);
-        CloseableIterator<SAMRecord> it = samReader.iterator();
-        while (it.hasNext()) {
-            bamWriter.addAlignment(it.next());
-        }
-        bamWriter.close();
-        it.close();
-        samReader.close();
 
+        try(
+        final SamReader samReader = samRecordSetBuilder.getSamReader();
+        final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(samReader.getFileHeader(), presorted, bamFile))
+        {
+            samReader.getFileHeader().setSortOrder(sortOrder);
+            CloseableIterator<SAMRecord> it = samReader.iterator();
+            while (it.hasNext()) {
+                bamWriter.addAlignment(it.next());
+            }
+            it.close();
+        }
         if (presorted) { // If SAM text input was presorted, then we can compare SAM object to BAM object
             verifyBAMFile(samRecordSetBuilder, bamFile);
         }
     }
 
-    private void verifyBAMFile(final SAMRecordSetBuilder samRecordSetBuilder, final File bamFile) {
+    private void verifyBAMFile(final SAMRecordSetBuilder samRecordSetBuilder, final File bamFile) throws IOException {
+        try (
+                final SamReader bamReader = SamReaderFactory.makeDefault().open(bamFile);
+                final SamReader samReader = samRecordSetBuilder.getSamReader();
+                final CloseableIterator<SAMRecord> it = samReader.iterator();
+                final CloseableIterator<SAMRecord> bamIt = bamReader.iterator();
+        ) {
+            samReader.getFileHeader().setSortOrder(bamReader.getFileHeader().getSortOrder());
+            Assert.assertEquals(bamReader.getFileHeader(), samReader.getFileHeader());
+            while (it.hasNext()) {
+                Assert.assertTrue(bamIt.hasNext());
+                final SAMRecord samRecord = it.next();
+                final SAMRecord bamRecord = bamIt.next();
 
-        final SamReader bamReader = SamReaderFactory.makeDefault().open(bamFile);
-        final SamReader samReader = samRecordSetBuilder.getSamReader();
-        samReader.getFileHeader().setSortOrder(bamReader.getFileHeader().getSortOrder());
-        Assert.assertEquals(bamReader.getFileHeader(), samReader.getFileHeader());
-        final CloseableIterator<SAMRecord> it = samReader.iterator();
-        final CloseableIterator<SAMRecord> bamIt = bamReader.iterator();
-        while (it.hasNext()) {
-            Assert.assertTrue(bamIt.hasNext());
-            final SAMRecord samRecord = it.next();
-            final SAMRecord bamRecord = bamIt.next();
+                // SAMRecords don't have this set, so stuff it in there
+                samRecord.setIndexingBin(bamRecord.getIndexingBin());
 
-            // SAMRecords don't have this set, so stuff it in there
-            samRecord.setIndexingBin(bamRecord.getIndexingBin());
+                // Force reference index attributes to be populated
+                samRecord.getReferenceIndex();
+                bamRecord.getReferenceIndex();
+                samRecord.getMateReferenceIndex();
+                bamRecord.getMateReferenceIndex();
 
-            // Force reference index attributes to be populated
-            samRecord.getReferenceIndex();
-            bamRecord.getReferenceIndex();
-            samRecord.getMateReferenceIndex();
-            bamRecord.getMateReferenceIndex();
-
-            Assert.assertEquals(bamRecord, samRecord);
+                Assert.assertEquals(bamRecord, samRecord);
+            }
+            Assert.assertFalse(bamIt.hasNext());
         }
-        Assert.assertFalse(bamIt.hasNext());
-        CloserUtil.close(samReader);
-    }
 
-    @DataProvider(name = "test1")
+    }
+        @DataProvider(name = "test1")
     public Object[][] createTestData() {
         return new Object[][]{
                 {"coordinate sorted", getRecordSetBuilder(false, SAMFileHeader.SortOrder.unsorted), SAMFileHeader.SortOrder.coordinate, false},
@@ -174,7 +177,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
 
         final SAMRecordSetBuilder samRecordSetBuilder = getRecordSetBuilder(true, SAMFileHeader.SortOrder.queryname);
 
-        // create a fake header to make sure the records cannot  be written using an invalid
+        // create a fake header to make sure the records cannot be written using an invalid
         // sequence dictionary and unresolvable references
         final SAMFileHeader fakeHeader = new SAMFileHeader();
         fakeHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
@@ -229,4 +232,61 @@ public class BAMFileWriterTest extends HtsjdkTest {
         Assert.assertEquals(recordFromBAM.getReadBases(), SequenceUtil.toBamReadBasesInPlace(originalSAMRecord.getReadBases()));
     }
 
+
+    @DataProvider
+    public Object[][] longCigarsData(){
+        return new Object[][]{
+                {1},
+                {10},
+                {100},
+                {1_000},
+                {10_000},
+                {100_000},
+                {1_000_000}};
+    }
+
+    @Test(dataProvider = "longCigarsData")
+    public void testLongCigars(int numOps) throws Exception {
+        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate);
+
+        final List<CigarOperator> operators = new ArrayList<>(numOps);
+        final CigarOperator operatorstoUse[] = new CigarOperator[]{CigarOperator.M, CigarOperator.D, CigarOperator.M, CigarOperator.I};
+        for (int i = 0; i < numOps; i++) {
+            operators.add(operatorstoUse[i % operatorstoUse.length]);
+        }
+        operators.add(CigarOperator.M);
+
+        final Cigar cigar = Cigar.fromCigarOperators(operators);
+
+        builder.addFrag("frag1",0,1,false,false,cigar.toString(),null,30);
+        builder.addPair("pair1",0,1,100_000,false,false,cigar.toString(),cigar.toString(),true,false,30);
+
+        testHelper(builder, SAMFileHeader.SortOrder.coordinate,true);
+    }
+
+
+    //why is this not breaking?
+    @Test(dataProvider = "longCigarsData")
+    public void testMisplacedCGTag(int numOps) throws Exception {
+        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate);
+
+        final List<CigarOperator> operators = new ArrayList<>(numOps);
+        final CigarOperator operatorstoUse[] = new CigarOperator[]{CigarOperator.M, CigarOperator.D, CigarOperator.M, CigarOperator.I};
+        for (int i = 0; i < numOps; i++) {
+            operators.add(operatorstoUse[i % operatorstoUse.length]);
+        }
+        operators.add(CigarOperator.M);
+
+        final Cigar cigar = Cigar.fromCigarOperators(operators);
+
+        final SAMRecord record = builder.addFrag("frag1",0,1,false,false,cigar.toString(),null,30);
+        record.setAttribute("CG","Ceci n'est pas une pipe!");
+
+        final List<SAMRecord> pairOfReads = builder.addPair("pair1",0,1,100_000,false,false,cigar.toString(),cigar.toString(),true,false,30);
+        for(final SAMRecord rec :pairOfReads){
+            rec.setAttribute("CG","Ceci n'est pas une pipe!");
+        }
+
+        testHelper(builder, SAMFileHeader.SortOrder.coordinate,true);
+    }
 }


### PR DESCRIPTION
### Description

This PR implements the long-cigar solution that @yfarjoun and I have agreed on. In the presence of CIGAR with >65535 operators, we move the real CIGAR to the CG tag and put a fake full clipping CIGAR (i.e. `<readLength>S`) in place.

<strike>`./gradlew test` reported one test failure due to `EnaRefServiceTest`. Looking at the call stack, I don't think that is my fault. The rest of tests have passed.</strike>

On an example SAM and BAM (from <http://lh3lh3.users.sourceforge.net/data>), `PrintReadsExample` gives the desired BAM output when taking both SAM and BAM as input. Both shallow and deep decoding also write correct BAMs.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

