### PR TITLE
Remove JAXB.  See issue #1204

### DIFF
--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -23,7 +23,7 @@
  */
 package htsjdk.samtools;
 
-import javax.xml.bind.annotation.XmlTransient;
+
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -33,7 +33,7 @@ import java.util.Set;
  * Base class for the various concrete records in a SAM header, providing uniform
  * access to the attributes.
  */
-@XmlTransient /* don't consider this class for XML-serialization */
+
 public abstract class AbstractSAMHeaderRecord implements Serializable {
     public static final long serialVersionUID = 1L;
 

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionary.java
@@ -31,9 +31,6 @@ import java.security.MessageDigest;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
 
 import static htsjdk.samtools.SAMSequenceRecord.*;
 import static java.util.stream.Collectors.toList;
@@ -41,14 +38,14 @@ import static java.util.stream.Collectors.toList;
 /**
  * Collection of SAMSequenceRecords.
  */
-@XmlRootElement(name="References")
+
 public class SAMSequenceDictionary implements Serializable {
     public static final long serialVersionUID = 1L;
 
     /* xml Serialization , for `m_sequence` we use the field instead of the
     getter because the later wraps the list into an unmodifiable List 
     see http://tech.joshuacummings.com/2010/10/problems-with-defensive-collection.html */
-    @XmlElement(name="Reference")
+
     private List<SAMSequenceRecord> mSequences = new ArrayList<>();
     private final Map<String, SAMSequenceRecord> mSequenceMap = new HashMap<>();
 
@@ -60,7 +57,6 @@ public class SAMSequenceDictionary implements Serializable {
         setSequences(list);
     }
 
-    @XmlTransient //we use the field instead of getter/setter
     public List<SAMSequenceRecord> getSequences() {
         return Collections.unmodifiableList(mSequences);
     }

--- a/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -23,9 +23,7 @@
  */
 package htsjdk.samtools;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlValue;
+
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -38,7 +36,7 @@ import java.util.regex.Pattern;
 /**
  * Header information about a reference sequence.  Corresponds to @SQ header record in SAM text header.
  */
-@XmlRootElement(name="Reference")
+
 public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Cloneable
 {
     public static final long serialVersionUID = 1L; // AbstractSAMHeaderRecord implements Serializable
@@ -99,8 +97,7 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
         }
         mSequenceLength = sequenceLength;
     }
-    
-    @XmlValue
+
     public String getSequenceName() { return mSequenceName; }
    
     /* this private method is used by XML serialization */
@@ -113,27 +110,22 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
             mSequenceName = null;
         }
     }
-    
-    @XmlAttribute(name="length")
+
     public int getSequenceLength() { return mSequenceLength; }
     public void setSequenceLength(final int value) { mSequenceLength = value; }
 
-    @XmlAttribute(name="assembly")
     public String getAssembly() { return (String) getAttribute(ASSEMBLY_TAG); }
     public void setAssembly(final String value) { setAttribute(ASSEMBLY_TAG, value); }
 
-    @XmlAttribute(name="species")
     public String getSpecies() { return (String) getAttribute(SPECIES_TAG); }
     public void setSpecies(final String value) { setAttribute(SPECIES_TAG, value); }
 
-    @XmlAttribute(name="md5")
     public String getMd5() { return (String) getAttribute(MD5_TAG); }
     public void setMd5(final String value) { setAttribute(MD5_TAG, value); }
 
     /**
      * @return Index of this record in the sequence dictionary it lives in. 
      */
-    @XmlAttribute(name="index")
     public int getSequenceIndex() { return mSequenceIndex; }
 
     // Private state used only by SAM implementation.

--- a/src/main/java/htsjdk/samtools/cram/structure/EncodingParams.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/EncodingParams.java
@@ -18,6 +18,8 @@
 package htsjdk.samtools.cram.structure;
 
 
+import htsjdk.samtools.util.StringUtil;
+
 import java.util.Arrays;
 
 public class EncodingParams {
@@ -33,7 +35,7 @@ public class EncodingParams {
 
     @Override
     public String toString() {
-        return id.name() + ":" + javax.xml.bind.DatatypeConverter.printHexBinary(Arrays.copyOfRange(params, 0, Math.max(20, params.length)));
+        return id.name() + ":" + StringUtil.bytesToHexString(Arrays.copyOfRange(params, 0, Math.max(20, params.length)));
     }
 
 }

--- a/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceDictionaryTest.java
@@ -31,10 +31,6 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
@@ -59,38 +55,7 @@ public class SAMSequenceDictionaryTest extends HtsjdkTest {
         Assert.assertNull(dict.getSequence("chr2"));
     }
 
-    /**
-     * should be saved as XML
-     * 
-     * <pre>
-     * <?xml version="1.0" encoding="UTF-8" standalone="yes"?><References><Reference assembly="as" md5="68b329da9893e34099c7d8ad5cb9c940" index="0" length="1" species="sp">1</Reference><Reference index="1" length="1">2</Reference></References>
-     * </pre>
-     * 
-     * @throws JAXBException
-     */
-    @Test
-    public void testXmlSeralization() throws JAXBException {
-        // create dict
-        final SAMSequenceRecord ssr1 = new SAMSequenceRecord("1", 1);
-        ssr1.setMd5("68b329da9893e34099c7d8ad5cb9c940");
-        ssr1.setAssembly("as");
-        ssr1.setSpecies("sp");
-        final SAMSequenceRecord ssr2 = new SAMSequenceRecord("2", 1);
-        final StringWriter xmlWriter = new StringWriter();
-        final SAMSequenceDictionary dict1 = new SAMSequenceDictionary(
-                Arrays.asList(ssr1, ssr2));
-        // create jaxb context
-        JAXBContext jaxbContext = JAXBContext
-                .newInstance(SAMSequenceDictionary.class);
-        // save to XML
-        Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
-        jaxbMarshaller.marshal(dict1, xmlWriter);
-        // reload XML
-        Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
-        final SAMSequenceDictionary dict2 = (SAMSequenceDictionary) jaxbUnmarshaller
-                .unmarshal(new StringReader(xmlWriter.toString()));
-        Assert.assertEquals(dict1, dict2);
-    }
+
 
     @DataProvider(name="testMergeDictionariesData")
     public Object[][] testMergeDictionariesData(){


### PR DESCRIPTION
Removes JAXB annotations.   These were not used anywhere except 1 unit test which was also removed.

4 unit tests are failing,  but the same tests failed before the changes.   See screenshot.

<img width="571" alt="screen shot 2018-10-25 at 7 52 51 pm" src="https://user-images.githubusercontent.com/933148/47542330-c4e50100-d891-11e8-93da-3f02d47fbe13.png">
