### PR TITLE
fixing crash on shutdown hook #1029

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -360,16 +360,16 @@ public class IOUtil {
      *
      * @see #deleteOnExit(Path)
      */
-    protected static final class DeletePathThread extends Thread {
+    static final class DeletePathThread extends Thread {
 
         private final Path path;
 
-        protected DeletePathThread(Path path) {this.path = path;}
+        DeletePathThread(Path path) {this.path = path;}
 
         @Override
         public void run() {
             try {
-                Files.delete(path);
+                Files.deleteIfExists(path);
             } catch (IOException e) {
                 throw new RuntimeIOException(e);
             }


### PR DESCRIPTION
fixing the crash on shutdown introduced in #910 by changin the command
that gets run on deleteOnExit
Files.delete() -> Files.deleteIfExists()
this will prevent the jvm from crashing on shutdown if the temporary
files get cleaned up before it closes

This still leaves open the possibilty of crash on shutdown if the
temporary file is unable to be removed for some other reason.  That's
subtly different than the File version of deleteOnExit, but it may be
useful to get these error messages in the unusual case of failing to
delete a file that exists.

fixes #1029 