### PR TITLE
Profiled approximate file overhead instead of a flat % when calculating memory needed per file.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -131,6 +131,8 @@ public class SortingCollection<T> implements Iterable<T> {
 
     private final TempStreamFactory tempStreamFactory = new TempStreamFactory();
 
+    private final boolean sampleRecordSize;
+
     /**
      * Prepare to accumulate records to be sorted
      *
@@ -141,7 +143,8 @@ public class SortingCollection<T> implements Iterable<T> {
      * @param tmpDir          Where to write files of records that will not fit in RAM
      */
     private SortingCollection(final Class<T> componentType, final SortingCollection.Codec<T> codec,
-                              final Comparator<T> comparator, final int maxRecordsInRam, final Path... tmpDir) {
+                              final Comparator<T> comparator, final int maxRecordsInRam,
+                              final boolean sampleRecordSize, final Path... tmpDir) {
         if (maxRecordsInRam <= 0) {
             throw new IllegalArgumentException("maxRecordsInRam must be > 0");
         }
@@ -157,6 +160,7 @@ public class SortingCollection<T> implements Iterable<T> {
         @SuppressWarnings("unchecked")
         T[] ramRecords = (T[]) Array.newInstance(componentType, maxRecordsInRam);
         this.ramRecords = ramRecords;
+        this.sampleRecordSize = sampleRecordSize;
     }
 
     public void add(final T rec) {
@@ -167,10 +171,9 @@ public class SortingCollection<T> implements Iterable<T> {
             throw new IllegalStateException("Cannot add after calling iterator()");
         }
         if (numRecordsInRam == maxRecordsInRam) {
-            // sample every 100 files written.
+
             long startMem = 0;
-            boolean printRecordSizeSampling = files.size() % 100 == 0 && Log.getGlobalLogLevel() == Log.LogLevel.DEBUG;
-            if (printRecordSizeSampling) {
+            if (sampleRecordSize) {
                 // Garbage collect and get free memory
                 Runtime.getRuntime().gc();
                 startMem = Runtime.getRuntime().freeMemory();
@@ -178,7 +181,7 @@ public class SortingCollection<T> implements Iterable<T> {
 
             spillToDisk();
 
-            if (printRecordSizeSampling) {
+            if (sampleRecordSize) {
                 //Garbage collect again and get free memory
                 Runtime.getRuntime().gc();
                 long endMem = Runtime.getRuntime().freeMemory();
@@ -320,7 +323,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM,
                                                        final File... tmpDir) {
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, Arrays.stream(tmpDir).map(File::toPath).toArray(Path[]::new));
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, false, Arrays.stream(tmpDir).map(File::toPath).toArray(Path[]::new));
 
     }
 
@@ -344,10 +347,47 @@ public class SortingCollection<T> implements Iterable<T> {
                 codec,
                 comparator,
                 maxRecordsInRAM,
+                false,
                 tmpDirs.stream().map(File::toPath).toArray(Path[]::new));
 
     }
 
+    /**
+     * Syntactic sugar around the ctor, to save some typing of type parameters.  Writes files to java.io.tmpdir
+     *
+     * @param componentType    Class of the record to be sorted.  Necessary because of Java generic lameness.
+     * @param codec            For writing records to file and reading them back into RAM
+     * @param comparator       Defines output sort order
+     * @param maxRecordsInRAM  how many records to accumulate in memory before spilling to disk
+     * @param sampleRecordSize If true record size will be sampled and output at DEBUG log level
+     */
+    public static <T> SortingCollection<T> newInstance(final Class<T> componentType,
+                                                       final SortingCollection.Codec<T> codec,
+                                                       final Comparator<T> comparator,
+                                                       final int maxRecordsInRAM,
+                                                       final boolean sampleRecordSize) {
+        final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, sampleRecordSize, tmpDir);
+    }
+
+    /**
+     * Syntactic sugar around the ctor, to save some typing of type parameters
+     *
+     * @param componentType    Class of the record to be sorted.  Necessary because of Java generic lameness.
+     * @param codec            For writing records to file and reading them back into RAM
+     * @param comparator       Defines output sort order
+     * @param maxRecordsInRAM  how many records to accumulate in memory before spilling to disk
+     * @param sampleRecordSize If true record size will be sampled and output at DEBUG log level
+     * @param tmpDir           Where to write files of records that will not fit in RAM
+     */
+    public static <T> SortingCollection<T> newInstance(final Class<T> componentType,
+                                                       final SortingCollection.Codec<T> codec,
+                                                       final Comparator<T> comparator,
+                                                       final int maxRecordsInRAM,
+                                                       final boolean sampleRecordSize,
+                                                       final Path... tmpDir) {
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, sampleRecordSize, tmpDir);
+    }
 
     /**
      * Syntactic sugar around the ctor, to save some typing of type parameters.  Writes files to java.io.tmpdir
@@ -361,9 +401,8 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final SortingCollection.Codec<T> codec,
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM) {
-
         final Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, false, tmpDir);
     }
 
     /**
@@ -380,8 +419,7 @@ public class SortingCollection<T> implements Iterable<T> {
                                                        final Comparator<T> comparator,
                                                        final int maxRecordsInRAM,
                                                        final Path... tmpDir) {
-        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, tmpDir);
-
+        return new SortingCollection<>(componentType, codec, comparator, maxRecordsInRAM, false, tmpDir);
     }
 
     /**
@@ -402,8 +440,8 @@ public class SortingCollection<T> implements Iterable<T> {
                 codec,
                 comparator,
                 maxRecordsInRAM,
+                false,
                 tmpDirs.toArray(new Path[tmpDirs.size()]));
-
     }
 
     /**
@@ -489,12 +527,15 @@ public class SortingCollection<T> implements Iterable<T> {
             // garbage collect so that our calculation is accurate.
             Runtime.getRuntime().gc();
 
-            // 90% of free memory to allow for some overhead.
-            final long freeMemory = (long) (Runtime.getRuntime().freeMemory() * 0.90);
+            // There is ~20k in overhead per file.
+            final long freeMemory = Runtime.getRuntime().freeMemory() - (numFiles * 20 * 1024);
             // use the floor value from the divide
             final int memoryPerFile = (int) (freeMemory / numFiles);
 
-            if (bufferSize > memoryPerFile) {
+            if (memoryPerFile < 0) {
+                log.warn("There is not enough memory per file for buffering. Reading will be unbuffered.");
+                bufferSize = 0;
+            } else if (bufferSize > memoryPerFile) {
                 log.warn(String.format("Default io buffer size of %s is larger than available memory per file of %s.",
                         StringUtil.humanReadableByteCount(bufferSize),
                         StringUtil.humanReadableByteCount(memoryPerFile)));


### PR DESCRIPTION
Also moved sampling boolean to constructor.
This should help in low memory situations to allow use to be a little bit more conservative as to when we turn off buffering.
### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

