### PR TITLE
Simple sv alt allele

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -26,7 +26,6 @@
 package htsjdk.variant.variantcontext;
 
 import htsjdk.samtools.util.StringUtil;
-import htsjdk.variant.vcf.VCFConstants;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -200,6 +199,16 @@ public class Allele implements Comparable<Allele>, Serializable {
     public final static Allele NO_CALL = new Allele(NO_CALL_STRING, false);
     public final static Allele NON_REF_ALLELE = new Allele(NON_REF_STRING, false);
 
+    // for simple deletion, e.g. "ALT==<DEL>" (note that the spec allows, for now at least, alt alleles like <DEL:ME>)
+    public final static Allele SV_SIMPLE_DEL = StructuralVariantType.DEL.toSymbolicAltAllele();
+    // for simple insertion, e.g. "ALT==<INS>"
+    public final static Allele SV_SIMPLE_INS = StructuralVariantType.INS.toSymbolicAltAllele();
+    // for simple inversion, e.g. "ALT==<INV>"
+    public final static Allele SV_SIMPLE_INV = StructuralVariantType.INV.toSymbolicAltAllele();
+    // for simple generic cnv, e.g. "ALT==<CNV>"
+    public final static Allele SV_SIMPLE_CNV = StructuralVariantType.CNV.toSymbolicAltAllele();
+    // for simple duplication, e.g. "ALT==<DUP>"
+    public final static Allele SV_SIMPLE_DUP = StructuralVariantType.DUP.toSymbolicAltAllele();
 
     // ---------------------------------------------------------------------------------------------------------
     //

--- a/src/main/java/htsjdk/variant/variantcontext/StructuralVariantType.java
+++ b/src/main/java/htsjdk/variant/variantcontext/StructuralVariantType.java
@@ -43,5 +43,18 @@ public enum StructuralVariantType {
      *  event can be summarized as a set of novel adjacencies.
      *  Each adjacency ties together two breakends.</cite>
      */
-    BND
+    BND;
+
+    // TODO: 10/10/18 one caveat: BND's have symbolic alt allele, but it takes more information (novel adjacency at the minimum)
+    /**
+     * Create angle-bracketed alt allele for simple SV types
+     * @return angle-bracketed alt allele for simple SV types
+     * @throws UnsupportedOperationException if this is invoked on a {@link #BND} object
+     */
+    Allele toSymbolicAltAllele() {
+        if (this.equals(StructuralVariantType.BND)) {
+            throw new UnsupportedOperationException("BND type does not have angle bracketed alt allele");
+        }
+        return Allele.create("<" + name() + ">", false);
+    }
 }


### PR DESCRIPTION
### Description

__Simple__ alt allele constants for SV.
Two implementations, not sure which one is preferred.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

