### PR TITLE
fix an copy-paste error in VCFHeader

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeader.java
@@ -246,16 +246,16 @@ public class VCFHeader implements Serializable {
     }
 
     /**
-     * @return all of the VCF FILTER lines in their original file order, or an empty list if none were present
+     * @return all of the VCF ID-based header lines in their original file order, or an empty list if none were present
      */
     public List<VCFIDHeaderLine> getIDHeaderLines() {
-        final List<VCFIDHeaderLine> filters = new ArrayList<VCFIDHeaderLine>();
+        final List<VCFIDHeaderLine> lines = new ArrayList<VCFIDHeaderLine>();
         for (final VCFHeaderLine line : mMetaData) {
             if (line instanceof VCFIDHeaderLine)  {
-                filters.add((VCFIDHeaderLine)line);
+                lines.add((VCFIDHeaderLine)line);
             }
         }
-        return filters;
+        return lines;
     }
 
     /**


### PR DESCRIPTION
### Description

Fix a simple copy-paste error in documentation that clearly doesn't say what the method is doing.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

@lbergelson should I do more?