### PR TITLE
Make CRAMReferenceSource Closeable so IO resources are properly cleaned up.

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -135,6 +135,7 @@ public class CRAMContainerStreamWriter {
                 indexer.finish();
             }
             outputStream.close();
+            source.close();
         } catch (final IOException e) {
             throw new RuntimeIOException(e);
         } catch (final IllegalAccessException e) {

--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -436,6 +436,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
         CloserUtil.close(iterator);
         CloserUtil.close(inputStream);
         CloserUtil.close(mIndex);
+        CloserUtil.close(referenceSource);
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.cram.structure.CramCompressionRecord;
 import htsjdk.samtools.cram.structure.CramHeader;
 import htsjdk.samtools.cram.structure.Slice;
 import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Log;
 
 import java.io.IOException;
@@ -282,12 +283,8 @@ public class CRAMIterator implements SAMRecordIterator {
     @Override
     public void close() {
         records.clear();
-        //noinspection EmptyCatchBlock
-        try {
-            if (countingInputStream != null)
-                countingInputStream.close();
-        } catch (final IOException e) {
-        }
+        CloserUtil.close(countingInputStream);
+        CloserUtil.close(referenceSource);
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/cram/ref/CRAMReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/CRAMReferenceSource.java
@@ -2,10 +2,12 @@ package htsjdk.samtools.cram.ref;
 
 import htsjdk.samtools.SAMSequenceRecord;
 
+import java.io.Closeable;
+
 /**
  * Interface used to supply a reference source when reading CRAM files.
  */
-public interface CRAMReferenceSource {
+public interface CRAMReferenceSource extends Closeable {
 
     /**
      * getReferenceBases

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -26,6 +26,7 @@ import htsjdk.samtools.cram.io.InputStreamUtils;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
@@ -278,5 +279,10 @@ public class ReferenceSource implements CRAMReferenceSource {
 
     public void setDownloadTriesBeforeFailing(final int downloadTriesBeforeFailing) {
         this.downloadTriesBeforeFailing = downloadTriesBeforeFailing;
+    }
+
+    @Override
+    public void close() {
+        CloserUtil.close(rsFile);
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceSourceTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceSourceTest.java
@@ -30,5 +30,9 @@ public class ReferenceSourceTest extends HtsjdkTest{
 
         Assert.assertNotEquals(refBasesFromSource, originalRefBases);
         Assert.assertEquals(refBasesFromSource, SequenceUtil.upperCase(originalRefBases));
+
+        Assert.assertFalse(memoryReferenceSequenceFile.isClosed());
+        referenceSource.close();
+        Assert.assertTrue(memoryReferenceSequenceFile.isClosed());
     }
 }

--- a/src/test/java/htsjdk/samtools/reference/InMemoryReferenceSequenceFile.java
+++ b/src/test/java/htsjdk/samtools/reference/InMemoryReferenceSequenceFile.java
@@ -12,6 +12,7 @@ public class InMemoryReferenceSequenceFile implements
     Map<String, ReferenceSequence> map = new HashMap<String, ReferenceSequence>();
     List<String> index;
     int current = 0;
+    boolean closed = false;
 
     public void add(final String name, final byte[] bases) {
         final ReferenceSequence sequence = new ReferenceSequence(name,
@@ -60,7 +61,14 @@ public class InMemoryReferenceSequenceFile implements
     @Override
     public void close() throws IOException {
         map.clear();
-        index.clear();
+        if (index != null) {
+            index.clear();
+        }
         current = 0;
+        closed = true;
+    }
+
+    public boolean isClosed() {
+        return closed;
     }
 }


### PR DESCRIPTION
### Description

This is a fix for closing dangling open file descriptors. It was uncovered while working on #1112.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is backward compatible

