### PR TITLE
Fix reading a CRAM with an index from a non-File Path.

### DIFF
--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -406,7 +406,17 @@ public abstract class SamReaderFactory {
                             referenceSource = ReferenceSource.getDefaultCRAMReferenceSource();
                         }
                         if (sourceFile == null || !sourceFile.isFile()) {
-                            primitiveSamReader = new CRAMFileReader(bufferedStream, indexFile, referenceSource, validationStringency);
+                            final SeekableStream indexSeekableStream =
+                                    indexMaybe == null ?
+                                            null :
+                                            indexMaybe.asUnbufferedSeekableStream();
+                            final SeekableStream sourceSeekableStream = data.asUnbufferedSeekableStream();
+                            if (null == sourceSeekableStream || null == indexSeekableStream) {
+                                primitiveSamReader = new CRAMFileReader(bufferedStream, indexFile, referenceSource, validationStringency);
+                            } else {
+                                sourceSeekableStream.seek(0);
+                                primitiveSamReader = new CRAMFileReader(sourceSeekableStream, indexSeekableStream, referenceSource, validationStringency);
+                            }
                         } else {
                             bufferedStream.close();
                             primitiveSamReader = new CRAMFileReader(sourceFile, indexFile, referenceSource, validationStringency);


### PR DESCRIPTION
Fix for GATK issue https://github.com/broadinstitute/gatk/issues/3669. Testing the change requires opening a CRAM through a Path that is backed by something that isn't a File. The newly added test, which simulates this condition, fails without this change. Is there a better way to force execution of this code path without adding any additional dependencies ?