### PR TITLE
Load tribble index from a stream.

### DIFF
--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -162,7 +162,7 @@ public class IndexFactory {
      * @param indexFile from which to load the index
      */
     public static Index loadIndex(final String indexFile) {
-        return loadIndex(indexFile, null);
+        return loadIndex(indexFile, (Function<SeekableByteChannel, SeekableByteChannel>) null);
     }
 
     /**
@@ -174,18 +174,30 @@ public class IndexFactory {
      *                     {@link java.nio.file.Path}
      */
     public static Index loadIndex(final String indexFile, Function<SeekableByteChannel, SeekableByteChannel> indexWrapper) {
+        try {
+            return loadIndex(indexFile, indexFileInputStream(indexFile, indexWrapper));
+        } catch (final IOException ex) {
+            throw new TribbleException.UnableToReadIndexFile("Unable to read index file", indexFile, ex);
+        }
+    }
+
+    /**
+     * Load in index from the specified stream. Note that the caller is responsible for decompressing the stream if necessary.
+     *
+     * @param source the stream source (typically the file name)
+     * @param inputStream the raw byte stream of the index
+     */
+    public static Index loadIndex(final String source, final InputStream inputStream) {
         // Must be buffered, because getIndexType uses mark and reset
-        try (BufferedInputStream bufferedInputStream = new BufferedInputStream(indexFileInputStream(indexFile, indexWrapper), Defaults.NON_ZERO_BUFFER_SIZE)) {
+        try (BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream, Defaults.NON_ZERO_BUFFER_SIZE)) {
             final Class<Index> indexClass = IndexType.getIndexType(bufferedInputStream).getIndexType();
             final Constructor<Index> ctor = indexClass.getConstructor(InputStream.class);
             return ctor.newInstance(bufferedInputStream);
         } catch (final TribbleException ex) {
             throw ex;
-        } catch (final IOException ex) {
-            throw new TribbleException.UnableToReadIndexFile("Unable to read index file", indexFile, ex);
         } catch (final InvocationTargetException ex) {
             if (ex.getCause() instanceof EOFException) {
-                throw new TribbleException.CorruptedIndexFile("Index file is corrupted", indexFile, ex);
+                throw new TribbleException.CorruptedIndexFile("Index file is corrupted", source, ex);
             }
             throw new RuntimeException(ex);
         } catch (final Exception ex) {

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -19,6 +19,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.FileSystem;
@@ -59,6 +60,13 @@ public class IndexTest extends HtsjdkTest {
         Assert.assertTrue(allSize >= Math.max(leftSize,rightSize), "Expected size of joint query " + allSize + " to be at least >= max of left " + leftSize + " and right queries " + rightSize);
     }
 
+    @Test()
+    public void testLoadFromStream() throws IOException {
+        LinearIndex index = (LinearIndex)IndexFactory.loadIndex(MassiveIndexFile.getAbsolutePath(), new FileInputStream(MassiveIndexFile));
+        List<String> sequenceNames = index.getSequenceNames();
+        Assert.assertEquals(sequenceNames.size(), 1);
+        Assert.assertEquals(sequenceNames.get(0), CHR);
+    }
 
     @DataProvider(name = "writeIndexData")
     public Object[][] writeIndexData() {


### PR DESCRIPTION
Make it possible to load a tribble index from a stream, not just a file. This is needed for #1112.

The change is covered by existing tests.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

