### PR TITLE
BinaryCodec.readBytesOrFewer fails if no data is requested AND no date is available in the underlying input stream

### DIFF
--- a/src/main/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/main/java/htsjdk/samtools/util/BinaryCodec.java
@@ -415,7 +415,8 @@ public class BinaryCodec implements Closeable {
             throw new IllegalStateException("Calling read method on BinaryCodec open for write.");
         }
         try {
-            return inputStream.read(buffer, offset, length);
+            if (length == 0) return 0;
+            else return inputStream.read(buffer, offset, length);
         } catch (IOException e) {
             throw new RuntimeIOException(constructErrorMessage("Read error"), e);
         }

--- a/src/main/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/main/java/htsjdk/samtools/util/BinaryCodec.java
@@ -415,8 +415,10 @@ public class BinaryCodec implements Closeable {
             throw new IllegalStateException("Calling read method on BinaryCodec open for write.");
         }
         try {
-            if (length == 0) return 0;
-            else return inputStream.read(buffer, offset, length);
+            // Some implementations of InputStream do not behave well when the buffer is empty and length is zero, for
+            // example ByteArrayInputStream, so we must check for length equal to zero.
+            // See: https://bugs.java.com/view_bug.do?bug_id=6766844
+            return (length == 0) ? 0 : inputStream.read(buffer, offset, length);
         } catch (IOException e) {
             throw new RuntimeIOException(constructErrorMessage("Read error"), e);
         }

--- a/src/test/java/htsjdk/samtools/util/BinaryCodecTest.java
+++ b/src/test/java/htsjdk/samtools/util/BinaryCodecTest.java
@@ -27,12 +27,7 @@ import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 
 
 /*
@@ -284,5 +279,11 @@ public class BinaryCodecTest extends HtsjdkTest {
         readCodec.close();
     }
 
-
+    @Test
+    public void testReadBytesOrFewerNoneAvailable() {
+        final byte[] value = new byte[0];
+        final ByteArrayInputStream instream = new ByteArrayInputStream(value);
+        final BinaryCodec readCodec = new BinaryCodec(instream);
+        Assert.assertEquals(readCodec.readBytesOrFewer(value, 0, 0), 0);
+    }
 }


### PR DESCRIPTION
I ran into this bug when writing an empty string as the last element into a byte buffer (ex `binaryCodec.writeString("", true, false)`) and then trying to read it back in (ex. `binaryCodec.readLengthAndString(false)`).  The main issue is that `InputStream.read` will return `-1` even if the maximum number of bytes to read is zero (i.e. `InputStream.read(buffer, 0, 0)` will return `-1`).

I made a commit with a test to show the bug and a commit to fix it.
