### PR TITLE
Implement SeekableStream.available

### DIFF
--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
@@ -90,15 +90,15 @@ public abstract class SeekableStream extends InputStream {
     }
 
     /**
-     * Computes how many bytes are available in the stream.
+     * The return value of this method is unusable for any purpose, and we are only implementing it
+     * because certain Java classes like {@link java.util.zip.GZIPInputStream} incorrectly rely on
+     * it to detect EOF
      *
      * <p>If {@code eof() == true}, 0 bytes are available. Otherwise, available bytes are the
      * difference between the length of the stream ({@link #length()}) and the current position
      * ({@link #position()}.
      *
-     * <p>Note: implementations might override to provide more reliable results.
-     *
-     * @return {@code 0} if the end of the file has been reached or the length cannot be determine;
+     * @return {@code 0} if the end of the file has been reached or the length cannot be determined;
      * number of bytes remaining in the stream otherwise.
      */
     @Override

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
@@ -90,6 +90,28 @@ public abstract class SeekableStream extends InputStream {
     }
 
     /**
+     * Computes how many bytes are available in the stream.
+     *
+     * <p>If {@code eof() == true}, 0 bytes are available. Otherwise, available bytes are the
+     * difference between the length of the stream ({@link #length()}) and the current position
+     * ({@link #position()}.
+     *
+     * <p>Note: implementations might override to provide more reliable results.
+     *
+     * @return {@code 0} if the end of the file has been reached or the length cannot be determine;
+     * number of bytes remaining in the stream otherwise.
+     */
+    @Override
+    public int available() throws IOException {
+        if (eof()) {
+            return 0;
+        }
+        final long remaining = length() - position();
+        // the remaining might be negative if the length is not available (0)
+        return (remaining < 0) ? 0 : (int) remaining;
+    }
+
+    /**
      * Mark the current position of the stream.
      *
      * <p>Note: there is no limit for reading.

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamGZIPinputStreamIntegrationTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamGZIPinputStreamIntegrationTest.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools.seekablestream;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.BufferedLineReader;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.LineReader;
+import htsjdk.samtools.util.TestUtil;
+import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.VariantContextBuilder;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
+import htsjdk.variant.vcf.VCFHeader;
+import htsjdk.variant.vcf.VCFHeaderLineType;
+import htsjdk.variant.vcf.VCFInfoHeaderLine;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Tests for the integration between SeekableStream and GZIPInputStream.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class SeekableStreamGZIPinputStreamIntegrationTest extends HtsjdkTest {
+    private static final String TEST_CHR = "1";
+    private static Collection<Allele> alleles = Arrays.asList(Allele.create("A", true), Allele.create("C"));
+    private static String RANDOM_ATTRIBUTE = "RD";
+
+
+    private static File createBgzipVcfsWithVariableSize(final int firstRecordAttributeLength, final int nSmallRecords) throws Exception {
+        final VariantContext longRecord = new VariantContextBuilder("long", TEST_CHR, 1, 1, alleles)
+                .attribute(RANDOM_ATTRIBUTE, generateRandomString(firstRecordAttributeLength))
+                .make();
+        final File tempFile = Files.createTempFile("test" + firstRecordAttributeLength + "_" + nSmallRecords, ".vcf.gz").toFile();
+        try (final VariantContextWriter writer = new VariantContextWriterBuilder()
+                .setOptions(VariantContextWriterBuilder.NO_OPTIONS)
+                .setOutputFile(tempFile).build()) {
+            writer.setHeader(createTestHeader()); // do not write the header
+            writer.add(longRecord);
+            for (int i = 2; i <= nSmallRecords + 1; i++) {
+                final VariantContext smallRecord = new VariantContextBuilder("short", TEST_CHR, i, i, alleles).attribute(RANDOM_ATTRIBUTE, ".").make();
+                writer.add(smallRecord);
+            }
+        }
+        return tempFile;
+    }
+
+
+    private static VCFHeader createTestHeader() {
+        final VCFHeader header = new VCFHeader();
+        header.addMetaDataLine(new VCFInfoHeaderLine(RANDOM_ATTRIBUTE, 1, VCFHeaderLineType.Character, "random string"));
+        return header;
+    }
+
+    private static String generateRandomString(final int length) {
+        final Random random = new Random(TestUtil.RANDOM_SEED);
+        final StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            // generate number from 0 to 9, and append to the builder
+            builder.append(random.nextInt(10));
+        }
+        return builder.toString();
+    }
+
+    @DataProvider
+    public Iterator<Object[]> compressedVcfsToTest() throws Exception {
+        final List<Object[]> data = new ArrayList<>();
+        final int nSmallRecords = 1000000;
+        for (int firstRecordLength = 1000; firstRecordLength <= 10000; firstRecordLength+=1000) {
+            data.add(new Object[]{createBgzipVcfsWithVariableSize(firstRecordLength, nSmallRecords), nSmallRecords+1});
+        }
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "compressedVcfsToTest")
+    public void testWrappedSeekableStreamInGZIPinputStream(final File input, final long nLines) throws Exception {
+        try (final LineReader reader = new BufferedLineReader(new GZIPInputStream(new SeekableFileStream(input)))) {
+            for (int i = 0; i < nLines; i++) {
+                Assert.assertNotNull(reader.readLine(), "line #" + reader.getLineNumber());
+            }
+            Assert.assertNull(reader.readLine());
+            Assert.assertEquals(reader.getLineNumber(), nLines);
+        }
+    }
+}

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamTest.java
@@ -25,7 +25,7 @@
 package htsjdk.samtools.seekablestream;
 
 import htsjdk.HtsjdkTest;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Random;
@@ -63,6 +63,22 @@ public class SeekableStreamTest extends HtsjdkTest {
         Assert.assertEquals(stream.read(), -1);
         stream.reset();
         Assert.assertEquals(stream.read(), current);
+    }
+
+    @Test
+    public void testAvailable() throws Exception {
+        // initiate random stream
+        final int length = 100;
+        final SeekableStream stream = getRandomSeekableStream(length);
+        // check that available returns the length
+        Assert.assertEquals(stream.available(), length);
+        // consume the stream
+        for(int i = 1; i < length + 1; i++) {
+            Assert.assertNotEquals(stream.read(), -1);
+            Assert.assertEquals(stream.available(), length - i);
+        }
+        // once consumed, no stream available
+        Assert.assertEquals(stream.available(), 0);
     }
 
     private static SeekableStream getRandomSeekableStream(final int size) {


### PR DESCRIPTION
### Description

Addresses #898 by using a common `SeekableStream` available implementation. This is necessary to fix problems while reading (b)gzip compressed files with a wrapped `SeekableStream` in a `GZIPInputStream`.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

