### PR TITLE
MergeSamFiles accept SO:UNKNOWN

### DIFF
--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -66,7 +66,13 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
         if (value == null) {
             mAttributes.remove(key);
         } else {
-            mAttributes.put(key, value);
+            if (!key.equals("SO") && !key.equals("GO")) {
+                mAttributes.put(key, value);
+            } else if (!value.matches("[a-z]+")) {
+                mAttributes.put(key, value.toLowerCase());
+                System.out.printf("Warning! %s must be assigned with a value in lowercase instead of \"%s\", "
+                                          + "reformatted input data to lowercase.\n", key, value);
+            } else mAttributes.put(key, value);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import javax.xml.bind.annotation.XmlTransient;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -70,13 +71,13 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
             mAttributes.remove(key);
         } else {
             String modified = value;
-            if ((key.equals("SO") || key.equals("GO")) && !modified.matches("[a-z]+")) {
-                log.warn("Warning! "
-                                 + key + " must be assigned with a value in lowercase instead of "
-                                 + value + ", reformatted input data to lowercase.");
-                modified = modified.toLowerCase();
+            if (key.equals("SO") && Arrays.stream(SAMFileHeader.SortOrder.values())
+                                          .noneMatch((t) -> t.name().equals(value))) {
+                modified = "unknown";
+                log.warn("Warning! Found non-conforming header " + key + " tag: " + value + ". Treating as 'unknown'.");
             }
             mAttributes.put(key, modified);
+//            mAttributes.put(key, value);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -25,11 +25,9 @@ package htsjdk.samtools;
 
 import javax.xml.bind.annotation.XmlTransient;
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import htsjdk.samtools.util.Log;
 
 /**
  * Base class for the various concrete records in a SAM header, providing uniform
@@ -40,8 +38,6 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
     public static final long serialVersionUID = 1L;
 
     private final Map<String,String> mAttributes = new LinkedHashMap<String, String>();
-    private static final Log log = Log.getInstance(AbstractSAMHeaderRecord.class);
-
 
     public String getAttribute(final String key) {
         return mAttributes.get(key);
@@ -70,14 +66,7 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
         if (value == null) {
             mAttributes.remove(key);
         } else {
-            String modified = value;
-            if (key.equals("SO") && Arrays.stream(SAMFileHeader.SortOrder.values())
-                                          .noneMatch((t) -> t.name().equals(value))) {
-                modified = "unknown";
-                log.warn("Warning! Found non-conforming header " + key + " tag: " + value + ". Treating as 'unknown'.");
-            }
-            mAttributes.put(key, modified);
-//            mAttributes.put(key, value);
+            mAttributes.put(key, value);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import htsjdk.samtools.util.Log;
 
 /**
  * Base class for the various concrete records in a SAM header, providing uniform
@@ -38,6 +39,8 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
     public static final long serialVersionUID = 1L;
 
     private final Map<String,String> mAttributes = new LinkedHashMap<String, String>();
+    private static final Log log = Log.getInstance(AbstractSAMHeaderRecord.class);
+
 
     public String getAttribute(final String key) {
         return mAttributes.get(key);
@@ -66,13 +69,14 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
         if (value == null) {
             mAttributes.remove(key);
         } else {
-            if (!key.equals("SO") && !key.equals("GO")) {
-                mAttributes.put(key, value);
-            } else if (!value.matches("[a-z]+")) {
-                mAttributes.put(key, value.toLowerCase());
-                System.out.printf("Warning! %s must be assigned with a value in lowercase instead of \"%s\", "
-                                          + "reformatted input data to lowercase.\n", key, value);
-            } else mAttributes.put(key, value);
+            String modified = value;
+            if ((key.equals("SO") || key.equals("GO")) && !modified.matches("[a-z]+")) {
+                log.warn("Warning! "
+                                 + key + " must be assigned with a value in lowercase instead of "
+                                 + value + ", reformatted input data to lowercase.");
+                modified = modified.toLowerCase();
+            }
+            mAttributes.put(key, modified);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -259,20 +259,20 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
             if (so == null) {
                 sortOrder = SortOrder.unsorted;
             } else {
-                try {
-                    String modified = so;
-                    if (!SortOrder.valueOf(modified).toString().matches("[a-z]+")) {
-                        log.warn("Warning! Your sort order value has improper case("
-                                         + SortOrder.valueOf(so) + "), "
-                                         + "reformatted input data to lowercase. "
-                                         + "NOTE: Your input file WASN'T modified.");
-                        modified = modified.toLowerCase();
-                    }
-                    return SortOrder.valueOf(modified);
-                } catch (IllegalArgumentException e) {
+//                try {
+//                    return SortOrder.valueOf(so);
+//                } catch (IllegalArgumentException e) {
+//                    log.warn("Found non conforming header SO tag: " + so + ". Treating as 'unknown'.");
+//                    sortOrder = SortOrder.unknown;
+//                }
+//**********************
+                String modified = so;
+                if(Arrays.stream(SortOrder.values())
+                         .noneMatch((t)->t.name().equals(so))) {
+                    modified = "unknown";
                     log.warn("Found non conforming header SO tag: " + so + ". Treating as 'unknown'.");
-                    sortOrder = SortOrder.unknown;
                 }
+                return SortOrder.valueOf(modified);
             }
         }
         return sortOrder;

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -260,12 +260,15 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
                 sortOrder = SortOrder.unsorted;
             } else {
                 try {
-                    if (!SortOrder.valueOf(so).toString().matches("[a-z]+")) {
-                        System.out.printf("Warning! Your sort order value has improper case(%s), "
-                                                  + "reformatted input data to lowercase. "
-                                                  + "NOTE: Your input file WASN'T modified.\n", SortOrder.valueOf(so));
-                        return SortOrder.valueOf(so.toLowerCase());
-                    } else return SortOrder.valueOf(so);
+                    String modified = so;
+                    if (!SortOrder.valueOf(modified).toString().matches("[a-z]+")) {
+                        log.warn("Warning! Your sort order value has improper case("
+                                         + SortOrder.valueOf(so) + "), "
+                                         + "reformatted input data to lowercase. "
+                                         + "NOTE: Your input file WASN'T modified.");
+                        modified = modified.toLowerCase();
+                    }
+                    return SortOrder.valueOf(modified);
                 } catch (IllegalArgumentException e) {
                     log.warn("Found non conforming header SO tag: " + so + ". Treating as 'unknown'.");
                     sortOrder = SortOrder.unknown;

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -259,20 +259,12 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
             if (so == null) {
                 sortOrder = SortOrder.unsorted;
             } else {
-//                try {
-//                    return SortOrder.valueOf(so);
-//                } catch (IllegalArgumentException e) {
-//                    log.warn("Found non conforming header SO tag: " + so + ". Treating as 'unknown'.");
-//                    sortOrder = SortOrder.unknown;
-//                }
-//**********************
-                String modified = so;
-                if(Arrays.stream(SortOrder.values())
-                         .noneMatch((t)->t.name().equals(so))) {
-                    modified = "unknown";
-                    log.warn("Found non conforming header SO tag: " + so + ". Treating as 'unknown'.");
+                try {
+                    return SortOrder.valueOf(so);
+                } catch (IllegalArgumentException e) {
+                    log.warn("Found non-conforming header SO tag: " + so + ". Treating as 'unknown'.");
+                    sortOrder = SortOrder.unknown;
                 }
-                return SortOrder.valueOf(modified);
             }
         }
         return sortOrder;
@@ -332,12 +324,18 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
      */
     @Override
     public void setAttribute(final String key, final String value) {
+        String tempVal = value;
         if (key.equals(SORT_ORDER_TAG)) {
-            this.sortOrder = null;
+            try {
+                this.sortOrder = null;
+                tempVal = SortOrder.valueOf(value).toString();
+            } catch (IllegalArgumentException e) {
+                tempVal = "unknown";
+            }
         } else if (key.equals(GROUP_ORDER_TAG)) {
             this.groupOrder = null;
         }
-        super.setAttribute(key, value);
+        super.setAttribute(key, tempVal);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -326,11 +326,11 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     public void setAttribute(final String key, final String value) {
         String tempVal = value;
         if (key.equals(SORT_ORDER_TAG)) {
+            this.sortOrder = null;
             try {
-                this.sortOrder = null;
                 tempVal = SortOrder.valueOf(value).toString();
             } catch (IllegalArgumentException e) {
-                tempVal = "unknown";
+                tempVal = SortOrder.unknown.toString();
             }
         } else if (key.equals(GROUP_ORDER_TAG)) {
             this.groupOrder = null;

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -260,7 +260,12 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
                 sortOrder = SortOrder.unsorted;
             } else {
                 try {
-                    return SortOrder.valueOf(so);
+                    if (!SortOrder.valueOf(so).toString().matches("[a-z]+")) {
+                        System.out.printf("Warning! Your sort order value has improper case(%s), "
+                                                  + "reformatted input data to lowercase. "
+                                                  + "NOTE: Your input file WASN'T modified.\n", SortOrder.valueOf(so));
+                        return SortOrder.valueOf(so.toLowerCase());
+                    } else return SortOrder.valueOf(so);
                 } catch (IllegalArgumentException e) {
                     log.warn("Found non conforming header SO tag: " + so + ". Treating as 'unknown'.");
                     sortOrder = SortOrder.unknown;

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.samtools.SAMFileHeader.SortOrder;
 import htsjdk.samtools.util.DateParser;
 import htsjdk.samtools.util.LineReader;
 import htsjdk.samtools.util.RuntimeIOException;
@@ -71,7 +72,6 @@ public class SAMTextHeaderCodec {
 
     public static final String COMMENT_PREFIX = HEADER_LINE_START + HeaderRecordType.CO.name() + FIELD_SEPARATOR;
     private static final Log log = Log.getInstance(SAMTextHeaderCodec.class);
-
 
     void setWriter(final BufferedWriter writer) {
         this.writer = writer;
@@ -234,9 +234,9 @@ public class SAMTextHeaderCodec {
 
         final String soString = parsedHeaderLine.getValue(SAMFileHeader.SORT_ORDER_TAG);
         try {
-            if (soString != null) SAMFileHeader.SortOrder.valueOf(soString);
+            if (soString != null) SortOrder.valueOf(soString);
         } catch (IllegalArgumentException e) {
-                reportErrorParsingLine(HEADER_LINE_START + parsedHeaderLine.getHeaderRecordType() +
+            reportErrorParsingLine(HEADER_LINE_START + parsedHeaderLine.getHeaderRecordType() +
                             " line has non-conforming SO tag value: " + soString + ".",
                     SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE, null);
         }
@@ -333,19 +333,19 @@ public class SAMTextHeaderCodec {
         }
 
         private void validateSortOrderValue(String[] value) {
-            if ("SO".equals(value[0])) {
+            if (SAMFileHeader.SORT_ORDER_TAG.equals(value[0])) {
                 try {
-                    SAMFileHeader.SortOrder.valueOf(value[1]);
+                    SortOrder.valueOf(value[1]);
                 } catch (IllegalArgumentException e) {
                     if (validationStringency == ValidationStringency.STRICT) {
-                        throw new SAMFormatException("Found non conforming header SO tag: "
+                        throw new SAMFormatException("Found non-conforming header SO tag: "
                                                      + value[1]
                                                      + ", exiting because VALIDATION_STRINGENCY=STRICT");
                     } else if (validationStringency == ValidationStringency.LENIENT) {
-                        log.warn("Found non conforming header SO tag: "
+                        log.warn("Found non-conforming header SO tag: "
                                  + value[1] + ". Treating as 'unknown'.");
                     }
-                    value[1] = "unknown";
+                    value[1] = SortOrder.unknown.toString();
                 }
             }
         }

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -27,7 +27,6 @@ import htsjdk.samtools.util.DateParser;
 import htsjdk.samtools.util.LineReader;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.StringUtil;
-import htsjdk.samtools.util.Log;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -70,8 +69,6 @@ public class SAMTextHeaderCodec {
     private static final Pattern FIELD_SEPARATOR_RE = Pattern.compile(FIELD_SEPARATOR);
 
     public static final String COMMENT_PREFIX = HEADER_LINE_START + HeaderRecordType.CO.name() + FIELD_SEPARATOR;
-
-    private static final Log log = Log.getInstance(AbstractSAMHeaderRecord.class);
 
     void setWriter(final BufferedWriter writer) {
         this.writer = writer;
@@ -236,9 +233,11 @@ public class SAMTextHeaderCodec {
         try {
             if (soString != null) SAMFileHeader.SortOrder.valueOf(soString);
         } catch (IllegalArgumentException e) {
-            reportErrorParsingLine(HEADER_LINE_START + parsedHeaderLine.getHeaderRecordType() +
-                            " line has non-conforming SO tag value: "+ soString + ".",
-                    SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE, null);
+//            if (!validationStringency.equals(ValidationStringency.STRICT)) {
+                reportErrorParsingLine(HEADER_LINE_START + parsedHeaderLine.getHeaderRecordType() +
+                                               " line has non-conforming SO tag value: " + soString + ".",
+                                       SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE, null);
+//            }
         }
 
         final String goString = parsedHeaderLine.getValue(SAMFileHeader.GROUP_ORDER_TAG);
@@ -297,15 +296,7 @@ public class SAMTextHeaderCodec {
 
             // Parse the HeaderRecordType
             try {
-                String value = fields[0].substring(1);
-                if (!value.matches("[A-Z]+")) {
-                    log.warn("Warning! Your tag has improper case("
-                                     + fields[0].substring(1)
-                                     + "), reformatted to uppercase. "
-                                     + "NOTE: Your input file WASN'T modified.");
-                    value = value.toUpperCase();
-                }
-                mHeaderRecordType = HeaderRecordType.valueOf(value);
+                mHeaderRecordType = HeaderRecordType.valueOf(fields[0].substring(1));
             } catch (IllegalArgumentException e) {
                 reportErrorParsingLine("Unrecognized header record type", SAMValidationError.Type.UNRECOGNIZED_HEADER_TYPE, null);
                 mHeaderRecordType = null;

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -80,6 +80,7 @@ public class SAMTextHeaderCodec {
 
     /**
      * Reads text SAM header and converts to a SAMFileHeader object.
+     *
      * @param reader Where to get header text from.
      * @param source Name of the input file, for error messages.  May be null.
      * @return complete header object.
@@ -115,7 +116,7 @@ public class SAMTextHeaderCodec {
                     break;
                 default:
                     throw new IllegalStateException("Unrecognized header record type: " +
-                            parsedHeaderLine.getHeaderRecordType());
+                                                            parsedHeaderLine.getHeaderRecordType());
             }
         }
         mFileHeader.setSequenceDictionary(new SAMSequenceDictionary(sequences));
@@ -143,7 +144,8 @@ public class SAMTextHeaderCodec {
     /**
      * Transfer standard and non-standard tags from text representation to in-memory representation.
      * All values are now stored as Strings.
-     * @param record attributes get set into this object.
+     *
+     * @param record         attributes get set into this object.
      * @param textAttributes Map of tag type to value.  Some values may be removed by this method.
      */
     private void transferAttributes(final AbstractSAMHeaderRecord record, final Map<String, String> textAttributes) {
@@ -155,42 +157,47 @@ public class SAMTextHeaderCodec {
     }
 
     private void parsePGLine(final ParsedHeaderLine parsedHeaderLine) {
-        assert(HeaderRecordType.PG.equals(parsedHeaderLine.getHeaderRecordType()));
+        assert (HeaderRecordType.PG.equals(parsedHeaderLine.getHeaderRecordType()));
         if (!parsedHeaderLine.requireTag(SAMProgramRecord.PROGRAM_GROUP_ID_TAG)) {
             return;
         }
-        final SAMProgramRecord programRecord = new SAMProgramRecord(parsedHeaderLine.removeValue(SAMProgramRecord.PROGRAM_GROUP_ID_TAG));
+        final SAMProgramRecord programRecord = new SAMProgramRecord(
+                parsedHeaderLine.removeValue(SAMProgramRecord.PROGRAM_GROUP_ID_TAG));
 
         transferAttributes(programRecord, parsedHeaderLine.mKeyValuePairs);
         mFileHeader.addProgramRecord(programRecord);
     }
 
     private void parseRGLine(final ParsedHeaderLine parsedHeaderLine) {
-        assert(HeaderRecordType.RG.equals(parsedHeaderLine.getHeaderRecordType()));
+        assert (HeaderRecordType.RG.equals(parsedHeaderLine.getHeaderRecordType()));
         if (!parsedHeaderLine.requireTag(SAMReadGroupRecord.READ_GROUP_ID_TAG)) {
             return;
         }
         // Allow no SM tag if validation stringency is not strict.  This call has the side effect of reporting an error
         // or throwing an exception depending on validation stringency if this is missing.
         parsedHeaderLine.requireTag(SAMReadGroupRecord.READ_GROUP_SAMPLE_TAG);
-        final SAMReadGroupRecord samReadGroupRecord = new SAMReadGroupRecord(parsedHeaderLine.removeValue(SAMReadGroupRecord.READ_GROUP_ID_TAG));
+        final SAMReadGroupRecord samReadGroupRecord = new SAMReadGroupRecord(
+                parsedHeaderLine.removeValue(SAMReadGroupRecord.READ_GROUP_ID_TAG));
         transferAttributes(samReadGroupRecord, parsedHeaderLine.mKeyValuePairs);
 
         // Convert non-String attributes to the appropriate types
         final String predictedMedianInsertSize =
-                (String)samReadGroupRecord.getAttribute(SAMReadGroupRecord.PREDICTED_MEDIAN_INSERT_SIZE_TAG);
+                (String) samReadGroupRecord.getAttribute(SAMReadGroupRecord.PREDICTED_MEDIAN_INSERT_SIZE_TAG);
         if (predictedMedianInsertSize != null) {
             try {
                 Integer.parseInt(predictedMedianInsertSize);
-                samReadGroupRecord.setAttribute(SAMReadGroupRecord.PREDICTED_MEDIAN_INSERT_SIZE_TAG,predictedMedianInsertSize);
+                samReadGroupRecord
+                        .setAttribute(SAMReadGroupRecord.PREDICTED_MEDIAN_INSERT_SIZE_TAG, predictedMedianInsertSize);
             } catch (NumberFormatException e) {
                 reportErrorParsingLine(SAMReadGroupRecord.PREDICTED_MEDIAN_INSERT_SIZE_TAG +
-                        " is not numeric: " + predictedMedianInsertSize, SAMValidationError.Type.INVALID_PREDICTED_MEDIAN_INSERT_SIZE,
-                        e);
+                                               " is not numeric: " + predictedMedianInsertSize,
+                                       SAMValidationError.Type.INVALID_PREDICTED_MEDIAN_INSERT_SIZE,
+                                       e);
             }
         }
 
-        final String dateRunProduced = (String)samReadGroupRecord.getAttribute(SAMReadGroupRecord.DATE_RUN_PRODUCED_TAG);
+        final String dateRunProduced = (String) samReadGroupRecord
+                .getAttribute(SAMReadGroupRecord.DATE_RUN_PRODUCED_TAG);
         if (dateRunProduced != null) {
             Object date;
             try {
@@ -200,8 +207,9 @@ public class SAMTextHeaderCodec {
                 //  stringency allows it.
                 date = dateRunProduced;
                 reportErrorParsingLine(SAMReadGroupRecord.DATE_RUN_PRODUCED_TAG + " tag value '" +
-                dateRunProduced + "' is not parseable as a date", SAMValidationError.Type.INVALID_DATE_STRING,
-                        e);
+                                               dateRunProduced + "' is not parseable as a date",
+                                       SAMValidationError.Type.INVALID_DATE_STRING,
+                                       e);
             }
             samReadGroupRecord.setAttribute(SAMReadGroupRecord.DATE_RUN_PRODUCED_TAG, date.toString());
         }
@@ -210,7 +218,7 @@ public class SAMTextHeaderCodec {
     }
 
     private void parseSQLine(final ParsedHeaderLine parsedHeaderLine) {
-        assert(HeaderRecordType.SQ.equals(parsedHeaderLine.getHeaderRecordType()));
+        assert (HeaderRecordType.SQ.equals(parsedHeaderLine.getHeaderRecordType()));
         if (!parsedHeaderLine.requireTag(SAMSequenceRecord.SEQUENCE_NAME_TAG) ||
                 !parsedHeaderLine.requireTag(SAMSequenceRecord.SEQUENCE_LENGTH_TAG)) {
             return;
@@ -218,13 +226,14 @@ public class SAMTextHeaderCodec {
         String sequenceName = parsedHeaderLine.removeValue(SAMSequenceRecord.SEQUENCE_NAME_TAG);
         sequenceName = SAMSequenceRecord.truncateSequenceName(sequenceName);
         final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord(sequenceName,
-                Integer.parseInt(parsedHeaderLine.removeValue(SAMSequenceRecord.SEQUENCE_LENGTH_TAG)));
+                                                                          Integer.parseInt(parsedHeaderLine.removeValue(
+                                                                                  SAMSequenceRecord.SEQUENCE_LENGTH_TAG)));
         transferAttributes(samSequenceRecord, parsedHeaderLine.mKeyValuePairs);
         sequences.add(samSequenceRecord);
     }
 
     private void parseHDLine(final ParsedHeaderLine parsedHeaderLine) {
-        assert(HeaderRecordType.HD.equals(parsedHeaderLine.getHeaderRecordType()));
+        assert (HeaderRecordType.HD.equals(parsedHeaderLine.getHeaderRecordType()));
         if (!parsedHeaderLine.requireTag(SAMFileHeader.VERSION_TAG)) {
             return;
         }
@@ -234,8 +243,8 @@ public class SAMTextHeaderCodec {
             if (soString != null) SAMFileHeader.SortOrder.valueOf(soString);
         } catch (IllegalArgumentException e) {
             reportErrorParsingLine(HEADER_LINE_START + parsedHeaderLine.getHeaderRecordType() +
-                            " line has non-conforming SO tag value: "+ soString + ".",
-                    SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE, null);
+                                           " line has non-conforming SO tag value: " + soString + ".",
+                                   SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE, null);
         }
 
         final String goString = parsedHeaderLine.getValue(SAMFileHeader.GROUP_ORDER_TAG);
@@ -243,14 +252,15 @@ public class SAMTextHeaderCodec {
             if (goString != null) SAMFileHeader.GroupOrder.valueOf(goString);
         } catch (IllegalArgumentException e) {
             reportErrorParsingLine(HEADER_LINE_START + parsedHeaderLine.getHeaderRecordType() +
-                            " line has non-conforming GO tag value: "+ goString + ".",
-                    SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE, null);
+                                           " line has non-conforming GO tag value: " + goString + ".",
+                                   SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE, null);
         }
 
         transferAttributes(mFileHeader, parsedHeaderLine.mKeyValuePairs);
     }
 
-    private void reportErrorParsingLine(String reason, final SAMValidationError.Type type, final Throwable nestedException) {
+    private void reportErrorParsingLine(String reason, final SAMValidationError.Type type,
+                                        final Throwable nestedException) {
         reason = "Error parsing SAM header. " + reason + ". Line:\n" + mCurrentLine;
         if (validationStringency != ValidationStringency.STRICT) {
             final SAMValidationError error = new SAMValidationError(type, reason, null, mReader.getLineNumber());
@@ -262,7 +272,7 @@ public class SAMTextHeaderCodec {
                 fileMessage = "File " + mSource;
             }
             throw new SAMFormatException(reason + "; " + fileMessage +
-                    "; Line number " + mReader.getLineNumber(), nestedException);
+                                                 "; Line number " + mReader.getLineNumber(), nestedException);
         }
     }
 
@@ -281,7 +291,7 @@ public class SAMTextHeaderCodec {
         private boolean lineValid = false;
 
         ParsedHeaderLine(final String line) {
-            assert(line.startsWith(HEADER_LINE_START));
+            assert (line.startsWith(HEADER_LINE_START));
 
             // Tab-separate
             String[] fields = new String[1024];
@@ -294,9 +304,14 @@ public class SAMTextHeaderCodec {
 
             // Parse the HeaderRecordType
             try {
-                mHeaderRecordType = HeaderRecordType.valueOf(fields[0].substring(1));
+                if (!fields[0].substring(1).matches("[A-Z]+")) {
+                    mHeaderRecordType = HeaderRecordType.valueOf(fields[0].substring(1).toUpperCase());
+                    System.out.printf("Warning! Your tag has improper case(%s), reformatted to uppercase. "
+                                              + "NOTE: Your input file WASN'T modified.\n", fields[0].substring(1));
+                } else mHeaderRecordType = HeaderRecordType.valueOf(fields[0].substring(1));
             } catch (IllegalArgumentException e) {
-                reportErrorParsingLine("Unrecognized header record type", SAMValidationError.Type.UNRECOGNIZED_HEADER_TYPE, null);
+                reportErrorParsingLine("Unrecognized header record type",
+                                       SAMValidationError.Type.UNRECOGNIZED_HEADER_TYPE, null);
                 mHeaderRecordType = null;
                 return;
             }
@@ -310,17 +325,20 @@ public class SAMTextHeaderCodec {
             final String[] keyAndValue = new String[2];
             // Parse they key:value pairs
             for (int i = 1; i < numFields; ++i) {
-                if (StringUtil.splitConcatenateExcessTokens(fields[i], keyAndValue, TAG_KEY_VALUE_SEPARATOR_CHAR) != 2) {
+                if (StringUtil
+                        .splitConcatenateExcessTokens(fields[i], keyAndValue, TAG_KEY_VALUE_SEPARATOR_CHAR) != 2) {
                     reportErrorParsingLine("Problem parsing " + HEADER_LINE_START + mHeaderRecordType +
-                            " key:value pair", SAMValidationError.Type.POORLY_FORMATTED_HEADER_TAG, null);
+                                                   " key:value pair",
+                                           SAMValidationError.Type.POORLY_FORMATTED_HEADER_TAG, null);
                     continue;
                 }
                 if (mKeyValuePairs.containsKey(keyAndValue[0]) &&
-                        ! mKeyValuePairs.get(keyAndValue[0]).equals(keyAndValue[1])) {
+                        !mKeyValuePairs.get(keyAndValue[0]).equals(keyAndValue[1])) {
                     reportErrorParsingLine("Problem parsing " + HEADER_LINE_START + mHeaderRecordType +
-                            " key:value pair " + keyAndValue[0] + ":" + keyAndValue[1] +
-                            " clashes with " + keyAndValue[0] + ":" + mKeyValuePairs.get(keyAndValue[0]),
-                            SAMValidationError.Type.HEADER_TAG_MULTIPLY_DEFINED, null);
+                                                   " key:value pair " + keyAndValue[0] + ":" + keyAndValue[1] +
+                                                   " clashes with " + keyAndValue[0] + ":" + mKeyValuePairs
+                                                   .get(keyAndValue[0]),
+                                           SAMValidationError.Type.HEADER_TAG_MULTIPLY_DEFINED, null);
                     continue;
                 }
                 mKeyValuePairs.put(keyAndValue[0], keyAndValue[1]);
@@ -338,13 +356,14 @@ public class SAMTextHeaderCodec {
         /**
          * Handling depends on the validation stringency.  If the tag is not present, and stringency is strict,
          * an exception is thrown.  If stringency is not strict, false is returned.
+         *
          * @param tag Must be present for the line to be considered value.
          * @return True if tag is present.
          */
         boolean requireTag(final String tag) {
             if (!mKeyValuePairs.containsKey(tag)) {
                 reportErrorParsingLine(HEADER_LINE_START + mHeaderRecordType + " line missing " + tag + " tag",
-                        SAMValidationError.Type.HEADER_RECORD_MISSING_REQUIRED_TAG, null);
+                                       SAMValidationError.Type.HEADER_RECORD_MISSING_REQUIRED_TAG, null);
                 return false;
             }
             return true;
@@ -376,6 +395,7 @@ public class SAMTextHeaderCodec {
     /**
      * Convert SAMFileHeader from in-memory representation to text representation. Always writes
      * SAMFileHeader.CURRENT_VERSION as the version in the header.
+     *
      * @param writer where to write the header text.
      * @param header object to be converted to text.
      */
@@ -385,8 +405,9 @@ public class SAMTextHeaderCodec {
 
     /**
      * Convert SAMFileHeader from in-memory representation to text representation.
-     * @param writer where to write the header text.
-     * @param header object to be converted to text.
+     *
+     * @param writer                    where to write the header text.
+     * @param header                    object to be converted to text.
      * @param keepExistingVersionNumber If true, writes whatever version # was in the header.  If false, writes
      *                                  SAMFileHeader.CURRENT_VERSION.
      */
@@ -394,7 +415,7 @@ public class SAMTextHeaderCodec {
         mFileHeader = header;
         this.writer = new BufferedWriter(writer);
         writeHDLine(keepExistingVersionNumber);
-        for (final SAMSequenceRecord sequenceRecord: header.getSequenceDictionary().getSequences()) {
+        for (final SAMSequenceRecord sequenceRecord : header.getSequenceDictionary().getSequences()) {
             writeSQLine(sequenceRecord);
         }
 
@@ -417,6 +438,7 @@ public class SAMTextHeaderCodec {
     /**
      * Encode {@link SAMSequenceRecord}.
      * Designed for using in {@link SAMSequenceDictionaryCodec}, allows to implement recording on the fly.
+     *
      * @throws IllegalStateException, if writer is null.
      */
     void encodeSequenceRecord(final SAMSequenceRecord sequenceRecord) {
@@ -429,6 +451,7 @@ public class SAMTextHeaderCodec {
     /**
      * Encode HD line.
      * Designed for using in {@link SAMSequenceDictionaryCodec}, allows to implement recording on the fly.
+     *
      * @throws IllegalStateException, if writer is null.
      */
     void encodeHeaderLine(final boolean keepExistingVersionNumber) {
@@ -462,13 +485,13 @@ public class SAMTextHeaderCodec {
     private void writeRGLine(final SAMReadGroupRecord readGroup) {
         println(getRGLine(readGroup));
     }
-    
+
     protected String getRGLine(final SAMReadGroupRecord readGroup) {
-      final String[] fields = new String[2 + readGroup.getAttributes().size()];
-      fields[0] = HEADER_LINE_START + HeaderRecordType.RG;
-      fields[1] = SAMReadGroupRecord.READ_GROUP_ID_TAG + TAG_KEY_VALUE_SEPARATOR + readGroup.getReadGroupId();
-      encodeTags(readGroup, fields, 2);
-      return StringUtil.join(FIELD_SEPARATOR, fields);
+        final String[] fields = new String[2 + readGroup.getAttributes().size()];
+        fields[0] = HEADER_LINE_START + HeaderRecordType.RG;
+        fields[1] = SAMReadGroupRecord.READ_GROUP_ID_TAG + TAG_KEY_VALUE_SEPARATOR + readGroup.getReadGroupId();
+        encodeTags(readGroup, fields, 2);
+        return StringUtil.join(FIELD_SEPARATOR, fields);
     }
 
     private void writeHDLine(final boolean keepExistingVersionNumber) {
@@ -502,19 +525,21 @@ public class SAMTextHeaderCodec {
         final String[] fields = new String[3 + numAttributes];
         fields[0] = HEADER_LINE_START + HeaderRecordType.SQ;
         fields[1] = SAMSequenceRecord.SEQUENCE_NAME_TAG + TAG_KEY_VALUE_SEPARATOR + sequenceRecord.getSequenceName();
-        fields[2] = SAMSequenceRecord.SEQUENCE_LENGTH_TAG + TAG_KEY_VALUE_SEPARATOR + Integer.toString(sequenceRecord.getSequenceLength());
+        fields[2] = SAMSequenceRecord.SEQUENCE_LENGTH_TAG + TAG_KEY_VALUE_SEPARATOR + Integer
+                .toString(sequenceRecord.getSequenceLength());
         encodeTags(sequenceRecord, fields, 3);
         return StringUtil.join(FIELD_SEPARATOR, fields);
     }
 
     /**
      * Encode all the attributes in the given object as text
-     * @param rec object containing attributes, and knowledge of which are standard tags
+     *
+     * @param rec    object containing attributes, and knowledge of which are standard tags
      * @param fields where to put the text representation of the tags.  Must be big enough to hold all tags.
      * @param offset where to start putting text tag representations.
      */
     private void encodeTags(final AbstractSAMHeaderRecord rec, final String[] fields, int offset) {
-        for (final Map.Entry<String, String> entry: rec.getAttributes()) {
+        for (final Map.Entry<String, String> entry : rec.getAttributes()) {
             fields[offset++] = mTagCodec.encodeUntypedTag(entry.getKey(), entry.getValue());
         }
     }

--- a/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
@@ -24,20 +24,10 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.BufferedLineReader;
-import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.ProgressLogger;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Arrays;
-
-import static htsjdk.samtools.Defaults.CREATE_INDEX;
-import static org.apache.commons.compress.archivers.ar.ArArchiveEntry.HEADER;
 
 public class SAMFileHeaderTest extends HtsjdkTest {
 
@@ -47,18 +37,15 @@ public class SAMFileHeaderTest extends HtsjdkTest {
 
         header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
-                            SAMFileHeader.SortOrder.coordinate.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.coordinate.name());
 
         header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, SAMFileHeader.SortOrder.queryname.name());
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.queryname);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
-                            SAMFileHeader.SortOrder.queryname.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.queryname.name());
 
         header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, SAMFileHeader.SortOrder.coordinate);
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
-                            SAMFileHeader.SortOrder.coordinate.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.coordinate.name());
 
         header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, "UNKNOWN");
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.unknown);
@@ -82,18 +69,15 @@ public class SAMFileHeaderTest extends HtsjdkTest {
 
         header.setGroupOrder(SAMFileHeader.GroupOrder.query);
         Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.query);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG),
-                            SAMFileHeader.GroupOrder.query.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.query.name());
 
         header.setAttribute(SAMFileHeader.GROUP_ORDER_TAG, SAMFileHeader.GroupOrder.reference.name());
         Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.reference);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG),
-                            SAMFileHeader.GroupOrder.reference.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.reference.name());
 
         header.setAttribute(SAMFileHeader.GROUP_ORDER_TAG, SAMFileHeader.GroupOrder.query);
         Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.query);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG),
-                            SAMFileHeader.GroupOrder.query.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.query.name());
     }
 
     @Test
@@ -107,30 +91,28 @@ public class SAMFileHeaderTest extends HtsjdkTest {
     @Test
     public void testGetSequenceIfNameIsNotFound() {
         final SAMFileHeader header = new SAMFileHeader();
-        final SAMSequenceRecord rec = new SAMSequenceRecord("chr1", 1);
+        final SAMSequenceRecord rec = new SAMSequenceRecord("chr1",1);
         final SAMSequenceDictionary dict = new SAMSequenceDictionary(Arrays.asList(rec));
         header.setSequenceDictionary(dict);
 
         Assert.assertNull(header.getSequence("chr2"));
     }
 
-    @DataProvider(name = "dataForTestTagsWithImproperCase")
-    public Object[][] dataForTestTagsWithImproperCase() {
-        return new Object[][]{
-                {"@hd\tVN:1.0\tSO:unsorted\n"},
-                {"@sq\tSN:chrM\tLN:16571\n"},
-                {"@rg\tID:1\tSM:sample1\n"},
-                {"@pg\tID:1\tPN:A\n"},
-                {"@co\tVN:1.0\tSO:unsorted\n"}
+    @Test
+    public void testTagsWithImproperCase() {
+        String[] testData = new String[]{
+                "@hd\tVN:1.0\tSO:unsorted\n",
+                "@sq\tSN:chrM\tLN:16571\n",
+                "@rg\tID:1\tSM:sample1\n",
+                "@pg\tID:1\tPN:A\n",
+                "@co\tVN:1.0\tSO:unsorted\n"
         };
-    }
-
-    @Test(dataProvider = "dataForTestTagsWithImproperCase")
-    public void testTagsWithImproperCase(String s) {
-        Assert.assertEquals(
-                new SAMTextHeaderCodec().decode(BufferedLineReader.fromString(s), null)
-                                        .getValidationErrors()
-                                        .toString()
-                                        .contains("Unrecognized header record type"), false);
+        for (String s : testData) {
+            Assert.assertEquals(
+                    new SAMTextHeaderCodec().decode(BufferedLineReader.fromString(s), null)
+                                            .getValidationErrors()
+                                            .toString()
+                                            .contains("Unrecognized header record type"), false);
+        }
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.BufferedLineReader;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -32,7 +33,7 @@ import java.util.Arrays;
 public class SAMFileHeaderTest extends HtsjdkTest {
 
     @Test
-    public void testSortOrder() {
+    public void testSortOrderManualSetting() {
         final SAMFileHeader header = new SAMFileHeader();
 
         header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
@@ -99,28 +100,74 @@ public class SAMFileHeaderTest extends HtsjdkTest {
     }
 
     @Test
-    public void testTagsWithImproperCase() {
+    public void testWrongTag() {
         String[] testData = new String[]{
                 "@hd\tVN:1.0\tSO:unsorted\n",
                 "@sq\tSN:chrM\tLN:16571\n",
                 "@rg\tID:1\tSM:sample1\n",
                 "@pg\tID:1\tPN:A\n",
-                "@co\tVN:1.0\tSO:unsorted\n",
-                "@HD\tVN:1.0\tSO:UNSORTED\n",
-                "@HD\tVN:1.0\tSO:FALSE\n",
-                "@HD\tVN:1.0\tSO:COORDINATE\n",
-                "@HD\tVN:1.0\tSO:uNknOWn\n",
-                "@HD\tVN:1.0\tSO:cOoRdinate\n"
+                "@co\tVN:1.0\tSO:unsorted\n"
         };
-        for (String s : testData) {
-            SAMFileHeader hd = new SAMTextHeaderCodec().decode(BufferedLineReader.fromString(s), null);
-            String validationErrors = hd.getValidationErrors().toString();
-            Assert.assertEquals(validationErrors.contains("Unrecognized header record type") ||
-                                       validationErrors.contains("@HD line has non-conforming SO tag value"),
-                                true);
-            Assert.assertEquals(hd.getSortOrder().toString().equals("unsorted") ||
-                                       hd.getSortOrder().toString().equals("unknown"),
-                                true);
+        for (String stringHeader : testData) {
+            SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
+            SAMFileHeader header = codec.decode(BufferedLineReader.fromString(stringHeader), null);
+            String validationErrors = header.getValidationErrors().toString();
+            Assert.assertTrue(validationErrors.contains("Unrecognized header record type"));
         }
+
+    }
+
+    @DataProvider(name = "DataForWrongTagTests")
+    public Object[][] dataForWrongTagTests() {
+        return new Object[][] {
+                {"@HD\tVN:1.0\tSO:UNSORTED\n"},
+                {"@HD\tVN:1.0\tSO:FALSE\n"},
+                {"@HD\tVN:1.0\tSO:COORDINATE\n"},
+                {"@HD\tVN:1.0\tSO:uNknOWn\n"},
+                {"@HD\tVN:1.0\tSO:cOoRdinate\n"},
+                };
+    }
+
+    @Test(dataProvider = "DataForWrongTagTests")
+    public void testSortOrderCodecSetting(String hdr) {
+        String validString = "@HD\tVN:1.0\tSO:unknown\n";
+
+        SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
+        SAMFileHeader header = codec.decode(BufferedLineReader.fromString(validString), null);
+
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.coordinate.name());
+
+        header.setSortOrder(SAMFileHeader.SortOrder.unsorted);
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.unsorted);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.unsorted.name());
+
+        header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, "badname");
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.unknown);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.unknown.name());
+
+        header = codec.decode(BufferedLineReader.fromString(hdr), null);
+        Assert.assertTrue(header.getSortOrder().toString().equals("unknown"));
+    }
+
+    @Test(dataProvider = "DataForWrongTagTests", expectedExceptions = SAMFormatException.class)
+    public void testValidationStringencyStrict(String stringHeader) {
+        SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
+        codec.setValidationStringency(ValidationStringency.STRICT);
+        codec.decode(BufferedLineReader.fromString(stringHeader), null);
+    }
+
+    @Test(dataProvider = "DataForWrongTagTests")
+    public void testValidationStringencyLenientAndSilent(String stringHeader) {
+        SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
+
+        codec.setValidationStringency(ValidationStringency.LENIENT);
+        SAMFileHeader headerLenient = codec.decode(BufferedLineReader.fromString(stringHeader), null);
+        Assert.assertTrue(headerLenient.getSortOrder().equals(SAMFileHeader.SortOrder.unknown));
+
+        codec.setValidationStringency(ValidationStringency.SILENT);
+        SAMFileHeader headerSilent = codec.decode(BufferedLineReader.fromString(stringHeader), null);
+        Assert.assertTrue(headerSilent.getSortOrder().equals(SAMFileHeader.SortOrder.unknown));
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
@@ -23,10 +23,21 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.BufferedLineReader;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.ProgressLogger;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
+
+import static htsjdk.samtools.Defaults.CREATE_INDEX;
+import static org.apache.commons.compress.archivers.ar.ArArchiveEntry.HEADER;
 
 public class SAMFileHeaderTest extends HtsjdkTest {
 
@@ -36,15 +47,33 @@ public class SAMFileHeaderTest extends HtsjdkTest {
 
         header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.coordinate.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
+                            SAMFileHeader.SortOrder.coordinate.name());
 
         header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, SAMFileHeader.SortOrder.queryname.name());
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.queryname);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.queryname.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
+                            SAMFileHeader.SortOrder.queryname.name());
 
         header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, SAMFileHeader.SortOrder.coordinate);
         Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG), SAMFileHeader.SortOrder.coordinate.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
+                            SAMFileHeader.SortOrder.coordinate.name());
+
+        header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, "UNKNOWN");
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.unknown);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
+                            SAMFileHeader.SortOrder.unknown.name());
+
+        header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, "uNknOWn");
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.unknown);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
+                            SAMFileHeader.SortOrder.unknown.name());
+
+        header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, "cOoRdinate");
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
+                            SAMFileHeader.SortOrder.coordinate.name());
     }
 
     @Test
@@ -53,15 +82,18 @@ public class SAMFileHeaderTest extends HtsjdkTest {
 
         header.setGroupOrder(SAMFileHeader.GroupOrder.query);
         Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.query);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.query.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG),
+                            SAMFileHeader.GroupOrder.query.name());
 
         header.setAttribute(SAMFileHeader.GROUP_ORDER_TAG, SAMFileHeader.GroupOrder.reference.name());
         Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.reference);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.reference.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG),
+                            SAMFileHeader.GroupOrder.reference.name());
 
         header.setAttribute(SAMFileHeader.GROUP_ORDER_TAG, SAMFileHeader.GroupOrder.query);
         Assert.assertEquals(header.getGroupOrder(), SAMFileHeader.GroupOrder.query);
-        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG), SAMFileHeader.GroupOrder.query.name());
+        Assert.assertEquals(header.getAttribute(SAMFileHeader.GROUP_ORDER_TAG),
+                            SAMFileHeader.GroupOrder.query.name());
     }
 
     @Test
@@ -75,10 +107,30 @@ public class SAMFileHeaderTest extends HtsjdkTest {
     @Test
     public void testGetSequenceIfNameIsNotFound() {
         final SAMFileHeader header = new SAMFileHeader();
-        final SAMSequenceRecord rec = new SAMSequenceRecord("chr1",1);
+        final SAMSequenceRecord rec = new SAMSequenceRecord("chr1", 1);
         final SAMSequenceDictionary dict = new SAMSequenceDictionary(Arrays.asList(rec));
         header.setSequenceDictionary(dict);
 
         Assert.assertNull(header.getSequence("chr2"));
+    }
+
+    @DataProvider(name = "dataForTestTagsWithImproperCase")
+    public Object[][] dataForTestTagsWithImproperCase() {
+        return new Object[][]{
+                {"@hd\tVN:1.0\tSO:unsorted\n"},
+                {"@sq\tSN:chrM\tLN:16571\n"},
+                {"@rg\tID:1\tSM:sample1\n"},
+                {"@pg\tID:1\tPN:A\n"},
+                {"@co\tVN:1.0\tSO:unsorted\n"}
+        };
+    }
+
+    @Test(dataProvider = "dataForTestTagsWithImproperCase")
+    public void testTagsWithImproperCase(String s) {
+        Assert.assertEquals(
+                new SAMTextHeaderCodec().decode(BufferedLineReader.fromString(s), null)
+                                        .getValidationErrors()
+                                        .toString()
+                                        .contains("Unrecognized header record type"), false);
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
@@ -58,9 +58,9 @@ public class SAMFileHeaderTest extends HtsjdkTest {
                             SAMFileHeader.SortOrder.unknown.name());
 
         header.setAttribute(SAMFileHeader.SORT_ORDER_TAG, "cOoRdinate");
-        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.coordinate);
+        Assert.assertEquals(header.getSortOrder(), SAMFileHeader.SortOrder.unknown);
         Assert.assertEquals(header.getAttribute(SAMFileHeader.SORT_ORDER_TAG),
-                            SAMFileHeader.SortOrder.coordinate.name());
+                            SAMFileHeader.SortOrder.unknown.name());
     }
 
     @Test
@@ -105,14 +105,22 @@ public class SAMFileHeaderTest extends HtsjdkTest {
                 "@sq\tSN:chrM\tLN:16571\n",
                 "@rg\tID:1\tSM:sample1\n",
                 "@pg\tID:1\tPN:A\n",
-                "@co\tVN:1.0\tSO:unsorted\n"
+                "@co\tVN:1.0\tSO:unsorted\n",
+                "@HD\tVN:1.0\tSO:UNSORTED\n",
+                "@HD\tVN:1.0\tSO:FALSE\n",
+                "@HD\tVN:1.0\tSO:COORDINATE\n",
+                "@HD\tVN:1.0\tSO:uNknOWn\n",
+                "@HD\tVN:1.0\tSO:cOoRdinate\n"
         };
         for (String s : testData) {
-            Assert.assertEquals(
-                    new SAMTextHeaderCodec().decode(BufferedLineReader.fromString(s), null)
-                                            .getValidationErrors()
-                                            .toString()
-                                            .contains("Unrecognized header record type"), false);
+            SAMFileHeader hd = new SAMTextHeaderCodec().decode(BufferedLineReader.fromString(s), null);
+            String validationErrors = hd.getValidationErrors().toString();
+            Assert.assertEquals(validationErrors.contains("Unrecognized header record type") ||
+                                       validationErrors.contains("@HD line has non-conforming SO tag value"),
+                                true);
+            Assert.assertEquals(hd.getSortOrder().toString().equals("unsorted") ||
+                                       hd.getSortOrder().toString().equals("unknown"),
+                                true);
         }
     }
 }

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -552,12 +552,6 @@ public class ValidateSamFileTest extends HtsjdkTest {
                         "@RG\tID:0\tSM:Hi,Mom!\n" +
                         "E\t147\tchr1\t15\t255\t10M\t=\t2\t-30\tCAACAGAAGC\t)'.*.+2,))\tU2:Z:CAA";
 
-        final String SOTagCorrectlyProcessTestData =
-                "@HD\tVN:1.0\tSO:NOTKNOWN\n" +
-                        "@SQ\tSN:chr1\tLN:101\n" +
-                        "@RG\tID:0\tSM:Hi,Mom!\n" +
-                        "E\t147\tchr1\t15\t255\t10M\t=\t2\t-30\tCAACAGAAGC\t)'.*.+2,))\tU2:Z:CAA";
-
         final String GOTagCorrectlyProcessTestData =
                 "@HD\tVN:1.0\tGO:NOTKNOWN\n" +
                         "@SQ\tSN:chr1\tLN:101\n" +
@@ -568,7 +562,6 @@ public class ValidateSamFileTest extends HtsjdkTest {
                 {E2TagCorrectlyProcessTestData.getBytes(), SAMValidationError.Type.E2_BASE_EQUALS_PRIMARY_BASE},
                 {E2TagCorrectlyProcessTestData.getBytes(), SAMValidationError.Type.MISMATCH_READ_LENGTH_AND_E2_LENGTH},
                 {U2TagCorrectlyProcessTestData.getBytes(), SAMValidationError.Type.MISMATCH_READ_LENGTH_AND_U2_LENGTH},
-                {SOTagCorrectlyProcessTestData.getBytes(), SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE},
                 {GOTagCorrectlyProcessTestData.getBytes(), SAMValidationError.Type.HEADER_TAG_NON_CONFORMING_VALUE}
         };
     }


### PR DESCRIPTION
### Description

Request is associated with Picard's issue https://github.com/broadinstitute/picard/issues/796

As said in that issue MergeSamFiles can't accept SAM-file with SO:UNKNOWN. That behavior is expected, because tag's value is in improper case(in accordance with SAM-format specification, SO value must be in lowercase). We've found that wrong tag case also provides an exception.

The idea of implementation is that htsjdk must check case of header's tags and values. If tag/value itself is valid, but in improper case(e.g. lowercase instead of uppercase) - it should be converted to proper case before sending the result to output(without changing the source file). Also, there must be a message if that conversion was made.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

