### PR TITLE
Have SortingCollection check prior to final sort to adjust file buffer size given the amount of memory we have left.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -150,7 +150,6 @@ public class SortingCollection<T> implements Iterable<T> {
         this.codec = codec;
         this.comparator = comparator;
         this.maxRecordsInRam = maxRecordsInRam;
-
         this.ramRecords = (T[])Array.newInstance(componentType, maxRecordsInRam);
     }
 
@@ -480,7 +479,7 @@ public class SortingCollection<T> implements Iterable<T> {
 
         // Since we need to open and buffer all temp files in the sorting collection at once it is important
         // to have enough memory left to do this. This method checks to make sure that, given the number of files and
-        // the size of the buffer, we can reasonable open all files. If we can't it will return a buffer size that
+        // the size of the buffer, we can reasonably open all files. If we can't it will return a buffer size that
         // is appropriate given the number of temp files and the amount of memory left on the heap. If there isn't
         // enough memory for buffering it will return zero and all reading will be unbuffered.
         private int checkMemoryAndAdjustBuffer(int numFiles, int bufferSize) {

--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -474,10 +474,11 @@ public class SortingCollection<T> implements Iterable<T> {
             log.info(String.format("Creating merging iterator from %d files", files.size()));
             int suggestedBufferSize = checkMemoryAndAdjustBuffer(files.size(), Defaults.BUFFER_SIZE);
             for (final Path f : files) {
-                try (final FileRecordIterator it = new FileRecordIterator(f, suggestedBufferSize)) {
-                    if (it.hasNext()) {
-                        this.queue.add(new PeekFileRecordIterator(it, n++));
-                    }
+                final FileRecordIterator it = new FileRecordIterator(f, suggestedBufferSize);
+                if (it.hasNext()) {
+                    this.queue.add(new PeekFileRecordIterator(it, n++));
+                } else {
+                    it.close();
                 }
             }
         }

--- a/src/main/java/htsjdk/samtools/util/StringUtil.java
+++ b/src/main/java/htsjdk/samtools/util/StringUtil.java
@@ -606,4 +606,18 @@ public class StringUtil {
         }
         return true;
     }
+
+    /**
+     * Takes a long value representing the number of bytes and produces a human readable byte count.
+     * @param bytes The number of bytes to create a human readable string for.
+     * @return A human readable string of the number of bytes given.
+     */
+    public static String humanReadableByteCount(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        }
+
+        int exp = (int) (Math.log(bytes) / Math.log(1024));
+        return String.format("%.1f %sB", bytes / Math.pow(1024, exp), "kMGTPE".charAt(exp - 1));
+    }
 }


### PR DESCRIPTION
Added debugging messages that estimate the size per record for further tweaking if needed.
Use java 8 parallel sort.

These changes address issues seen in https://broadinstitute.atlassian.net/browse/DSDEGP-2232

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

