### PR TITLE
Adding check on validator on VCFHeadLineCount

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
@@ -202,12 +202,12 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
     }
 
     private void validate() {
-        if (countType == VCFHeaderLineCount.INTEGER && count <= 0)
+        if (type != VCFHeaderLineType.Flag && countType == VCFHeaderLineCount.INTEGER && count <= 0)
             throw new IllegalArgumentException(String.format("Invalid count number, with fixed count the number should be 1 or higher: key=%s name=%s type=%s desc=%s lineType=%s count=%s",
-                    super.getKey(), name, type, description, lineType, count));
+                    getKey(), name, type, description, lineType, count));
         if (name == null || type == null || description == null || lineType == null)
             throw new IllegalArgumentException(String.format("Invalid VCFCompoundHeaderLine: key=%s name=%s type=%s desc=%s lineType=%s",
-                    super.getKey(), name, type, description, lineType));
+                    getKey(), name, type, description, lineType));
         if (name.contains("<") || name.contains(">"))
             throw new IllegalArgumentException("VCFHeaderLine: ID cannot contain angle brackets");
         if (name.contains("="))

--- a/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
@@ -202,6 +202,9 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
     }
 
     private void validate() {
+        if (countType == VCFHeaderLineCount.INTEGER && count <= 0)
+            throw new IllegalArgumentException(String.format("Invalid count number, with fixed count the number should be 1 or higher: key=%s name=%s type=%s desc=%s lineType=%s count=%s",
+                    super.getKey(), name, type, description, lineType, count));
         if (name == null || type == null || description == null || lineType == null)
             throw new IllegalArgumentException(String.format("Invalid VCFCompoundHeaderLine: key=%s name=%s type=%s desc=%s lineType=%s",
                     super.getKey(), name, type, description, lineType));

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderLineUnitTest.java
@@ -25,7 +25,6 @@ public class VCFHeaderLineUnitTest extends VariantBaseTest {
         assertEquals(encodedAttributes, expectedEncoding);
     }
 
-
     @Test
     public void testEncodeVCFHeaderLineWithEscapedQuotes() {
 
@@ -40,4 +39,28 @@ public class VCFHeaderLineUnitTest extends VariantBaseTest {
         assertEquals(encodedAttributes, expectedEncoding);
     }
 
+    @Test(expectedExceptions = { IllegalArgumentException.class }, expectedExceptionsMessageRegExp = "Invalid count number, with fixed count the number should be 1 or higher: .*")
+    public void testFormatNumberExeptions() {
+        new VCFFormatHeaderLine("test",
+                0,
+                VCFHeaderLineType.Integer,
+                "");
+    }
+
+    @Test(expectedExceptions = { IllegalArgumentException.class }, expectedExceptionsMessageRegExp = "Invalid count number, with fixed count the number should be 1 or higher: .*")
+    public void testInfoNumberExeptions() {
+        new VCFInfoHeaderLine("test",
+                0,
+                VCFHeaderLineType.Integer,
+                "");
+    }
+
+    @Test
+    public void testNumberExceptionFlag() {
+        // Should not raise an exception
+        new VCFInfoHeaderLine("test",
+                0,
+                VCFHeaderLineType.Flag,
+                "");
+    }
 }


### PR DESCRIPTION
### Description

A header with a incorrect count number can be created but after that is not readable anymore with htsjdk itself. Adding a exception to prevent this from happening.

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

