### PR TITLE
Add out/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/htsjdk.iml
 *.iml
 *.ipr
 *.iws
+out/
 
 
 


### PR DESCRIPTION
### Description

Building with Intellij 2017.2 generates an /out directory instead of
using the build/ folder from gradle. This commit remove this directory
from the tracked files.

This folder cannot be changed, even if the compiler output is changed (see CrazyCoder comment in https://stackoverflow.com/questions/45174989/building-with-intellij-2017-2-out-directory-duplicates-files-in-build-director).

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

