### PR TITLE
Update AbstractFastaSequenceFile.java

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -137,7 +137,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     /** default implementation -- override if index is supported */
     @Override
     public ReferenceSequence getSequence( String contig ) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Index does not appear to exist for " + getAbsolutePath() + ".  samtools faidx can be used to create an index");
     }
 
     /** default implementation -- override if index is supported */


### PR DESCRIPTION
Add the same verbose message to the UnsupportedOperationException when you fetch an entire contig's sequence as you receive when you fetch a portion of a contig.

### Description

When fetching an entire contig of an unindexed fasta, the operation fails with an UnsupportedOperationException that has no message.  This is difficult for users to determine what the problem is and how to fix it.  Since the exception is a RuntimeException, it's not easy to catch and warn the user.
