### PR TITLE
ReferenceSequenceFileWalker ctor accepts Path

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
@@ -30,6 +30,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * Manages a ReferenceSequenceFile.  Loads the requested sequence, ensuring that
@@ -43,6 +44,10 @@ public class ReferenceSequenceFileWalker implements Closeable {
 
     public ReferenceSequenceFileWalker(final ReferenceSequenceFile referenceSequenceFile) {
         this.referenceSequenceFile = referenceSequenceFile;
+    }
+
+    public ReferenceSequenceFileWalker(final Path path) {
+        this(ReferenceSequenceFileFactory.getReferenceSequenceFile(path, true, false));
     }
 
     public ReferenceSequenceFileWalker(final File file) {

--- a/src/test/java/htsjdk/samtools/reference/ReferenceSequenceFileWalkerTest.java
+++ b/src/test/java/htsjdk/samtools/reference/ReferenceSequenceFileWalkerTest.java
@@ -3,6 +3,8 @@ package htsjdk.samtools.reference;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.util.CloserUtil;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -27,6 +29,19 @@ public class ReferenceSequenceFileWalkerTest extends HtsjdkTest {
 
     @Test(dataProvider = "TestReference")
     public void testGet(final String fileName, final int index1, final int index2) throws SAMException {
+        final Path refPath = Paths.get(fileName);
+        final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(refPath);
+
+        ReferenceSequence sequence = refWalker.get(index1);
+        Assert.assertEquals(sequence.getContigIndex(), index1);
+
+        sequence = refWalker.get(index2);
+        Assert.assertEquals(sequence.getContigIndex(), index2);
+        CloserUtil.close(refWalker);
+    }
+
+    @Test(dataProvider = "TestReference")
+    public void testGetFile(final String fileName, final int index1, final int index2) throws SAMException {
         final File refFile = new File(fileName);
         final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(refFile);
 
@@ -57,8 +72,8 @@ public class ReferenceSequenceFileWalkerTest extends HtsjdkTest {
 
     @Test(expectedExceptions = {SAMException.class}, dataProvider = "TestFailReference")
     public void testFailGet(final String fileName, final int index1, final int index2) throws SAMException {
-        final File refFile = new File(fileName);
-        final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(refFile);
+        final Path refPath = Paths.get(fileName);
+        final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(refPath);
 
         try {
             refWalker.get(index1);


### PR DESCRIPTION
### Description

All `File`s are `Path`s, but not vice versa (paths can point to e.g. cloud storage). Hence it's important to have a version of the `ReferenceSequenceFileWalker` constructor that accepts a `Path` for ease of use (even though, now that I look at the code carefully, I see the caller could work around this by constructing their own `ReferenceSequenceFile` first).

This came up while working on an aspect of [Cloud support for GATK](https://github.com/broadinstitute/gatk/pull/3921).

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

