### PR TITLE
VariantContextFilter extends Predicate<VariantContext>

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/filter/VariantContextFilter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/filter/VariantContextFilter.java
@@ -24,20 +24,14 @@
 package htsjdk.variant.variantcontext.filter;
 
 import htsjdk.variant.variantcontext.VariantContext;
+import java.util.function.Predicate;
 
 /**
  *
- * API for filtering VariantContexts
+ * API for filtering VariantContexts.
  *
  * @author Yossi Farjoun
  *
  */
-public interface VariantContextFilter {
-    /**
-     * Determines whether a VariantContext matches this filter
-     *
-     * @param record the VariantContext to evaluate
-     * @return true if the VariantContext matches the filter, otherwise false
-     */
-    boolean test(VariantContext record);
+public interface VariantContextFilter extends Predicate<VariantContext> {
 }


### PR DESCRIPTION
### Description

small simplication : `VariantContextFilter` is just a  `Predicate<VariantContext>`.

We can now use this in a `stream().filter(ctxFilter)`

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

