### PR TITLE
Invalid buffer access in SeekableBufferedStream

### DIFF
--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableBufferedStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableBufferedStream.java
@@ -43,19 +43,19 @@ public class SeekableBufferedStream extends SeekableStream {
 
         /** Returns the number of bytes that can be read from the buffer without reading more into the buffer. */
         int getBytesInBufferAvailable() {
-            if (this.count == this.pos) return 0; // documented test for "is buffer empty"
-            else return this.buf.length - this.pos;
+            return this.count - this.pos;
         }
 
         /** Return true if the position can be changed by the given delta and remain in the buffer. */
         boolean canChangePos(long delta) {
-            return this.pos + delta >= 0 && delta < getBytesInBufferAvailable();
+            long newPos = this.pos + delta;
+            return newPos >= 0 && newPos < this.count;
         }
 
         /** Changes the position in the buffer by a given delta. */
         void changePos(int delta) {
             int newPos = this.pos + delta;
-            if (newPos < 0 || newPos > this.buf.length) {
+            if (newPos < 0 || newPos >= this.count) {
                 throw new IllegalArgumentException("New position not in buffer pos=" + this.pos + ", delta=" + delta);
             }
             this.pos = newPos;


### PR DESCRIPTION
Fix a bug where invalid bytes in BufferedInputStream's buffer were being accessed.

Only bytes up to BufferedInputStream's `count` field in its internal buffer
are valid; this change ensures accesses are limited to this range.

The new test ensures that the internal buffer is not completely filled, and without the fix it fails.

The problem has been present for a long time, but possibly has only been exposed since #1121 in some circumstances. I encountered the bug while running the GATK test suite with Disq (which uses SeekableBufferedStream extensively) - see https://github.com/broadinstitute/gatk/pull/5138.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

