### PR TITLE
Fix MergingIterator.close() to avoid ConcurrentModificationException

### DIFF
--- a/src/main/java/htsjdk/samtools/util/MergingIterator.java
+++ b/src/main/java/htsjdk/samtools/util/MergingIterator.java
@@ -132,9 +132,11 @@ public class MergingIterator<T> implements CloseableIterator<T> {
 	 */
 	@Override
 	public void close() {
-		for (final ComparableIterator iterator : this.queue) {
-			iterator.close();
-			this.queue.remove(iterator);
+		final Iterator<ComparableIterator> iterator = this.queue.iterator();
+		while (iterator.hasNext()) {
+			final ComparableIterator subIterator = iterator.next();
+			subIterator.close();
+			iterator.remove();
 		}
 	}
 

--- a/src/test/java/htsjdk/samtools/util/MergingIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/MergingIteratorTest.java
@@ -173,4 +173,40 @@ public class MergingIteratorTest extends HtsjdkTest {
 		Assert.assertEquals(mergingIterator.next().intValue(), 4);
 		mergingIterator.next(); // fails, because the next element would be "2"
 	}
+
+	@Test()
+	public void testCloseMultipleIteratorsMidIteration() {
+		final Queue<Integer> queueOne = new LinkedList<Integer>();
+		queueOne.add(1);
+		queueOne.add(4);
+		queueOne.add(7);
+
+		final Queue<Integer> queueTwo = new LinkedList<Integer>();
+		queueTwo.add(2);
+		queueTwo.add(5);
+		queueTwo.add(8);
+
+		final Queue<Integer> queueThree = new LinkedList<Integer>();
+		queueThree.add(3);
+		queueThree.add(6);
+		queueThree.add(9);
+
+		final Collection<CloseableIterator<Integer>> iterators = new ArrayList<CloseableIterator<Integer>>(3);
+		Collections.addAll(
+				iterators,
+				new QueueBackedIterator<>(queueOne),
+				new QueueBackedIterator<>(queueTwo),
+				new QueueBackedIterator<>(queueThree));
+
+		final MergingIterator<Integer> mergingIterator = new MergingIterator<Integer>(
+				INTEGER_COMPARATOR,
+				iterators);
+
+		Assert.assertEquals(mergingIterator.next().intValue(), 1);
+		Assert.assertEquals(mergingIterator.next().intValue(), 2);
+		Assert.assertEquals(mergingIterator.next().intValue(), 3);
+
+		mergingIterator.close();
+		Assert.assertFalse(mergingIterator.hasNext());
+	}
 }


### PR DESCRIPTION

### Description

`MergingIterator.close()` could throw `ConcurrentModificationException` when called mid-iteration with at least three sub-iterators as described in https://github.com/samtools/htsjdk/issues/1055.

This PR changes the `close()` method to remove iterators from `MergingIterator`'s internal queue via an iterator rather than from the collection directly.

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

