### PR TITLE
Add DeleteOnExitPathHook to register java.nio.Path for deletion

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -31,6 +31,7 @@ import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableHTTPStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.tribble.Tribble;
+import htsjdk.samtools.util.nio.DeleteOnExitPathHook;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -353,34 +354,12 @@ public class IOUtil {
     }
 
     /**
-     * Deletes on exit a path by creating a shutdown hook.
+     * Register a {@link Path} for deletion on JVM exit.
+     *
+     * @see DeleteOnExitPathHook
      */
     public static void deleteOnExit(final Path path) {
-        // add a shutdown hook to remove the path on exit
-        Runtime.getRuntime().addShutdownHook(new DeletePathThread(path));
-    }
-
-    /**
-     * WARNING: visible for testing. Do not use.
-     *
-     * Class for delete a path, used in a shutdown hook for delete on exit.
-     *
-     * @see #deleteOnExit(Path)
-     */
-    static final class DeletePathThread extends Thread {
-
-        private final Path path;
-
-        DeletePathThread(Path path) {this.path = path;}
-
-        @Override
-        public void run() {
-            try {
-                Files.deleteIfExists(path);
-            } catch (IOException e) {
-                throw new RuntimeIOException(e);
-            }
-        }
+        DeleteOnExitPathHook.add(path);
     }
 
     /** Returns the name of the file minus the extension (i.e. text after the last "." in the filename). */

--- a/src/main/java/htsjdk/samtools/util/nio/DeleteOnExitPathHook.java
+++ b/src/main/java/htsjdk/samtools/util/nio/DeleteOnExitPathHook.java
@@ -1,0 +1,63 @@
+package htsjdk.samtools.util.nio;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+
+/**
+ * Class to hold a set of {@link Path} to be delete on the JVM exit through a shutdown hook.
+ *
+ * <p>This class is a modification of {@link java.io.DeleteOnExitHook} to handle {@link Path}
+ * instead of {@link java.io.File}.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class DeleteOnExitPathHook {
+    private static LinkedHashSet<Path> paths = new LinkedHashSet<>();
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(DeleteOnExitPathHook::runHooks));
+    }
+
+    private DeleteOnExitPathHook() {}
+
+    /**
+     * Adds a {@link Path} for deletion on JVM exit.
+     *
+     * @param path path to be deleted.
+     *
+     * @throws IllegalStateException if the shutdown hook is in progress.
+     */
+    public static synchronized void add(Path path) {
+        if(paths == null) {
+            // DeleteOnExitHook is running. Too late to add a file
+            throw new IllegalStateException("Shutdown in progress");
+        }
+
+        paths.add(path);
+    }
+
+    static void runHooks() {
+        LinkedHashSet<Path> thePaths;
+
+        synchronized (DeleteOnExitPathHook.class) {
+            thePaths = paths;
+            paths = null;
+        }
+
+        ArrayList<Path> toBeDeleted = new ArrayList<>(thePaths);
+
+        // reverse the list to maintain previous jdk deletion order.
+        // Last in first deleted.
+        Collections.reverse(toBeDeleted);
+        for (Path path : toBeDeleted) {
+            try {
+                Files.delete(path);
+            } catch (IOException | RuntimeException e) {
+                // do nothing if cannot be deleted, because it is a shutdown hook
+            }
+        }
+    }
+}

--- a/src/main/java/htsjdk/samtools/util/nio/DeleteOnExitPathHook.java
+++ b/src/main/java/htsjdk/samtools/util/nio/DeleteOnExitPathHook.java
@@ -55,7 +55,7 @@ public class DeleteOnExitPathHook {
         for (Path path : toBeDeleted) {
             try {
                 Files.delete(path);
-            } catch (IOException | RuntimeException e) {
+            } catch (IOException | SecurityException e) {
                 // do nothing if cannot be deleted, because it is a shutdown hook
             }
         }

--- a/src/test/java/htsjdk/samtools/util/IoUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IoUtilTest.java
@@ -353,21 +353,6 @@ public class IoUtilTest extends HtsjdkTest {
     }
 
     @DataProvider
-    public Object[][] pathsForDeletePathThread() throws Exception {
-        return new Object[][] {
-                {File.createTempFile("testDeletePathThread", "file").toPath()},
-                {Files.createFile(inMemoryfileSystem.getPath("testDeletePathThread"))}
-        };
-    }
-
-    @Test(dataProvider = "pathsForDeletePathThread")
-    public void testDeletePathThread(final Path path) throws Exception {
-        Assert.assertTrue(Files.exists(path));
-        new IOUtil.DeletePathThread(path).run();
-        Assert.assertFalse(Files.exists(path));
-    }
-
-    @DataProvider
     public Object[][] pathsForWritableDirectory() throws Exception {
         return new Object[][] {
                 // non existent


### PR DESCRIPTION
### Description

After https://github.com/samtools/htsjdk/pull/910, I introduced an crash while deleting on exit a `java.nio.Path`. This was fixed by https://github.com/samtools/htsjdk/pull/1032, but I explore a bit the java base code to check what the `File` version is handling the deletion on exit.

It turns out that it is also using a shutdown hook, but a common one for all the registered files (see [`java.io.DeleteOnExitHook`](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/java/io/DeleteOnExitHook.java)). Here, I mimic that class to register for deletion the `java.nio.Path` in `IOUtils` and run a single shutdown hook for all of them, ignoring any `IOException` or `RuntimeException`. I think that this will be more consistent with the behaviour expected by `File.deleteOnExit()`

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

