### PR TITLE
Fix for issue #1021

### DIFF
--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -189,7 +189,13 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      * @return
      */
     public static boolean hasBlockCompressedExtension (final URI uri) {
-        return hasBlockCompressedExtension(uri.getPath());
+
+        String path = uri.getPath();
+        int qIdx = path.indexOf('?');
+        if(qIdx > 0) {
+            path = path.substring(0, qIdx);
+        }
+        return hasBlockCompressedExtension(path);
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -167,8 +167,16 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      * @return
      */
     public static boolean hasBlockCompressedExtension (final String fileName) {
+
+        String path = fileName;
+        if(path.startsWith("http://") || path.startsWith("https://")) {
+            int qIdx = path.indexOf('?');
+            if (qIdx > 0) {
+                path = path.substring(0, qIdx);
+            }
+        }
         for (final String extension : BLOCK_COMPRESSED_EXTENSIONS) {
-            if (fileName.toLowerCase().endsWith(extension))
+            if (path.toLowerCase().endsWith(extension))
                 return true;
         }
         return false;
@@ -191,9 +199,14 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
     public static boolean hasBlockCompressedExtension (final URI uri) {
 
         String path = uri.getPath();
-        int qIdx = path.indexOf('?');
-        if(qIdx > 0) {
-            path = path.substring(0, qIdx);
+
+        // JTR -- it appears that this method is called for both local and remote files.
+        // Path might be a local file, in which case a '?' is a legal part of the filename.
+        if(path.startsWith("http://") || path.startsWith("https://")) {
+            int qIdx = path.indexOf('?');
+            if (qIdx > 0) {
+                path = path.substring(0, qIdx);
+            }
         }
         return hasBlockCompressedExtension(path);
     }


### PR DESCRIPTION
This is a patch for issue #1021.  It is admittedly crude, you might want to handle it in some other way, in which case consider this PR illustrative.

It looks like someone has assumed that uri.getPath() will return the path minus query parameters, which in fact it does not.

