### PR TITLE
HttpUtils: set Method to HEAD for HttpUtils.getHeaders

### DIFF
--- a/src/main/java/htsjdk/samtools/util/HttpUtils.java
+++ b/src/main/java/htsjdk/samtools/util/HttpUtils.java
@@ -29,9 +29,14 @@ public class HttpUtils {
         try {
             // Create a URLConnection object for a URL
             conn = openConnection(url);
+            if(conn instanceof HttpURLConnection) {
+                // The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response.
+                final HttpURLConnection httpConn = HttpURLConnection.class.cast(conn);
+                httpConn.setRequestMethod("HEAD");
+            }
             return conn.getHeaderField(name);
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
             e.printStackTrace();
             return null;
         }

--- a/src/main/java/htsjdk/samtools/util/HttpUtils.java
+++ b/src/main/java/htsjdk/samtools/util/HttpUtils.java
@@ -17,7 +17,7 @@ public class HttpUtils {
     }
 
     private static URLConnection openConnection(final URL url) throws IOException{
-        URLConnection conn = url.openConnection();
+        final URLConnection conn = url.openConnection();
         conn.setReadTimeout(3000);
         conn.setDefaultUseCaches(false);
         conn.setUseCaches(false);
@@ -29,10 +29,9 @@ public class HttpUtils {
         try {
             // Create a URLConnection object for a URL
             conn = openConnection(url);
-            if(conn instanceof HttpURLConnection) {
+            if (conn instanceof HttpURLConnection) {
                 // The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response.
-                final HttpURLConnection httpConn = HttpURLConnection.class.cast(conn);
-                httpConn.setRequestMethod("HEAD");
+                ((HttpURLConnection) conn).setRequestMethod("HEAD");
             }
             return conn.getHeaderField(name);
 

--- a/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
@@ -1,0 +1,33 @@
+package htsjdk.samtools.util;
+import java.io.IOException;
+import java.net.URL;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class HttpUtilsTest {
+    @DataProvider(name = "existing_urls")
+    public Object[][] testExistingURLsData() {
+        return new Object[][]{
+                {"http://broadinstitute.github.io/picard/testdata/index_test.bam"}
+        };
+    }
+    
+    @Test(dataProvider="existing_urls")
+    public void testGetHeaderField(final String url) throws IOException {
+    final String field = HttpUtils.getHeaderField(
+            new URL(url),
+            "Content-Length"
+            );
+    Assert.assertNotNull(field);
+    final long length = Long.parseLong(field);
+    Assert.assertTrue(length>0L);
+    }
+    
+    @Test(dataProvider="existing_urls")
+    public void testGetETag(final String url) throws IOException {
+    final String field = HttpUtils.getETag(new URL(url));
+    Assert.assertNotNull(field);
+    }
+}

--- a/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
@@ -6,7 +6,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class HttpUtilsTest {
+import htsjdk.HtsjdkTest;
+
+public class HttpUtilsTest extends HtsjdkTest {
     @DataProvider(name = "existing_urls")
     public Object[][] testExistingURLsData() {
         return new Object[][]{

--- a/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
@@ -12,24 +12,22 @@ public class HttpUtilsTest extends HtsjdkTest {
     @DataProvider(name = "existing_urls")
     public Object[][] testExistingURLsData() {
         return new Object[][]{
-                {"http://broadinstitute.github.io/picard/testdata/index_test.bam"}
+            {"http://broadinstitute.github.io/picard/testdata/index_test.bam"},
+            {"http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/current.tree"}
         };
     }
-    
+
     @Test(dataProvider="existing_urls")
     public void testGetHeaderField(final String url) throws IOException {
-    final String field = HttpUtils.getHeaderField(
-            new URL(url),
-            "Content-Length"
-            );
-    Assert.assertNotNull(field);
-    final long length = Long.parseLong(field);
-    Assert.assertTrue(length>0L);
+        final String field = HttpUtils.getHeaderField(new URL(url), "Content-Length");
+        Assert.assertNotNull(field);
+        final long length = Long.parseLong(field);
+        Assert.assertTrue(length > 0L);
     }
-    
+
     @Test(dataProvider="existing_urls")
     public void testGetETag(final String url) throws IOException {
-    final String field = HttpUtils.getETag(new URL(url));
-    Assert.assertNotNull(field);
+        final String field = HttpUtils.getETag(new URL(url));
+        Assert.assertNotNull(field);
     }
 }


### PR DESCRIPTION
### Description

Minor change: in httpUtils `getHeaderField` I set the Http-method to '**HEAD**'  instead of '**GET**' in order to only fetch the header fields.

I also added a test file for HttpUtils.


### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

