### PR TITLE
Add VCFHeaderReader

### DIFF
--- a/src/main/java/htsjdk/variant/utils/VCFHeaderReader.java
+++ b/src/main/java/htsjdk/variant/utils/VCFHeaderReader.java
@@ -1,0 +1,56 @@
+package htsjdk.variant.utils;
+
+import htsjdk.samtools.SamStreams;
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.tribble.FeatureCodecHeader;
+import htsjdk.tribble.TribbleException;
+import htsjdk.tribble.readers.AsciiLineReader;
+import htsjdk.tribble.readers.AsciiLineReaderIterator;
+import htsjdk.tribble.readers.PositionalBufferedStream;
+import htsjdk.variant.bcf2.BCF2Codec;
+import htsjdk.variant.vcf.VCFCodec;
+import htsjdk.variant.vcf.VCFHeader;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Utility class to read a VCF header without being told beforehand whether the input is VCF or BCF.
+ */
+public final class VCFHeaderReader {
+    /**
+     * Read a VCF header from a stream assuming first that it is a VCF file (possibly gzip or block compressed),
+     * and falling back to trying BCF if reading VCF fails. After successfully reading a header the stream is
+     * positioned immediately after the header, otherwise, if an exception is thrown, the state of the stream is
+     * undefined.
+     *
+     * @param in the stream to read the header from
+     * @return the VCF header read from the stream
+     * @throws IOException if no VCF header is found
+     */
+    public static VCFHeader readHeaderFrom(final SeekableStream in) throws IOException {
+        FeatureCodecHeader headerCodec;
+        final long initialPos = in.position();
+        try {
+            BufferedInputStream bis = new BufferedInputStream(in);
+            // despite the name, SamStreams.isGzippedSAMFile looks for any gzipped stream (including block compressed)
+            InputStream is = SamStreams.isGzippedSAMFile(bis) ? new GZIPInputStream(bis) : bis;
+            headerCodec = new VCFCodec().readHeader(new AsciiLineReaderIterator(AsciiLineReader.from(is)));
+        } catch (TribbleException e) {
+            in.seek(initialPos);
+            InputStream bin = new BufferedInputStream(in);
+            if (BlockCompressedInputStream.isValidFile(bin)) {
+                bin = new BlockCompressedInputStream(bin);
+            }
+            try {
+                headerCodec = new BCF2Codec().readHeader(new PositionalBufferedStream(bin));
+            } catch (TribbleException e2) {
+                throw new IOException("No VCF header found", e2);
+            }
+        }
+        return (VCFHeader) headerCodec.getHeaderValue();
+    }
+}

--- a/src/test/java/htsjdk/variant/utils/VCFHeaderReaderTest.java
+++ b/src/test/java/htsjdk/variant/utils/VCFHeaderReaderTest.java
@@ -1,0 +1,47 @@
+package htsjdk.variant.utils;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.seekablestream.SeekableFileStream;
+import htsjdk.variant.vcf.VCFHeader;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class VCFHeaderReaderTest extends HtsjdkTest {
+    @DataProvider(name = "files")
+    Object[][] pathsData() {
+
+        final String TEST_DATA_DIR = "src/test/resources/htsjdk/variant/";
+        return new Object[][]{
+                {TEST_DATA_DIR + "VcfThatLacksAnIndex.bcf"},
+                {TEST_DATA_DIR + "VcfThatLacksAnIndex.vcf"},
+                {TEST_DATA_DIR + "VcfThatLacksAnIndex.vcf.bgz"},
+                {TEST_DATA_DIR + "VcfThatLacksAnIndex.vcf.gz"},
+        };
+    }
+
+    @Test(dataProvider = "files")
+    public void testReadHeaderFrom(final String file) throws IOException {
+        VCFHeader vcfHeader = VCFHeaderReader.readHeaderFrom(new SeekableFileStream(new File(file)));
+        Assert.assertNotNull(vcfHeader);
+    }
+
+    @Test(expectedExceptions = IOException.class)
+    public void testReadHeaderFromThrowsIOExceptionForInvalidFile() throws IOException {
+        try {
+            VCFHeaderReader.readHeaderFrom(new SeekableFileStream(new File("src/test/resources/htsjdk/samtools/empty.bam")));
+        } catch (FileNotFoundException e) {
+            Assert.fail("Should fail with IOException, not FileNotFoundException");
+        }
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void testReadHeaderFromThrowsFileNotFoundExceptionForNonExistentFile() throws IOException {
+        VCFHeaderReader.readHeaderFrom(new SeekableFileStream(new File("NonExistentFile.vcf")));
+    }
+
+}


### PR DESCRIPTION
### Description

Add a utility class (VCFHeaderReader) to read a VCFHeader from a stream without knowing if the file is VCF or BCF, or compressed or not. This is used a lot in Hadoop-BAM and GATK, but has general utility (it's not tied to Hadoop or Spark, for example), so htsjdk would be an appropriate home for it. See #1112

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

