### PR TITLE
Issue #1030: Restore default tmpdir for SortingCollection before PR #910.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ final gitVersion = gitVersion().replaceAll(".dirty", "")
 version = isRelease ? gitVersion : gitVersion + "-SNAPSHOT"
 
 logger.info("build for version:" + version)
-group = 'com.github.samtools'
+group = 'com.github.tbl3rd'
 
 defaultTasks 'jar'
 
@@ -188,8 +188,8 @@ uploadArchives {
                 }
 
                 scm {
-                    url 'git@github.com:samtools/htsjdk.git'
-                    connection 'scm:git:git@github.com:samtools/htsjdk.git'
+                    url 'git@github.com:tbl3rd/htsjdk.git'
+                    connection 'scm:git:git@github.com:tbl3rd/htsjdk.git'
                 }
 
                 licenses {

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ final gitVersion = gitVersion().replaceAll(".dirty", "")
 version = isRelease ? gitVersion : gitVersion + "-SNAPSHOT"
 
 logger.info("build for version:" + version)
-group = 'com.github.tbl3rd'
+group = 'com.github.samtools'
 
 defaultTasks 'jar'
 
@@ -188,8 +188,8 @@ uploadArchives {
                 }
 
                 scm {
-                    url 'git@github.com:tbl3rd/htsjdk.git'
-                    connection 'scm:git:git@github.com:tbl3rd/htsjdk.git'
+                    url 'git@github.com:samtools/htsjdk.git'
+                    connection 'scm:git:git@github.com:samtools/htsjdk.git'
                 }
 
                 licenses {

--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -344,7 +345,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM) {
 
-        final Path tmpDir = IOUtil.getDefaultTmpDirPath();
+        final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
         return new SortingCollection<T>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
     }
 


### PR DESCRIPTION
Fix Issue #1030 by restoring `SortingCollection.newInstance()` to its behavior before PR #910.

- [x] Code compiles correctly
It compiles.
- [x] New tests covering changes and new functionality
Wasn't tested before. Isn't tested now.
- [x] All tests passing
They pass, but the JVM throws on shutdown as before. See Issue #1029.
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)


