### PR TITLE
Make BlockCompressedFilePointerUtil#makeFilePointer public

### DIFF
--- a/src/main/java/htsjdk/samtools/util/BlockCompressedFilePointerUtil.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedFilePointerUtil.java
@@ -60,10 +60,18 @@ public class BlockCompressedFilePointerUtil {
 
     /**
      * @param blockAddress File offset of start of BGZF block.
+     * @return Virtual file pointer that points to the start of a BGZF block.
+     */
+    public static long makeFilePointer(final long blockAddress) {
+        return makeFilePointer(blockAddress, 0);
+    }
+
+    /**
+     * @param blockAddress File offset of start of BGZF block.
      * @param blockOffset Offset into uncompressed block.
      * @return Virtual file pointer that embodies the input parameters.
      */
-    static long makeFilePointer(final long blockAddress, final int blockOffset) {
+    public static long makeFilePointer(final long blockAddress, final int blockOffset) {
         if (blockOffset < 0) {
             throw new IllegalArgumentException("Negative blockOffset " + blockOffset + " not allowed.");
         }


### PR DESCRIPTION
### Description

Make a method in BlockCompressedFilePointerUtil public so that other libraries (Hadoop-BAM, Squark) can use it. Also add an overloaded version for convenience. See #1112

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

