### PR TITLE
Add wrapper class AutoClose to allow classes that aren't AutoCloseable to be used in a try-with-resources block

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AutoClose.java
+++ b/src/main/java/htsjdk/samtools/util/AutoClose.java
@@ -1,0 +1,26 @@
+package htsjdk.samtools.util;
+
+/**
+ * Use this class to enable using try-with-resources on objects that do not implement AutoCloseable but
+ * do have a close() method.
+ *
+ * <pre>{@code
+ * try (AutoClose<Connection> auto = new AutoClose<>(makeConnection()) {
+ *     Connection conection = auto.object;
+ *     ...
+ * }}
+ *</pre>
+ */
+public class AutoClose<T> implements AutoCloseable {
+
+    public final T object;
+
+    public AutoClose(T object) {
+        this.object = object;
+    }
+
+    @Override
+    public void close() {
+        CloserUtil.close(object);
+    }
+}

--- a/src/test/java/htsjdk/samtools/util/AutoCloseTest.java
+++ b/src/test/java/htsjdk/samtools/util/AutoCloseTest.java
@@ -1,0 +1,30 @@
+package htsjdk.samtools.util;
+
+import htsjdk.HtsjdkTest;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class AutoCloseTest extends HtsjdkTest {
+
+    @Test
+    public void testClose() {
+
+        class CanClose {
+            private boolean wasClosed = false;
+            public void close() {
+                wasClosed = true;
+            }
+        }
+
+        CanClose canClose = new CanClose();
+
+        try (AutoClose<CanClose> auto = new AutoClose<>(canClose)) {
+            CanClose innerCanClose = auto.object;
+            assertFalse(innerCanClose.wasClosed);
+        }
+
+        assertTrue(canClose.wasClosed);
+    }
+}

--- a/src/test/java/htsjdk/samtools/util/AutoCloseTest.java
+++ b/src/test/java/htsjdk/samtools/util/AutoCloseTest.java
@@ -1,10 +1,10 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class AutoCloseTest extends HtsjdkTest {
 


### PR DESCRIPTION
### Description

- add wrapper class `AutoClose` to allow classes that aren't `AutoCloseable` to be used in a try-with-resources block, by using CloserUtil.

- minor cleanups to `CloserUtil`

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

