### PR TITLE
Expose VCFCodec version and header fields.

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -228,7 +228,22 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
         return this.header;
     }
 
-	/**
+    /**
+     * @return the header that was either explicitly set on this codec, or read from the file. May be null.
+     * The returned value should not be modified.
+     */
+    public VCFHeader getHeader() {
+        return header;
+    }
+
+    /**
+     * @return the version number that was either explicitly set on this codec, or read from the file. May be null.
+     */
+    public VCFHeaderVersion getVersion() {
+        return version;
+    }
+
+    /**
 	 * Explicitly set the VCFHeader on this codec. This will overwrite the header read from the file
 	 * and the version state stored in this instance; conversely, reading the header from a file will
 	 * overwrite whatever is set here. The returned header may not be identical to the header argument


### PR DESCRIPTION
### Description

This change adds getters for the version and header fields in AbstractVCFCodec. Access to these fields is needed by Disq, see https://github.com/broadinstitute/gatk/pull/5138.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

