### PR TITLE
Remove Files.exist from the .of(Path) method in SamInputResource

### DIFF
--- a/src/main/java/htsjdk/samtools/SamInputResource.java
+++ b/src/main/java/htsjdk/samtools/SamInputResource.java
@@ -93,7 +93,7 @@ public class SamInputResource {
     /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
     public static SamInputResource of(final Path path) {
 
-        if (Files.isRegularFile(path) &&  Files.exists(path)) {
+        if (Files.isRegularFile(path)) {
             return new SamInputResource(new PathInputResource(path));
         } else {
             // in the case of named pipes and other non-seekable paths there's a bug in the implementation of

--- a/src/main/java/htsjdk/samtools/SamInputResource.java
+++ b/src/main/java/htsjdk/samtools/SamInputResource.java
@@ -103,6 +103,9 @@ public class SamInputResource {
 
         // This still doesn't support the case where someone is creating a named pipe in a non-default
         // file system and then using it as input and passing a GZIPed into the other end of the pipe.
+
+        // To work around this bug, we fall back to using a FileInputResource rather than a PathInputResource
+        // when we encounter a non-regular file using the default NIO filesystem (file://)
         if (path.getFileSystem() == FileSystems.getDefault() && !Files.isRegularFile(path)) {
             return of(path.toFile());
         } else {


### PR DESCRIPTION
- According to @droazen: "This operation is expensive over certain NIO… filesystems (eg., takes on the order of seconds over GCS), so forcing it at reader creation time could potentially add hours to the wall-clock time of a task that needed to access many bams over GCS.

                        
 It's also not particularly logical to go to the else clause here if the file doesn't exist -- if it's a non-existent GCS file, PathInputResource is better equipped to produce a more relevant error message."

