### PR TITLE
Fix CRAM container offset calculation

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
@@ -29,7 +29,7 @@ public class CramContainerIterator implements Iterator<Container> {
     void readNextContainer() {
         try {
             nextContainer = containerFromStream(cramHeader.getVersion(), countingInputStream);
-            final long containerSizeInBytes = countingInputStream.getCount();
+            final long containerSizeInBytes = countingInputStream.getCount() - offset;
 
             nextContainer.offset = offset;
             offset += containerSizeInBytes;

--- a/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
@@ -4,6 +4,7 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.cram.build.CramContainerHeaderIterator;
 import htsjdk.samtools.cram.build.CramContainerIterator;
 import htsjdk.samtools.cram.structure.Container;
+import htsjdk.samtools.cram.structure.ContainerIO;
 import htsjdk.samtools.cram.structure.CramHeader;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.Iterables;
@@ -52,6 +53,15 @@ public class CramContainerHeaderIteratorTest extends HtsjdkTest {
             Assert.assertNull(headerOnlyContainer.blocks);
             Assert.assertNull(headerOnlyContainer.header);
             Assert.assertNull(headerOnlyContainer.slices);
+            // try to read a container from the offset to check it's correct
+            try (SeekableFileStream seekableFileStream = new SeekableFileStream(cramFile)) {
+                seekableFileStream.seek(headerOnlyContainer.offset);
+                Container container = ContainerIO.readContainer(actualHeader.getVersion(), seekableFileStream);
+                Assert.assertEquals(container.alignmentStart, fullContainer.alignmentStart);
+                Assert.assertEquals(container.alignmentSpan, fullContainer.alignmentSpan);
+                Assert.assertEquals(container.nofRecords, fullContainer.nofRecords);
+                Assert.assertEquals(container.checksum, fullContainer.checksum);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description

Fixes a bug from #1129, and added a test to check for the error (which fails without the fix).

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

