### PR TITLE
Set explicitly jacoco version to 0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ repositories {
     mavenCentral()
 }
 
+// JaCoCo version
+jacoco {
+    toolVersion = "0.8.0"
+}
+
 jacocoTestReport {
     group = "Reporting"
     description = "Generate Jacoco coverage reports after running tests."


### PR DESCRIPTION
### Description

The motivation for this PR is updating the version of JaCoCo to 0.8.0, which filter out some artifacts generated on the reports and producing the coverage to be reduced (e.g., empty private constructors).

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

