### PR TITLE
fix for #1042

### DIFF
--- a/src/main/java/htsjdk/tribble/TabixFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TabixFeatureReader.java
@@ -23,10 +23,10 @@
  */
 package htsjdk.tribble;
 
+import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.readers.*;
-import htsjdk.tribble.util.ParsingUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -95,7 +95,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
     private void readHeader() throws IOException {
         SOURCE source = null;
         try {
-            source = codec.makeSourceFromStream(new PositionalBufferedStream(new BlockCompressedInputStream(ParsingUtils.openInputStream(path, wrapper))));
+            source = codec.makeSourceFromStream(new PositionalBufferedStream(new BlockCompressedInputStream(SeekableStreamFactory.getInstance().getStreamFor(path, wrapper))));
             header = codec.readHeader(source);
         } catch (Exception e) {
             throw new TribbleException.MalformedFeatureFile("Unable to parse header with error: " + e.getMessage(), path, e);
@@ -140,7 +140,7 @@ public class TabixFeatureReader<T extends Feature, SOURCE> extends AbstractFeatu
 
     @Override
     public CloseableTribbleIterator<T> iterator() throws IOException {
-        final InputStream is = new BlockCompressedInputStream(ParsingUtils.openInputStream(path, wrapper));
+        final InputStream is = new BlockCompressedInputStream(SeekableStreamFactory.getInstance().getStreamFor(path, wrapper));
         final PositionalBufferedStream stream = new PositionalBufferedStream(is);
         final LineReader reader = new SynchronousLineReader(stream);
         return new FeatureIterator<T>(reader, 0, Integer.MAX_VALUE);


### PR DESCRIPTION
### Description

In `readHeader()` and `iterator()` methods, use `SeekableStreamFactory` instance to read the feature file instead of `ParsingUtils`. This brings them into line with how it's accessed via `TabixReader` everywhere else in this class. The reason it's not just foolish consistency is explained in #1042; i.e. if you implement your own `ISeekableStreamFactory` to handle some special protocol then that will be used everywhere that the URL is opened in `TabixFeatureReader`, not just in some places.

### Checklist

- [x] Code compiles correctly
- [x] No new tests required (no new functionality)
- [x] All tests passing
- [x] Documentation update not required
- [x] IS backward compatible
