### PR TITLE
Adds option to validator to skip mate validation

### DIFF
--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -147,6 +147,10 @@ public class SamFileValidator {
         this.skipMateValidation = skipMateValidation;
     }
 
+    public boolean getSkipMateValidation() {
+        return skipMateValidation;
+    }
+
     /**
      * Outputs validation summary report to out.
      *

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -140,8 +140,8 @@ public class SamFileValidator {
     }
 
     /**
-     * Sets whether or not we should go ahead and run mate validation.  For extreme cases, mate validation
-     * can require a ton of memory and we want to provide the option of skipping it.
+     * Sets whether or not we should go ahead and run mate validation beyond the mate cigar check.  For extreme cases,
+     * mate validation can require a ton of memory and we want to provide the option of skipping it.
      */
     public void setSkipMateValidation(final boolean skipMateValidation) {
         this.skipMateValidation = skipMateValidation;
@@ -311,10 +311,7 @@ public class SamFileValidator {
                     }
                 }
 
-                if (!skipMateValidation) {
-                    validateMateFields(record, recordNumber);
-                }
-
+                validateMateFields(record, recordNumber);
                 final boolean hasValidSortOrder = validateSortOrder(record, recordNumber);
                 validateReadGroup(record, header);
                 final boolean cigarIsValid = validateCigar(record, recordNumber);
@@ -520,6 +517,10 @@ public class SamFileValidator {
             return;
         }
         validateMateCigar(record, recordNumber);
+
+        if (skipMateValidation) {
+            return;
+        }
 
         final PairEndInfo pairEndInfo = pairEndInfoByName.remove(record.getReferenceIndex(), record.getReadName());
         if (pairEndInfo == null) {

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -94,6 +94,7 @@ public class SamFileValidator {
     private SAMSortOrderChecker orderChecker;
     private Set<Type> errorsToIgnore;
     private boolean ignoreWarnings;
+    private boolean skipMateValidation;
     private boolean bisulfiteSequenced;
     private IndexValidationStringency indexValidationStringency;
     private boolean sequenceDictionaryEmptyAndNoWarningEmitted;
@@ -114,6 +115,7 @@ public class SamFileValidator {
         this.errorsToIgnore = EnumSet.noneOf(Type.class);
         this.verbose = false;
         this.ignoreWarnings = false;
+        this.skipMateValidation = false;
         this.bisulfiteSequenced = false;
         this.sequenceDictionaryEmptyAndNoWarningEmitted = false;
         this.numWarnings = 0;
@@ -135,6 +137,14 @@ public class SamFileValidator {
 
     public void setIgnoreWarnings(final boolean ignoreWarnings) {
         this.ignoreWarnings = ignoreWarnings;
+    }
+
+    /**
+     * Sets whether or not we should go ahead and run mate validation.  For extreme cases, mate validation
+     * can require a ton of memory and we want to provide the option of skipping it.
+     */
+    public void setSkipMateValidation(final boolean skipMateValidation) {
+        this.skipMateValidation = skipMateValidation;
     }
 
     /**
@@ -301,7 +311,10 @@ public class SamFileValidator {
                     }
                 }
 
-                validateMateFields(record, recordNumber);
+                if (!skipMateValidation) {
+                    validateMateFields(record, recordNumber);
+                }
+
                 final boolean hasValidSortOrder = validateSortOrder(record, recordNumber);
                 validateReadGroup(record, header);
                 final boolean cigarIsValid = validateCigar(record, recordNumber);

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -140,13 +140,18 @@ public class SamFileValidator {
     }
 
     /**
-     * Sets whether or not we should go ahead and run mate validation beyond the mate cigar check.  For extreme cases,
-     * mate validation can require a ton of memory and we want to provide the option of skipping it.
+     * Sets whether or not we should run mate validation beyond the mate cigar check, which
+     * is useful in extreme edge cases that would require a lot of memory to do the validation.
+     *
+     * @param skipMateValidation should this tool skip mate validation
      */
     public void setSkipMateValidation(final boolean skipMateValidation) {
         this.skipMateValidation = skipMateValidation;
     }
 
+    /**
+     * @return true if the validator will skip mate validation, otherwise false
+     */
     public boolean getSkipMateValidation() {
         return skipMateValidation;
     }
@@ -255,7 +260,6 @@ public class SamFileValidator {
             out.flush();
         }
     }
-
 
     /**
      * Report on reads marked as paired, for which the mate was not found.

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -199,7 +199,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
         records.next();
         records.remove();
         final Histogram<String> results = executeValidationWithErrorIgnoring(samBuilder.getSamReader(), null, IndexValidationStringency.EXHAUSTIVE, Collections.EMPTY_LIST, true);
-        Assert.assertEquals(results.isEmpty(), true);
+        Assert.assertEquals(results.get(SAMValidationError.Type.MATE_NOT_FOUND.getHistogramString()).getValue(), 0.0);
     }
 
     @DataProvider(name = "missingMateTestCases")


### PR DESCRIPTION
### Description

Added an option to the SAM validator to skip mate validation.

Mate validation is an extremely expensive operation memory-wise for certain classes of data.  Specifically, inputs that either have duplicate sets with many millions of reads or that have high rates of chimerism will trigger terrible edge case behavior requiring the tool to maintain many (many, many) reads in memory.  This just provides a simple way for one to generally validate those files without requiring the massive memory footprint (or ripping the guts out and rewriting it all). 
    
### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

