### PR TITLE
Fix for incorrect MISMATCH_CIGAR_SEQ_LENGTH check

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -2101,7 +2101,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             if (firstOnly) return ret;
         }
 
-        if (getCigar().getReadLength() != 0 && getCigar().getReadLength() != getReadLength()) {
+        if (getReadLength() != 0 && getCigar().getReadLength() != 0 && getCigar().getReadLength() != getReadLength()) {
             if (ret == null) ret = new ArrayList<>();
             ret.add(new SAMValidationError(SAMValidationError.Type.MISMATCH_CIGAR_SEQ_LENGTH,
                     "CIGAR covers " + getCigar().getReadLength() + " bases but the sequence is " + getReadLength() + " read bases ",

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -420,6 +420,16 @@ public class ValidateSamFileTest extends HtsjdkTest {
         Assert.assertNotNull(results.get(SAMValidationError.Type.CIGAR_MAPS_OFF_REFERENCE.getHistogramString()));
         Assert.assertEquals(results.get(SAMValidationError.Type.CIGAR_MAPS_OFF_REFERENCE.getHistogramString()).getValue(), 1.0);
     }
+    
+    @Test
+    public void testCigarNoSeqValidation() throws Exception {
+        final SAMRecordSetBuilder samBuilder = new SAMRecordSetBuilder();
+        samBuilder.addFrag("name", 0, 1, false);
+        samBuilder.iterator().next().setReadBases(SAMRecord.NULL_SEQUENCE);
+        samBuilder.iterator().next().setBaseQualities(SAMRecord.NULL_SEQUENCE);
+        final Histogram<String> results = executeValidation(samBuilder.getSamReader(), null, IndexValidationStringency.EXHAUSTIVE);
+        Assert.assertNull(results.get(SAMValidationError.Type.MISMATCH_CIGAR_SEQ_LENGTH .getHistogramString()));
+    }
 
     @Test(expectedExceptions = SAMFormatException.class)
     public void testConflictingTags() throws Exception {


### PR DESCRIPTION
### Description

Removed MISMATCH_CIGAR_SEQ_LENGTH validation check when no read sequence is defined.

When bwa reports split read alignments it only includes read sequence for the primary alignment record. Omitting the read sequence at the supplementary alignment reduces the file size without loss of information as the read sequence for the supplementary alignment records can be reconstructed from the primary alignment record and the supplementary alignment CIGAR.

