### PR TITLE
VCFWriter accepts Path

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -78,7 +78,7 @@ public class BAMFileWriter extends SAMFileWriterImpl {
     }
 
     protected BAMFileWriter(final OutputStream os, final String absoluteFilename, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-      blockCompressedOutputStream = new BlockCompressedOutputStream(os, null, compressionLevel, deflaterFactory);
+      blockCompressedOutputStream = new BlockCompressedOutputStream(os, (Path)null, compressionLevel, deflaterFactory);
       outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
       outputBinaryCodec.setOutputFileName(absoluteFilename);
     }
@@ -206,7 +206,7 @@ public class BAMFileWriter extends SAMFileWriterImpl {
      * @param samFileHeader the header to write
      */
     public static void writeHeader(final OutputStream outputStream, final SAMFileHeader samFileHeader) {
-        final BlockCompressedOutputStream blockCompressedOutputStream = new BlockCompressedOutputStream(outputStream, null);
+        final BlockCompressedOutputStream blockCompressedOutputStream = new BlockCompressedOutputStream(outputStream, (Path)null);
         final BinaryCodec outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         writeHeader(outputBinaryCodec, samFileHeader);
         try {

--- a/src/main/java/htsjdk/samtools/BamFileIoUtils.java
+++ b/src/main/java/htsjdk/samtools/BamFileIoUtils.java
@@ -15,6 +15,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.List;
 
 public class BamFileIoUtils {
@@ -86,7 +87,7 @@ public class BamFileIoUtils {
                 // If we found the end of the header then write the remainder of this block out as a
                 // new gzip block and then break out of the while loop
                 if (remainingInBlock >= 0) {
-                    final BlockCompressedOutputStream blockOut = new BlockCompressedOutputStream(outputStream, null);
+                    final BlockCompressedOutputStream blockOut = new BlockCompressedOutputStream(outputStream, (Path)null);
                     IOUtil.transferByStream(blockIn, blockOut, remainingInBlock);
                     blockOut.flush();
                     // Don't close blockOut because closing underlying stream would break everything

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedInputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedInputStream.java
@@ -610,7 +610,7 @@ public class BlockCompressedInputStream extends InputStream implements LocationA
      * @throws IOException
      */
     public static FileTermination checkTermination(final File file) throws IOException {
-        return checkTermination(file == null ? null : file.toPath());
+        return checkTermination(IOUtil.toPath(file));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1127,6 +1127,17 @@ public class IOUtil {
         }
     }
 
+    /*
+     * Converts the File to a Path, preserving nullness.
+     *
+     * @param fileOrNull a File, or null
+     * @return           the corresponding Path (or null)
+     */
+    public static Path toPath(File fileOrNull) {
+        return (null == fileOrNull ? null : fileOrNull.toPath());
+    }
+
+
     public static List<Path> getPaths(List<String> uriStrings) throws RuntimeIOException {
         return uriStrings.stream().map(s -> {
             try {

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1127,17 +1127,6 @@ public class IOUtil {
         }
     }
 
-    /*
-     * Converts the File to a Path, preserving nullness.
-     *
-     * @param fileOrNull a File, or null
-     * @return           the corresponding Path (or null)
-     */
-    public static Path toPath(File fileOrNull) {
-        return (null == fileOrNull ? null : fileOrNull.toPath());
-    }
-
-
     public static List<Path> getPaths(List<String> uriStrings) throws RuntimeIOException {
         return uriStrings.stream().map(s -> {
             try {
@@ -1146,6 +1135,16 @@ public class IOUtil {
                 throw new RuntimeIOException(e);
             }
         }).collect(Collectors.toList());
+    }
+
+    /*
+     * Converts the File to a Path, preserving nullness.
+     *
+     * @param fileOrNull a File, or null
+     * @return           the corresponding Path (or null)
+     */
+    public static Path toPath(File fileOrNull) {
+        return (null == fileOrNull ? null : fileOrNull.toPath());
     }
 
     /** Takes a list of Files and converts them to a list of Paths

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -215,7 +215,7 @@ public class TabixIndex implements Index {
      */
     @Override
     public void write(final Path tabixPath) throws IOException {
-        try(final LittleEndianOutputStream los = new LittleEndianOutputStream(new BlockCompressedOutputStream(Files.newOutputStream(tabixPath), null))) {
+        try(final LittleEndianOutputStream los = new LittleEndianOutputStream(new BlockCompressedOutputStream(Files.newOutputStream(tabixPath), (Path)null))) {
             write(los);
         }
     }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.IndexCreator;
 import htsjdk.variant.bcf2.BCF2Codec;
@@ -49,6 +50,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -128,12 +130,24 @@ class BCF2Writer extends IndexingVariantContextWriter {
 
     public BCF2Writer(final File location, final OutputStream output, final SAMSequenceDictionary refDict,
                       final boolean enableOnTheFlyIndexing, final boolean doNotWriteGenotypes) {
+        this(IOUtil.toPath(location), output, refDict, enableOnTheFlyIndexing, doNotWriteGenotypes);
+    }
+
+    public BCF2Writer(final Path location, final OutputStream output, final SAMSequenceDictionary refDict,
+        final boolean enableOnTheFlyIndexing, final boolean doNotWriteGenotypes) {
         super(writerName(location, output), location, output, refDict, enableOnTheFlyIndexing);
         this.outputStream = getOutputStream();
         this.doNotWriteGenotypes = doNotWriteGenotypes;
     }
 
     public BCF2Writer(final File location, final OutputStream output, final SAMSequenceDictionary refDict,
+        final IndexCreator indexCreator,
+        final boolean enableOnTheFlyIndexing, final boolean doNotWriteGenotypes) {
+        this(IOUtil.toPath(location), output, refDict, indexCreator, enableOnTheFlyIndexing,
+            doNotWriteGenotypes);
+    }
+
+    public BCF2Writer(final Path location, final OutputStream output, final SAMSequenceDictionary refDict,
                       final IndexCreator indexCreator,
                       final boolean enableOnTheFlyIndexing, final boolean doNotWriteGenotypes) {
         super(writerName(location, output), location, output, refDict, enableOnTheFlyIndexing, indexCreator);

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.IndexCreator;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -43,6 +44,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.Path;
 
 /**
  * this class writes VCF files
@@ -86,6 +88,14 @@ class VCFWriter extends IndexingVariantContextWriter {
                      final boolean enableOnTheFlyIndexing,
                      final boolean doNotWriteGenotypes, final boolean allowMissingFieldsInHeader,
                      final boolean writeFullFormatField) {
+        this(IOUtil.toPath(location), output, refDict, enableOnTheFlyIndexing, doNotWriteGenotypes,
+            allowMissingFieldsInHeader,writeFullFormatField);
+    }
+
+    public VCFWriter(final Path location, final OutputStream output, final SAMSequenceDictionary refDict,
+        final boolean enableOnTheFlyIndexing,
+        final boolean doNotWriteGenotypes, final boolean allowMissingFieldsInHeader,
+        final boolean writeFullFormatField) {
         super(writerName(location, output), location, output, refDict, enableOnTheFlyIndexing);
         this.doNotWriteGenotypes = doNotWriteGenotypes;
         this.allowMissingFieldsInHeader = allowMissingFieldsInHeader;
@@ -96,11 +106,20 @@ class VCFWriter extends IndexingVariantContextWriter {
                      final IndexCreator indexCreator, final boolean enableOnTheFlyIndexing,
                      final boolean doNotWriteGenotypes, final boolean allowMissingFieldsInHeader,
                      final boolean writeFullFormatField) {
+        this(IOUtil.toPath(location), output, refDict, indexCreator, enableOnTheFlyIndexing,
+            doNotWriteGenotypes, allowMissingFieldsInHeader, writeFullFormatField);
+    }
+
+    public VCFWriter(final Path location, final OutputStream output, final SAMSequenceDictionary refDict,
+        final IndexCreator indexCreator, final boolean enableOnTheFlyIndexing,
+        final boolean doNotWriteGenotypes, final boolean allowMissingFieldsInHeader,
+        final boolean writeFullFormatField) {
         super(writerName(location, output), location, output, refDict, enableOnTheFlyIndexing, indexCreator);
         this.doNotWriteGenotypes = doNotWriteGenotypes;
         this.allowMissingFieldsInHeader = allowMissingFieldsInHeader;
         this.writeFullFormatField = writeFullFormatField;
     }
+
     // --------------------------------------------------------------------------------
     //
     // VCFWriter interface functions

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -504,6 +504,9 @@ public class VariantContextWriterBuilder {
                 if (!canonicalPath.equals(path)) {
                     return determineOutputTypeFromFile(canonicalPath);
                 }
+            } catch (java.nio.file.NoSuchFileException nsf) {
+                // toRealPath failed because the "real" file couldn't be found.
+                // We do nothing, just continue with the original path.
             } catch (IOException x) {
                 throw new RuntimeIOException(x);
             }
@@ -516,11 +519,11 @@ public class VariantContextWriterBuilder {
     }
 
     private static boolean isVCF(final Path outPath) {
-        return outPath != null && outPath.toString().endsWith(IOUtil.VCF_FILE_EXTENSION);
+        return outPath != null && outPath.getFileName().toString().endsWith(IOUtil.VCF_FILE_EXTENSION);
     }
 
     private static boolean isBCF(final Path outPath) {
-        return outPath != null && outPath.toString().endsWith(IOUtil.BCF_FILE_EXTENSION);
+        return outPath != null && outPath.getFileName().toString().endsWith(IOUtil.BCF_FILE_EXTENSION);
     }
 
     private static boolean isCompressedVCF(final Path outPath) {

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -39,7 +39,11 @@ import htsjdk.tribble.index.tabix.TabixIndexCreator;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
 import java.util.EnumSet;
 
 /*
@@ -119,7 +123,7 @@ public class VariantContextWriterBuilder {
 
     private SAMSequenceDictionary refDict = null;
     private OutputType outType = OutputType.UNSPECIFIED;
-    private File outFile = null;
+    private Path outPath = null;
     private OutputStream outStream = null;
     private IndexCreator idxCreator = null;
     private int bufferSize = Defaults.BUFFER_SIZE;
@@ -154,9 +158,20 @@ public class VariantContextWriterBuilder {
      * @return this <code>VariantContextWriterBuilder</code>
      */
     public VariantContextWriterBuilder setOutputFile(final File outFile) {
-        this.outFile = outFile;
+        return setOutputPath(IOUtil.toPath(outFile));
+    }
+
+    /**
+     * Set the output file for the next <code>VariantContextWriter</code> created by this builder.
+     * Determines file type implicitly from the filename.
+     *
+     * @param outPath the file the <code>VariantContextWriter</code> will write to
+     * @return this <code>VariantContextWriterBuilder</code>
+     */
+    public VariantContextWriterBuilder setOutputPath(final Path outPath) {
+        this.outPath = outPath;
         this.outStream = null;
-        this.outType = determineOutputTypeFromFile(outFile);
+        this.outType = determineOutputTypeFromFile(outPath);
         return this;
     }
 
@@ -181,7 +196,7 @@ public class VariantContextWriterBuilder {
         if (!FILE_TYPES.contains(outType))
             throw new IllegalArgumentException("Must choose a file type, not other output types.");
 
-        if (this.outFile == null || this.outStream != null)
+        if (this.outPath == null || this.outStream != null)
             throw new IllegalArgumentException("Cannot set a file type if the output is not to a file.");
 
         this.outType = outType;
@@ -197,7 +212,7 @@ public class VariantContextWriterBuilder {
      */
     public VariantContextWriterBuilder setOutputVCFStream(final OutputStream outStream) {
         this.outStream = outStream;
-        this.outFile = null;
+        this.outPath = null;
         this.outType = OutputType.VCF_STREAM;
         return this;
     }
@@ -211,7 +226,7 @@ public class VariantContextWriterBuilder {
      */
     public VariantContextWriterBuilder setOutputBCFStream(final OutputStream outStream) {
         this.outStream = outStream;
-        this.outFile = null;
+        this.outPath = null;
         this.outType = OutputType.BCF_STREAM;
         return this;
     }
@@ -387,13 +402,14 @@ public class VariantContextWriterBuilder {
     /**
      * Validate and build the <code>VariantContextWriter</code>.
      *
-     * @return the <code>VariantContextWriter</code> as specified by previous method calls
+     * @return the <code>VariantContextWriter</code> as specified by previous method calls,
+     *         optionally applying the specified OpenOptions.
      * @throws RuntimeIOException if the writer is configured to write to a file, and the corresponding path does not exist.
      * @throws IllegalArgumentException if no output file or stream is specified.
      * @throws IllegalArgumentException if <code>Options.INDEX_ON_THE_FLY</code> is specified and no reference dictionary is provided.
      * @throws IllegalArgumentException if <code>Options.INDEX_ON_THE_FLY</code> is specified and a stream output is specified.
      */
-    public VariantContextWriter build() {
+    public VariantContextWriter build(OpenOption... openOptions) {
         VariantContextWriter writer = null;
 
         // don't allow FORCE_BCF to modify the outType state
@@ -410,13 +426,14 @@ public class VariantContextWriterBuilder {
         OutputStream outStreamFromFile = this.outStream;
         if (FILE_TYPES.contains(this.outType) || (STREAM_TYPES.contains(this.outType) && this.outStream == null)) {
             try {
-                outStreamFromFile = IOUtil.maybeBufferOutputStream(new FileOutputStream(outFile), bufferSize);
+                outStreamFromFile = IOUtil.maybeBufferOutputStream(Files.newOutputStream(outPath, openOptions), bufferSize);
             } catch (final FileNotFoundException e) {
-                throw new RuntimeIOException("File not found: " + outFile, e);
+                throw new RuntimeIOException("File not found: " + outPath, e);
+            } catch (final IOException e) {
+                throw new RuntimeIOException("File not found: " + outPath, e);
             }
-
             if (createMD5)
-                outStreamFromFile = new Md5CalculatingOutputStream(outStreamFromFile, new File(outFile.getAbsolutePath() + ".md5"));
+                outStreamFromFile = new Md5CalculatingOutputStream(outStreamFromFile, IOUtil.addExtension(outPath, ".md5"));
         }
 
         switch (typeToBuild) {
@@ -426,7 +443,7 @@ public class VariantContextWriterBuilder {
                 if ((refDict == null) && (options.contains(Options.INDEX_ON_THE_FLY)))
                     throw new IllegalArgumentException("A reference dictionary is required for creating Tribble indices on the fly");
 
-                writer = createVCFWriter(outFile, outStreamFromFile);
+                writer = createVCFWriter(outPath, outStreamFromFile);
                 break;
             case BLOCK_COMPRESSED_VCF:
                 if (refDict == null)
@@ -434,13 +451,14 @@ public class VariantContextWriterBuilder {
                 else
                     idxCreator = new TabixIndexCreator(refDict, TabixFormat.VCF);
 
-                writer = createVCFWriter(outFile, new BlockCompressedOutputStream(outStreamFromFile, outFile));
+                writer = createVCFWriter(
+                    outPath, new BlockCompressedOutputStream(outStreamFromFile, outPath));
                 break;
             case BCF:
                 if ((refDict == null) && (options.contains(Options.INDEX_ON_THE_FLY)))
                     throw new IllegalArgumentException("A reference dictionary is required for creating Tribble indices on the fly");
 
-                writer = createBCFWriter(outFile, outStreamFromFile);
+                writer = createBCFWriter(outPath, outStreamFromFile);
                 break;
             case VCF_STREAM:
                 if (options.contains(Options.INDEX_ON_THE_FLY))
@@ -471,21 +489,28 @@ public class VariantContextWriterBuilder {
      * @param f A file whose {@link OutputType} we want to infer
      * @return The file's {@link OutputType}. Never {@code null}.
      */
-    public static OutputType determineOutputTypeFromFile(final File f) {
-        if (isBCF(f)) {
+    public static OutputType determineOutputTypeFromFile(final Path path) {
+        if (isBCF(path)) {
             return OutputType.BCF;
-        } else if (isCompressedVCF(f)) {
+        } else if (isCompressedVCF(path)) {
             return OutputType.BLOCK_COMPRESSED_VCF;
-        } else if (isVCF(f)) {
+        } else if (isVCF(path)) {
             return OutputType.VCF;
         }
         else {
             // See if we have a special file (device, named pipe, etc.)
-            final File canonical = new File(IOUtil.getFullCanonicalPath(f));
-            if (!canonical.equals(f)) {
-                return determineOutputTypeFromFile(canonical);
+            try {
+                // Try to resolve symlinks etc.
+                File file = path.toFile();
+                final File canonical = new File(IOUtil.getFullCanonicalPath(file));
+                if (!canonical.equals(file)) {
+                    return determineOutputTypeFromFile(IOUtil.toPath(canonical));
+                }
+            } catch (UnsupportedOperationException x) {
+                // Thrown for paths that are not from the default provider
+                // those are not going to have symlinks anyways
             }
-            else if (f.exists() && !f.isFile() && !f.isDirectory()) {
+            if (Files.exists(path) && !Files.isRegularFile(path) && !Files.isDirectory(path)) {
                 return OutputType.VCF_STREAM;
             } else {
                 return OutputType.UNSPECIFIED;
@@ -493,31 +518,31 @@ public class VariantContextWriterBuilder {
         }
     }
 
-    private static boolean isVCF(final File outFile) {
-        return outFile != null && outFile.getName().endsWith(IOUtil.VCF_FILE_EXTENSION);
+    private static boolean isVCF(final Path outPath) {
+        return outPath != null && outPath.toString().endsWith(IOUtil.VCF_FILE_EXTENSION);
     }
 
-    private static boolean isBCF(final File outFile) {
-        return outFile != null && outFile.getName().endsWith(IOUtil.BCF_FILE_EXTENSION);
+    private static boolean isBCF(final Path outPath) {
+        return outPath != null && outPath.toString().endsWith(IOUtil.BCF_FILE_EXTENSION);
     }
 
-    private static boolean isCompressedVCF(final File outFile) {
-        if (outFile == null)
+    private static boolean isCompressedVCF(final Path outPath) {
+        if (outPath == null)
             return false;
 
-        return IOUtil.hasBlockCompressedExtension(outFile);
+        return IOUtil.hasBlockCompressedExtension(outPath);
     }
 
-    private VariantContextWriter createVCFWriter(final File writerFile, final OutputStream writerStream) {
+    private VariantContextWriter createVCFWriter(final Path writerPath, final OutputStream writerStream) {
         if (idxCreator == null) {
-            return new VCFWriter(writerFile, writerStream, refDict,
+            return new VCFWriter(writerPath, writerStream, refDict,
                     options.contains(Options.INDEX_ON_THE_FLY),
                     options.contains(Options.DO_NOT_WRITE_GENOTYPES),
                     options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER),
                     options.contains(Options.WRITE_FULL_FORMAT_FIELD));
         }
         else {
-            return new VCFWriter(writerFile, writerStream, refDict, idxCreator,
+            return new VCFWriter(writerPath, writerStream, refDict, idxCreator,
                     options.contains(Options.INDEX_ON_THE_FLY),
                     options.contains(Options.DO_NOT_WRITE_GENOTYPES),
                     options.contains(Options.ALLOW_MISSING_FIELDS_IN_HEADER),
@@ -525,14 +550,14 @@ public class VariantContextWriterBuilder {
         }
     }
 
-    private VariantContextWriter createBCFWriter(final File writerFile, final OutputStream writerStream) {
+    private VariantContextWriter createBCFWriter(final Path writerPath, final OutputStream writerStream) {
         if (idxCreator == null) {
-            return new BCF2Writer(writerFile, writerStream, refDict,
+            return new BCF2Writer(writerPath, writerStream, refDict,
                     options.contains(Options.INDEX_ON_THE_FLY),
                     options.contains(Options.DO_NOT_WRITE_GENOTYPES));
         }
         else {
-            return new BCF2Writer(writerFile, writerStream, refDict, idxCreator,
+            return new BCF2Writer(writerPath, writerStream, refDict, idxCreator,
                     options.contains(Options.INDEX_ON_THE_FLY),
                     options.contains(Options.DO_NOT_WRITE_GENOTYPES));
         }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -500,15 +500,12 @@ public class VariantContextWriterBuilder {
         else {
             // See if we have a special file (device, named pipe, etc.)
             try {
-                // Try to resolve symlinks etc.
-                File file = path.toFile();
-                final File canonical = new File(IOUtil.getFullCanonicalPath(file));
-                if (!canonical.equals(file)) {
-                    return determineOutputTypeFromFile(IOUtil.toPath(canonical));
+                final Path canonicalPath = path.toRealPath();
+                if (!canonicalPath.equals(path)) {
+                    return determineOutputTypeFromFile(canonicalPath);
                 }
-            } catch (UnsupportedOperationException x) {
-                // Thrown for paths that are not from the default provider
-                // those are not going to have symlinks anyways
+            } catch (IOException x) {
+                throw new RuntimeIOException(x);
             }
             if (Files.exists(path) && !Files.isRegularFile(path) && !Files.isDirectory(path)) {
                 return OutputType.VCF_STREAM;

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -1,27 +1,27 @@
 /*
-* Copyright (c) 2014 The Broad Institute
-* 
-* Permission is hereby granted, free of charge, to any person
-* obtaining a copy of this software and associated documentation
-* files (the "Software"), to deal in the Software without
-* restriction, including without limitation the rights to use,
-* copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the
-* Software is furnished to do so, subject to the following
-* conditions:
-* 
-* The above copyright notice and this permission notice shall be
-* included in all copies or substantial portions of the Software.
-* 
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
-* THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
+ * Copyright (c) 2014 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+ * THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 package htsjdk.variant.variantcontext.writer;
 
@@ -32,7 +32,6 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
-import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Tribble;
 import htsjdk.tribble.util.TabixUtils;
 import htsjdk.variant.VariantBaseTest;
@@ -58,429 +57,449 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
-	private static final String TEST_BASENAME = "htsjdk-test VariantContextWriterBuilderUnitTest";
-    private SAMSequenceDictionary dictionary;
+  private static final String TEST_BASENAME = "htsjdk-test VariantContextWriterBuilderUnitTest";
+  private SAMSequenceDictionary dictionary;
 
-    private File vcf;
-    private File vcfIdx;
-    private File vcfMD5;
-    private File bcf;
-    private File bcfIdx;
-    private File unknown;
+  private File vcf;
+  private File vcfIdx;
+  private File vcfMD5;
+  private File bcf;
+  private File bcfIdx;
+  private File unknown;
 
-    private List<File> blockCompressedVCFs;
-    private List<File> blockCompressedIndices;
+  private List<File> blockCompressedVCFs;
+  private List<File> blockCompressedIndices;
 
-    @BeforeSuite
-    public void before() throws IOException {
-        dictionary = createArtificialSequenceDictionary();
-        vcf = File.createTempFile(TEST_BASENAME, IOUtil.VCF_FILE_EXTENSION);
-        vcf.deleteOnExit();
-        vcfIdx = Tribble.indexFile(vcf);
-        vcfIdx.deleteOnExit();
-        vcfMD5 = new File(vcf.getAbsolutePath() + ".md5");
-        vcfMD5.deleteOnExit();
-        bcf = File.createTempFile(TEST_BASENAME, IOUtil.BCF_FILE_EXTENSION);
-        bcf.deleteOnExit();
-        bcfIdx = Tribble.indexFile(bcf);
-        bcfIdx.deleteOnExit();
-        unknown = File.createTempFile(TEST_BASENAME, ".unknown");
-        unknown.deleteOnExit();
+  @BeforeSuite
+  public void before() throws IOException {
+    dictionary = createArtificialSequenceDictionary();
+    vcf = File.createTempFile(TEST_BASENAME, IOUtil.VCF_FILE_EXTENSION);
+    vcf.deleteOnExit();
+    vcfIdx = Tribble.indexFile(vcf);
+    vcfIdx.deleteOnExit();
+    vcfMD5 = new File(vcf.getAbsolutePath() + ".md5");
+    vcfMD5.deleteOnExit();
+    bcf = File.createTempFile(TEST_BASENAME, IOUtil.BCF_FILE_EXTENSION);
+    bcf.deleteOnExit();
+    bcfIdx = Tribble.indexFile(bcf);
+    bcfIdx.deleteOnExit();
+    unknown = File.createTempFile(TEST_BASENAME, ".unknown");
+    unknown.deleteOnExit();
 
-        blockCompressedVCFs = new ArrayList<File>();
-        blockCompressedIndices = new ArrayList<File>();
-        for (final String extension : IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
-            final File blockCompressed = File.createTempFile(TEST_BASENAME, IOUtil.VCF_FILE_EXTENSION + extension);
-            blockCompressed.deleteOnExit();
-            blockCompressedVCFs.add(blockCompressed);
+    blockCompressedVCFs = new ArrayList<File>();
+    blockCompressedIndices = new ArrayList<File>();
+    for (final String extension : IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
+      final File blockCompressed = File.createTempFile(TEST_BASENAME, IOUtil.VCF_FILE_EXTENSION + extension);
+      blockCompressed.deleteOnExit();
+      blockCompressedVCFs.add(blockCompressed);
 
-            final File index = new File(blockCompressed.getAbsolutePath() + TabixUtils.STANDARD_INDEX_EXTENSION);
-            index.deleteOnExit();
-            blockCompressedIndices.add(index);
-        }
+      final File index = new File(blockCompressed.getAbsolutePath() + TabixUtils.STANDARD_INDEX_EXTENSION);
+      index.deleteOnExit();
+      blockCompressedIndices.add(index);
+    }
+  }
+
+  @Test
+  public void testSetOutputFile() throws IOException {
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary);
+
+    VariantContextWriter writer = builder.setOutputFile(vcf.getAbsolutePath()).build();
+    Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF String");
+    Assert.assertFalse(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile VCF String was compressed");
+
+    writer = builder.setOutputFile(vcf).build();
+    Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF File");
+    Assert.assertFalse(((VCFWriter)writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile VCF File was compressed");
+
+    for (final String extension : IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
+      final File file = File.createTempFile(TEST_BASENAME + ".setoutput", extension);
+      file.deleteOnExit();
+      final String filename = file.getAbsolutePath();
+
+      writer = builder.setOutputFile(filename).build();
+      Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile " + extension + " String");
+      Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile " + extension + " String was not compressed");
+
+      writer = builder.setOutputFile(file).build();
+      Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile " + extension + " File");
+      Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile " + extension + " File was not compressed");
     }
 
-    @Test
-    public void testSetOutputFile() throws IOException {
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary);
+    writer = builder.setOutputFile(bcf).build();
+    Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFile BCF String");
 
-        VariantContextWriter writer = builder.setOutputFile(vcf.getAbsolutePath()).build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF String");
-        Assert.assertFalse(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile VCF String was compressed");
+    writer = builder.setOutputFile(bcf.getAbsolutePath()).build();
+    Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFile BCF File");
+  }
 
-        writer = builder.setOutputFile(vcf).build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF File");
-        Assert.assertFalse(((VCFWriter)writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile VCF File was compressed");
-
-        for (final String extension : IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
-            final File file = File.createTempFile(TEST_BASENAME + ".setoutput", extension);
-            file.deleteOnExit();
-            final String filename = file.getAbsolutePath();
-
-            writer = builder.setOutputFile(filename).build();
-            Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile " + extension + " String");
-            Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile " + extension + " String was not compressed");
-
-            writer = builder.setOutputFile(file).build();
-            Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile " + extension + " File");
-            Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile " + extension + " File was not compressed");
-        }
-
-        writer = builder.setOutputFile(bcf).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFile BCF String");
-
-        writer = builder.setOutputFile(bcf.getAbsolutePath()).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFile BCF File");
+  @Test
+  public void testDetermineOutputType() {
+    Assert.assertEquals(OutputType.VCF, VariantContextWriterBuilder.determineOutputTypeFromFile(this.vcf.toPath()));
+    Assert.assertEquals(OutputType.BCF, VariantContextWriterBuilder.determineOutputTypeFromFile(this.bcf.toPath()));
+    Assert.assertEquals(OutputType.VCF_STREAM, VariantContextWriterBuilder.determineOutputTypeFromFile(new File("/dev/stdout").toPath()));
+    for (final File f: this.blockCompressedVCFs) {
+      Assert.assertEquals(OutputType.BLOCK_COMPRESSED_VCF, VariantContextWriterBuilder.determineOutputTypeFromFile(f.toPath()));
     }
 
-    @Test
-    public void testDetermineOutputType() {
-        Assert.assertEquals(OutputType.VCF, VariantContextWriterBuilder.determineOutputTypeFromFile(this.vcf.toPath()));
-        Assert.assertEquals(OutputType.BCF, VariantContextWriterBuilder.determineOutputTypeFromFile(this.bcf.toPath()));
-        Assert.assertEquals(OutputType.VCF_STREAM, VariantContextWriterBuilder.determineOutputTypeFromFile(new File("/dev/stdout").toPath()));
-        for (final File f: this.blockCompressedVCFs) {
-            Assert.assertEquals(OutputType.BLOCK_COMPRESSED_VCF, VariantContextWriterBuilder.determineOutputTypeFromFile(f.toPath()));
-        }
-
-        // Test symlinking
-        try {
-            final Path link = Files.createTempFile("foo.", ".tmp");
-            Files.deleteIfExists(link);
-            Files.createSymbolicLink(link, this.vcf.toPath());
-            link.toFile().deleteOnExit();
-            Assert.assertEquals(OutputType.VCF, VariantContextWriterBuilder.determineOutputTypeFromFile(link));
-            link.toFile().delete();
-        }
-        catch (final IOException ioe) {
-            throw new RuntimeIOException(ioe);
-        }
+    // Test symlinking
+    try {
+      final Path link = Files.createTempFile("foo.", ".tmp");
+      Files.deleteIfExists(link);
+      Files.createSymbolicLink(link, this.vcf.toPath());
+      link.toFile().deleteOnExit();
+      Assert.assertEquals(OutputType.VCF, VariantContextWriterBuilder.determineOutputTypeFromFile(link));
+      link.toFile().delete();
     }
-
-    @Test
-    public void testSetOutputFileType() {
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputFile(unknown);
-
-        VariantContextWriter writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.VCF).build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFileType VCF");
-        Assert.assertFalse(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFileType VCF was compressed");
-
-        writer = builder.setOption(Options.FORCE_BCF).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFileType FORCE_BCF set -> expected BCF, was VCF");
-
-        // test that FORCE_BCF remains in effect, overriding the explicit setting of VCF
-        writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.VCF).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFileType FORCE_BCF set 2 -> expected BCF, was VCF");
-
-        writer = builder.unsetOption(Options.FORCE_BCF).build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFileType FORCE_BCF unset -> expected VCF, was BCF");
-        Assert.assertFalse(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFileType FORCE_BCF unset was compressed");
-
-        writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.BLOCK_COMPRESSED_VCF).build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile BLOCK_COMPRESSED_VCF");
-        Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFileType BLOCK_COMPRESSED_VCF was not compressed");
-
-        writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.BCF).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFileType BCF");
+    catch (final IOException ioe) {
+      throw new RuntimeIOException(ioe);
     }
+  }
 
-    @Test
-    public void testSetOutputStream() {
-        final OutputStream stream = new ByteArrayOutputStream();
+  @Test
+  public void testSetOutputFileType() {
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputFile(unknown);
 
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .unsetOption(Options.INDEX_ON_THE_FLY)
-                .setOutputStream(stream);
+    VariantContextWriter writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.VCF).build();
+    Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFileType VCF");
+    Assert.assertFalse(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFileType VCF was compressed");
 
-        VariantContextWriter writer = builder.build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputStream default");
+    writer = builder.setOption(Options.FORCE_BCF).build();
+    Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFileType FORCE_BCF set -> expected BCF, was VCF");
 
-        writer = builder.setOption(Options.FORCE_BCF).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputStream FORCE_BCF set -> expected BCF stream, was VCF stream");
+    // test that FORCE_BCF remains in effect, overriding the explicit setting of VCF
+    writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.VCF).build();
+    Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFileType FORCE_BCF set 2 -> expected BCF, was VCF");
 
-        // test that FORCE_BCF remains in effect, overriding the explicit setting of VCF
-        writer = builder.setOutputVCFStream(stream).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputStream FORCE_BCF set 2 -> expected BCF stream, was VCF stream");
+    writer = builder.unsetOption(Options.FORCE_BCF).build();
+    Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFileType FORCE_BCF unset -> expected VCF, was BCF");
+    Assert.assertFalse(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFileType FORCE_BCF unset was compressed");
 
-        writer = builder.unsetOption(Options.FORCE_BCF).build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputStream FORCE_BCF unset -> expected VCF stream, was BCF stream");
+    writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.BLOCK_COMPRESSED_VCF).build();
+    Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile BLOCK_COMPRESSED_VCF");
+    Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFileType BLOCK_COMPRESSED_VCF was not compressed");
 
-        writer = builder.setOutputBCFStream(stream).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputStream BCF");
+    writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.BCF).build();
+    Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFileType BCF");
+  }
 
-        writer = builder.setOutputVCFStream(stream).build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputStream VCF");
+  @Test
+  public void testSetOutputStream() {
+    final OutputStream stream = new ByteArrayOutputStream();
+
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .unsetOption(Options.INDEX_ON_THE_FLY)
+        .setOutputStream(stream);
+
+    VariantContextWriter writer = builder.build();
+    Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputStream default");
+
+    writer = builder.setOption(Options.FORCE_BCF).build();
+    Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputStream FORCE_BCF set -> expected BCF stream, was VCF stream");
+
+    // test that FORCE_BCF remains in effect, overriding the explicit setting of VCF
+    writer = builder.setOutputVCFStream(stream).build();
+    Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputStream FORCE_BCF set 2 -> expected BCF stream, was VCF stream");
+
+    writer = builder.unsetOption(Options.FORCE_BCF).build();
+    Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputStream FORCE_BCF unset -> expected VCF stream, was BCF stream");
+
+    writer = builder.setOutputBCFStream(stream).build();
+    Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputStream BCF");
+
+    writer = builder.setOutputVCFStream(stream).build();
+    Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputStream VCF");
+  }
+
+  @Test
+  public void testAsync() {
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputFile(vcf);
+
+    VariantContextWriter writer = builder.build();
+    Assert.assertEquals(writer instanceof AsyncVariantContextWriter, Defaults.USE_ASYNC_IO_WRITE_FOR_TRIBBLE, "testAsync default");
+
+    writer = builder.setOption(Options.USE_ASYNC_IO).build();
+    Assert.assertTrue(writer instanceof AsyncVariantContextWriter, "testAsync option=set");
+
+    writer = builder.unsetOption(Options.USE_ASYNC_IO).build();
+    Assert.assertFalse(writer instanceof AsyncVariantContextWriter, "testAsync option=unset");
+  }
+
+  @Test
+  public void testBuffering() {
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputFile(vcf)
+        .unsetOption(Options.INDEX_ON_THE_FLY);     // so the potential BufferedOutputStream is not wrapped in a PositionalOutputStream
+
+    VariantContextWriter writer = builder.build();
+    Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BufferedOutputStream, "testBuffering was not buffered by default");
+
+    writer = builder.unsetBuffering().build();
+    Assert.assertFalse(((VCFWriter) writer).getOutputStream() instanceof BufferedOutputStream, "testBuffering was buffered when unset");
+
+    writer = builder.setBuffer(8192).build();
+    Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BufferedOutputStream, "testBuffering was not buffered when set");
+  }
+
+  @Test
+  public void testMD5() {
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputFile(vcf);
+
+    VariantContextWriter writer = builder.build();
+    writer.close();
+    Assert.assertEquals(vcfMD5.exists(), Defaults.CREATE_MD5, "MD5 default setting not respected");
+
+    if (vcfMD5.exists())
+      vcfMD5.delete();
+
+    writer = builder.setCreateMD5().build();
+    writer.close();
+    Assert.assertTrue(vcfMD5.exists(), "MD5 not created when requested");
+    vcfMD5.delete();
+
+    writer = builder.unsetCreateMD5().build();
+    writer.close();
+    Assert.assertFalse(vcfMD5.exists(), "MD5 created when not requested");
+
+    writer = builder.setCreateMD5(false).build();
+    writer.close();
+    Assert.assertFalse(vcfMD5.exists(), "MD5 created when not requested via boolean parameter");
+
+    writer = builder.setCreateMD5(true).build();
+    writer.close();
+    Assert.assertTrue(vcfMD5.exists(), "MD5 not created when requested via boolean parameter");
+    vcfMD5.delete();
+
+    for (final File blockCompressed : blockCompressedVCFs) {
+      final File md5 = new File(blockCompressed + ".md5");
+      if (md5.exists())
+        md5.delete();
+      md5.deleteOnExit();
+      writer = builder.setOutputFile(blockCompressed).build();
+      writer.close();
+      Assert.assertTrue(md5.exists(), "MD5 digest not created for " + blockCompressed);
     }
+  }
 
-    @Test
-    public void testAsync() {
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputFile(vcf);
+  @Test
+  public void testIndexingOnTheFly() {
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOption(Options.INDEX_ON_THE_FLY);
 
-        VariantContextWriter writer = builder.build();
-        Assert.assertEquals(writer instanceof AsyncVariantContextWriter, Defaults.USE_ASYNC_IO_WRITE_FOR_TRIBBLE, "testAsync default");
+    if (vcfIdx.exists())
+      vcfIdx.delete();
+    VariantContextWriter writer = builder.setOutputFile(vcf).build();
+    writer.close();
+    Assert.assertTrue(vcfIdx.exists(), String.format("VCF index not created for %s / %s", vcf, vcfIdx));
 
-        writer = builder.setOption(Options.USE_ASYNC_IO).build();
-        Assert.assertTrue(writer instanceof AsyncVariantContextWriter, "testAsync option=set");
+    if (bcfIdx.exists())
+      bcfIdx.delete();
+    writer = builder.setOutputFile(bcf).build();
+    writer.close();
+    Assert.assertTrue(bcfIdx.exists(), String.format("BCF index not created for %s / %s", bcf, bcfIdx));
 
-        writer = builder.unsetOption(Options.USE_ASYNC_IO).build();
-        Assert.assertFalse(writer instanceof AsyncVariantContextWriter, "testAsync option=unset");
+    for (int i = 0; i < blockCompressedVCFs.size(); i++) {
+      final File blockCompressed = blockCompressedVCFs.get(i);
+      final File index = blockCompressedIndices.get(i);
+      if (index.exists())
+        index.delete();
+      writer = builder.setOutputFile(blockCompressed).setReferenceDictionary(dictionary).build();
+      writer.close();
+      Assert.assertTrue(index.exists(), String.format("Block-compressed index not created for %s / %s", blockCompressed, index));
+
+      // Tabix does not require a reference dictionary.
+      // Tribble does: see tests testRefDictRequiredForVCFIndexOnTheFly / testRefDictRequiredForBCFIndexOnTheFly
+
+      index.delete();
+      writer = builder.setReferenceDictionary(null).build();
+      writer.close();
+      Assert.assertTrue(index.exists(), String.format("Block-compressed index not created for %s / %s", blockCompressed, index));
     }
+  }
 
-    @Test
-    public void testBuffering() {
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputFile(vcf)
-                .unsetOption(Options.INDEX_ON_THE_FLY);     // so the potential BufferedOutputStream is not wrapped in a PositionalOutputStream
+  @Test
+  public void testIndexingOnTheFlyForPath() throws IOException {
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOption(Options.INDEX_ON_THE_FLY);
 
-        VariantContextWriter writer = builder.build();
-        Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BufferedOutputStream, "testBuffering was not buffered by default");
+    try (FileSystem fs = Jimfs.newFileSystem("test", Configuration.unix())) {
+      final Path vcfPath = fs.getPath(vcf.getName());
+      final Path vcfIdxPath = Tribble.indexPath(vcfPath);
+      try(final VariantContextWriter writer = builder.setOutputPath(vcfPath).build())
+      {
+        //deliberately empty
+      }
 
-        writer = builder.unsetBuffering().build();
-        Assert.assertFalse(((VCFWriter) writer).getOutputStream() instanceof BufferedOutputStream, "testBuffering was buffered when unset");
+      Assert.assertTrue(Files.exists(vcfIdxPath),
+          String.format("VCF index not created for %s / %s", vcfPath, vcfIdxPath));
 
-        writer = builder.setBuffer(8192).build();
-        Assert.assertTrue(((VCFWriter) writer).getOutputStream() instanceof BufferedOutputStream, "testBuffering was not buffered when set");
-    }
+      final Path bcfPath = fs.getPath(bcf.getName());
+      final Path bcfIdxPath = Tribble.indexPath(bcfPath);
+      try(final VariantContextWriter writer = builder.setOutputPath(bcfPath).build()){
+        //deliberately empty
+      }
+      Assert.assertTrue(Files.exists(bcfIdxPath),
+          String.format("BCF index not created for %s / %s", bcfPath, bcfIdxPath));
 
-    @Test
-    public void testMD5() {
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputFile(vcf);
+      for (int i = 0; i < blockCompressedVCFs.size(); i++) {
+        final File blockCompressed = blockCompressedVCFs.get(i);
+        final File index = blockCompressedIndices.get(i);
 
-        VariantContextWriter writer = builder.build();
-        writer.close();
-        Assert.assertEquals(vcfMD5.exists(), Defaults.CREATE_MD5, "MD5 default setting not respected");
+        final Path blockCompressedPath = fs.getPath(blockCompressed.getName());
+        final Path indexPath = fs.getPath(index.getName());
 
-        if (vcfMD5.exists())
-            vcfMD5.delete();
-
-        writer = builder.setCreateMD5().build();
-        writer.close();
-        Assert.assertTrue(vcfMD5.exists(), "MD5 not created when requested");
-        vcfMD5.delete();
-
-        writer = builder.unsetCreateMD5().build();
-        writer.close();
-        Assert.assertFalse(vcfMD5.exists(), "MD5 created when not requested");
-
-        writer = builder.setCreateMD5(false).build();
-        writer.close();
-        Assert.assertFalse(vcfMD5.exists(), "MD5 created when not requested via boolean parameter");
-
-        writer = builder.setCreateMD5(true).build();
-        writer.close();
-        Assert.assertTrue(vcfMD5.exists(), "MD5 not created when requested via boolean parameter");
-        vcfMD5.delete();
-
-        for (final File blockCompressed : blockCompressedVCFs) {
-            final File md5 = new File(blockCompressed + ".md5");
-            if (md5.exists())
-                md5.delete();
-            md5.deleteOnExit();
-            writer = builder.setOutputFile(blockCompressed).build();
-            writer.close();
-            Assert.assertTrue(md5.exists(), "MD5 digest not created for " + blockCompressed);
+        Assert.assertFalse(Files.exists(indexPath));
+        try(VariantContextWriter writer = builder.setOutputPath(blockCompressedPath).setReferenceDictionary(dictionary).build()){
+          //deliberately empty
         }
-    }
+        Assert.assertTrue(Files.exists(indexPath), String
+            .format("Block-compressed index not created for %s / %s", blockCompressedPath, indexPath));
 
-    @Test
-    public void testIndexingOnTheFly() {
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOption(Options.INDEX_ON_THE_FLY);
-
-        if (vcfIdx.exists())
-            vcfIdx.delete();
-        VariantContextWriter writer = builder.setOutputFile(vcf).build();
-        writer.close();
-        Assert.assertTrue(vcfIdx.exists(), String.format("VCF index not created for %s / %s", vcf, vcfIdx));
-
-        if (bcfIdx.exists())
-            bcfIdx.delete();
-        writer = builder.setOutputFile(bcf).build();
-        writer.close();
-        Assert.assertTrue(bcfIdx.exists(), String.format("BCF index not created for %s / %s", bcf, bcfIdx));
-
-        for (int i = 0; i < blockCompressedVCFs.size(); i++) {
-            final File blockCompressed = blockCompressedVCFs.get(i);
-            final File index = blockCompressedIndices.get(i);
-            if (index.exists())
-                index.delete();
-            writer = builder.setOutputFile(blockCompressed).setReferenceDictionary(dictionary).build();
-            writer.close();
-            Assert.assertTrue(index.exists(), String.format("Block-compressed index not created for %s / %s", blockCompressed, index));
-
-            // Tabix does not require a reference dictionary.
-            // Tribble does: see tests testRefDictRequiredForVCFIndexOnTheFly / testRefDictRequiredForBCFIndexOnTheFly
-
-            index.delete();
-            writer = builder.setReferenceDictionary(null).build();
-            writer.close();
-            Assert.assertTrue(index.exists(), String.format("Block-compressed index not created for %s / %s", blockCompressed, index));
+        // Tabix does not require a reference dictionary.
+        // Tribble does: see tests testRefDictRequiredForVCFIndexOnTheFly / testRefDictRequiredForBCFIndexOnTheFly
+        Files.delete(indexPath);
+        try (VariantContextWriter writer = builder.setReferenceDictionary(null).build()){
+          //deliberately empty
         }
-    }
-
-    @Test
-    public void testIndexingOnTheFlyForPath() throws IOException {
-      final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-          .setReferenceDictionary(dictionary)
-          .setOption(Options.INDEX_ON_THE_FLY);
-
-      try (FileSystem fs = Jimfs.newFileSystem("test", Configuration.unix())) {
-        Path vcfPath = fs.getPath("testIndexingOnTheFlyForPath" + IOUtil.VCF_FILE_EXTENSION);
-        Path vcfIdxPath = Tribble.indexPath(vcfPath);
-        VariantContextWriter writer = builder.setOutputPath(vcfPath).build();
-        writer.close();
-        Assert.assertTrue(Files.exists(vcfIdxPath),
-            String.format("VCF index not created for %s / %s", vcfPath, vcfIdxPath));
-
-        if (bcfIdx.exists()) {
-          bcfIdx.delete();
-        }
-        writer = builder.setOutputPath(bcf.toPath()).build();
-        writer.close();
-        Assert.assertTrue(bcfIdx.exists(),
-            String.format("BCF index not created for %s / %s", bcf, bcfIdx));
-
-        for (int i = 0; i < blockCompressedVCFs.size(); i++) {
-          final File blockCompressed = blockCompressedVCFs.get(i);
-          final File index = blockCompressedIndices.get(i);
-          if (index.exists())
-            index.delete();
-          writer = builder.setOutputPath(blockCompressed.toPath()).setReferenceDictionary(dictionary).build();
-          writer.close();
-          Assert.assertTrue(index.exists(), String
-              .format("Block-compressed index not created for %s / %s", blockCompressed, index));
-
-          // Tabix does not require a reference dictionary.
-          // Tribble does: see tests testRefDictRequiredForVCFIndexOnTheFly / testRefDictRequiredForBCFIndexOnTheFly
-
-          index.delete();
-          writer = builder.setReferenceDictionary(null).build();
-          writer.close();
-          Assert.assertTrue(index.exists(), String
-              .format("Block-compressed index not created for %s / %s", blockCompressed, index));
-        }
+        Assert.assertTrue(Files.exists(indexPath), String
+            .format("Block-compressed index not created for %s / %s", blockCompressedPath, indexPath));
       }
     }
+  }
 
-    @Test(singleThreaded = true, groups = "unix")
-    public void testWriteToFifo() throws IOException, InterruptedException, ExecutionException {
-      long length = testWriteToPipe(this::innerWriteToFifo);
-      // length>0 means we wrote to the named pipe, so all is well.
-      Assert.assertTrue(length>0,
-          "VariantContextWriterBuilder did not write to the named pipe as it should.");
+  @Test(singleThreaded = true, groups = "unix")
+  public void testWriteToFifo() throws IOException, InterruptedException, ExecutionException {
+    long length = testWriteToPipe(this::innerWriteToFifo);
+    // length>0 means we wrote to the named pipe, so all is well.
+    Assert.assertTrue(length>0,
+        "VariantContextWriterBuilder did not write to the named pipe as it should.");
+  }
+
+  private void innerWriteToFifo(String pathToFifo) {
+    // Do not enable INDEX_OF_THE_FLY because that is not compatible with writing to a pipe.
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
+        .clearOptions()
+        .setReferenceDictionary(dictionary);
+
+    Path vcfPath = Paths.get(pathToFifo);
+    VariantContextWriter writer = builder.setOutputPath(vcfPath).build();
+    writer.writeHeader(new VCFHeader());
+    writer.close();
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testInvalidImplicitFileType() {
+    new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputFile("test.bam")
+        .build();
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testSetInvalidFileType() {
+    new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputFile("test.bam")
+        .setOutputFileType(VariantContextWriterBuilder.OutputType.VCF_STREAM)
+        .build();
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testInvalidSetFileTypeForStream() {
+    new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputStream(new ByteArrayOutputStream())
+        .setOutputFileType(VariantContextWriterBuilder.OutputType.VCF)
+        .build();
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUnsupportedIndexOnTheFlyForStreaming() {
+    new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputStream(new ByteArrayOutputStream())
+        .setOption(Options.INDEX_ON_THE_FLY)
+        .build();
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUnsupportedDefaultIndexOnTheFlyForStreaming() {
+    new VariantContextWriterBuilder()
+        .setReferenceDictionary(dictionary)
+        .setOutputStream(new ByteArrayOutputStream())
+        .build();
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testRefDictRequiredForVCFIndexOnTheFly() {
+    new VariantContextWriterBuilder()
+        .setOutputFile(vcf)
+        .setOption(Options.INDEX_ON_THE_FLY)
+        .build();
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testRefDictRequiredForBCFIndexOnTheFly() {
+    new VariantContextWriterBuilder()
+        .setOutputFile(bcf)
+        .setOption(Options.INDEX_ON_THE_FLY)
+        .build();
+  }
+
+  @Test
+  public void testClearOptions() {
+    // Verify that clearOptions doesn't have a side effect of carrying previously set options
+    // forward to subsequent builders
+    VariantContextWriterBuilder vcwb = new VariantContextWriterBuilder();
+    vcwb.clearOptions().setOption(Options.INDEX_ON_THE_FLY);
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder().clearOptions();
+    Assert.assertTrue(builder.options.isEmpty());
+  }
+
+  @Test
+  public void testModifyOption() {
+    final VariantContextWriterBuilder builder = new VariantContextWriterBuilder().clearOptions();
+    for (final Options option : Options.values()) {
+      Assert.assertFalse(builder.isOptionSet(option)); // shouldn't be set
+      builder.modifyOption(option, false);
+      Assert.assertFalse(builder.isOptionSet(option)); // still shouldn't be set
+      builder.modifyOption(option, true);
+      Assert.assertTrue(builder.isOptionSet(option)); // now is set
+      builder.modifyOption(option, false);
+      Assert.assertFalse(builder.isOptionSet(option)); // has been unset
     }
+  }
 
-    private void innerWriteToFifo(String pathToFifo) {
-      // Do not enable INDEX_OF_THE_FLY because that is not compatible with writing to a pipe.
-      final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
-          .clearOptions()
-          .setReferenceDictionary(dictionary);
+  @Test
+  public void testStdOut() {
+    final VariantContextWriter writer = new VariantContextWriterBuilder().setOutputFile("/dev/stdout").clearOptions().build();
+    OutputStream s = ((VCFWriter) writer).getOutputStream();
+    Assert.assertNotNull(((VCFWriter) writer).getOutputStream());
+    Assert.assertNotEquals(((VCFWriter) writer).getStreamName(), IndexingVariantContextWriter.DEFAULT_READER_NAME);
+  }
 
-      Path vcfPath = Paths.get(pathToFifo);
-      VariantContextWriter writer = builder.setOutputPath(vcfPath).build();
-      writer.writeHeader(new VCFHeader());
-      writer.close();
-    }
+  @Test(expectedExceptions = java.util.concurrent.ExecutionException.class)
+  public void demonstrateTestWriteToPipeDoesNotHang_1() throws Exception {
+      testWriteToPipe((str) -> {
+        throw new RuntimeException("oops");
+      });
+  }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testInvalidImplicitFileType() {
-        new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputFile("test.bam")
-                .build();
-    }
+  @Test(expectedExceptions = java.util.concurrent.ExecutionException.class)
+  public void demonstrateTestWriteToPipeDoesNotHang_2() throws Exception {
+    long x = testWriteToPipe((str) -> {try{Files.write(Paths.get(str), "hello world".getBytes());}catch(IOException ex){}; throw new RuntimeException("oops");});
+  }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testSetInvalidFileType() {
-        new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputFile("test.bam")
-                .setOutputFileType(VariantContextWriterBuilder.OutputType.VCF_STREAM)
-                .build();
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testInvalidSetFileTypeForStream() {
-        new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputStream(new ByteArrayOutputStream())
-                .setOutputFileType(VariantContextWriterBuilder.OutputType.VCF)
-                .build();
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testUnsupportedIndexOnTheFlyForStreaming() {
-        new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputStream(new ByteArrayOutputStream())
-                .setOption(Options.INDEX_ON_THE_FLY)
-                .build();
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testUnsupportedDefaultIndexOnTheFlyForStreaming() {
-        new VariantContextWriterBuilder()
-                .setReferenceDictionary(dictionary)
-                .setOutputStream(new ByteArrayOutputStream())
-                .build();
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testRefDictRequiredForVCFIndexOnTheFly() {
-        new VariantContextWriterBuilder()
-                .setOutputFile(vcf)
-                .setOption(Options.INDEX_ON_THE_FLY)
-                .build();
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testRefDictRequiredForBCFIndexOnTheFly() {
-        new VariantContextWriterBuilder()
-                .setOutputFile(bcf)
-                .setOption(Options.INDEX_ON_THE_FLY)
-                .build();
-    }
-
-    @Test
-    public void testClearOptions() {
-        // Verify that clearOptions doesn't have a side effect of carrying previously set options
-        // forward to subsequent builders
-        VariantContextWriterBuilder vcwb = new VariantContextWriterBuilder();
-        vcwb.clearOptions().setOption(Options.INDEX_ON_THE_FLY);
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder().clearOptions();
-        Assert.assertTrue(builder.options.isEmpty());
-    }
-
-    @Test
-    public void testModifyOption() {
-        final VariantContextWriterBuilder builder = new VariantContextWriterBuilder().clearOptions();
-        for (final Options option : Options.values()) {
-            Assert.assertFalse(builder.isOptionSet(option)); // shouldn't be set
-            builder.modifyOption(option, false);
-            Assert.assertFalse(builder.isOptionSet(option)); // still shouldn't be set
-            builder.modifyOption(option, true);
-            Assert.assertTrue(builder.isOptionSet(option)); // now is set
-            builder.modifyOption(option, false);
-            Assert.assertFalse(builder.isOptionSet(option)); // has been unset
-        }
-    }
-
-    @Test
-    public void testStdOut() {
-        final VariantContextWriter writer = new VariantContextWriterBuilder().setOutputFile("/dev/stdout").clearOptions().build();
-        OutputStream s = ((VCFWriter) writer).getOutputStream();
-        Assert.assertNotNull(((VCFWriter) writer).getOutputStream());
-        Assert.assertNotEquals(((VCFWriter) writer).getStreamName(), IndexingVariantContextWriter.DEFAULT_READER_NAME);
-    }
 
   /**
    * Create a named pipe, call "codeThatWritesToAFilename" with the name as argument,
@@ -489,42 +508,50 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
    * This only works on Unix. Use this decoration for the tests that use it:
    * @Test(singleThreaded = true, groups = "unix")
    */
-    private long testWriteToPipe(final Consumer<String> codeThatWritesToAFilename) throws IOException, InterruptedException, ExecutionException {
-      // make the fifo
-      final File fifo = File.createTempFile("fifo.for.testWriteToPipe", "");
-      Assert.assertTrue(fifo.delete());
-      fifo.deleteOnExit();
-      final Process exec = new ProcessBuilder("mkfifo", fifo.getAbsolutePath()).start();
-      exec.waitFor(1, TimeUnit.MINUTES);
-      Assert.assertEquals(exec.exitValue(), 0, "mkfifo failed with exit code " + 0);
+  private static long testWriteToPipe(final Consumer<String> codeThatWritesToAFilename) throws IOException, InterruptedException, ExecutionException {
+    final File fifo = makeFifo();
 
-      // run the code in a separate thread
-      ExecutorService executor = null;
-      try {
-        executor = Executors.newSingleThreadExecutor();
-        Future result = executor.submit(() -> {
-          try {
-            codeThatWritesToAFilename.accept(fifo.getAbsolutePath());
-          } catch (Exception x) {
-            // since the main thread is blocked reading the pipe, we may not notice the exception.
-            // Better to print it to the console to aid debugging.
-            x.printStackTrace();
-            throw(x);
-          }
-        });
-
-        // drain the pipe with the output.
-        InputStream inputStream = Files.newInputStream(fifo.toPath(), StandardOpenOption.READ);
-        int count = 0;
-        while (inputStream.read() >= 0) {
-          count++;
+    // run the code in a separate thread
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      final Future<?> writeResult = executor.submit(() -> {
+        try {
+          codeThatWritesToAFilename.accept(fifo.getAbsolutePath());
+        } catch (Exception x) {
+          // Print to the console to aid debugging, in case the exception doesn't surface.
+          x.printStackTrace();
+          throw(x);
         }
-        // done. If it was in error, the line below will throw the exception.
-        result.get();
-        return count;
-      } finally {
-        if (executor != null) executor.shutdownNow();
-      }
+      });
+
+      // drain the pipe with the output.
+      final Future<Integer> readResult = executor.submit(() -> {
+        try(final InputStream inputStream = Files.newInputStream(fifo.toPath(), StandardOpenOption.READ)) {
+          int count = 0;
+          while (inputStream.read() >= 0) {
+            count++;
+          }
+          return count;
+        }
+      });
+
+      // done. If it was in error, the line below will throw the exception.
+      writeResult.get();
+      return readResult.get();
+    } finally {
+      executor.shutdownNow();
     }
+  }
+
+  private static File makeFifo() throws IOException, InterruptedException {
+    // make the fifo
+    final File fifo = File.createTempFile("fifo.for.testWriteToPipe", "");
+    Assert.assertTrue(fifo.delete());
+    fifo.deleteOnExit();
+    final Process exec = new ProcessBuilder("mkfifo", fifo.getAbsolutePath()).start();
+    exec.waitFor(1, TimeUnit.MINUTES);
+    Assert.assertEquals(exec.exitValue(), 0, "mkfifo failed with exit code " + 0);
+    return fifo;
+  }
 
 }


### PR DESCRIPTION
### Description
VCFWriter accepts Path, and associated changes necessary for this to happen.

I also added a Path test to VariantContextWriterBuilderUnitTest (using JimFS).

The benefit of this change is that a Path can point to files on the cloud (e.g. via [GCloud's NIO Filesystem Provider for Google Cloud Storage](https://github.com/GoogleCloudPlatform/google-cloud-java/tree/master/google-cloud-clients/google-cloud-contrib/google-cloud-nio)). So htsjdk users can now easily write VCF files on the cloud.

For example, with this change, I was able to change GATK to write VCF output
to the cloud:

`$ ./gatk GatherVcfsCloud -I ./sample.vcf -O gs://jps_bucket/out.vcf`

### Checklist

- [X] Code compiles correctly
- [X] New tests covering changes and new functionality
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

