### PR TITLE
Add mark support for SeekableStream

### DIFF
--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
@@ -23,9 +23,12 @@
  */
 package htsjdk.samtools.seekablestream;
 
+import htsjdk.samtools.util.RuntimeIOException;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.ClosedChannelException;
 import java.util.OptionalLong;
 
 /**
@@ -92,13 +95,17 @@ public abstract class SeekableStream extends InputStream {
      * <p>Note: there is no limit for reading.
      *
      * @param readlimit ignored.
+     * @throws RuntimeIOException if an IO error occurs other than an already closed stream.
      */
     @Override
     public final synchronized void mark(int readlimit) {
         try {
             mark = OptionalLong.of(position());
-        } catch (IOException e) {
-            // do nothing (most likely already closed stream)
+        } catch (final ClosedChannelException e) {
+            // do nothing, respecting the contract of mark
+        } catch (final IOException e) {
+            // other exceptions are re-thrown
+            throw new RuntimeIOException(e);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
@@ -28,6 +28,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.OptionalLong;
 
+/**
+ * InputStream with random access support (seek).
+ *
+ * <p>{@link SeekableStream} provides an interface for random access support in {@link InputStream},
+ * thought the implementation of {@link #seek(long)}. As a random access stream, it supports mark
+ * by design, being able to seek to a concrete position.
+ */
 public abstract class SeekableStream extends InputStream {
 
     /**
@@ -36,10 +43,13 @@ public abstract class SeekableStream extends InputStream {
      */
     protected OptionalLong mark = OptionalLong.empty();
 
+    /** @return the length of the stream; 0 if not available or empty. */
     public abstract long length();
 
+    /** @return the current byte position of the stream. */
     public abstract long position() throws IOException;
 
+    /** Seeks the stream to the provided position. */
     public abstract void seek(long position) throws IOException;
 
     @Override
@@ -48,6 +58,7 @@ public abstract class SeekableStream extends InputStream {
     @Override
     public abstract void close() throws IOException;
 
+    /** @return {@code true} if the stream is already consumed; {@code false} otherwise. */
     public abstract boolean eof() throws IOException;
 
     /**

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableMemoryStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableMemoryStreamTest.java
@@ -85,10 +85,15 @@ public class SeekableMemoryStreamTest extends HtsjdkTest {
         Assert.assertEquals(copy, data);
     }
 
-    @Test(expectedExceptions = IOException.class)
+    @Test
     public void test_reset() throws IOException {
         SeekableMemoryStream stream = new SeekableMemoryStream("qwe".getBytes(), null);
         stream.mark(3);
+        // read fully
+        final int l = (int) stream.length();
+        Assert.assertEquals(stream.read(new byte[l]), l);
+        Assert.assertEquals(stream.read(), -1);
         stream.reset();
+        Assert.assertEquals(stream.read(new byte[l]), l);
     }
 }

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools.seekablestream;
+
+import htsjdk.HtsjdkTest;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class SeekableStreamTest extends HtsjdkTest {
+
+    @Test
+    public void testMarkAndReset() throws Exception {
+        final int length = 100;
+        // instantiate the stream
+        final SeekableStream stream = getRandomSeekableStream(length);
+        // read one byte and mark the stream
+        stream.read();
+        stream.mark(0);
+        final int current = stream.read();
+        // consume the stream
+        stream.readFully(new byte[length - 2]);
+        Assert.assertEquals(stream.read(), -1);
+        // come back to the mark
+        stream.reset();
+        Assert.assertEquals(stream.read(), current);
+    }
+
+    @Test
+    public void testResetUnmark() throws Exception {
+        final int length = 100;
+        // instantiate the stream
+        final SeekableStream stream = getRandomSeekableStream(100);
+        // consume the stream
+        final int current = stream.read();
+        stream.readFully(new byte[length - 1]);
+        Assert.assertEquals(stream.read(), -1);
+        stream.reset();
+        Assert.assertEquals(stream.read(), current);
+    }
+
+    private static SeekableStream getRandomSeekableStream(final int size) {
+        // generate random array
+        final byte[] array = new byte[size];
+        new Random().nextBytes(array);
+        // instantiate the stream
+        return new SeekableMemoryStream(array, "test");
+    }
+
+}


### PR DESCRIPTION
### Description

`SeekableStream` is a random access implementation of `InputStream`, which conceptually is able to support marking in any case. This PR adds mark support to the abstract class `SeekableStream`, to allow every implementation to support marks.

In addition, it improves the seekable stream documentation.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

