### PR TITLE
Use ReferenceSequenceFileFactory with streams

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFile.java
@@ -69,6 +69,18 @@ abstract class AbstractIndexedFastaSequenceFile extends AbstractFastaSequenceFil
         }
     }
 
+    /**
+     * Initialise the given indexed fasta sequence file stream.
+     * @param source The named source of the reference file (used in error messages).
+     * @param index The fasta index.
+     * @param dictionary The sequence dictionary, or null if there isn't one.
+     */
+    protected AbstractIndexedFastaSequenceFile(String source, final FastaSequenceIndex index, SAMSequenceDictionary dictionary) {
+        super(null, source, dictionary);
+        this.index = index;
+        reset();
+    }
+
     protected static Path findRequiredFastaIndexFile(Path fastaFile) throws FileNotFoundException {
         Path ret = findFastaIndex(fastaFile);
         if (ret == null) throw new FileNotFoundException(ReferenceSequenceFileFactory.getFastaIndexFileName(fastaFile) + " not found.");
@@ -192,7 +204,7 @@ abstract class AbstractIndexedFastaSequenceFile extends AbstractFastaSequenceFil
                 startOffset += readFromPosition(channelBuffer, indexEntry.getLocation()+startOffset);
             }
             catch(IOException ex) {
-                throw new SAMException("Unable to load " + contig + "(" + start + ", " + stop + ") from " + getAbsolutePath(), ex);
+                throw new SAMException("Unable to load " + contig + "(" + start + ", " + stop + ") from " + getSource(), ex);
             }
 
             // Reset the buffer for outbound transfers.

--- a/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
@@ -25,6 +25,9 @@
 package htsjdk.samtools.reference;
 
 import htsjdk.samtools.SAMException;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.seekablestream.ReadableSeekableStreamByteChannel;
+import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.IOUtil;
 
@@ -93,6 +96,18 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
      */
     public IndexedFastaSequenceFile(final Path path) throws FileNotFoundException {
         this(path, new FastaSequenceIndex((findRequiredFastaIndexFile(path))));
+    }
+
+    /**
+     * Initialise the given indexed fasta sequence file stream.
+     * @param source The named source of the reference file (used in error messages).
+     * @param in The input stream to read the fasta file from.
+     * @param index The fasta index.
+     * @param dictionary The sequence dictionary, or null if there isn't one.
+     */
+    public IndexedFastaSequenceFile(String source, final SeekableStream in, final FastaSequenceIndex index, SAMSequenceDictionary dictionary) {
+        super(source, index, dictionary);
+        this.channel = new ReadableSeekableStreamByteChannel(in);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/seekablestream/ReadableSeekableStreamByteChannel.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/ReadableSeekableStreamByteChannel.java
@@ -1,0 +1,70 @@
+package htsjdk.samtools.seekablestream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+
+/**
+ * A class to wrap a {@link SeekableStream} in a read-only {@link SeekableByteChannel}.
+ */
+public class ReadableSeekableStreamByteChannel implements SeekableByteChannel {
+
+    private final SeekableStream seekableStream;
+    private final ReadableByteChannel rbc;
+    private long pos;
+
+    public ReadableSeekableStreamByteChannel(SeekableStream seekableStream) {
+        this.seekableStream = seekableStream;
+        this.rbc = Channels.newChannel(seekableStream);
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        int n = rbc.read(dst);
+        if (n > 0) {
+            pos += n;
+        }
+        return n;
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        throw new NonWritableChannelException();
+    }
+
+    @Override
+    public long position() {
+        return pos;
+    }
+
+    @Override
+    public SeekableByteChannel position(long newPosition) throws IOException {
+        // ReadableByteChannel is not buffered, so it reads through
+        seekableStream.seek(newPosition);
+        pos = newPosition;
+        return this;
+    }
+
+    @Override
+    public long size() {
+        return seekableStream.length();
+    }
+
+    @Override
+    public SeekableByteChannel truncate(long size) {
+        throw new NonWritableChannelException();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return rbc.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        rbc.close();
+    }
+}

--- a/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
+++ b/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
@@ -26,6 +26,7 @@ package htsjdk.samtools.reference;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMException;
+import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.StringUtil;
 import org.testng.Assert;
@@ -33,16 +34,18 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
 /**
  * Test the indexed fasta sequence file reader.
  */
 public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
-    private static File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/reference");
-    private static File SEQUENCE_FILE = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta");
-    private static File SEQUENCE_FILE_BGZ = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta.gz");
-    private static File SEQUENCE_FILE_NODICT = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.nodict.fasta");
+    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/reference");
+    private static final File SEQUENCE_FILE = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta");
+    private static final File SEQUENCE_FILE_INDEX = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta.fai");
+    private static final File SEQUENCE_FILE_BGZ = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta.gz");
+    private static final File SEQUENCE_FILE_NODICT = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.nodict.fasta");
 
     private final String firstBasesOfChrM = "GATCACAGGTCTATCACCCT";
     private final String extendedBasesOfChrM = "GATCACAGGTCTATCACCCTATTAACCACTCACGGGAGCTCTCCATGCAT" +
@@ -75,11 +78,19 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
                 new Object[] { ReferenceSequenceFileFactory.getReferenceSequenceFile(
                         SEQUENCE_FILE_BGZ),
                                                new BlockCompressedIndexedFastaSequenceFile(
-                                                       SEQUENCE_FILE_BGZ.toPath())},
+                                                       SEQUENCE_FILE_BGZ.toPath()) },
                 new Object[] { ReferenceSequenceFileFactory.getReferenceSequenceFile(
                         SEQUENCE_FILE_BGZ, true),
                                                new BlockCompressedIndexedFastaSequenceFile(
-                                                       SEQUENCE_FILE_BGZ.toPath())}
+                                                       SEQUENCE_FILE_BGZ.toPath()) },
+                new Object[] { ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE.getAbsolutePath(),
+                                                       new SeekableFileStream(SEQUENCE_FILE), new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX))),
+                                               new IndexedFastaSequenceFile(SEQUENCE_FILE.getAbsolutePath(), new SeekableFileStream(SEQUENCE_FILE),
+                                                       new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX)), null) },
+                new Object[] { ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE.getAbsolutePath(),
+                                                       new SeekableFileStream(SEQUENCE_FILE), new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX)), null, true),
+                                               new IndexedFastaSequenceFile(SEQUENCE_FILE.getAbsolutePath(), new SeekableFileStream(SEQUENCE_FILE),
+                                                       new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX)), null) },
         };
     }
 

--- a/src/test/java/htsjdk/samtools/reference/FastaSequenceIndexTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaSequenceIndexTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.nio.file.Files;
@@ -51,7 +52,9 @@ public class FastaSequenceIndexTest extends HtsjdkTest {
         final File sequenceIndexFile = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.fasta.fai");
         return new Object[][] { new Object[]
             { new FastaSequenceIndex(sequenceIndexFile) },
-            { new FastaSequenceIndex(sequenceIndexFile.toPath()) } };
+            { new FastaSequenceIndex(sequenceIndexFile.toPath()) },
+            { new FastaSequenceIndex(new FileInputStream(sequenceIndexFile)) }
+        };
     }
 
     @DataProvider(name="specialcharacters")
@@ -59,7 +62,9 @@ public class FastaSequenceIndexTest extends HtsjdkTest {
         final File sequenceIndexFile = new File(TEST_DATA_DIR,"testing.fai");
         return new Object[][] { new Object[]
             { new FastaSequenceIndex(sequenceIndexFile) },
-            { new FastaSequenceIndex(sequenceIndexFile.toPath()) } };
+            { new FastaSequenceIndex(sequenceIndexFile.toPath()) },
+            { new FastaSequenceIndex(new FileInputStream(sequenceIndexFile)) }
+        };
     }
 
     @Test(dataProvider="homosapiens")


### PR DESCRIPTION
### Description

Add a method to open a reference sequence by passing an input stream to a FASTA (and to its index). This would allow reading from Hadoop filesystems without having to use the file NIO library. See #1112

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

