### PR TITLE
Add utilities for check block-compressed files in IOUtils

### DIFF
--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -208,10 +208,8 @@ public class SamFileValidator {
     }
 
     public void validateBamFileTermination(final File inputFile) {
-        BufferedInputStream inputStream = null;
         try {
-            inputStream = IOUtil.toBufferedStream(new FileInputStream(inputFile));
-            if (!BlockCompressedInputStream.isValidFile(inputStream)) {
+            if (!IOUtil.isBlockCompressed(inputFile.toPath(), false)) {
                 return;
             }
             final BlockCompressedInputStream.FileTermination terminationState =
@@ -227,10 +225,6 @@ public class SamFileValidator {
             }
         } catch (IOException e) {
             throw new SAMException("IOException", e);
-        } finally {
-            if (inputStream != null) {
-                CloserUtil.close(inputStream);
-            }
         }
     }
 

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -209,7 +209,7 @@ public class SamFileValidator {
 
     public void validateBamFileTermination(final File inputFile) {
         try {
-            if (!IOUtil.isBlockCompressed(inputFile.toPath(), false)) {
+            if (!IOUtil.isBlockCompressed(inputFile.toPath())) {
                 return;
             }
             final BlockCompressedInputStream.FileTermination terminationState =

--- a/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
@@ -86,7 +86,7 @@ public class BlockCompressedIndexedFastaSequenceFile extends AbstractIndexedFast
     private static boolean canCreateBlockCompresedIndexedFastaSequence(final Path path) {
         try {
             // check if the it is a valid block-compressed file and if the .gzi index exits
-            return IOUtil.isBlockCompressed(path) && Files.exists(GZIIndex.resolveIndexNameForBgzipFile(path));
+            return IOUtil.isBlockCompressed(path, true) && Files.exists(GZIIndex.resolveIndexNameForBgzipFile(path));
         } catch (IOException e) {
             return false;
         }

--- a/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.GZIIndex;
+import htsjdk.samtools.util.IOUtil;
 
 import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
@@ -83,16 +84,12 @@ public class BlockCompressedIndexedFastaSequenceFile extends AbstractIndexedFast
     }
 
     private static boolean canCreateBlockCompresedIndexedFastaSequence(final Path path) {
-        try (final InputStream stream = new BufferedInputStream(Files.newInputStream(path))) {
-            // check if the it is a valid block-compressed file
-            if(BlockCompressedInputStream.isValidFile(stream)) {
-                // check if the .gzi index exits
-                return Files.exists(GZIIndex.resolveIndexNameForBgzipFile(path));
-            }
+        try {
+            // check if the it is a valid block-compressed file and if the .gzi index exits
+            return IOUtil.isBlockCompressed(path) && Files.exists(GZIIndex.resolveIndexNameForBgzipFile(path));
         } catch (IOException e) {
             return false;
         }
-        return false;
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
@@ -77,7 +77,7 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
         super(path, index);
         try {
             // check if the it is a valid block-compressed file
-            if (IOUtil.isBlockCompressed(path)) {
+            if (IOUtil.isBlockCompressed(path, true)) {
                 throw new SAMException("Indexed block-compressed FASTA file cannot be handled: " + path);
             }
             this.channel = Files.newByteChannel(path);
@@ -109,7 +109,7 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
     @Deprecated
     public static boolean canCreateIndexedFastaReader(final Path fastaFile) {
         try {
-            if (IOUtil.isBlockCompressed(fastaFile)) {
+            if (IOUtil.isBlockCompressed(fastaFile, true)) {
                 return false;
             }
             return (Files.exists(fastaFile) &&

--- a/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
@@ -75,9 +75,9 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
      */
     public IndexedFastaSequenceFile(final Path path, final FastaSequenceIndex index) {
         super(path, index);
-        try (final InputStream stream = IOUtil.maybeBufferInputStream(Files.newInputStream(path))) {
+        try {
             // check if the it is a valid block-compressed file
-            if (BlockCompressedInputStream.isValidFile(stream)) {
+            if (IOUtil.isBlockCompressed(path)) {
                 throw new SAMException("Indexed block-compressed FASTA file cannot be handled: " + path);
             }
             this.channel = Files.newByteChannel(path);
@@ -108,8 +108,8 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
      */
     @Deprecated
     public static boolean canCreateIndexedFastaReader(final Path fastaFile) {
-        try (final InputStream stream = new BufferedInputStream(Files.newInputStream(fastaFile))) {
-            if (BlockCompressedInputStream.isValidFile(stream)) {
+        try {
+            if (IOUtil.isBlockCompressed(fastaFile)) {
                 return false;
             }
             return (Files.exists(fastaFile) &&

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
@@ -127,7 +127,7 @@ public class ReferenceSequenceFileFactory {
         // Using faidx requires truncateNamesAtWhitespace
         if (truncateNamesAtWhitespace && preferIndexed && canCreateIndexedFastaReader(path)) {
             try {
-                return IOUtil.isBlockCompressed(path) ? new BlockCompressedIndexedFastaSequenceFile(path) : new IndexedFastaSequenceFile(path);
+                return IOUtil.isBlockCompressed(path, true) ? new BlockCompressedIndexedFastaSequenceFile(path) : new IndexedFastaSequenceFile(path);
             } catch (final IOException e) {
                 throw new SAMException("Error opening FASTA: " + path, e);
             }
@@ -157,7 +157,7 @@ public class ReferenceSequenceFileFactory {
             // open the file for checking for block-compressed input
             try {
                 // if it is bgzip, it requires the .gzi index
-                return !IOUtil.isBlockCompressed(fastaFile) ||
+                return !IOUtil.isBlockCompressed(fastaFile, true) ||
                         Files.exists(GZIIndex.resolveIndexNameForBgzipFile(fastaFile));
             } catch (IOException e) {
                 return false;

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
@@ -126,10 +126,8 @@ public class ReferenceSequenceFileFactory {
         getFastaExtension(path);
         // Using faidx requires truncateNamesAtWhitespace
         if (truncateNamesAtWhitespace && preferIndexed && canCreateIndexedFastaReader(path)) {
-            // TODO: change for IOUtils.isBlockCompressed (https://github.com/samtools/htsjdk/issues/1130)
-            try (final InputStream stream = new BufferedInputStream(Files.newInputStream(path))) {
-                return (BlockCompressedInputStream.isValidFile(stream)) ?
-                        new BlockCompressedIndexedFastaSequenceFile(path) : new IndexedFastaSequenceFile(path);
+            try {
+                return IOUtil.isBlockCompressed(path) ? new BlockCompressedIndexedFastaSequenceFile(path) : new IndexedFastaSequenceFile(path);
             } catch (final IOException e) {
                 throw new SAMException("Error opening FASTA: " + path, e);
             }
@@ -157,9 +155,9 @@ public class ReferenceSequenceFileFactory {
         // both the FASTA file should exists and the .fai index should exist
         if (Files.exists(fastaFile) && Files.exists(getFastaIndexFileName(fastaFile))) {
             // open the file for checking for block-compressed input
-            try (final InputStream stream = new BufferedInputStream(Files.newInputStream(fastaFile))) {
+            try {
                 // if it is bgzip, it requires the .gzi index
-                return !BlockCompressedInputStream.isValidFile(stream) ||
+                return !IOUtil.isBlockCompressed(fastaFile) ||
                         Files.exists(GZIIndex.resolveIndexNameForBgzipFile(fastaFile));
             } catch (IOException e) {
                 return false;

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1159,6 +1159,42 @@ public class IOUtil {
     }
 
     /**
+     * Checks if the provided path is block-compressed.
+     *
+     * <p>Note that using {@code checkExtension=true} would avoid the cost of opening the file, but
+     * if {@link #hasBlockCompressedExtension(String)} returns {@code false} this would not detect
+     * block-compressed files such BAM.
+     *
+     * @param path file to check if it is block-compressed.
+     * @param checkExtension if {@code true}, checks the extension before opening the file.
+     * @return {@code true} if the file is block-compressed; {@code false} otherwise.
+     * @throws IOException if there is an I/O error.
+     */
+    public static boolean isBlockCompressed(final Path path, final boolean checkExtension) throws IOException {
+        if (checkExtension && !hasBlockCompressedExtension(path.toString())) {
+            return false;
+        }
+        try (final InputStream stream = new BufferedInputStream(Files.newInputStream(path), Math.max(Defaults.BUFFER_SIZE, BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE))) {
+            return BlockCompressedInputStream.isValidFile(stream);
+        }
+    }
+
+    /**
+     * Checks if the provided path is block-compressed (including extension).
+     *
+     * <p>Note that block-compressed files with extensions not in {@link #BLOCK_COMPRESSED_EXTENSIONS}
+     * would return {@code false} with this method (e.g., BAM files) even if they are block-compressed.
+     * Use {@link #isBlockCompressed(Path, boolean)} if this is not expected.
+     *
+     * @param path file to check if it is block-compressed.
+     * @return {@code true} if the file is block-compressed; {@code false} otherwise.
+     * @throws IOException if there is an I/O error.
+     */
+    public static boolean isBlockCompressed(final Path path) throws IOException {
+        return isBlockCompressed(path, true);
+    }
+
+    /**
      * Checks if a file ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
      *
      * @param fileName string name for the file. May be an HTTP/S url.

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -64,9 +64,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.Stack;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -104,6 +106,8 @@ public class IOUtil {
     public static final String SAM_FILE_EXTENSION = ".sam";
 
     public static final String DICT_FILE_EXTENSION = ".dict";
+
+    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
 
     private static int compressionLevel = Defaults.COMPRESSION_LEVEL;
 
@@ -1153,4 +1157,60 @@ public class IOUtil {
     public static Path addExtension(Path path, String extension) {
         return path.resolveSibling(path.getFileName() + extension);
     }
+
+    /**
+     * Checks if a file ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
+     *
+     * @param fileName string name for the file. May be an HTTP/S url.
+     *
+     * @return {@code true} if the file has a block-compressed extension; {@code false} otherwise.
+     */
+    public static boolean hasBlockCompressedExtension (final String fileName) {
+        String cleanedPath = stripQueryStringIfPathIsAnHttpUrl(fileName);
+        for (final String extension : BLOCK_COMPRESSED_EXTENSIONS) {
+            if (cleanedPath.toLowerCase().endsWith(extension))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if a file ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
+     *
+     * @param file object to extract the name from.
+     *
+     * @return {@code true} if the file has a block-compressed extension; {@code false} otherwise.
+     */
+    public static boolean hasBlockCompressedExtension (final File file) {
+        return hasBlockCompressedExtension(file.getName());
+    }
+
+    /**
+     * Checks if a file ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
+     *
+     * @param uri file as an URI.
+     *
+     * @return {@code true} if the file has a block-compressed extension; {@code false} otherwise.
+     */
+    public static boolean hasBlockCompressedExtension (final URI uri) {
+        String path = uri.getPath();
+        return hasBlockCompressedExtension(path);
+    }
+
+    /**
+     * Remove http query before checking extension
+     * Path might be a local file, in which case a '?' is a legal part of the filename.
+     * @param path a string representing some sort of path, potentially an http url
+     * @return path with no trailing queryString (ex: http://something.com/path.vcf?stuff=something => http://something.com/path.vcf)
+     */
+    private static String stripQueryStringIfPathIsAnHttpUrl(String path) {
+        if(path.startsWith("http://") || path.startsWith("https://")) {
+            int qIdx = path.indexOf('?');
+            if (qIdx > 0) {
+                return path.substring(0, qIdx);
+            }
+        }
+        return path;
+    }
+
 }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1171,7 +1171,7 @@ public class IOUtil {
      * @throws IOException if there is an I/O error.
      */
     public static boolean isBlockCompressed(final Path path, final boolean checkExtension) throws IOException {
-        if (checkExtension && !hasBlockCompressedExtension(path.toString())) {
+        if (checkExtension && !hasBlockCompressedExtension(path)) {
             return false;
         }
         try (final InputStream stream = new BufferedInputStream(Files.newInputStream(path), Math.max(Defaults.BUFFER_SIZE, BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE))) {
@@ -1182,16 +1182,15 @@ public class IOUtil {
     /**
      * Checks if the provided path is block-compressed (including extension).
      *
-     * <p>Note that block-compressed files with extensions not in {@link #BLOCK_COMPRESSED_EXTENSIONS}
-     * would return {@code false} with this method (e.g., BAM files) even if they are block-compressed.
-     * Use {@link #isBlockCompressed(Path, boolean)} if this is not expected.
+     * <p>Note that block-compressed file extensions {@link #BLOCK_COMPRESSED_EXTENSIONS} are not
+     * checked by this method.
      *
      * @param path file to check if it is block-compressed.
      * @return {@code true} if the file is block-compressed; {@code false} otherwise.
      * @throws IOException if there is an I/O error.
      */
     public static boolean isBlockCompressed(final Path path) throws IOException {
-        return isBlockCompressed(path, true);
+        return isBlockCompressed(path, false);
     }
 
     /**
@@ -1208,6 +1207,17 @@ public class IOUtil {
                 return true;
         }
         return false;
+    }
+
+    /**
+     * Checks if a path ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
+     *
+     * @param path object to extract the name from.
+     *
+     * @return {@code true} if the path has a block-compressed extension; {@code false} otherwise.
+     */
+    public static boolean hasBlockCompressedExtension(final Path path) {
+        return hasBlockCompressedExtension(path.getName().toString());
     }
 
     /**
@@ -1248,5 +1258,4 @@ public class IOUtil {
         }
         return path;
     }
-
 }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1217,7 +1217,7 @@ public class IOUtil {
      * @return {@code true} if the path has a block-compressed extension; {@code false} otherwise.
      */
     public static boolean hasBlockCompressedExtension(final Path path) {
-        return hasBlockCompressedExtension(path.getName().toString());
+        return hasBlockCompressedExtension(path.getFileName().toString());
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -18,6 +18,7 @@
 
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.tribble.util.TabixUtils;
@@ -57,6 +58,8 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
 
     private static ComponentMethods methods = new ComponentMethods();
 
+    /** @deprecated use {@link IOUtil#BLOCK_COMPRESSED_EXTENSIONS} instead. */
+    @Deprecated
     public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
 
     /**
@@ -170,52 +173,28 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
     }
 
     /**
-     * Whether a filename ends in one of the BLOCK_COMPRESSED_EXTENSIONS
-     * @param fileName
-     * @return
+     * @deprecated use {@link IOUtil#hasBlockCompressedExtension(String)}.
      */
+    @Deprecated
     public static boolean hasBlockCompressedExtension (final String fileName) {
-        String cleanedPath = stripQueryStringIfPathIsAnHttpUrl(fileName);
-        for (final String extension : BLOCK_COMPRESSED_EXTENSIONS) {
-            if (cleanedPath.toLowerCase().endsWith(extension))
-                return true;
-        }
-        return false;
+        return IOUtil.hasBlockCompressedExtension(fileName);
     }
 
     /**
-     * Remove http query before checking extension
-     * Path might be a local file, in which case a '?' is a legal part of the filename.
-     * @param path a string representing some sort of path, potentially an http url
-     * @return path with no trailing queryString (ex: http://something.com/path.vcf?stuff=something => http://something.com/path.vcf)
+     * @deprecated use {@link IOUtil#hasBlockCompressedExtension(File)}.
      */
-    private static String stripQueryStringIfPathIsAnHttpUrl(String path) {
-        if(path.startsWith("http://") || path.startsWith("https://")) {
-            int qIdx = path.indexOf('?');
-            if (qIdx > 0) {
-                return path.substring(0, qIdx);
-            }
-        }
-        return path;
-    }
-
-    /**
-     * Whether the name of a file ends in one of the BLOCK_COMPRESSED_EXTENSIONS
-     * @param file
-     * @return
-     */
+    @Deprecated
     public static boolean hasBlockCompressedExtension (final File file) {
-        return hasBlockCompressedExtension(file.getName());
+        return IOUtil.hasBlockCompressedExtension(file.getName());
     }
 
     /**
-     * Whether the path of a URI resource ends in one of the BLOCK_COMPRESSED_EXTENSIONS
-     * @param uri a URI representing the resource to check
-     * @return
+     * @deprecated use {@link IOUtil#hasBlockCompressedExtension(URI)}.
      */
+    @Deprecated
     public static boolean hasBlockCompressedExtension (final URI uri) {
         String path = uri.getPath();
-        return hasBlockCompressedExtension(path);
+        return IOUtil.hasBlockCompressedExtension(path);
     }
 
     /**
@@ -240,7 +219,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
         if(indexPath == null){
             indexPath = ParsingUtils.appendToPath(resourcePath, TabixUtils.STANDARD_INDEX_EXTENSION);
         }
-        return hasBlockCompressedExtension(resourcePath) && ParsingUtils.resourceExists(indexPath);
+        return IOUtil.hasBlockCompressedExtension(resourcePath) && ParsingUtils.resourceExists(indexPath);
     }
 
     public static class ComponentMethods{

--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -60,7 +60,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
 
     /** @deprecated use {@link IOUtil#BLOCK_COMPRESSED_EXTENSIONS} instead. */
     @Deprecated
-    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
+    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = IOUtil.BLOCK_COMPRESSED_EXTENSIONS;
 
     /**
      * Calls {@link #getFeatureReader(String, FeatureCodec, boolean)} with {@code requireIndex} = true

--- a/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -25,6 +25,7 @@ package htsjdk.tribble;
 
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
@@ -250,7 +251,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
         PositionalBufferedStream pbs = null;
         try {
             is = ParsingUtils.openInputStream(path, wrapper);
-            if (hasBlockCompressedExtension(new URI(URLEncoder.encode(path, "UTF-8")))) {
+            if (IOUtil.hasBlockCompressedExtension(new URI(URLEncoder.encode(path, "UTF-8")))) {
                 // TODO: TEST/FIX THIS! https://github.com/samtools/htsjdk/issues/944
                 // TODO -- warning I don't think this can work, the buffered input stream screws up position
                 is = new GZIPInputStream(new BufferedInputStream(is));
@@ -324,7 +325,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
             final InputStream inputStream = ParsingUtils.openInputStream(path, wrapper);
 
             final PositionalBufferedStream pbs;
-            if (hasBlockCompressedExtension(path)) {
+            if (IOUtil.hasBlockCompressedExtension(path)) {
                 // Gzipped -- we need to buffer the GZIPInputStream methods as this class makes read() calls,
                 // and seekableStream does not support single byte reads
                 final InputStream is = new GZIPInputStream(new BufferedInputStream(inputStream, 512000));

--- a/src/main/java/htsjdk/tribble/bed/BEDCodec.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDCodec.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.tribble.bed;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.AsciiFeatureCodec;
 import htsjdk.tribble.annotation.Strand;
@@ -229,7 +230,7 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
     @Override
     public boolean canDecode(final String path) {
         final String toDecode;
-        if (AbstractFeatureReader.hasBlockCompressedExtension(path)) {
+        if (IOUtil.hasBlockCompressedExtension(path)) {
             toDecode = path.substring(0, path.lastIndexOf("."));
         } else {
             toDecode = path;

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -429,7 +429,7 @@ public class IndexFactory {
             this.codec = codec;
             this.inputFile = inputFile;
             try {
-                if (AbstractFeatureReader.hasBlockCompressedExtension(inputFile)) {
+                if (IOUtil.hasBlockCompressedExtension(inputFile)) {
                     final BlockCompressedInputStream bcs = initIndexableBlockCompressedStream(inputFile);
                     source = (SOURCE) codec.makeIndexableSourceFromStream(bcs);
                 } else {

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -455,7 +455,7 @@ public class IndexFactory {
         private static BlockCompressedInputStream initIndexableBlockCompressedStream(final File inputFile) {
             // test that this is in fact a valid block compressed file
             try {
-                if (!IOUtil.isBlockCompressed(inputFile.toPath())) {
+                if (!IOUtil.isBlockCompressed(inputFile.toPath(), true)) {
                     throw new TribbleException.MalformedFeatureFile("Input file is not in valid block compressed format.",
                             inputFile.getAbsolutePath());
                 }

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -453,12 +453,9 @@ public class IndexFactory {
         }
 
         private static BlockCompressedInputStream initIndexableBlockCompressedStream(final File inputFile) {
-            final int bufferSize = Math.max(Defaults.BUFFER_SIZE, BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE);
-
-            // make a buffered stream to test that this is in fact a valid block compressed file
-            try (final BufferedInputStream bufferedStream = new BufferedInputStream(new FileInputStream(inputFile), bufferSize)){
-
-                if (!BlockCompressedInputStream.isValidFile(bufferedStream)) {
+            // test that this is in fact a valid block compressed file
+            try {
+                if (!IOUtil.isBlockCompressed(inputFile.toPath())) {
                     throw new TribbleException.MalformedFeatureFile("Input file is not in valid block compressed format.",
                             inputFile.getAbsolutePath());
                 }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -502,7 +502,7 @@ public class VariantContextWriterBuilder {
         if (outFile == null)
             return false;
 
-        return AbstractFeatureReader.hasBlockCompressedExtension(outFile);
+        return IOUtil.hasBlockCompressedExtension(outFile);
     }
 
     private VariantContextWriter createVCFWriter(final File writerFile, final OutputStream writerStream) {

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -26,6 +26,8 @@ package htsjdk.samtools.util;
 import htsjdk.HtsjdkTest;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+
+import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -424,5 +426,65 @@ public class IOUtilTest extends HtsjdkTest {
         List<Path> paths = IOUtil.unrollPaths(Collections.singleton(p), extensions);
 
         Assert.assertEquals(paths.size(), expectedNumberOfUnrolledPaths);
+    }
+
+    @DataProvider(name = "blockCompressedExtensionExtensionStrings")
+    public static Object[][] createBlockCompressedExtensionStrings() {
+        return new Object[][] {
+                { "testzip.gz", true },
+                { "test.gzip", true },
+                { "test.bgz", true },
+                { "test.bgzf", true },
+                { "test.bzip2", false }
+        };
+    }
+
+    @Test(dataProvider = "blockCompressedExtensionExtensionStrings")
+    public void testBlockCompressionExtensionString(final String testString, final boolean expected) {
+        Assert.assertEquals(IOUtil.hasBlockCompressedExtension(testString), expected);
+    }
+
+    @Test(dataProvider = "blockCompressedExtensionExtensionStrings")
+    public void testBlockCompressionExtensionFile(final String testString, final boolean expected) {
+        Assert.assertEquals(IOUtil.hasBlockCompressedExtension(new File(testString)), expected);
+    }
+
+    @DataProvider(name = "blockCompressedExtensionExtensionURIStrings")
+    public static Object[][] createBlockCompressedExtensionURIs() {
+        return new Object[][]{
+                {"testzip.gz", true},
+                {"test.gzip", true},
+                {"test.bgz", true},
+                {"test.bgzf", true},
+                {"test", false},
+                {"test.bzip2", false},
+
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gz", true},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gzip", true},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgz", true},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgzf", true},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bzip2", false},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877", false},
+
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gz?alt=media", true},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gzip?alt=media", true},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgz?alt=media", true},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgzf?alt=media", true},
+                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bzip2?alt=media", false},
+
+                {"ftp://ftp.broadinstitute.org/distribution/igv/TEST/cpgIslands.hg18.gz", true},
+                {"ftp://ftp.broadinstitute.org/distribution/igv/TEST/cpgIslands.hg18.bed", false}
+        };
+    }
+
+    @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings")
+    public void testBlockCompressionExtension(final String testURIString, final boolean expected) {
+        URI testURI = URI.create(testURIString);
+        Assert.assertEquals(IOUtil.hasBlockCompressedExtension(testURI), expected);
+    }
+
+    @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings")
+    public void testBlockCompressionExtensionStringVersion(final String testURIString, final boolean expected) {
+        Assert.assertEquals(IOUtil.hasBlockCompressedExtension(testURIString), expected);
     }
 }

--- a/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
@@ -4,6 +4,8 @@ import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.FileTruncatedException;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.IOUtilTest;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.bed.BEDFeature;
@@ -77,62 +79,23 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
         }
     }
 
-    @DataProvider(name = "blockCompressedExtensionExtensionStrings")
-    public Object[][] createBlockCompressedExtensionStrings() {
-        return new Object[][] {
-                { "testzip.gz", true },
-                { "test.gzip", true },
-                { "test.bgz", true },
-                { "test.bgzf", true },
-                { "test.bzip2", false }
-        };
-    }
-
-    @Test(dataProvider = "blockCompressedExtensionExtensionStrings")
+    @Test(dataProvider = "blockCompressedExtensionExtensionStrings", dataProviderClass = IOUtilTest.class)
     public void testBlockCompressionExtensionString(final String testString, final boolean expected) {
         Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(testString), expected);
     }
 
-    @Test(dataProvider = "blockCompressedExtensionExtensionStrings")
+    @Test(dataProvider = "blockCompressedExtensionExtensionStrings", dataProviderClass = IOUtilTest.class)
     public void testBlockCompressionExtensionFile(final String testString, final boolean expected) {
         Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(new File(testString)), expected);
     }
 
-    @DataProvider(name = "blockCompressedExtensionExtensionURIStrings")
-    public Object[][] createBlockCompressedExtensionURIs() {
-        return new Object[][]{
-                {"testzip.gz", true},
-                {"test.gzip", true},
-                {"test.bgz", true},
-                {"test.bgzf", true},
-                {"test", false},
-                {"test.bzip2", false},
-
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gz", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gzip", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgz", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgzf", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bzip2", false},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877", false},
-
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gz?alt=media", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.gzip?alt=media", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgz?alt=media", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bgzf?alt=media", true},
-                {"https://www.googleapis.com/download/storage/v1/b/deflaux-public-test/o/NA12877.vcf.bzip2?alt=media", false},
-
-                {"ftp://ftp.broadinstitute.org/distribution/igv/TEST/cpgIslands.hg18.gz", true},
-                {"ftp://ftp.broadinstitute.org/distribution/igv/TEST/cpgIslands.hg18.bed", false}
-        };
-    }
-
-    @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings")
+    @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings", dataProviderClass = IOUtilTest.class)
     public void testBlockCompressionExtension(final String testURIString, final boolean expected) {
         URI testURI = URI.create(testURIString);
         Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(testURI), expected);
     }
 
-    @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings")
+    @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings", dataProviderClass = IOUtilTest.class)
     public void testBlockCompressionExtensionStringVersion(final String testURIString, final boolean expected) {
         Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(testURIString), expected);
     }

--- a/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
@@ -27,6 +27,7 @@ package htsjdk.tribble.bed;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureReader;
@@ -250,7 +251,7 @@ public class BEDCodecTest extends HtsjdkTest {
     public void testCanDecode() {
         final BEDCodec codec = new BEDCodec();
         final String pattern = "filename.%s%s";
-        for(final String bcExt: AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS) {
+        for(final String bcExt: IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
             Assert.assertTrue(codec.canDecode(String.format(pattern, "bed", bcExt)));
             Assert.assertFalse(codec.canDecode(String.format(pattern, "vcf", bcExt)));
             Assert.assertFalse(codec.canDecode(String.format(pattern, "bed.gzip", bcExt)));

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -78,7 +78,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
 
         blockCompressedVCFs = new ArrayList<File>();
         blockCompressedIndices = new ArrayList<File>();
-        for (final String extension : AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS) {
+        for (final String extension : IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
             final File blockCompressed = File.createTempFile(TEST_BASENAME, IOUtil.VCF_FILE_EXTENSION + extension);
             blockCompressed.deleteOnExit();
             blockCompressedVCFs.add(blockCompressed);
@@ -102,7 +102,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
         Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF File");
         Assert.assertFalse(((VCFWriter)writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile VCF File was compressed");
 
-        for (final String extension : AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS) {
+        for (final String extension : IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
             final File file = File.createTempFile(TEST_BASENAME + ".setoutput", extension);
             file.deleteOnExit();
             final String filename = file.getAbsolutePath();


### PR DESCRIPTION
### Description

* Move `AbstractFeatureReader.hasBlockCompressedExtension` methods to `IOUtil`
* Move `AbstractFeatureReader.BLOCK_COMPRESSED_EXTENSIONS` field to `IOUtil`
* Deprecate `AbstractFeatureReader` methods/field in favor of the `IOUtil` counterparts
* Change usages of `AbstractFeatureReader` methods/field for the `IOUtil` counterparts
* Add `IOUtil.isBlockCompressed` method to check for a block-compressed file (with or without extension check)

Closes #1130 
Related to https://github.com/broadinstitute/gatk/issues/3792

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

