### PR TITLE
fix CRAMIterator when next() is called without hasNext()

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -266,7 +266,7 @@ public class CRAMIterator implements SAMRecordIterator {
 
     @Override
     public SAMRecord next() {
-        if(hasNext()) {
+        if (hasNext()) {
             return iterator.next();
         } else {
             throw new NoSuchElementException();

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -34,10 +34,7 @@ import htsjdk.samtools.util.Log;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import htsjdk.samtools.cram.CRAMException;
 
@@ -259,9 +256,7 @@ public class CRAMIterator implements SAMRecordIterator {
         if (!iterator.hasNext()) {
             try {
                 nextContainer();
-            } catch (IOException e) {
-                throw new SAMException(e);
-            } catch (IllegalAccessException e) {
+            } catch (IOException | IllegalAccessException e) {
                 throw new SAMException(e);
             }
         }
@@ -271,7 +266,11 @@ public class CRAMIterator implements SAMRecordIterator {
 
     @Override
     public SAMRecord next() {
-        return iterator.next();
+        if(hasNext()) {
+            return iterator.next();
+        } else {
+            throw new NoSuchElementException();
+        }
     }
 
     @Override

--- a/src/test/java/htsjdk/samtools/CRAMFileReaderTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileReaderTest.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.NoSuchElementException;
 
 /**
  * Additional tests for CRAMFileReader are in CRAMFileIndexTest
@@ -228,5 +229,15 @@ public class CRAMFileReaderTest extends HtsjdkTest {
         File indexFile = null;
         CRAMFileReader reader = new CRAMFileReader(CRAM_WITHOUT_CRAI, indexFile, REFERENCE, ValidationStringency.STRICT);
         reader.getIndex();
+    }
+
+    @Test
+    public void testCramIteratorWithoutCallingHasNextFirst() throws IOException {
+        final SAMRecordSetBuilder builder = new SAMRecordSetBuilder(false, SAMFileHeader.SortOrder.unsorted);
+        builder.addFrag("1", 0, 2, false);
+        final CRAMFileReader reader = CRAMTestUtils.writeAndReadFromInMemoryCram(builder);
+        final SAMRecordIterator iterator = reader.getIterator();
+        Assert.assertNotNull(iterator.next());
+        Assert.assertThrows(NoSuchElementException.class, iterator::next);
     }
 }

--- a/src/test/java/htsjdk/samtools/CRAMTestUtils.java
+++ b/src/test/java/htsjdk/samtools/CRAMTestUtils.java
@@ -1,0 +1,64 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.cram.ref.CRAMReferenceSource;
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
+import htsjdk.samtools.seekablestream.SeekableStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+
+public final class CRAMTestUtils {
+
+    private CRAMTestUtils(){};
+
+    /**
+     * Write a collection of SAMRecords into an in memory Cram file and then open a reader over it
+     * @param records a Collection of SAMRecords
+     * @param ref a set of bases to use as the single reference contig named "chr1"
+     * @return a CRAMFileReader reading from an in memory buffer that has had the records written into it
+     */
+    public static CRAMFileReader writeAndReadFromInMemoryCram(Collection<SAMRecord> records, byte[] ref) throws IOException {
+        InMemoryReferenceSequenceFile refFile = new InMemoryReferenceSequenceFile();
+        refFile.add("chr1", ref);
+        ReferenceSource source = new ReferenceSource(refFile);
+        final SAMFileHeader header = records.iterator().next().getHeader();
+        return writeAndReadFromInMemoryCram(records, source, header);
+    }
+
+    /**
+     * Write a collection of SAMRecords into an in memory Cram file and then open a reader over it
+     * @param records a SAMRecordSetBuilder which has been initialized with records
+     * @return a CRAMFileReader reading from an in memory buffer that has had the records written into it, uses a fake reference with all A's
+     */
+    public static CRAMFileReader writeAndReadFromInMemoryCram(SAMRecordSetBuilder records) throws IOException {
+        return writeAndReadFromInMemoryCram(records.getRecords(), getFakeReferenceSource(), records.getHeader());
+    }
+
+    private static CRAMFileReader writeAndReadFromInMemoryCram(Collection<SAMRecord> records, CRAMReferenceSource source, SAMFileHeader header) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CRAMFileWriter cramFileWriter = new CRAMFileWriter(baos, source, header, "whatever");
+
+        for (SAMRecord record : records) {
+            cramFileWriter.addAlignment(record);
+        }
+        cramFileWriter.close();
+
+        return new CRAMFileReader(new ByteArrayInputStream(baos.toByteArray()), (SeekableStream) null, source, ValidationStringency.SILENT);
+    }
+
+    /**
+     * return a CRAMReferenceSource that returns all A's for any sequence queried
+     */
+    public static CRAMReferenceSource getFakeReferenceSource(){
+        return (sequenceRecord, tryNameVariants) -> {
+            byte[] bases = new byte[sequenceRecord.getSequenceLength()];
+            Arrays.fill(bases, (byte)'A');
+            return bases;
+        };
+    }
+}


### PR DESCRIPTION
* fixing a bug in CRAMIterator which previously threw if next() was called without first calling hasNext()
* adding CRAMTestUtils and extracting a method to it from CramEdgeCasesTest

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

