### PR TITLE
Do not accumulate entire header in StringBuilder.

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -136,7 +136,6 @@ public class SAMTextHeaderCodec {
             return null;
         }
         mCurrentLine = mReader.readLine();
-        textHeader.append(mCurrentLine).append('\n');
         return mCurrentLine;
     }
 


### PR DESCRIPTION
Fixes #1045.

I haven't a clue why the entire header was accumulated in a `StringBuilder`, but removing the line that did so still passes all unit tests.