### PR TITLE
restore no-args VariantContextWriterBuilder.build()

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -402,9 +402,7 @@ public class VariantContextWriterBuilder {
     /**
      * Validate and build the <code>VariantContextWriter</code>.
      *
-     *
-     * @return the <code>VariantContextWriter</code> as specified by previous method calls,
-     *         optionally applying the specified OpenOptions.
+     * @return the <code>VariantContextWriter</code> as specified by previous method calls.
      * @throws RuntimeIOException if the writer is configured to write to a file, and the corresponding path does not exist.
      * @throws IllegalArgumentException if no output file or stream is specified.
      * @throws IllegalArgumentException if <code>Options.INDEX_ON_THE_FLY</code> is specified and no reference dictionary is provided.


### PR DESCRIPTION
* VariantContextWriterBuilder.build() was replaced by a varargs version of itself in a previous commit
  While this is a source compatible change it's not binary compatible and since it's a commonly used function it breaks a lot of libaries
* add a parameterless build() which just calls through to the varargs version with an empty array


