### PR TITLE
Add checks on Histogram::getPercentile to protect against total sum…

### DIFF
--- a/src/main/java/htsjdk/samtools/util/Histogram.java
+++ b/src/main/java/htsjdk/samtools/util/Histogram.java
@@ -324,17 +324,17 @@ public final class Histogram<K extends Comparable> implements Serializable {
                 .filter(b -> b.getValue() < 0)
                 .findFirst()
                 .ifPresent(b -> {
-            throw new IllegalArgumentException("Cannot calculate Percentile when negative counts are present " +
+            throw new IllegalStateException("Cannot calculate Percentile when negative counts are present " +
                     "in histogram. Bin " + b.getId() + "=" + b.getValue());
         });
 
         final double total = getCount();
-        if (total == 0) throw new IllegalArgumentException("Cannot calculate percentiles when total is zero.");
+        if (total == 0) throw new IllegalStateException("Cannot calculate percentiles when total is zero.");
 
-        double sofar = 0;
+        double soFar = 0;
         for (Bin<K> bin : values()) {
-            sofar += bin.getValue();
-            if (sofar / total >= percentile) return bin.getIdValue();
+            soFar += bin.getValue();
+            if (soFar / total >= percentile) return bin.getIdValue();
         }
 
         throw new IllegalStateException("UNPOSSIBLE! Could not find percentile: " + percentile);

--- a/src/test/java/htsjdk/samtools/util/HistogramTest.java
+++ b/src/test/java/htsjdk/samtools/util/HistogramTest.java
@@ -230,7 +230,7 @@ public class HistogramTest extends HtsjdkTest {
         };
     }
 
-    @Test(dataProvider = "percentileFailData",expectedExceptions = IllegalArgumentException.class)
+    @Test(dataProvider = "percentileFailData",expectedExceptions = IllegalStateException.class)
     public void testPercentileFail1(final Histogram<Integer> histo) {
         histo.getPercentile(0.01);
     }

--- a/src/test/java/htsjdk/samtools/util/HistogramTest.java
+++ b/src/test/java/htsjdk/samtools/util/HistogramTest.java
@@ -212,6 +212,29 @@ public class HistogramTest extends HtsjdkTest {
         Assert.assertEquals(histo.getPercentile(0.99999), 6.0);
     }
 
+    @DataProvider
+    Object[][] percentileFailData(){
+        Histogram<Integer> histo1 = new Histogram<>();
+        Histogram<Integer> histo2 = new Histogram<>();
+        histo2.increment(0,0);
+
+        Histogram<Integer> histo3 = new Histogram<>();
+        final int[] is = {2, 3, 4, -1};
+        int j=0;
+        for (final int i : is) histo3.increment(j++, i);
+
+        return new Object[][]{
+                {histo1},
+                {histo2},
+                {histo3},
+        };
+    }
+
+    @Test(dataProvider = "percentileFailData",expectedExceptions = IllegalArgumentException.class)
+    public void testPercentileFail1(final Histogram<Integer> histo) {
+        histo.getPercentile(0.01);
+    }
+
     @Test
     public void testGetMinMax() {
         final int[] is = {4,4,5,5,5,6,6,6,6};


### PR DESCRIPTION
… equalling zero and negative values.

### Description
a recent (short-lived) picard issue showed that it is possible to get to an unreasonable part of the code of getPercentile if the histogram contains values that do not lend themselves to calculating percentiles...this PR adds protective code to error out more gracefully in that case.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

