### PR TITLE
Modify FilterTag to Pass or Filter reads

### DIFF
--- a/src/main/java/htsjdk/samtools/filter/ReadNameFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/ReadNameFilter.java
@@ -81,17 +81,7 @@ public class ReadNameFilter implements SamRecordFilter {
      */
     @Override
     public boolean filterOut(final SAMRecord record) {
-        if (includeReads) {
-            if (readNameFilterSet.contains(record.getReadName())) {
-                return false;
-            }
-        } else {
-            if (!readNameFilterSet.contains(record.getReadName())) {
-                return false;
-            }
-        }
-
-        return true;
+        return readNameFilterSet.contains(record.getReadName()) != includeReads;
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/filter/TagFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/TagFilter.java
@@ -37,6 +37,7 @@ public class TagFilter implements SamRecordFilter {
 
     private final String tag;           // The key of the tag to match
     private final List<Object> values;  // The list of matching values
+    private boolean includeReads = false;
 
     /**
      * Constructor for a single value
@@ -44,9 +45,10 @@ public class TagFilter implements SamRecordFilter {
      * @param tag       the key of the tag to match
      * @param value     the value to match
      */
-    public TagFilter(String tag, Object value) {
+    public TagFilter(String tag, Object value, final boolean includeReads) {
         this.tag = tag;
         this.values = Arrays.asList(value);
+        this.includeReads = includeReads;
     }
 
     /**
@@ -55,9 +57,10 @@ public class TagFilter implements SamRecordFilter {
      * @param tag       the key of the tag to match
      * @param values    the matching values
      */
-    public TagFilter(String tag, List<Object> values) {
+    public TagFilter(String tag, List<Object> values, final boolean includeReads) {
         this.tag = tag;
         this.values = values;
+        this.includeReads = includeReads;
     }
 
     /**
@@ -68,7 +71,16 @@ public class TagFilter implements SamRecordFilter {
      */
     @Override
     public boolean filterOut(SAMRecord record) {
-        return values.contains(record.getAttribute(tag));
+        if (includeReads) {
+            if (values.contains(record.getAttribute(tag))) {
+                return false;
+            }
+        } else {
+            if (!values.contains(record.getAttribute(tag))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -82,6 +94,15 @@ public class TagFilter implements SamRecordFilter {
     @Override
     public boolean filterOut(final SAMRecord first, final SAMRecord second) {
         // both first and second must have the tag in order for it to be filtered out
-         return values.contains(first.getAttribute(tag)) && values.contains(second.getAttribute(tag));
+        if (includeReads) {
+            if (values.contains(first.getAttribute(tag)) && values.contains(second.getAttribute(tag))) {
+                return false;
+            }
+        } else {
+            if (!values.contains(first.getAttribute(tag)) && values.contains(second.getAttribute(tag))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/htsjdk/samtools/filter/TagFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/TagFilter.java
@@ -104,7 +104,8 @@ public class TagFilter implements SamRecordFilter {
      */
     @Override
     public boolean filterOut(final SAMRecord first, final SAMRecord second) {
-
+        // With includeReads==true, allow any pairs through that contain the tag value
+        // With includeReads==false, exclude pairs where both reads contain the tag value
         if (includeReads) {
             return !(values.contains(first.getAttribute(tag)) || values.contains(second.getAttribute(tag)));
         } else {

--- a/src/main/java/htsjdk/samtools/filter/TagFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/TagFilter.java
@@ -37,7 +37,7 @@ public class TagFilter implements SamRecordFilter {
 
     private final String tag;           // The key of the tag to match
     private final List<Object> values;  // The list of matching values
-    private boolean includeReads = false;
+    private boolean includeReads;
 
     /**
      * Constructor for a single value

--- a/src/main/java/htsjdk/samtools/filter/TagFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/TagFilter.java
@@ -37,13 +37,36 @@ public class TagFilter implements SamRecordFilter {
 
     private final String tag;           // The key of the tag to match
     private final List<Object> values;  // The list of matching values
-    private boolean includeReads;
+    private boolean includeReads = false;
 
     /**
      * Constructor for a single value
      *
      * @param tag       the key of the tag to match
      * @param value     the value to match
+     */
+    public TagFilter(String tag, Object value) {
+        this.tag = tag;
+        this.values = Arrays.asList(value);
+    }
+
+    /**
+     * Constructor for multiple values
+     *
+     * @param tag       the key of the tag to match
+     * @param values    the matching values
+     */
+    public TagFilter(String tag, List<Object> values) {
+        this.tag = tag;
+        this.values = values;
+    }
+
+    /**
+     * Constructor for a single value
+     *
+     * @param tag           the key of the tag to match
+     * @param value         the value to match
+     * @param includeReads  whether to include or not include reads that match filter
      */
     public TagFilter(String tag, Object value, final boolean includeReads) {
         this.tag = tag;
@@ -54,8 +77,9 @@ public class TagFilter implements SamRecordFilter {
     /**
      * Constructor for multiple values
      *
-     * @param tag       the key of the tag to match
-     * @param values    the matching values
+     * @param tag           the key of the tag to match
+     * @param values        the matching values
+     * @param includeReads  whether to include or not include reads that match filter
      */
     public TagFilter(String tag, List<Object> values, final boolean includeReads) {
         this.tag = tag;
@@ -71,16 +95,7 @@ public class TagFilter implements SamRecordFilter {
      */
     @Override
     public boolean filterOut(SAMRecord record) {
-        if (includeReads) {
-            if (values.contains(record.getAttribute(tag))) {
-                return false;
-            }
-        } else {
-            if (!values.contains(record.getAttribute(tag))) {
-                return false;
-            }
-        }
-        return true;
+        return values.contains(record.getAttribute(tag)) != includeReads;
     }
 
     /**
@@ -93,16 +108,6 @@ public class TagFilter implements SamRecordFilter {
      */
     @Override
     public boolean filterOut(final SAMRecord first, final SAMRecord second) {
-        // both first and second must have the tag in order for it to be filtered out
-        if (includeReads) {
-            if (values.contains(first.getAttribute(tag)) && values.contains(second.getAttribute(tag))) {
-                return false;
-            }
-        } else {
-            if (!values.contains(first.getAttribute(tag)) && values.contains(second.getAttribute(tag))) {
-                return false;
-            }
-        }
-        return true;
+        return (values.contains(first.getAttribute(tag)) && values.contains(second.getAttribute(tag))) != includeReads;
     }
 }

--- a/src/main/java/htsjdk/samtools/filter/TagFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/TagFilter.java
@@ -100,7 +100,9 @@ public class TagFilter implements SamRecordFilter {
      * @param first  the first SAMRecord to evaluate
      * @param second the second SAMRecord to evaluate
      *
-     * @return the XOR of paired SAMRecord matches the filter and includeReads
+     * @return  true if includeReads is true and neither SAMRecord matches filter
+     *          true if includeReads is false and both SAMRecords match filter
+     *          otherwise false
      */
     @Override
     public boolean filterOut(final SAMRecord first, final SAMRecord second) {
@@ -111,6 +113,5 @@ public class TagFilter implements SamRecordFilter {
         } else {
             return values.contains(first.getAttribute(tag)) && values.contains(second.getAttribute(tag));
         }
-
     }
 }

--- a/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
@@ -39,8 +39,7 @@ import java.util.List;
  */
 public class TagFilterTest extends HtsjdkTest {
     private final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
-
-
+    
     /**
      * Basic positive and negative tests for the TagFilter
      *
@@ -49,8 +48,8 @@ public class TagFilterTest extends HtsjdkTest {
      * @param testValue         The value to test for in the record
      * @param expectedResult    The expected result (true is the sequence should match the filter, otherwise false)
      */
-    @Test(dataProvider="data")
-    public void testTagFilter(final String testName, final String tag, final List<Object> validValues,
+    @Test(dataProvider="dataInclude")
+    public void testIncludeTagFilter(final String testName, final String tag, final List<Object> validValues,
                               final Object testValue, final boolean expectedResult, final boolean includeReads) {
         final TagFilter filter = new TagFilter(tag, validValues, includeReads);
         builder.addUnmappedFragment("testfrag");
@@ -61,18 +60,43 @@ public class TagFilterTest extends HtsjdkTest {
         Assert.assertEquals(filter.filterOut(record), expectedResult, testName);
     }
 
+    /**
+     * Data for various sequences which may or may not match the filter.
+     */
+    @DataProvider(name = "dataInclude")
+    private Object[][] getTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, false, true},
+                {"Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true},
+                {"Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true},
+                {"Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, true, true}
+        };
+    }
+
+    @Test(dataProvider="dataExclude")
+    public void testExcludeTagFilter(final String testName, final String tag, final List<Object> validValues,
+                              final Object testValue, final boolean expectedResult) {
+        final TagFilter filter = new TagFilter(tag, validValues);
+        builder.addUnmappedFragment("testfrag");
+        final SAMRecord record = builder.iterator().next();
+        if (testValue != null) {
+            record.setAttribute(tag, testValue);
+        }
+        Assert.assertEquals(filter.filterOut(record), expectedResult, testName);
+    }
 
     /**
      * Data for various sequences which may or may not match the filter.
      */
-    @DataProvider(name = "data")
-    private Object[][] getTagFilterTestData()
+    @DataProvider(name = "dataExclude")
+    private Object[][] getExcludeTagFilterTestData()
     {
         return new Object[][]{
-                {"Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, true, false},
-                {"Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true},
-                {"Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false},
-                {"Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, true, true}
+                {"Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, true},
+                {"Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true},
+                {"Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, false},
+                {"Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, false}
         };
     }
 }

--- a/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
@@ -41,175 +41,71 @@ import java.util.List;
 public class TagFilterTest extends HtsjdkTest {
 
     /**
-     * Basic positive and negative tests for the TagFilter
-     *
-     * @param tag               The tag to be tested
-     * @param validValues       The values the filter should test for
-     * @param testValue         The value to test for in the record
-     * @param expectedResult    The expected result (true is the sequence should match the filter, otherwise false)
-     */
-    @Test(dataProvider="dataIncludeFilter")
-    public void testIncludeTagFilter(final String testName, final String tag, final List<Object> validValues,
-                              final Object testValue, final boolean expectedResult, final Boolean includeReads) {
-        testTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads);
-    }
-
-    @Test(dataProvider="dataExcludeFilter")
-    public void testExcludeTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                     final Object testValue, final boolean expectedResult, Boolean includeReads) {
-        testTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads);
-    }
-
-    @Test(dataProvider="dataDefaultFilter")
-    public void testDefaultTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                     final Object testValue, final boolean expectedResult, Boolean includeReads) {
-        testTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads);
-    }
-
-    /**
-     * Data for various sequences which may or may not match the explicit includeReads=true filter.
-     */
-    @DataProvider(name = "dataIncludeFilter")
-    private Object[][] getInclueTagFilterTestData()
-    {
-        return new Object[][]{
-                {"Basic positive test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 1, false, true},
-                {"Multi-value positive test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true},
-                {"Incorrect value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true},
-                {"Null value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), null, true, true}
-        };
-    }
-
-    /**
-     * Data for various sequences which may or may not match the explicit includeReads=false filter.
-     */
-    @DataProvider(name = "dataExcludeFilter")
-    private Object[][] getExcludeTagFilterTestData()
-    {
-        return new Object[][]{
-                {"Basic positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 1, true, false},
-                {"Multi-value positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, false},
-                {"Incorrect value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false},
-                {"Null value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), null, false, false}
-        };
-    }
-
-    /**
-     * Data for various sequences which may or may not match the default filter.
-     */
-    @DataProvider(name = "dataDefaultFilter")
-    private Object[][] getDefaultTagFilterTestData()
-    {
-        return new Object[][]{
-                {"Basic positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 1, true, null},
-                {"Multi-value positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, null},
-                {"Incorrect value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 2, false, null},
-                {"Null value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), null, false, null}
-        };
-    }
-
-    // Base single record test
-    private void testTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                     final Object testValue, final boolean expectedResult, final Boolean includeReads) {
-        final TagFilter filter = new TagFilter(tag, validValues, includeReads);
-        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
-        builder.addUnmappedFragment("testfrag");
-        final SAMRecord record = builder.iterator().next();
-        if (testValue != null) {
-            record.setAttribute(tag, testValue);
-        }
-        Assert.assertEquals(filter.filterOut(record), expectedResult, testName);
-    }
-
-    /**
-
-        Start Paired Tests
-
+        Tests
      */
     @Test(dataProvider="dataDefaultMatchingPairedFilter")
     public void testDefaultPairedEndMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                          final Object testValue, final boolean expectedResult, Boolean includeReads,
-                                                          final boolean matchPairs) {
-        testPairedReadTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads, matchPairs);
+                                                      final Object testValue, final boolean firstReadExpectedResult,
+                                                      final boolean pairedExpectedResult, final Boolean includeReads,
+                                                      final boolean matchPairs) {
+        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
 
     @Test(dataProvider="dataDefaultNonMatchingPairedFilter")
     public void testDefaultPairedEndNonMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                          final Object testValue, final boolean expectedResult, Boolean includeReads,
-                                                          final boolean matchPairs) {
-        testPairedReadTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads, matchPairs);
+                                                         final Object testValue, final boolean firstReadExpectedResult,
+                                                         final boolean pairedExpectedResult, final Boolean includeReads,
+                                                         final boolean matchPairs) {
+        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+    }
+    @Test(dataProvider="dataExcludeMatchingPairedFilter")
+    public void testExludePairedEndMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                                      final Object testValue, final boolean firstReadExpectedResult,
+                                                      final boolean pairedExpectedResult, final Boolean includeReads,
+                                                      final boolean matchPairs) {
+        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+    }
+
+    @Test(dataProvider="dataExcludeNonMatchingPairedFilter")
+    public void testExcludePairedEndNonMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                                         final Object testValue, final boolean firstReadExpectedResult,
+                                                         final boolean pairedExpectedResult, final Boolean includeReads,
+                                                         final boolean matchPairs) {
+        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
 
     @Test(dataProvider="dataIncludeNonMatchingPairedFilter")
     public void testIncludePairedEndNonMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                             final Object testValue, final boolean expectedResult, Boolean includeReads,
-                                                             final boolean matchPairs) {
-        testPairedReadTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads, matchPairs);
+                                                         final Object testValue, final boolean firstReadExpectedResult,
+                                                         final boolean pairedExpectedResult, final Boolean includeReads,
+                                                         final boolean matchPairs) {
+        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+    }
+
+    @Test(dataProvider="dataIncludeMatchingPairedFilter")
+    public void testIncludePairedEndMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                                         final Object testValue, final boolean firstReadExpectedResult,
+                                                         final boolean pairedExpectedResult, final Boolean includeReads,
+                                                         final boolean matchPairs) {
+        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
 
     /**
-     * Data for various sequences which may or may not match the default filter with paired reads.
+     *
+     * @param tag                       The tag to be tested
+     * @param validValues               The values the filter should test for
+     * @param testValue                 The value to test for in the record
+     * @param firstReadExpectedResult   The expected result of the first read (true is the sequence should match the filter, otherwise false)
+     * @param pairedExpectedResult      The expected result of the paired reads (true is the sequence should match the filter, otherwise false)
+     * @param includeReads              The value of includeReads for the filter
+     * @param matchPairs                Whether or not to have matching values for tag the test is testing for
+     *
      */
-    @DataProvider(name = "dataDefaultMatchingPairedFilter")
-    private Object[][] getDefaultMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {"Paired Read Matching Basic positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 1, true, null, true},
-                {"Paired Read Matching Multi-value positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, null, true},
-                {"Paired Read Matching Incorrect value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 2, false, null, true},
-                {"Paired Read Matching Null value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), null, false, null, true}
-        };
-    }
 
-    /**
-     * Data for various sequences which may or may not match the default filter with paired reads.
-     */
-    @DataProvider(name = "dataDefaultNonMatchingPairedFilter")
-    private Object[][] getDefaultNonMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {"Paired Read Non Matching Basic positive test- includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 1, false, null, false},
-                {"Paired Read Non Matching Multi-value positive test- includeReads false", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, null, false},
-                {"Paired Read Non Matching Incorrect value negative test- includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 2, false, null, false},
-                // this is looking for value `null` which in our test cases
-                {"Paired Read Non Matching Null value negative test- includeReads false", ReservedTagConstants.XN, Arrays.asList(1), null, false, null, false},
-        };
-    }
-
-    /**
-     * Data for various sequences which may or may not match the includeReads=true filter with paired reads.
-     */
-    @DataProvider(name = "dataIncludeNonMatchingPairedFilter")
-    private Object[][] getIncludeNonMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {"Paired Read Non Matching Basic positive test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 1, false, true, false},
-                {"Paired Read Non Matching Multi-value positive tes - includeReads truet", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true, false},
-                {"Paired Read Non Matching Incorrect value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true, false},
-                // this is looking for value `null` which in our test cases
-                {"Paired Read Non Matching Null value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), null, true, true, false},
-        };
-    }
-
-    /**
-     * Data for various sequences which may or may not match the includeReads=true default filter with paired reads.
-     */
-    @DataProvider(name = "dataIncludeMatchingPairedFilter")
-    private Object[][] getIncludeMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {"Paired Read Matching Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, false, true, true},
-                {"Paired Read Matching Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true, true},
-                {"Paired Read Matching Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true, true},
-                // this is looking for value `null` which in our test cases
-                {"Paired Read Matching Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, true, true, true},
-        };
-    }
-
-    // Base paired read test
-    private void testPairedReadTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                         final Object testValue, final boolean expectedResult, final Boolean includeReads,
-                                         final boolean matchPairs) {
+    private void testTagFilter(final String testName, final String tag, final List<Object> validValues,
+                               final Object testValue, final boolean firstReadExpectedResult,
+                               final boolean pairedExpectedResult, final Boolean includeReads,
+                               final boolean matchPairs) {
         final TagFilter filter = new TagFilter(tag, validValues, includeReads);
         final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         builder.addPair("Paired", 1, 100, 200);
@@ -218,12 +114,87 @@ public class TagFilterTest extends HtsjdkTest {
         if (testValue != null) {
             record1.setAttribute(tag, testValue);
         }
+        // Test first read in pair
+        Assert.assertEquals(filter.filterOut(record1), firstReadExpectedResult, testName);
+
         final SAMRecord record2 = iterator.next();
         if (matchPairs && testValue != null) {
             record2.setAttribute(tag, testValue);
         } else if (!matchPairs){
             record2.setAttribute(tag, 0);
         }
-        Assert.assertEquals(filter.filterOut(record1, record2), expectedResult, testName);
+        // Test paired reads
+        Assert.assertEquals(filter.filterOut(record1, record2), pairedExpectedResult, testName);
     }
+
+    /**
+     * Data for various sequences for test
+     */
+
+    @DataProvider(name = "dataDefaultMatchingPairedFilter")
+    private Object[][] getDefaultMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Matching Basic positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 1, true, true, null, true},
+                {"Paired Read Matching Multi-value positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, true, null, true},
+                {"Paired Read Matching Incorrect value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false,  null, true},
+                {"Paired Read Matching Null value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), null, false, false, null, true}
+        };
+    }
+
+    @DataProvider(name = "dataDefaultNonMatchingPairedFilter")
+    private Object[][] getDefaultNonMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Non Matching Basic positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 1, true, false, null, false},
+                {"Paired Read Non Matching Multi-value positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, false, null, false},
+                {"Paired Read Non Matching Incorrect value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false, null, false},
+                {"Paired Read Non Matching Null value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), null, false, false, null, false},
+        };
+    }
+
+    @DataProvider(name = "dataExcludeMatchingPairedFilter")
+    private Object[][] getExcludeMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Matching Basic positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 1, true, true, false, true},
+                {"Paired Read Matching Multi-value positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, true, false, true},
+                {"Paired Read Matching Incorrect value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false,  false, true},
+                {"Paired Read Matching Null value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), null, false, false, false, true}
+        };
+    }
+
+    @DataProvider(name = "dataExcludeNonMatchingPairedFilter")
+    private Object[][] getExcludeNonMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Non Matching Basic positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 1, true, false, false, false},
+                {"Paired Read Non Matching Multi-value positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, false, false, false},
+                {"Paired Read Non Matching Incorrect value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false, false, false},
+                {"Paired Read Non Matching Null value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), null, false, false, false, false},
+        };
+    }
+
+    @DataProvider(name = "dataIncludeNonMatchingPairedFilter")
+    private Object[][] getIncludeNonMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Non Matching Basic positive test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 1, false, false, true, false},
+                {"Paired Read Non Matching Multi-value positive tes - includeReads truet", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, false, true, false},
+                {"Paired Read Non Matching Incorrect value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true, true, false},
+                {"Paired Read Non Matching Null value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), null, true, true, true, false},
+        };
+    }
+
+    @DataProvider(name = "dataIncludeMatchingPairedFilter")
+    private Object[][] getIncludeMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Matching Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, false, false, true, true},
+                {"Paired Read Matching Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, false, true, true},
+                {"Paired Read Matching Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true, true, true},
+                {"Paired Read Matching Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, true, true, true, true},
+        };
+    }
+
 }

--- a/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.ReservedTagConstants;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.util.CloseableIterator;
+import org.scalactic.Bool;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -44,57 +45,49 @@ public class TagFilterTest extends HtsjdkTest {
         Tests
      */
     @Test(dataProvider="dataDefaultMatchingPairedFilter")
-    public void testDefaultPairedEndMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                      final Object testValue, final boolean firstReadExpectedResult,
+    public void testDefaultPairedEndMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
                                                       final boolean pairedExpectedResult, final Boolean includeReads,
                                                       final boolean matchPairs) {
-        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
 
     @Test(dataProvider="dataDefaultNonMatchingPairedFilter")
-    public void testDefaultPairedEndNonMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                         final Object testValue, final boolean firstReadExpectedResult,
+    public void testDefaultPairedEndNonMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
                                                          final boolean pairedExpectedResult, final Boolean includeReads,
                                                          final boolean matchPairs) {
-        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
     @Test(dataProvider="dataExcludeMatchingPairedFilter")
-    public void testExludePairedEndMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                      final Object testValue, final boolean firstReadExpectedResult,
-                                                      final boolean pairedExpectedResult, final Boolean includeReads,
-                                                      final boolean matchPairs) {
-        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+    public void testExludePairedEndMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
+                                                     final boolean pairedExpectedResult, final Boolean includeReads,
+                                                     final boolean matchPairs) {
+        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
 
     @Test(dataProvider="dataExcludeNonMatchingPairedFilter")
-    public void testExcludePairedEndNonMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                         final Object testValue, final boolean firstReadExpectedResult,
+    public void testExcludePairedEndNonMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
                                                          final boolean pairedExpectedResult, final Boolean includeReads,
                                                          final boolean matchPairs) {
-        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
 
     @Test(dataProvider="dataIncludeNonMatchingPairedFilter")
-    public void testIncludePairedEndNonMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                         final Object testValue, final boolean firstReadExpectedResult,
+    public void testIncludePairedEndNonMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
                                                          final boolean pairedExpectedResult, final Boolean includeReads,
                                                          final boolean matchPairs) {
-        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
 
     @Test(dataProvider="dataIncludeMatchingPairedFilter")
-    public void testIncludePairedEndMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
-                                                         final Object testValue, final boolean firstReadExpectedResult,
-                                                         final boolean pairedExpectedResult, final Boolean includeReads,
-                                                         final boolean matchPairs) {
-        testTagFilter(testName, tag, validValues, testValue, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+    public void testIncludePairedEndMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
+                                                      final boolean pairedExpectedResult, final Boolean includeReads,
+                                                      final boolean matchPairs) {
+        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
     }
 
     /**
      *
-     * @param tag                       The tag to be tested
-     * @param validValues               The values the filter should test for
-     * @param testValue                 The value to test for in the record
+     * @param commonValuesIndex         The index of the common values to grab from commonTestValues
      * @param firstReadExpectedResult   The expected result of the first read (true is the sequence should match the filter, otherwise false)
      * @param pairedExpectedResult      The expected result of the paired reads (true is the sequence should match the filter, otherwise false)
      * @param includeReads              The value of includeReads for the filter
@@ -102,10 +95,15 @@ public class TagFilterTest extends HtsjdkTest {
      *
      */
 
-    private void testTagFilter(final String testName, final String tag, final List<Object> validValues,
-                               final Object testValue, final boolean firstReadExpectedResult,
+    private void testTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
                                final boolean pairedExpectedResult, final Boolean includeReads,
                                final boolean matchPairs) {
+
+        final String testName = (String) commonTestValues[commonValuesIndex][0];
+        final String tag = (String) commonTestValues[commonValuesIndex][1];
+        final List<Object> validValues = (List<Object>) commonTestValues[commonValuesIndex][2];
+        final Object testValue = commonTestValues[commonValuesIndex][3];
+
         final TagFilter filter = new TagFilter(tag, validValues, includeReads);
         final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
         builder.addPair("Paired", 1, 100, 200);
@@ -131,14 +129,22 @@ public class TagFilterTest extends HtsjdkTest {
      * Data for various sequences for test
      */
 
+    private final Object[][] commonTestValues =
+            new Object[][]{
+                    {"Paired Read Matching Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1},
+                    {"Paired Read Matching Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1},
+                    {"Paired Read Matching Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2},
+                    {"Paired Read Matching Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null}
+            };
+
     @DataProvider(name = "dataDefaultMatchingPairedFilter")
     private Object[][] getDefaultMatchingPairedTagFilterTestData()
     {
         return new Object[][]{
-                {"Paired Read Matching Basic positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 1, true, true, null, true},
-                {"Paired Read Matching Multi-value positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, true, null, true},
-                {"Paired Read Matching Incorrect value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false,  null, true},
-                {"Paired Read Matching Null value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), null, false, false, null, true}
+                {0, true, true, null, true},
+                {1, true, true, null, true},
+                {2, false, false,  null, true},
+                {3, false, false, null, true}
         };
     }
 
@@ -146,10 +152,10 @@ public class TagFilterTest extends HtsjdkTest {
     private Object[][] getDefaultNonMatchingPairedTagFilterTestData()
     {
         return new Object[][]{
-                {"Paired Read Non Matching Basic positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 1, true, false, null, false},
-                {"Paired Read Non Matching Multi-value positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, false, null, false},
-                {"Paired Read Non Matching Incorrect value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false, null, false},
-                {"Paired Read Non Matching Null value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), null, false, false, null, false},
+                {0, true, false, null, false},
+                {1, true, false, null, false},
+                {2, false, false, null, false},
+                {3, false, false, null, false},
         };
     }
 
@@ -157,10 +163,10 @@ public class TagFilterTest extends HtsjdkTest {
     private Object[][] getExcludeMatchingPairedTagFilterTestData()
     {
         return new Object[][]{
-                {"Paired Read Matching Basic positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 1, true, true, false, true},
-                {"Paired Read Matching Multi-value positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, true, false, true},
-                {"Paired Read Matching Incorrect value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false,  false, true},
-                {"Paired Read Matching Null value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), null, false, false, false, true}
+                {0, true, true, false, true},
+                {1, true, true, false, true},
+                {2, false, false,  false, true},
+                {3, false, false, false, true}
         };
     }
 
@@ -168,10 +174,10 @@ public class TagFilterTest extends HtsjdkTest {
     private Object[][] getExcludeNonMatchingPairedTagFilterTestData()
     {
         return new Object[][]{
-                {"Paired Read Non Matching Basic positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 1, true, false, false, false},
-                {"Paired Read Non Matching Multi-value positive test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, false, false, false},
-                {"Paired Read Non Matching Incorrect value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false, false, false},
-                {"Paired Read Non Matching Null value negative test - default includeReads", ReservedTagConstants.XN, Arrays.asList(1), null, false, false, false, false},
+                {0, true, false, false, false},
+                {1, true, false, false, false},
+                {2, false, false, false, false},
+                {3, false, false, false, false},
         };
     }
 
@@ -179,10 +185,10 @@ public class TagFilterTest extends HtsjdkTest {
     private Object[][] getIncludeNonMatchingPairedTagFilterTestData()
     {
         return new Object[][]{
-                {"Paired Read Non Matching Basic positive test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 1, false, false, true, false},
-                {"Paired Read Non Matching Multi-value positive tes - includeReads truet", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, false, true, false},
-                {"Paired Read Non Matching Incorrect value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true, true, false},
-                {"Paired Read Non Matching Null value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), null, true, true, true, false},
+                {0, false, false, true, false},
+                {1, false, false, true, false},
+                {2, true, true, true, false},
+                {3, true, true, true, false},
         };
     }
 
@@ -190,10 +196,10 @@ public class TagFilterTest extends HtsjdkTest {
     private Object[][] getIncludeMatchingPairedTagFilterTestData()
     {
         return new Object[][]{
-                {"Paired Read Matching Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, false, false, true, true},
-                {"Paired Read Matching Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, false, true, true},
-                {"Paired Read Matching Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true, true, true},
-                {"Paired Read Matching Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, true, true, true, true},
+                {0, false, false, true, true},
+                {1, false, false, true, true},
+                {2, true, true, true, true},
+                {3, true, true, true, true},
         };
     }
 

--- a/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
@@ -28,7 +28,6 @@ import htsjdk.samtools.ReservedTagConstants;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.util.CloseableIterator;
-import org.scalactic.Bool;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;

--- a/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
@@ -42,6 +42,7 @@ public class TagFilterTest extends HtsjdkTest {
 
     /**
      *
+     * @param testModule                Used with testName to uniquely identify tests
      * @param commonValuesIndex         The index of the common values to grab from commonTestValues
      * @param firstReadExpectedResult   The expected result of the first read (true is the sequence should match the filter, otherwise false)
      * @param pairedExpectedResult      The expected result of the paired reads (true is the sequence should match the filter, otherwise false)
@@ -50,7 +51,8 @@ public class TagFilterTest extends HtsjdkTest {
      *
      */
 
-    private void testTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
+    @Test(dataProvider="testData")
+    public void testTagFilter(final String testModule, final int commonValuesIndex, final boolean firstReadExpectedResult,
                                final boolean pairedExpectedResult, final Boolean includeReads,
                                final boolean matchPairs) {
 
@@ -68,7 +70,7 @@ public class TagFilterTest extends HtsjdkTest {
             record1.setAttribute(tag, testValue);
         }
         // Test first read in pair
-        Assert.assertEquals(filter.filterOut(record1), firstReadExpectedResult, testName);
+        Assert.assertEquals(filter.filterOut(record1), firstReadExpectedResult, testModule + " - " + testName);
 
         final SAMRecord record2 = iterator.next();
         if (matchPairs && testValue != null) {
@@ -77,48 +79,7 @@ public class TagFilterTest extends HtsjdkTest {
             record2.setAttribute(tag, 0);
         }
         // Test paired reads
-        Assert.assertEquals(filter.filterOut(record1, record2), pairedExpectedResult, testName);
-    }
-
-    @Test(dataProvider="dataDefaultMatchingPairedFilter")
-    public void testDefaultPairedEndMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
-                                                      final boolean pairedExpectedResult, final Boolean includeReads,
-                                                      final boolean matchPairs) {
-        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
-    }
-
-    @Test(dataProvider="dataDefaultNonMatchingPairedFilter")
-    public void testDefaultPairedEndNonMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
-                                                         final boolean pairedExpectedResult, final Boolean includeReads,
-                                                         final boolean matchPairs) {
-        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
-    }
-    @Test(dataProvider="dataExcludeMatchingPairedFilter")
-    public void testExludePairedEndMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
-                                                     final boolean pairedExpectedResult, final Boolean includeReads,
-                                                     final boolean matchPairs) {
-        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
-    }
-
-    @Test(dataProvider="dataExcludeNonMatchingPairedFilter")
-    public void testExcludePairedEndNonMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
-                                                         final boolean pairedExpectedResult, final Boolean includeReads,
-                                                         final boolean matchPairs) {
-        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
-    }
-
-    @Test(dataProvider="dataIncludeNonMatchingPairedFilter")
-    public void testIncludePairedEndNonMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
-                                                         final boolean pairedExpectedResult, final Boolean includeReads,
-                                                         final boolean matchPairs) {
-        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
-    }
-
-    @Test(dataProvider="dataIncludeMatchingPairedFilter")
-    public void testIncludePairedEndMatchingTagFilter(final int commonValuesIndex, final boolean firstReadExpectedResult,
-                                                      final boolean pairedExpectedResult, final Boolean includeReads,
-                                                      final boolean matchPairs) {
-        testTagFilter(commonValuesIndex, firstReadExpectedResult, pairedExpectedResult, includeReads, matchPairs);
+        Assert.assertEquals(filter.filterOut(record1, record2), pairedExpectedResult, testModule + " - " + testName);
     }
 
     /**
@@ -133,69 +94,34 @@ public class TagFilterTest extends HtsjdkTest {
                     {"Paired Read Matching Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null}
             };
 
-    @DataProvider(name = "dataDefaultMatchingPairedFilter")
-    private Object[][] getDefaultMatchingPairedTagFilterTestData()
+    @DataProvider(name = "testData")
+    private Object[][] getTestData()
     {
         return new Object[][]{
-                {0, true, true, null, true},
-                {1, true, true, null, true},
-                {2, false, false,  null, true},
-                {3, false, false, null, true}
-        };
-    }
-
-    @DataProvider(name = "dataDefaultNonMatchingPairedFilter")
-    private Object[][] getDefaultNonMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {0, true, false, null, false},
-                {1, true, false, null, false},
-                {2, false, false, null, false},
-                {3, false, false, null, false},
-        };
-    }
-
-    @DataProvider(name = "dataExcludeMatchingPairedFilter")
-    private Object[][] getExcludeMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {0, true, true, false, true},
-                {1, true, true, false, true},
-                {2, false, false,  false, true},
-                {3, false, false, false, true}
-        };
-    }
-
-    @DataProvider(name = "dataExcludeNonMatchingPairedFilter")
-    private Object[][] getExcludeNonMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {0, true, false, false, false},
-                {1, true, false, false, false},
-                {2, false, false, false, false},
-                {3, false, false, false, false},
-        };
-    }
-
-    @DataProvider(name = "dataIncludeNonMatchingPairedFilter")
-    private Object[][] getIncludeNonMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {0, false, false, true, false},
-                {1, false, false, true, false},
-                {2, true, true, true, false},
-                {3, true, true, true, false},
-        };
-    }
-
-    @DataProvider(name = "dataIncludeMatchingPairedFilter")
-    private Object[][] getIncludeMatchingPairedTagFilterTestData()
-    {
-        return new Object[][]{
-                {0, false, false, true, true},
-                {1, false, false, true, true},
-                {2, true, true, true, true},
-                {3, true, true, true, true},
+                {"dataDefaultMatchingPairedFilter", 0, true, true, null, true},
+                {"dataDefaultMatchingPairedFilter", 1, true, true, null, true},
+                {"dataDefaultMatchingPairedFilter", 2, false, false,  null, true},
+                {"dataDefaultMatchingPairedFilter",3, false, false, null, true},
+                {"dataDefaultNonMatchingPairedFilter", 0, true, false, null, false},
+                {"dataDefaultNonMatchingPairedFilter", 1, true, false, null, false},
+                {"dataDefaultNonMatchingPairedFilter", 2, false, false, null, false},
+                {"dataDefaultNonMatchingPairedFilter", 3, false, false, null, false},
+                {"dataExcludeMatchingPairedFilter", 0, true, true, false, true},
+                {"dataExcludeMatchingPairedFilter", 1, true, true, false, true},
+                {"dataExcludeMatchingPairedFilter", 2, false, false,  false, true},
+                {"dataExcludeMatchingPairedFilter", 3, false, false, false, true},
+                {"dataExcludeNonMatchingPairedFilter", 0, true, false, false, false},
+                {"dataExcludeNonMatchingPairedFilter", 1, true, false, false, false},
+                {"dataExcludeNonMatchingPairedFilter", 2, false, false, false, false},
+                {"dataExcludeNonMatchingPairedFilter", 3, false, false, false, false},
+                {"dataIncludeNonMatchingPairedFilter", 0, false, false, true, false},
+                {"dataIncludeNonMatchingPairedFilter", 1, false, false, true, false},
+                {"dataIncludeNonMatchingPairedFilter", 2, true, true, true, false},
+                {"dataIncludeNonMatchingPairedFilter", 3, true, true, true, false},
+                {"dataIncludeMatchingPairedFilter", 0, false, false, true, true},
+                {"dataIncludeMatchingPairedFilter", 1, false, false, true, true},
+                {"dataIncludeMatchingPairedFilter", 2, true, true, true, true},
+                {"dataIncludeMatchingPairedFilter", 3, true, true, true, true}
         };
     }
 }

--- a/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
@@ -51,8 +51,8 @@ public class TagFilterTest extends HtsjdkTest {
      */
     @Test(dataProvider="data")
     public void testTagFilter(final String testName, final String tag, final List<Object> validValues,
-                              final Object testValue, final boolean expectedResult) {
-        final TagFilter filter = new TagFilter(tag, validValues);
+                              final Object testValue, final boolean expectedResult, final boolean includeReads) {
+        final TagFilter filter = new TagFilter(tag, validValues, includeReads);
         builder.addUnmappedFragment("testfrag");
         final SAMRecord record = builder.iterator().next();
         if (testValue != null) {
@@ -69,10 +69,10 @@ public class TagFilterTest extends HtsjdkTest {
     private Object[][] getTagFilterTestData()
     {
         return new Object[][]{
-            {"Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, true},
-            {"Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true},
-            {"Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, false},
-            {"Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, false} 
+                {"Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, true, false},
+                {"Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true},
+                {"Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false},
+                {"Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, true, true}
         };
     }
 }

--- a/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/TagFilterTest.java
@@ -27,6 +27,7 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.ReservedTagConstants;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordSetBuilder;
+import htsjdk.samtools.util.CloseableIterator;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -38,8 +39,7 @@ import java.util.List;
  * Tests for the TagFilter class
  */
 public class TagFilterTest extends HtsjdkTest {
-    private final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
-    
+
     /**
      * Basic positive and negative tests for the TagFilter
      *
@@ -48,55 +48,182 @@ public class TagFilterTest extends HtsjdkTest {
      * @param testValue         The value to test for in the record
      * @param expectedResult    The expected result (true is the sequence should match the filter, otherwise false)
      */
-    @Test(dataProvider="dataInclude")
+    @Test(dataProvider="dataIncludeFilter")
     public void testIncludeTagFilter(final String testName, final String tag, final List<Object> validValues,
-                              final Object testValue, final boolean expectedResult, final boolean includeReads) {
-        final TagFilter filter = new TagFilter(tag, validValues, includeReads);
-        builder.addUnmappedFragment("testfrag");
-        final SAMRecord record = builder.iterator().next();
-        if (testValue != null) {
-            record.setAttribute(tag, testValue);
-        }
-        Assert.assertEquals(filter.filterOut(record), expectedResult, testName);
+                              final Object testValue, final boolean expectedResult, final Boolean includeReads) {
+        testTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads);
+    }
+
+    @Test(dataProvider="dataExcludeFilter")
+    public void testExcludeTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                     final Object testValue, final boolean expectedResult, Boolean includeReads) {
+        testTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads);
+    }
+
+    @Test(dataProvider="dataDefaultFilter")
+    public void testDefaultTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                     final Object testValue, final boolean expectedResult, Boolean includeReads) {
+        testTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads);
     }
 
     /**
-     * Data for various sequences which may or may not match the filter.
+     * Data for various sequences which may or may not match the explicit includeReads=true filter.
      */
-    @DataProvider(name = "dataInclude")
-    private Object[][] getTagFilterTestData()
+    @DataProvider(name = "dataIncludeFilter")
+    private Object[][] getInclueTagFilterTestData()
     {
         return new Object[][]{
-                {"Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, false, true},
-                {"Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true},
-                {"Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true},
-                {"Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, true, true}
+                {"Basic positive test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 1, false, true},
+                {"Multi-value positive test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true},
+                {"Incorrect value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true},
+                {"Null value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), null, true, true}
         };
     }
 
-    @Test(dataProvider="dataExclude")
-    public void testExcludeTagFilter(final String testName, final String tag, final List<Object> validValues,
-                              final Object testValue, final boolean expectedResult) {
-        final TagFilter filter = new TagFilter(tag, validValues);
-        builder.addUnmappedFragment("testfrag");
-        final SAMRecord record = builder.iterator().next();
-        if (testValue != null) {
-            record.setAttribute(tag, testValue);
-        }
-        Assert.assertEquals(filter.filterOut(record), expectedResult, testName);
-    }
-
     /**
-     * Data for various sequences which may or may not match the filter.
+     * Data for various sequences which may or may not match the explicit includeReads=false filter.
      */
-    @DataProvider(name = "dataExclude")
+    @DataProvider(name = "dataExcludeFilter")
     private Object[][] getExcludeTagFilterTestData()
     {
         return new Object[][]{
-                {"Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, true},
-                {"Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true},
-                {"Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, false},
-                {"Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, false}
+                {"Basic positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 1, true, false},
+                {"Multi-value positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, false},
+                {"Incorrect value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 2, false, false},
+                {"Null value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), null, false, false}
         };
+    }
+
+    /**
+     * Data for various sequences which may or may not match the default filter.
+     */
+    @DataProvider(name = "dataDefaultFilter")
+    private Object[][] getDefaultTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Basic positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 1, true, null},
+                {"Multi-value positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, null},
+                {"Incorrect value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 2, false, null},
+                {"Null value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), null, false, null}
+        };
+    }
+
+    // Base single record test
+    private void testTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                     final Object testValue, final boolean expectedResult, final Boolean includeReads) {
+        final TagFilter filter = new TagFilter(tag, validValues, includeReads);
+        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.addUnmappedFragment("testfrag");
+        final SAMRecord record = builder.iterator().next();
+        if (testValue != null) {
+            record.setAttribute(tag, testValue);
+        }
+        Assert.assertEquals(filter.filterOut(record), expectedResult, testName);
+    }
+
+    /**
+
+        Start Paired Tests
+
+     */
+    @Test(dataProvider="dataDefaultMatchingPairedFilter")
+    public void testDefaultPairedEndMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                                          final Object testValue, final boolean expectedResult, Boolean includeReads,
+                                                          final boolean matchPairs) {
+        testPairedReadTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads, matchPairs);
+    }
+
+    @Test(dataProvider="dataDefaultNonMatchingPairedFilter")
+    public void testDefaultPairedEndNonMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                                          final Object testValue, final boolean expectedResult, Boolean includeReads,
+                                                          final boolean matchPairs) {
+        testPairedReadTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads, matchPairs);
+    }
+
+    @Test(dataProvider="dataIncludeNonMatchingPairedFilter")
+    public void testIncludePairedEndNonMatchingTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                                             final Object testValue, final boolean expectedResult, Boolean includeReads,
+                                                             final boolean matchPairs) {
+        testPairedReadTagFilter(testName, tag, validValues, testValue, expectedResult, includeReads, matchPairs);
+    }
+
+    /**
+     * Data for various sequences which may or may not match the default filter with paired reads.
+     */
+    @DataProvider(name = "dataDefaultMatchingPairedFilter")
+    private Object[][] getDefaultMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Matching Basic positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 1, true, null, true},
+                {"Paired Read Matching Multi-value positive test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, true, null, true},
+                {"Paired Read Matching Incorrect value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 2, false, null, true},
+                {"Paired Read Matching Null value negative test - includeReads false", ReservedTagConstants.XN, Arrays.asList(1), null, false, null, true}
+        };
+    }
+
+    /**
+     * Data for various sequences which may or may not match the default filter with paired reads.
+     */
+    @DataProvider(name = "dataDefaultNonMatchingPairedFilter")
+    private Object[][] getDefaultNonMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Non Matching Basic positive test- includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 1, false, null, false},
+                {"Paired Read Non Matching Multi-value positive test- includeReads false", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, null, false},
+                {"Paired Read Non Matching Incorrect value negative test- includeReads false", ReservedTagConstants.XN, Arrays.asList(1), 2, false, null, false},
+                // this is looking for value `null` which in our test cases
+                {"Paired Read Non Matching Null value negative test- includeReads false", ReservedTagConstants.XN, Arrays.asList(1), null, false, null, false},
+        };
+    }
+
+    /**
+     * Data for various sequences which may or may not match the includeReads=true filter with paired reads.
+     */
+    @DataProvider(name = "dataIncludeNonMatchingPairedFilter")
+    private Object[][] getIncludeNonMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Non Matching Basic positive test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 1, false, true, false},
+                {"Paired Read Non Matching Multi-value positive tes - includeReads truet", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true, false},
+                {"Paired Read Non Matching Incorrect value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true, false},
+                // this is looking for value `null` which in our test cases
+                {"Paired Read Non Matching Null value negative test - includeReads true", ReservedTagConstants.XN, Arrays.asList(1), null, true, true, false},
+        };
+    }
+
+    /**
+     * Data for various sequences which may or may not match the includeReads=true default filter with paired reads.
+     */
+    @DataProvider(name = "dataIncludeMatchingPairedFilter")
+    private Object[][] getIncludeMatchingPairedTagFilterTestData()
+    {
+        return new Object[][]{
+                {"Paired Read Matching Basic positive test", ReservedTagConstants.XN, Arrays.asList(1), 1, false, true, true},
+                {"Paired Read Matching Multi-value positive test", ReservedTagConstants.XN, Arrays.asList(1,2,3), 1, false, true, true},
+                {"Paired Read Matching Incorrect value negative test", ReservedTagConstants.XN, Arrays.asList(1), 2, true, true, true},
+                // this is looking for value `null` which in our test cases
+                {"Paired Read Matching Null value negative test", ReservedTagConstants.XN, Arrays.asList(1), null, true, true, true},
+        };
+    }
+
+    // Base paired read test
+    private void testPairedReadTagFilter(final String testName, final String tag, final List<Object> validValues,
+                                         final Object testValue, final boolean expectedResult, final Boolean includeReads,
+                                         final boolean matchPairs) {
+        final TagFilter filter = new TagFilter(tag, validValues, includeReads);
+        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder();
+        builder.addPair("Paired", 1, 100, 200);
+        CloseableIterator<SAMRecord> iterator = builder.iterator();
+        final SAMRecord record1 = iterator.next();
+        if (testValue != null) {
+            record1.setAttribute(tag, testValue);
+        }
+        final SAMRecord record2 = iterator.next();
+        if (matchPairs && testValue != null) {
+            record2.setAttribute(tag, testValue);
+        } else if (!matchPairs){
+            record2.setAttribute(tag, 0);
+        }
+        Assert.assertEquals(filter.filterOut(record1, record2), expectedResult, testName);
     }
 }


### PR DESCRIPTION
### Description

Some people would like to select reads based on tag values and not just filter.  This allows this filter to both pass and filter reads.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

