### PR TITLE
fixing bug in SeekableHttpStream.read

### DIFF
--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableHTTPStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableHTTPStream.java
@@ -100,8 +100,11 @@ public class SeekableHTTPStream extends SeekableStream {
         if (offset < 0 || len < 0 || (offset + len) > buffer.length) {
             throw new IndexOutOfBoundsException("Offset="+offset+",len="+len+",buflen="+buffer.length);
         }
-        if (len == 0 || position == contentLength) {
+        if (len == 0 ) {
             return 0;
+        }
+        if (position == contentLength) {
+            return -1;
         }
 
         HttpURLConnection connection = null;

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableBufferedStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableBufferedStreamTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.testng.Assert.assertEquals;
@@ -68,6 +69,20 @@ public class SeekableBufferedStreamTest extends HtsjdkTest {
 
         assertEquals(buffer1, buffer2);
     }
+
+    @Test
+    public void testReadExactlyOneByteAtEndOfFile() throws IOException {
+        try( SeekableStream stream = new SeekableHTTPStream(new URL(BAM_URL_STRING))){
+            byte[] buff = new byte[1];
+            long length = stream.length();
+            stream.seek(length - 1);
+            Assert.assertFalse(stream.eof());
+            Assert.assertEquals(stream.read(buff), 1);
+            Assert.assertTrue(stream.eof());
+            Assert.assertEquals(stream.read(buff), -1);
+        }
+    }
+
 
     /**
      * Test an attempt to read past the end of the file.  The test file is 594,149 bytes in length.  The test

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableBufferedStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableBufferedStreamTest.java
@@ -31,7 +31,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import static org.testng.Assert.assertEquals;
@@ -72,7 +71,7 @@ public class SeekableBufferedStreamTest extends HtsjdkTest {
 
     @Test
     public void testReadExactlyOneByteAtEndOfFile() throws IOException {
-        try( SeekableStream stream = new SeekableHTTPStream(new URL(BAM_URL_STRING))){
+        try (final SeekableStream stream = new SeekableHTTPStream(new URL(BAM_URL_STRING))){
             byte[] buff = new byte[1];
             long length = stream.length();
             stream.seek(length - 1);


### PR DESCRIPTION
* a bug in `SeekableHttpStream` could cause clients to go into an infinite loop because read would return 0 when trying to read one byte past the end of the file
* fixes #1181
