### PR TITLE
fixing resource leak in VCFFileReader.getSequenceDictionary()

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -35,9 +35,9 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
 	 * Returns the SAMSequenceDictionary from the provided VCF file.
 	 */
 	public static SAMSequenceDictionary getSequenceDictionary(final File file) {
-		final SAMSequenceDictionary dict = new VCFFileReader(file, false).getFileHeader().getSequenceDictionary();
-		CloserUtil.close(file);
-		return dict;
+	    try (final VCFFileReader vcfFileReader = new VCFFileReader(file, false)) {
+		    return vcfFileReader.getFileHeader().getSequenceDictionary();
+		}
 	}
 
     /** Constructs a VCFFileReader that requires the index to be present. */


### PR DESCRIPTION
### Description

Fixed a resource leak in VCFFileReader.getSequenceDictionary(), the vcfFileReader was not closed, replace with a try-with-resource

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

