### PR TITLE
Fixed ENA url to use https (instead of http) 

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/ref/EnaRefService.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/EnaRefService.java
@@ -16,6 +16,8 @@ public class EnaRefService {
     private static final int HTTP_NOT_FOUND = 404;
     private static final int HTTP_INTERNAL_SEVER_PROBLEM = 500;
     private static final int HTTP_CONNECTION_TIMEOUT = 522;
+    private static final int HTTP_MOVED_PERMANENTLY = 301;
+
 
     byte[] getSequence(final String md5) throws GaveUpException {
         final int restBetweenTries_ms = 0;
@@ -43,7 +45,7 @@ public class EnaRefService {
         if (!md5.matches("[a-z0-9]{32}"))
             throw new RuntimeException("Does not look like an md5 checksum: " + md5);
 
-        final String httpEbiString = "http://www.ebi.ac.uk/ena/cram/md5/%s";
+        final String httpEbiString = "https://www.ebi.ac.uk/ena/cram/md5/%s";
         final String urlString = String.format(httpEbiString, md5);
         final URL url;
         try {
@@ -75,6 +77,12 @@ public class EnaRefService {
                     case HTTP_CONNECTION_TIMEOUT:
                     case HTTP_INTERNAL_SEVER_PROBLEM:
                         break;
+                    case HTTP_MOVED_PERMANENTLY:
+                        log.error("It seems that the base URL for the ENA service has changed permanently. Got error:" + code +
+                        "\n Please contact the HtsJdk developers at www.github.com/samtools/htsjdk. \n" +
+                                "Tried to access "+ url + "\n" +
+                                "Response header: " + http.getHeaderFields().toString());
+                        throw new RuntimeException("Bad http status code: " + code);
                     default:
                         throw new RuntimeException("Unknown http status code: " + code);
                 }

--- a/src/main/java/htsjdk/samtools/cram/ref/EnaRefService.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/EnaRefService.java
@@ -11,12 +11,13 @@ import java.net.URL;
 
 public class EnaRefService {
     private static final Log log = Log.getInstance(EnaRefService.class);
-    private static final int HTTP_OK = 200;
+    private static final int HTTP_OK = HttpURLConnection.HTTP_OK;
     private static final int HTTP_FOUND = 302;
-    private static final int HTTP_NOT_FOUND = 404;
-    private static final int HTTP_INTERNAL_SEVER_PROBLEM = 500;
+    private static final int HTTP_NOT_FOUND = HttpURLConnection.HTTP_NOT_FOUND;
+    private static final int HTTP_INTERNAL_SEVER_PROBLEM = HttpURLConnection.HTTP_INTERNAL_ERROR;
+    // this is a non-standard code and I'm not sure why it's here
     private static final int HTTP_CONNECTION_TIMEOUT = 522;
-    private static final int HTTP_MOVED_PERMANENTLY = 301;
+    private static final int HTTP_MOVED_PERMANENTLY = HttpURLConnection.HTTP_MOVED_PERM;
 
 
     byte[] getSequence(final String md5) throws GaveUpException {

--- a/src/main/java/htsjdk/samtools/cram/ref/EnaRefService.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/EnaRefService.java
@@ -45,6 +45,7 @@ public class EnaRefService {
         if (!md5.matches("[a-z0-9]{32}"))
             throw new RuntimeException("Does not look like an md5 checksum: " + md5);
 
+        // from https://www.ebi.ac.uk/ena/software/cram-reference-registry
         final String httpEbiString = "https://www.ebi.ac.uk/ena/cram/md5/%s";
         final String urlString = String.format(httpEbiString, md5);
         final URL url;

--- a/src/main/java/htsjdk/samtools/cram/ref/EnaRefService.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/EnaRefService.java
@@ -19,7 +19,6 @@ public class EnaRefService {
     private static final int HTTP_CONNECTION_TIMEOUT = 522;
     private static final int HTTP_MOVED_PERMANENTLY = HttpURLConnection.HTTP_MOVED_PERM;
 
-
     byte[] getSequence(final String md5) throws GaveUpException {
         final int restBetweenTries_ms = 0;
         final int maxTries = 1;

--- a/src/test/java/htsjdk/samtools/cram/ref/EnaRefServiceTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/EnaRefServiceTest.java
@@ -2,15 +2,21 @@ package htsjdk.samtools.cram.ref;
 
 import htsjdk.HtsjdkTest;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 
 public class EnaRefServiceTest extends HtsjdkTest {
 
-    @Test
-    public void test() throws IOException, EnaRefService.GaveUpException {
-        Assert.assertNotNull(new EnaRefService().getSequence("57151e6196306db5d9f33133572a5482"));
-        Assert.assertNotNull(new EnaRefService().getSequence("0000088cbcebe818eb431d58c908c698"));
+    @DataProvider(name="testEnaRefServiceData")
+    public Object[][] testEnaRefServiceData(){
+        return new Object[][]{{"57151e6196306db5d9f33133572a5482"},
+                {"0000088cbcebe818eb431d58c908c698"}};
+    }
+
+    @Test(dataProvider = "testEnaRefServiceData")
+    public void testEnaRefServiceData(final String md5) throws IOException, EnaRefService.GaveUpException {
+        Assert.assertNotNull(new EnaRefService().getSequence(md5));
     }
 }


### PR DESCRIPTION
### Description

- It seems that the ENA has moved to https which is why tests are failing. 
- This probably also affected cram access to ena resources. fixed.
- Reformated tests to use a data provider


### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

