### PR TITLE
Bugfix for BAM index bins

### DIFF
--- a/src/test/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
@@ -2,11 +2,15 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.seekablestream.SeekableStream;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
 
 public class AbstractBAMFileIndexTest extends HtsjdkTest {
+
+    private static final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
 
     /**
      * @see <a href="https://github.com/samtools/htsjdk/issues/73">https://github.com/samtools/htsjdk/issues/73</a>
@@ -59,5 +63,47 @@ public class AbstractBAMFileIndexTest extends HtsjdkTest {
         buffer.readLong();
         buffer.readInteger();
         buffer.readBytes(new byte[10000]);
+    }
+
+    @Test
+    public static void testGetNumIndexLevels() {
+        Assert.assertEquals(AbstractBAMFileIndex.getNumIndexLevels(), 6);
+    }
+
+    @Test
+    public static void testGetFirstBinInLevelOK() {
+        Assert.assertEquals(AbstractBAMFileIndex.getFirstBinInLevel(0), 0);
+        Assert.assertEquals(AbstractBAMFileIndex.getFirstBinInLevel(1), 1);
+        Assert.assertEquals(AbstractBAMFileIndex.getFirstBinInLevel(2), 9);
+        Assert.assertEquals(AbstractBAMFileIndex.getFirstBinInLevel(3), 73);
+        Assert.assertEquals(AbstractBAMFileIndex.getFirstBinInLevel(4), 585);
+        Assert.assertEquals(AbstractBAMFileIndex.getFirstBinInLevel(5), 4681);
+    }
+
+    @Test (expectedExceptions = SAMException.class)
+    public static void testGetFirstBinInLevelFail() {
+        AbstractBAMFileIndex.getFirstBinInLevel(6);
+    }
+
+    @Test
+    public static void testGetLevelSizeOK() {
+
+        final AbstractBAMFileIndex afi = new DiskBasedBAMFileIndex(new File(BAM_FILE.getPath() + ".bai"),
+                null);
+
+        Assert.assertEquals(afi.getLevelSize(0), 1);
+        Assert.assertEquals(afi.getLevelSize(1), 8);
+        Assert.assertEquals(afi.getLevelSize(2), 64);
+        Assert.assertEquals(afi.getLevelSize(3), 512);
+        Assert.assertEquals(afi.getLevelSize(4), 4096);
+        Assert.assertEquals(afi.getLevelSize(5), 32768);
+    }
+
+    @Test (expectedExceptions = SAMException.class)
+    public static void testGetLevelSizeFail() {
+
+        final AbstractBAMFileIndex afi = new DiskBasedBAMFileIndex(new File(BAM_FILE.getPath() + ".bai"),
+                null);
+        afi.getFirstBinInLevel(6);
     }
 }

--- a/src/test/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 public class AbstractBAMFileIndexTest extends HtsjdkTest {
 
-    private static final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private static final AbstractBAMFileIndex afi = new DiskBasedBAMFileIndex(new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai"), null);
 
     /**
      * @see <a href="https://github.com/samtools/htsjdk/issues/73">https://github.com/samtools/htsjdk/issues/73</a>
@@ -87,10 +87,6 @@ public class AbstractBAMFileIndexTest extends HtsjdkTest {
 
     @Test
     public static void testGetLevelSizeOK() {
-
-        final AbstractBAMFileIndex afi = new DiskBasedBAMFileIndex(new File(BAM_FILE.getPath() + ".bai"),
-                null);
-
         Assert.assertEquals(afi.getLevelSize(0), 1);
         Assert.assertEquals(afi.getLevelSize(1), 8);
         Assert.assertEquals(afi.getLevelSize(2), 64);
@@ -101,9 +97,6 @@ public class AbstractBAMFileIndexTest extends HtsjdkTest {
 
     @Test (expectedExceptions = SAMException.class)
     public static void testGetLevelSizeFail() {
-
-        final AbstractBAMFileIndex afi = new DiskBasedBAMFileIndex(new File(BAM_FILE.getPath() + ".bai"),
-                null);
         afi.getLevelSize(6);
     }
 }

--- a/src/test/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
@@ -104,6 +104,6 @@ public class AbstractBAMFileIndexTest extends HtsjdkTest {
 
         final AbstractBAMFileIndex afi = new DiskBasedBAMFileIndex(new File(BAM_FILE.getPath() + ".bai"),
                 null);
-        afi.getFirstBinInLevel(6);
+        afi.getLevelSize(6);
     }
 }


### PR DESCRIPTION
1. Fixes a bug: `ArrayIndexOutOfBoundsException` would be thrown if `levelNumber` is too big.
2. Fixes a bug: the level size for the last level was miscalculated. It should be **32768** (2^15).
3. Removes the unused method `regionToBins`, whose code was already implemented in the class `GenomicIndexUtil`.

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

