### PR TITLE
VCFWriter.add() exception when no header has been set

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -219,9 +219,11 @@ class VCFWriter extends IndexingVariantContextWriter {
     public void add(final VariantContext context) {
         try {
             super.add(context);
-
-            if (this.doNotWriteGenotypes) write(this.vcfEncoder.encode(new VariantContextBuilder(context).noGenotypes().make()));
-            else write(this.vcfEncoder.encode(context));
+            if (this.mHeader == null) {
+                throw new IllegalStateException("Unable to write the VCF: header is missing, " +
+                                                   "try to call writeHeader or setHeader first.");
+            }
+            write(this.vcfEncoder.encode(this.doNotWriteGenotypes ? new VariantContextBuilder(context).noGenotypes().make() : context));
             write("\n");
 
             writeAndResetBuffer();

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -362,5 +362,25 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         Assert.assertNotNull(roundtripHeader.getOtherHeaderLine("FOOBAR"), "Could not find FOOBAR header line after a write/read cycle");
         Assert.assertEquals(roundtripHeader.getOtherHeaderLine("FOOBAR").getValue(), "foovalue", "Wrong value for FOOBAR header line after a write/read cycle");
     }
+
+
+    /**
+     *
+     * A test to check that we can't write VCF with missing header.
+     */
+    @Test(dataProvider = "vcfExtensionsDataProvider", expectedExceptions = IllegalStateException.class)
+    public void testWriteWithEmptyHeader(final String extension) throws IOException {
+        final File fakeVCFFile = File.createTempFile("testWriteAndReadVCFHeaderless.", extension, tempDir);
+        metaData = new HashSet<>();
+        additionalColumns = new HashSet<>();
+        final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
+        final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
+        try (final VariantContextWriter writer = new VariantContextWriterBuilder()
+                .setOutputFile(fakeVCFFile).setReferenceDictionary(sequenceDict)
+                .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
+                .build()) {
+            writer.add(createVC(header));
+        }
+    }
 }
 


### PR DESCRIPTION
### Description

Issue: https://github.com/samtools/htsjdk/issues/1008
This issue is associated with few different errors that occurs when trying to write VCF with empty header. According to an issue, currently there isn't any check in VCFWriter.add that the header has been set. If you try to add a variant with an unset header you get a variety of unhelpful error messages.
So, we've added 
- check for empty header in add() method;
- corresponding test with .vcf and .vcf.gz input files.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

