### PR TITLE
SortingCollection: freeUpMemory util method

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2009 The Broad Institute
+ * Copyright (c) 2018 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -215,7 +215,7 @@ public class SortingCollection<T> implements Iterable<T> {
     /**
      * Sort the records in memory, write them to a file, and clear the buffer of records in memory.
      */
-    private void spillToDisk() {
+    public void spillToDisk() {
         try {
             Arrays.sort(this.ramRecords, 0, this.numRecordsInRam, this.comparator);
             final Path f = newTempFile();

--- a/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
+++ b/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2009 The Broad Institute
+ * Copyright (c) 2018 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -99,6 +99,27 @@ public class SortingCollectionTest extends HtsjdkTest {
         assertIteratorEqualsList(strings, sortingCollection.iterator());
         assertIteratorEqualsList(strings, sortingCollection.iterator());
         
+        sortingCollection.cleanup();
+        Assert.assertEquals(tmpDir().list().length, 0);
+    }
+
+    @Test
+    public void spillToDiskTest() {
+        final SortingCollection<String> sortingCollection = makeSortingCollection(10);
+        final String[] strings = new String[] {
+                "1", "2", "3"
+        };
+
+        for (String str : strings) {
+            sortingCollection.add(str);
+        }
+
+        Assert.assertEquals(tmpDir().list().length, 0);
+        sortingCollection.spillToDisk();
+        Assert.assertEquals(tmpDir().list().length, 1);
+
+        assertIteratorEqualsList(strings, sortingCollection.iterator());
+
         sortingCollection.cleanup();
         Assert.assertEquals(tmpDir().list().length, 0);
     }


### PR DESCRIPTION
In parallel implementation of `MarkDuplicates` (https://github.com/broadinstitute/picard/pull/1036)  there is need to free up RAM held by `SortingCollection` with saving the ability to add records later.

There is such a functionality in `SortingCollection`: `spillToDisk()` method. But the method is encapsulated as private. To keep this encapsulation (we sure there could be no usage of the method out of the package) yet to provide public interface to this fully functional behavior, we introduce a new util class in the same package.