### PR TITLE
Make public SamReader.Type methods to allow other implementations

### DIFF
--- a/src/main/java/htsjdk/samtools/SamReader.java
+++ b/src/main/java/htsjdk/samtools/SamReader.java
@@ -43,13 +43,13 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
     /** Describes a type of SAM file. */
     public abstract class Type {
         /** A string representation of this type. */
-        abstract String name();
+        public abstract String name();
 
         /** The recommended file extension for SAMs of this type, without a period. */
         public abstract String fileExtension();
 
         /** The recommended file extension for SAM indexes of this type, without a period, or null if this type is not associated with indexes. */
-        abstract String indexExtension();
+        public abstract String indexExtension();
 
         static class TypeImpl extends Type {
             final String name, fileExtension, indexExtension;
@@ -61,7 +61,7 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
             }
 
             @Override
-            String name() {
+            public String name() {
                 return name;
             }
 
@@ -71,7 +71,7 @@ public interface SamReader extends Iterable<SAMRecord>, Closeable {
             }
 
             @Override
-            String indexExtension() {
+            public String indexExtension() {
                 return indexExtension;
             }
 


### PR DESCRIPTION
### Description

Currently, `SamReader` cannot be implemented for other "types" of data, unless the `getType`method returns any of the supported type implementations (SAM/BAM/CRAM/SRA). Other abstractions are impossible to implement unless some of the method of `Type` are implemented, and this is not possible because they aren't public.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

