### PR TITLE
toString method added to LineReader / LineIteratorImpl

### DIFF
--- a/src/main/java/htsjdk/tribble/readers/AsciiLineReader.java
+++ b/src/main/java/htsjdk/tribble/readers/AsciiLineReader.java
@@ -187,6 +187,10 @@ public class AsciiLineReader implements LineReader, LocationAware {
         if ( is != null ) is.close();
         lineBuffer = null;
     }
-
+    
+    @Override
+    public String toString() {
+        return "AsciiLineReader("+(this.is == null ? "closed"  : String.valueOf(this.is.getPosition())) +")";
+    }
 }
 

--- a/src/main/java/htsjdk/tribble/readers/LineIteratorImpl.java
+++ b/src/main/java/htsjdk/tribble/readers/LineIteratorImpl.java
@@ -31,4 +31,9 @@ public class LineIteratorImpl extends AbstractIterator<String> implements LineIt
     public void close() throws IOException {
         CloserUtil.close(lineReader);
     }
+    
+    @Override
+    public String toString() {
+        return "LineIteratorImpl(" + this.lineReader+")";
+    }
 }

--- a/src/main/java/htsjdk/tribble/readers/SynchronousLineReader.java
+++ b/src/main/java/htsjdk/tribble/readers/SynchronousLineReader.java
@@ -58,4 +58,9 @@ public final class SynchronousLineReader implements LineReader{
     public void close() {
         CloserUtil.close(longLineBufferedReader);
     }
+    
+    @Override
+    public String toString() {
+        return "SynchronousLineReader";
+    }
 }

--- a/src/main/java/htsjdk/tribble/readers/TabixIteratorLineReader.java
+++ b/src/main/java/htsjdk/tribble/readers/TabixIteratorLineReader.java
@@ -53,4 +53,9 @@ public class TabixIteratorLineReader implements LineReader {
     public void close() {
         // Ignore -
     }
+    
+    @Override
+    public String toString() {
+        return "TabixIteratorLineReader";
+    }
 }


### PR DESCRIPTION
### Description

I've added a few toString methods to fix cryptic error messages ( LineIteratorImpl.toString) . I've see an exception like this one today  https://github.com/igvteam/igv/issues/359 

```
Error parsing line at byte position: htsjdk.tribble.readers.LineIteratorImpl@36af05e8
```

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

