### PR TITLE
strip query from URL before testing extension

### DIFF
--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -167,11 +167,28 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      * @return
      */
     public static boolean hasBlockCompressedExtension (final String fileName) {
+        String cleanedPath = stripQueryStringIfPathIsAnHttpUrl(fileName);
         for (final String extension : BLOCK_COMPRESSED_EXTENSIONS) {
-            if (fileName.toLowerCase().endsWith(extension))
+            if (cleanedPath.toLowerCase().endsWith(extension))
                 return true;
         }
         return false;
+    }
+
+    /**
+     * Remove http query before checking extension
+     * Path might be a local file, in which case a '?' is a legal part of the filename.
+     * @param path a string representing some sort of path, potentially an http url
+     * @return path with no trailing queryString (ex: http://something.com/path.vcf?stuff=something => http://something.com/path.vcf)
+     */
+    private static String stripQueryStringIfPathIsAnHttpUrl(String path) {
+        if(path.startsWith("http://") || path.startsWith("https://")) {
+            int qIdx = path.indexOf('?');
+            if (qIdx > 0) {
+                return path.substring(0, qIdx);
+            }
+        }
+        return path;
     }
 
     /**
@@ -189,7 +206,8 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
      * @return
      */
     public static boolean hasBlockCompressedExtension (final URI uri) {
-        return hasBlockCompressedExtension(uri.getPath());
+        String path = uri.getPath();
+        return hasBlockCompressedExtension(path);
     }
 
     /**

--- a/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
@@ -127,10 +127,16 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings")
-    public void testBlockCompressionExtension(final String testURIString, final boolean expected) throws URISyntaxException {
+    public void testBlockCompressionExtension(final String testURIString, final boolean expected) {
         URI testURI = URI.create(testURIString);
         Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(testURI), expected);
     }
+
+    @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings")
+    public void testBlockCompressionExtensionStringVersion(final String testURIString, final boolean expected) {
+        Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(testURIString), expected);
+    }
+
 
     @DataProvider(name = "vcfFileAndWrapperCombinations")
     private static Object[][] vcfFileAndWrapperCombinations(){


### PR DESCRIPTION
Fixes htsjdk issue #1021

minor refactor of https://github.com/samtools/htsjdk/pull/1022 by @jrobinso 
added a test for the string case
