### PR TITLE
Add a mention of the cause to SAMFileWriterFactory error messages

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -32,7 +32,6 @@ import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -300,7 +300,7 @@ public class SAMFileWriterFactory implements Cloneable {
             if (this.useAsyncIo) return new AsyncSAMFileWriter(ret, this.asyncOutputBufferSize);
             else return ret;
         } catch (final IOException ioe) {
-            throw new RuntimeIOException("Error opening file: " + outputPath.toUri());
+            throw new RuntimeIOException("Error opening file '" + outputPath.toUri() + "': " + ioe);
         }
     }
 
@@ -352,7 +352,7 @@ public class SAMFileWriterFactory implements Cloneable {
                                         samFlagFieldOutput);
             return initWriter(header, presorted, ret);
         } catch (final IOException ioe) {
-            throw new RuntimeIOException("Error opening file: " + outputPath.toUri());
+            throw new RuntimeIOException("Error opening file '" + outputPath.toUri() + "': " + ioe);
         }
     }
 
@@ -588,7 +588,7 @@ public class SAMFileWriterFactory implements Cloneable {
                     indexOS = Files.newOutputStream(indexPath);
                 }
                 catch (final IOException ioe) {
-                    throw new RuntimeIOException("Error creating index file for: " + indexPath.toUri());
+                    throw new RuntimeIOException("Error creating index file for '" + indexPath.toUri()+ "': " + ioe);
                 }
             }
         }
@@ -597,7 +597,7 @@ public class SAMFileWriterFactory implements Cloneable {
             cramOS = IOUtil.maybeBufferOutputStream(Files.newOutputStream(outputFile), bufferSize);
         }
         catch (final IOException ioe) {
-            throw new RuntimeIOException("Error creating CRAM file: " + outputFile.toUri());
+            throw new RuntimeIOException("Error creating CRAM file '" + outputFile.toUri() + "': " + ioe);
         }
 
         final Path md5Path = IOUtil.addExtension(outputFile, ".md5");

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -300,7 +300,7 @@ public class SAMFileWriterFactory implements Cloneable {
             if (this.useAsyncIo) return new AsyncSAMFileWriter(ret, this.asyncOutputBufferSize);
             else return ret;
         } catch (final IOException ioe) {
-            throw new RuntimeIOException("Error opening file '" + outputPath.toUri() + "': " + ioe);
+            throw new RuntimeIOException("Error opening file: " + outputPath.toUri(), ioe);
         }
     }
 
@@ -352,7 +352,7 @@ public class SAMFileWriterFactory implements Cloneable {
                                         samFlagFieldOutput);
             return initWriter(header, presorted, ret);
         } catch (final IOException ioe) {
-            throw new RuntimeIOException("Error opening file '" + outputPath.toUri() + "': " + ioe);
+            throw new RuntimeIOException("Error opening file: " + outputPath.toUri(), ioe);
         }
     }
 
@@ -588,7 +588,7 @@ public class SAMFileWriterFactory implements Cloneable {
                     indexOS = Files.newOutputStream(indexPath);
                 }
                 catch (final IOException ioe) {
-                    throw new RuntimeIOException("Error creating index file for '" + indexPath.toUri()+ "': " + ioe);
+                    throw new RuntimeIOException("Error creating index file for: " + indexPath.toUri(), ioe);
                 }
             }
         }
@@ -597,7 +597,7 @@ public class SAMFileWriterFactory implements Cloneable {
             cramOS = IOUtil.maybeBufferOutputStream(Files.newOutputStream(outputFile), bufferSize);
         }
         catch (final IOException ioe) {
-            throw new RuntimeIOException("Error creating CRAM file '" + outputFile.toUri() + "': " + ioe);
+            throw new RuntimeIOException("Error creating CRAM file: " + outputFile.toUri(), ioe);
         }
 
         final Path md5Path = IOUtil.addExtension(outputFile, ".md5");

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -32,6 +32,7 @@ import htsjdk.samtools.util.IOUtil;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.file.FileSystem;
+import java.nio.file.Paths;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -73,6 +74,14 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
             Assert.assertTrue(Files.size(outputPath) > 0);
             Assert.assertTrue(Files.size(indexPath) > 0);
             Assert.assertTrue(Files.size(md5File) > 0);
+        }
+    }
+
+    @Test(expectedExceptions = {htsjdk.samtools.util.RuntimeIOException.class}, expectedExceptionsMessageRegExp = ".*NoSuchFileException.*")
+    public void PathWriterFailureMentionsCause() throws Exception {
+        try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path outputPath = Paths.get("nope://no.txt");
+            createSmallBam(outputPath);
         }
     }
 

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -83,7 +83,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
         try {
             final Path outputPath = Paths.get("nope://no.txt");
             createSmallBam(outputPath);
-            Assert.assertFalse(true, "Should have thrown a RuntimeIOException");
+            Assert.fail("Should have thrown a RuntimeIOException");
         } catch (RuntimeIOException expected) {
             Assert.assertTrue(expected.getCause().toString().contains("NoSuchFileException"));
         }

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -86,7 +86,6 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
             Assert.assertFalse(true, "Should have thrown a RuntimeIOException");
         } catch (RuntimeIOException expected) {
             Assert.assertTrue(expected.getCause().toString().contains("NoSuchFileException"));
-            throw(expected);
         }
     }
 

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -29,6 +29,7 @@ import com.google.common.jimfs.Jimfs;
 import htsjdk.samtools.cram.build.CramIO;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.RuntimeIOException;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.file.FileSystem;
@@ -77,11 +78,15 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
         }
     }
 
-    @Test(expectedExceptions = {htsjdk.samtools.util.RuntimeIOException.class}, expectedExceptionsMessageRegExp = ".*NoSuchFileException.*")
+    @Test()
     public void PathWriterFailureMentionsCause() throws Exception {
-        try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+        try {
             final Path outputPath = Paths.get("nope://no.txt");
             createSmallBam(outputPath);
+            Assert.assertFalse(true, "Should have thrown a RuntimeIOException");
+        } catch (RuntimeIOException expected) {
+            Assert.assertTrue(expected.getCause().toString().contains("NoSuchFileException"));
+            throw(expected);
         }
     }
 

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -79,7 +79,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
     }
 
     @Test()
-    public void PathWriterFailureMentionsCause() throws Exception {
+    public void pathWriterFailureMentionsCause() throws Exception {
         try {
             final Path outputPath = Paths.get("nope://no.txt");
             createSmallBam(outputPath);


### PR DESCRIPTION
### Description

Auth-related auth errors [would be easier to debug](https://github.com/broadinstitute/gatk/issues/2422#issuecomment-342255531) if our error message included something about the cause.

This change adds this bit of text for those errors with `SamFileWriterFactory`, and a test to make sure it's there. It only addresses the concern about clarity of the error, not about the correct display of the file name.

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [X] Extended the README / documentation, if necessary (not necessary)
- [ ] Is not backward compatible (breaks binary or source compatibility)

