### PR TITLE
Add a reset() method to ProgressLoggerInterface.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AbstractProgressLogger.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractProgressLogger.java
@@ -15,14 +15,13 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
     private final int n;
     private final String verb;
     private final String noun;
-    private final long startTime = System.currentTimeMillis();
+    private long startTime;
     private final NumberFormat fmt = new DecimalFormat("#,###");
     private final NumberFormat timeFmt = new DecimalFormat("00");
-    private long processed = 0;
-    // Set to -1 until the first record is added
-    private long lastStartTime = -1;
-    private String lastChrom = null;
-    private int lastPos = 0;
+    private long processed;
+    private long lastStartTime;
+    private String lastChrom;
+    private int lastPos;
 
     /**
      * Construct an AbstractProgressLogger.
@@ -37,6 +36,7 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
         this.noun = noun;
         this.verb = verb;
         this.n = n;
+        reset();
     }
 
     /**
@@ -123,6 +123,16 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
 
     /** Returns the number of seconds since progress tracking began. */
     public long getElapsedSeconds() { return (System.currentTimeMillis() - this.startTime) / 1000; }
+
+    /** Resets the start time to now and the number of records to zero. */
+    public void reset() {
+        startTime = System.currentTimeMillis();
+        processed = 0;
+        // Set to -1 until the first record is added
+        lastStartTime = -1;
+        lastChrom = null;
+        lastPos = 0;
+    }
 
     /** Left pads a string until it is at least the given length. */
     private String pad (String in, final int length) {

--- a/src/main/java/htsjdk/samtools/util/ProgressLoggerInterface.java
+++ b/src/main/java/htsjdk/samtools/util/ProgressLoggerInterface.java
@@ -34,5 +34,5 @@ public interface ProgressLoggerInterface {
 	boolean record(final String chrom, final int pos);
 	boolean record(final SAMRecord rec);
 	boolean record(final SAMRecord... recs);
-
+	void reset();
 }

--- a/src/main/java/htsjdk/samtools/util/ProgressLoggerInterface.java
+++ b/src/main/java/htsjdk/samtools/util/ProgressLoggerInterface.java
@@ -34,5 +34,5 @@ public interface ProgressLoggerInterface {
 	boolean record(final String chrom, final int pos);
 	boolean record(final SAMRecord rec);
 	boolean record(final SAMRecord... recs);
-	void reset();
+	default void reset() {};
 }


### PR DESCRIPTION
I have two uses for this method:

1. I may create a `ProgressLogger` earlier, but want to set the `startTime` so it is right before the logger is being used.  Yes, I can create the `ProgressLogger` at the last minute.
2. I may want to reuse a progress logger.