### PR TITLE
Fix very slow iteration over single read

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AbstractLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractLocusIterator.java
@@ -480,9 +480,7 @@ public abstract class AbstractLocusIterator<T extends AbstractRecordAndOffset, K
             i++;
         }
         if (i > 0){
-            List<K> temporaryList = new ArrayList<>(accumulator.subList(i, accumulator.size()));
-            accumulator.clear();
-            accumulator.addAll(temporaryList);
+            accumulator.subList(0, i).clear();
         }
     }
 

--- a/src/main/java/htsjdk/samtools/util/AbstractLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractLocusIterator.java
@@ -438,10 +438,8 @@ public abstract class AbstractLocusIterator<T extends AbstractRecordAndOffset, K
     private void populateCompleteQueue(final Locus stopBeforeLocus) {
         // Because of gapped alignments, it is possible to create LocusInfo's with no reads associated with them.
         // Skip over these if not including indels
-        while (!accumulator.isEmpty() && accumulator.get(0).isEmpty() &&
-                locusComparator.compare(accumulator.get(0), stopBeforeLocus) < 0) {
-            accumulator.remove(0);
-        }
+        accumulator.removeIf(x -> x.isEmpty() && locusComparator.compare(x, stopBeforeLocus) < 0);
+
         if (accumulator.isEmpty()) {
             return;
         }

--- a/src/main/java/htsjdk/samtools/util/AbstractLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractLocusIterator.java
@@ -438,7 +438,7 @@ public abstract class AbstractLocusIterator<T extends AbstractRecordAndOffset, K
     private void populateCompleteQueue(final Locus stopBeforeLocus) {
         // Because of gapped alignments, it is possible to create LocusInfo's with no reads associated with them.
         // Skip over these if not including indels
-        accumulator.removeIf(x -> x.isEmpty() && locusComparator.compare(x, stopBeforeLocus) < 0);
+        removeSkippedRegion(stopBeforeLocus);
 
         if (accumulator.isEmpty()) {
             return;
@@ -471,6 +471,19 @@ public abstract class AbstractLocusIterator<T extends AbstractRecordAndOffset, K
 
         lastReferenceSequence = sequenceIndex;
         lastPosition = locusInfo.getPosition();
+    }
+
+    private void removeSkippedRegion(Locus stopBeforeLocus) {
+        int i = 0;
+        while (i < accumulator.size() && accumulator.get(i).isEmpty() &&
+                locusComparator.compare(accumulator.get(i), stopBeforeLocus) < 0) {
+            i++;
+        }
+        if (i > 0){
+            List<K> temporaryList = new ArrayList<>(accumulator.subList(i, accumulator.size()));
+            accumulator.clear();
+            accumulator.addAll(temporaryList);
+        }
     }
 
     protected SAMSequenceRecord getReferenceSequence(final int referenceSequenceIndex) {


### PR DESCRIPTION
### Description
Optimization of the iteration algorithm of the `AbstractLocusIterator`. 

When we use `SamLocusIterator` iteration over read that contains a long skipped region is very slow (about 27 seconds to skip 500 kbp - measurement from [issue](https://github.com/samtools/htsjdk/issues/838)).

Method `populateCompleteQueue()` used to remove empty regions from the `accumulator` by multiple invocations of the 'ArrayList' method  `remove()` (which uses System.arrayCopy() on each invocation). 

## Implementation
Empty regions now removed from accumulator with `ArrayList` method `removeIf()`.

## Performance
Test from issue took 1,6 sec. in our environment (in old realization it took 120 sec under the same conditions).

Other performance measurements:

| Cigar | Old method (ops/ms) | New method (ops/ms) |
| ------ | ------ | ------ |
| 2M2N2M2N2M2N2M2N2M2N2M2N2M2N2M2N2M2N18M | 97.144 ± 7.383 | 91.954 ± 8.647 |
| 18M2N18M | 96.661 ± 7.635 | 97.909 ± 13.210 |
| 18M5N18M | 103.623 ± 9.811 | 115.499 ± 10.209 |
| 18M50N18M | 103.476 ± 3.624 | 86.691 ± 12.006 |
| 18M500N18M | 27.233 ± 1.057 | 29.789 ± 2.166 |
| 18M5000N18M | 0.986 ± 0.203 | 3.403 ± 0.183 |
| 18M50000N18M | 0.013 ± 0.001 | 0.297 ± 0.016 |
| 18M500000N18M | ~ 10⁻⁴ | 60 * 10⁻⁴ ± 10 * 10⁻⁴ |

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

