### PR TITLE
Adding Symbolic-name and version attribute to jar manifest to support…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,9 @@ jar {
     manifest {
         attributes 'Implementation-Title': 'HTSJDK',
                 'Implementation-Vendor' : 'Samtools Organization',
-                'Implementation-Version': version
+                'Implementation-Version': version,
+                'Bundle-SymbolicName': project.getGroup()+'.'+project.getName(),
+                'Bundle-Version': version
     }
 }
 


### PR DESCRIPTION
… OSGI bundles.

### Description

I have added two more attributes to the manifest creation part for the jar file to support OSGI bundles.
Relates to the issue: https://github.com/samtools/htsjdk/issues/1155 

