### PR TITLE
Add mark support to SeekableStream with a new class

### DIFF
--- a/src/main/java/htsjdk/samtools/seekablestream/ISeekableStreamFactory.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/ISeekableStreamFactory.java
@@ -52,4 +52,32 @@ public interface ISeekableStreamFactory {
             return this.getStreamFor(path);
         }
     }
+
+    /**
+     * Open a stream from the input path, with support for {@link java.io.InputStream#mark(int)}.
+     *
+     * <p>Default implementation wraps the result of {@link #getStreamFor(String)} into a {@link MarkSeekableStream}.
+     *
+     * @param path a uri like String representing a resource to open.
+     * @return a stream opened path with mark support.
+     */
+    default SeekableStream getMarkSupportedStreamFor(String path) throws IOException {
+        return new MarkSeekableStream(this.getStreamFor(path));
+    }
+
+    /**
+     * Open a stream from the input path, with support for {@link java.io.InputStream#mark(int)} and applying the wrapper to the stream.
+     *
+     * <p>The wrapper allows applying operations directly to the byte stream so that things like caching, prefetching, or decryption
+     * can be done at the raw byte level.
+     *
+     * <p>Default implementation wraps the result of {@link #getStreamFor(String, Function)} into a {@link MarkSeekableStream}.
+     *
+     * @param path a uri like String representing a resource to open.
+     * @param wrapper a wrapper to apply to the stream
+     * @return a stream opened path with mark support.
+     */
+    default SeekableStream getMarkSupportedStreamFor(String path, Function<SeekableByteChannel, SeekableByteChannel> wrapper) throws IOException {
+        return new MarkSeekableStream(this.getStreamFor(path, wrapper));
+    }
 }

--- a/src/main/java/htsjdk/samtools/seekablestream/MarkSeekableStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/MarkSeekableStream.java
@@ -1,0 +1,125 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools.seekablestream;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class MarkSeekableStream extends SeekableStream {
+
+    private final SeekableStream underlyingStream;
+    private OptionalLong mark = OptionalLong.empty();
+
+    public MarkSeekableStream(final SeekableStream underlyingStream) {
+        if (underlyingStream == null) {
+            throw new IllegalArgumentException("null stream");
+        }
+        this.underlyingStream = underlyingStream;
+    }
+
+    public static MarkSeekableStream asMarkSeekableStream(final SeekableStream stream) {
+        if (stream instanceof MarkSeekableStream) {
+            return (MarkSeekableStream) stream;
+        }
+        return new MarkSeekableStream(stream);
+    }
+
+    @Override
+    public long length() {
+        return underlyingStream.length();
+    }
+
+    @Override
+    public long position() throws IOException {
+        return underlyingStream.position();
+    }
+
+    @Override
+    public void seek(long position) throws IOException {
+        underlyingStream.seek(position);
+    }
+
+    @Override
+    public int read() throws IOException {
+        return underlyingStream.read();
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+        return underlyingStream.read(buffer, offset, length);
+    }
+
+    @Override
+    public void close() throws IOException {
+        underlyingStream.close();
+    }
+
+    @Override
+    public boolean eof() throws IOException {
+        return underlyingStream.eof();
+    }
+
+    @Override
+    public String getSource() {
+        return underlyingStream.getSource();
+    }
+
+    /**
+     * Mark the current position of the stream.
+     *
+     * <p>Note: there is not limit for reading.
+     *
+     * @param readlimit ignored.
+     */
+    @Override
+    public synchronized void mark(int readlimit) {
+        try {
+            mark = OptionalLong.of(position());
+        } catch (IOException e) {
+            // do nothing (most likely already closed stream)
+        }
+    }
+
+    /**
+     * Seeks to the marked position if set; otherwise to the beginning of the stream.
+     */
+    @Override
+    public synchronized void reset() throws IOException {
+        if (mark.isPresent()) {
+            seek(mark.getAsLong());
+        } else {
+            seek(0);
+        }
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+}

--- a/src/main/java/htsjdk/samtools/seekablestream/MarkSeekableStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/MarkSeekableStream.java
@@ -93,7 +93,7 @@ public class MarkSeekableStream extends SeekableStream {
     /**
      * Mark the current position of the stream.
      *
-     * <p>Note: there is not limit for reading.
+     * <p>Note: there is no limit for reading.
      *
      * @param readlimit ignored.
      */

--- a/src/test/java/htsjdk/samtools/seekablestream/MarkSeekableStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/MarkSeekableStreamTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools.seekablestream;
+
+import htsjdk.HtsjdkTest;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class MarkSeekableStreamTest extends HtsjdkTest {
+
+    @Test
+    public void testMarkAndReset() throws Exception {
+        final int length = 100;
+        // instantiate the stream
+        final SeekableStream stream = getRandomSeekableStream(length);
+        // read one byte and mark the stream
+        stream.read();
+        stream.mark(0);
+        final int current = stream.read();
+        // consume the stream
+        stream.readFully(new byte[length - 2]);
+        Assert.assertEquals(stream.read(), -1);
+        // come back to the mark
+        stream.reset();
+        Assert.assertEquals(stream.read(), current);
+    }
+
+    @Test
+    public void testResetUnmark() throws Exception {
+        final int length = 100;
+        // instantiate the stream
+        final SeekableStream stream = getRandomSeekableStream(100);
+        // consume the stream
+        final int current = stream.read();
+        stream.readFully(new byte[length - 1]);
+        Assert.assertEquals(stream.read(), -1);
+        stream.reset();
+        Assert.assertEquals(stream.read(), current);
+    }
+
+    private static SeekableStream getRandomSeekableStream(final int size) {
+        // generate random array
+        final byte[] array = new byte[size];
+        new Random().nextBytes(array);
+        // instantiate the stream
+        return new MarkSeekableStream(new SeekableMemoryStream(array, "test"));
+    }
+
+}


### PR DESCRIPTION
### Description

Currently, every `SeekableStream` does not have mark support. This PR adds it by a wrapper class, that is also used in factory methods to allow marking the stream and reset by using seek.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

