### PR TITLE
Make the TestSuite be more deterministic

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.SequenceUtil;
+import htsjdk.samtools.util.TestUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,7 +58,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
     private static final byte[] BASES = {'A', 'C', 'G', 'T'};
     private static final String READ_GROUP_ID = "1";
     private static final String SAMPLE = "FREE_SAMPLE";
-    private final Random random = new Random();
+    private final Random random = new Random(TestUtil.RANDOM_SEED);
 
     private SAMFileHeader header;
     private final Collection<SAMRecord> records;

--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -29,6 +29,9 @@ import java.io.*;
 
 public class TestUtil {
 
+    public static int RANDOM_SEED = 42;
+
+
     /**
      * Base url where all test files for http tests are found
      */

--- a/src/test/java/htsjdk/samtools/BAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileIndexTest.java
@@ -24,10 +24,7 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.util.CloseableIterator;
-import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.StopWatch;
-import htsjdk.samtools.util.StringUtil;
+import htsjdk.samtools.util.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -80,7 +77,7 @@ public class BAMFileIndexTest extends HtsjdkTest {
 
     @Test(groups = {"slow"})
     public void testRandomQueries() throws Exception {
-        runRandomTest(BAM_FILE, 1000, new Random());
+        runRandomTest(BAM_FILE, 1000, new Random(TestUtil.RANDOM_SEED));
     }
 
     @Test
@@ -252,7 +249,7 @@ public class BAMFileIndexTest extends HtsjdkTest {
     public void testMultiIntervalQuery(final boolean contained) {
         final List<String> referenceNames = getReferenceNames(BAM_FILE);
 
-        final QueryInterval[] intervals = generateRandomIntervals(referenceNames.size(), 1000, new Random());
+        final QueryInterval[] intervals = generateRandomIntervals(referenceNames.size(), 1000, new Random(TestUtil.RANDOM_SEED));
         final Set<SAMRecord> multiIntervalRecords = new HashSet<SAMRecord>();
         final Set<SAMRecord> singleIntervalRecords = new HashSet<SAMRecord>();
         final SamReader reader = SamReaderFactory.makeDefault().open(BAM_FILE);

--- a/src/test/java/htsjdk/samtools/BAMQueryMultipleIntervalsIteratorFilterTest.java
+++ b/src/test/java/htsjdk/samtools/BAMQueryMultipleIntervalsIteratorFilterTest.java
@@ -1,6 +1,7 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -11,7 +12,7 @@ import java.util.Random;
 public class BAMQueryMultipleIntervalsIteratorFilterTest extends HtsjdkTest {
 
     private final byte[] BASES = {'A', 'C', 'G', 'T'};
-    private final Random random = new Random();
+    private final Random random = new Random(TestUtil.RANDOM_SEED);
 
     @DataProvider(name="compareIntervalToRecord")
     public Object[][] compareIntervalToRecord() {

--- a/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
+++ b/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
@@ -67,7 +67,7 @@ public class BAMRemoteFileTest extends HtsjdkTest {
 
     @Test
     public void testRandomQueries() throws Exception {
-        runRandomTest(bamURL, 20, new Random());
+        runRandomTest(bamURL, 20, new Random(TestUtil.RANDOM_SEED));
     }
 
     @Test

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterWithIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterWithIndexTest.java
@@ -8,6 +8,7 @@ import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -29,6 +30,8 @@ public class CRAMFileWriterWithIndexTest extends HtsjdkTest {
     private InMemoryReferenceSequenceFile rsf;
     private ReferenceSource source;
     private SAMFileHeader header;
+
+    static private Random random = new Random(TestUtil.RANDOM_SEED);
 
     @Test
     public void test() throws IOException {
@@ -200,7 +203,6 @@ public class CRAMFileWriterWithIndexTest extends HtsjdkTest {
         String name = String.valueOf(header.getSequenceDictionary().size() + 1);
         header.addSequence(new SAMSequenceRecord(name, length));
         byte[] refBases = new byte[length];
-        Random random = new Random();
         byte[] alphabet = "ACGTN".getBytes();
         for (int i = 0; i < refBases.length; i++)
             refBases[i] = alphabet[random.nextInt(alphabet.length)];

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryCodecTest.java
@@ -27,6 +27,7 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.BufferedLineReader;
 import htsjdk.samtools.util.LineReader;
+import htsjdk.samtools.util.TestUtil;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -43,7 +44,7 @@ import static org.testng.Assert.assertTrue;
  */
 public class SAMSequenceDictionaryCodecTest extends HtsjdkTest {
 
-    private static final Random random = new Random();
+    private static final Random random = new Random(TestUtil.RANDOM_SEED);
     private SAMSequenceDictionary dictionary;
     private StringWriter writer;
     private SAMSequenceDictionaryCodec codec;

--- a/src/test/java/htsjdk/samtools/cram/encoding/rans/RansTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/rans/RansTest.java
@@ -1,6 +1,7 @@
 package htsjdk.samtools.cram.encoding.rans;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -199,7 +200,7 @@ public class RansTest extends HtsjdkTest {
         roundTrip(ByteBuffer.wrap(data), order);
     }
 
-    private Random random = new Random();
+    private Random random = new Random(TestUtil.RANDOM_SEED);
 
     private byte[] randomBytes_GD(int size, double p) {
         byte[] data = new byte[size];

--- a/src/test/java/htsjdk/samtools/reference/ReferenceSequenceTests.java
+++ b/src/test/java/htsjdk/samtools/reference/ReferenceSequenceTests.java
@@ -25,6 +25,7 @@
 package htsjdk.samtools.reference;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -41,7 +42,7 @@ import java.util.Random;
  */
 public class ReferenceSequenceTests extends HtsjdkTest {
     private static final byte[] BASES = "acgtACGTN".getBytes();
-    private final Random random = new Random();
+    private final Random random = new Random(TestUtil.RANDOM_SEED);
 
     @Test(dataProvider="fastaTestParameters")
     public void testSingleShortSequence(int chroms, int basesPerChrom) throws Exception {

--- a/src/test/java/htsjdk/samtools/util/CoordSpanInputSteamTest.java
+++ b/src/test/java/htsjdk/samtools/util/CoordSpanInputSteamTest.java
@@ -3,6 +3,7 @@ package htsjdk.samtools.util;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -18,10 +19,12 @@ import java.util.Random;
  */
 public class CoordSpanInputSteamTest extends HtsjdkTest {
 
+    private final Random random = new Random(TestUtil.RANDOM_SEED);
+
     @Test
     public void test_first_3_bytes() throws IOException {
         byte[] data = new byte[1024 * 1024];
-        new Random().nextBytes(data);
+        random.nextBytes(data);
 
         long[] coords = new long[]{0, 1, 1, 2, 2, 3};
 
@@ -37,7 +40,7 @@ public class CoordSpanInputSteamTest extends HtsjdkTest {
     @Test
     public void test_3_ranges_byte_single_read() throws IOException {
         byte[] data = new byte[1024 * 1024];
-        new Random().nextBytes(data);
+        random.nextBytes(data);
 
         long[] coords = new long[]{0, 100, 10, 20, 100, 200, data.length - 1, Long.MAX_VALUE};
 
@@ -58,7 +61,7 @@ public class CoordSpanInputSteamTest extends HtsjdkTest {
     @Test
     public void test_range_read() throws IOException {
         byte[] data = new byte[1024 * 1024];
-        new Random().nextBytes(data);
+        random.nextBytes(data);
 
         long[] coords = new long[]{0, 100, 10, 20, 100, 200, data.length - 1, Long.MAX_VALUE};
 
@@ -105,5 +108,4 @@ public class CoordSpanInputSteamTest extends HtsjdkTest {
         Assert.assertEquals(dis1.read(), -1);
         Assert.assertEquals(dis2.read(), -1);
     }
-
 }

--- a/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
+++ b/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
@@ -120,7 +120,7 @@ public class SortingCollectionTest extends HtsjdkTest {
      * Generate pseudo-random Strings for testing
      */
     static class RandomStringGenerator implements Iterable<String>, Iterator<String> {
-        Random random = new Random(0);
+        Random random = new Random(TestUtil.RANDOM_SEED);
         int numElementsToGenerate;
         int numElementsGenerated = 0;
 


### PR DESCRIPTION

### Description

Changes all the empty constructors of Random() to use a particular seed so that the tests are deterministic. The non-determinism may affect the coverage and in some cases cause intermittent failures, which can be confusing. 

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

