### PR TITLE
Cache result of OverlapDetector.getAll for speed

### DIFF
--- a/src/main/java/htsjdk/samtools/util/OverlapDetector.java
+++ b/src/main/java/htsjdk/samtools/util/OverlapDetector.java
@@ -103,7 +103,6 @@ public class OverlapDetector<T> {
      * and the corresponding objects.
      */
     public void addAll(final List<T> objects, final List<? extends Locatable> intervals) {
-        invalidateAllObjectsCache();
         if (objects == null) {
             throw new IllegalArgumentException("null objects");
         }

--- a/src/main/java/htsjdk/samtools/util/OverlapDetector.java
+++ b/src/main/java/htsjdk/samtools/util/OverlapDetector.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools.util;
 
+import java.lang.ref.SoftReference;
 import java.util.*;
 
 /**
@@ -42,7 +43,7 @@ public class OverlapDetector<T> {
     private final int lhsBuffer;
     private final int rhsBuffer;
 
-    private Set<T> allObjectsCache = null;
+    private transient SoftReference<Set<T>> allObjectsCache = new SoftReference<>(null);
 
     /**
      * Constructs an overlap detector.
@@ -122,10 +123,12 @@ public class OverlapDetector<T> {
      * Gets all the objects that could be returned by the overlap detector.
      */
     public Set<T> getAll() {
-        if (allObjectsCache == null) {
-            allObjectsCache = getAllNoCache();
+        Set<T> ret = allObjectsCache.get();
+        if (allObjectsCache.get() == null) {
+            ret = getAllNoCache();
+            allObjectsCache = new SoftReference<>(ret);
         }
-        return allObjectsCache;
+        return ret;
     }
 
     private void invalidateAllObjectsCache() {

--- a/src/main/java/htsjdk/samtools/util/OverlapDetector.java
+++ b/src/main/java/htsjdk/samtools/util/OverlapDetector.java
@@ -42,6 +42,8 @@ public class OverlapDetector<T> {
     private final int lhsBuffer;
     private final int rhsBuffer;
 
+    private Set<T> allObjectsCache = null;
+
     /**
      * Constructs an overlap detector.
      * @param lhsBuffer the amount by which to "trim" coordinates of mappings on the left
@@ -65,6 +67,7 @@ public class OverlapDetector<T> {
 
     /** Adds a Locatable to the set of Locatables against which to match candidates. */
     public void addLhs(final T object, final Locatable interval) {
+        invalidateAllObjectsCache();
         if (object == null) {
             throw new IllegalArgumentException("null object");
         }
@@ -100,6 +103,7 @@ public class OverlapDetector<T> {
      * and the corresponding objects.
      */
     public void addAll(final List<T> objects, final List<? extends Locatable> intervals) {
+        invalidateAllObjectsCache();
         if (objects == null) {
             throw new IllegalArgumentException("null objects");
         }
@@ -119,6 +123,17 @@ public class OverlapDetector<T> {
      * Gets all the objects that could be returned by the overlap detector.
      */
     public Set<T> getAll() {
+        if (allObjectsCache == null) {
+            allObjectsCache = getAllNoCache();
+        }
+        return allObjectsCache;
+    }
+
+    private void invalidateAllObjectsCache() {
+        allObjectsCache = null;
+    }
+
+    private Set<T> getAllNoCache() {
         final Set<T> all = new HashSet<>();
         for (final IntervalTree<Set<T>> tree : this.cache.values()) {
             for (IntervalTree.Node<Set<T>> node : tree) {


### PR DESCRIPTION
### Description

The result of getAll() method is cached, with cache invalidated if an object-modifying method is called.  For my test program, this reduces run time by about 1/3.  Note that the cache is not thread-safe, but this class is already not thread-safe.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

