### PR TITLE
Updating SAMTag and SAMTagUtils

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMRecord.java
+++ b/src/main/java/htsjdk/samtools/BAMRecord.java
@@ -310,7 +310,7 @@ public class BAMRecord extends SAMRecord {
      * extracts the CIGAR from the CG tag and places it into the (in memory) cigar.
      */
     private void extractCigarFromCGAttribute(final Cigar sentinelCigar) throws IllegalStateException {
-        final int[] cigarFromCG = (int[]) getAttribute(SAMTagUtil.getSingleton().CG);
+        final int[] cigarFromCG = (int[]) getAttribute(SAMTagUtil.CG);
 
         if (cigarFromCG == null) return;
 
@@ -353,7 +353,7 @@ public class BAMRecord extends SAMRecord {
         initializeCigar(decodedCigar);
 
         // remove CG attribute.
-        setAttribute(SAMTagUtil.getSingleton().CG, null);
+        setAttribute(SAMTagUtil.CG, null);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/BAMRecord.java
+++ b/src/main/java/htsjdk/samtools/BAMRecord.java
@@ -310,7 +310,7 @@ public class BAMRecord extends SAMRecord {
      * extracts the CIGAR from the CG tag and places it into the (in memory) cigar.
      */
     private void extractCigarFromCGAttribute(final Cigar sentinelCigar) throws IllegalStateException {
-        final int[] cigarFromCG = (int[]) getAttribute(SAMTagUtil.CG);
+        final int[] cigarFromCG = (int[]) getAttribute(SAMTag.CG.getBinaryTag());
 
         if (cigarFromCG == null) return;
 
@@ -353,7 +353,7 @@ public class BAMRecord extends SAMRecord {
         initializeCigar(decodedCigar);
 
         // remove CG attribute.
-        setAttribute(SAMTagUtil.CG, null);
+        setAttribute(SAMTag.CG.getBinaryTag(), null);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMBinaryTagAndUnsignedArrayValue.java
+++ b/src/main/java/htsjdk/samtools/SAMBinaryTagAndUnsignedArrayValue.java
@@ -35,7 +35,7 @@ public class SAMBinaryTagAndUnsignedArrayValue extends SAMBinaryTagAndValue {
         if (!value.getClass().isArray() || value instanceof float[]) {
             throw new IllegalArgumentException("Attribute type " + value.getClass() +
                     " cannot be encoded as an unsigned array. Tag: " +
-                    SAMTagUtil.getSingleton().makeStringTag(tag));
+                    SAMTagUtil.makeStringTag(tag));
         }
     }
 

--- a/src/main/java/htsjdk/samtools/SAMBinaryTagAndValue.java
+++ b/src/main/java/htsjdk/samtools/SAMBinaryTagAndValue.java
@@ -59,7 +59,7 @@ public class SAMBinaryTagAndValue implements Serializable {
         }
         if (!isAllowedAttributeValue(value)) {
             throw new IllegalArgumentException("Attribute type " + value.getClass() + " not supported. Tag: " +
-                    SAMTagUtil.getSingleton().makeStringTag(tag));
+                    SAMTagUtil.makeStringTag(tag));
         }
         this.tag = tag;
         this.value = value;

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -163,6 +163,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * Tags that are known to need the reverse complement if the read is reverse complemented.
      */
+    @SuppressWarnings("deprecated")
     public static List<String> TAGS_TO_REVERSE_COMPLEMENT = Arrays.asList(SAMTag.E2.name(), SAMTag.SQ.name());
 
     /**
@@ -868,7 +869,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws ClassCastException if RG tag does not have a String value.
      */
     public SAMReadGroupRecord getReadGroup() {
-        final String rgId = (String)getAttribute(SAMTagUtil.getSingleton().RG);
+        final String rgId = (String)getAttribute(SAMTagUtil.RG);
         if (rgId == null || getHeader() == null) {
             return null;
         } else {
@@ -1162,7 +1163,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return Appropriately typed tag value, or null if the requested tag is not present.
      */
     public Object getAttribute(final String tag) {
-        return getAttribute(SAMTagUtil.getSingleton().makeBinaryTag(tag));
+        return getAttribute(SAMTagUtil.makeBinaryTag(tag));
     }
 
     /**
@@ -1196,7 +1197,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws {@link htsjdk.samtools.SAMException} if the value is out of range for a 32-bit unsigned value, or not a Number
      */
     public Long getUnsignedIntegerAttribute(final String tag) throws SAMException {
-        return getUnsignedIntegerAttribute(SAMTagUtil.getSingleton().makeBinaryTag(tag));
+        return getUnsignedIntegerAttribute(SAMTagUtil.makeBinaryTag(tag));
     }
 
     /**
@@ -1219,11 +1220,11 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
                 return lValue;
             } else {
                 throw new SAMException("Unsigned integer value of tag " +
-                        SAMTagUtil.getSingleton().makeStringTag(tag) + " is out of bounds for a 32-bit unsigned integer: " + lValue);
+                        SAMTagUtil.makeStringTag(tag) + " is out of bounds for a 32-bit unsigned integer: " + lValue);
             }
         } else {
             throw new SAMException("Unexpected attribute value data type " + value.getClass() + " for tag " +
-                    SAMTagUtil.getSingleton().makeStringTag(tag));
+                    SAMTagUtil.makeStringTag(tag));
         }
     }
 
@@ -1374,7 +1375,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws SAMException if the tag is not present.
      */
     public boolean isUnsignedArrayAttribute(final String tag) {
-        final SAMBinaryTagAndValue tmp = this.mAttributes.find(SAMTagUtil.getSingleton().makeBinaryTag(tag));
+        final SAMBinaryTagAndValue tmp = this.mAttributes.find(SAMTagUtil.makeBinaryTag(tag));
         if (tmp != null) return tmp.isUnsignedArray();
         throw new SAMException("Tag " + tag + " is not present in this SAMRecord");
     }
@@ -1419,7 +1420,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * String values are not validated to ensure that they conform to SAM spec.
      */
     public void setAttribute(final String tag, final Object value) {
-        setAttribute(SAMTagUtil.getSingleton().makeBinaryTag(tag), value);
+        setAttribute(SAMTagUtil.makeBinaryTag(tag), value);
     }
 
     /**
@@ -1435,7 +1436,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         if (Array.getLength(value) == 0) {
             throw new IllegalArgumentException("Empty array passed to setUnsignedArrayAttribute for tag " + tag);
         }
-        setAttribute(SAMTagUtil.getSingleton().makeBinaryTag(tag), value, true);
+        setAttribute(SAMTagUtil.makeBinaryTag(tag), value, true);
     }
 
     /**
@@ -1556,8 +1557,8 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         SAMBinaryTagAndValue binaryAttributes = getBinaryAttributes();
         final List<SAMTagAndValue> ret = new ArrayList<>();
         while (binaryAttributes != null) {
-            ret.add(new SAMTagAndValue(SAMTagUtil.getSingleton().makeStringTag(binaryAttributes.tag),
-                    binaryAttributes.value));
+            ret.add(new SAMTagAndValue(SAMTagUtil.makeStringTag(binaryAttributes.tag),
+                                       binaryAttributes.value));
             binaryAttributes = binaryAttributes.getNext();
         }
         return ret;
@@ -1769,8 +1770,8 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         buffer.append(field);
     }
 
-    private String formatTagValue(final short tag, final Object value) {
-        final String tagString = SAMTagUtil.getSingleton().makeStringTag(tag);
+    private static String formatTagValue(final short tag, final Object value) {
+        final String tagString = SAMTagUtil.makeStringTag(tag);
         if (value == null || value instanceof String) {
             return tagString + ":Z:" + value;
         } else if (value instanceof Integer || value instanceof Long ||
@@ -2062,7 +2063,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 */
         }
         // Validate the RG ID is found in header
-        final String rgId = (String)getAttribute(SAMTagUtil.getSingleton().RG);
+        final String rgId = (String)getAttribute(SAMTagUtil.RG);
         if (rgId != null && getHeader() != null && getHeader().getReadGroup(rgId) == null) {
                 if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.READ_GROUP_NOT_FOUND,
@@ -2077,10 +2078,10 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         }
         // TODO(mccowan): Is this asking "is this the primary alignment"?
         if (this.getReadLength() == 0 && !this.isSecondaryAlignment()) {
-            final Object fz = getAttribute(SAMTagUtil.getSingleton().FZ);
+            final Object fz = getAttribute(SAMTagUtil.FZ);
             if (fz == null) {
-                final String cq = (String)getAttribute(SAMTagUtil.getSingleton().CQ);
-                final String cs = (String)getAttribute(SAMTagUtil.getSingleton().CS);
+                final String cq = (String)getAttribute(SAMTagUtil.CQ);
+                final String cs = (String)getAttribute(SAMTagUtil.CS);
                 if (cq == null || cq.isEmpty() || cs == null || cs.isEmpty()) {
                     if (ret == null) ret = new ArrayList<>();
                     ret.add(new SAMValidationError(SAMValidationError.Type.EMPTY_READ,

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -869,7 +869,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws ClassCastException if RG tag does not have a String value.
      */
     public SAMReadGroupRecord getReadGroup() {
-        final String rgId = (String)getAttribute(SAMTagUtil.RG);
+        final String rgId = (String)getAttribute(SAMTag.RG.getBinaryTag());
         if (rgId == null || getHeader() == null) {
             return null;
         } else {
@@ -2063,7 +2063,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 */
         }
         // Validate the RG ID is found in header
-        final String rgId = (String)getAttribute(SAMTagUtil.RG);
+        final String rgId = (String)getAttribute(SAMTag.RG.getBinaryTag());
         if (rgId != null && getHeader() != null && getHeader().getReadGroup(rgId) == null) {
                 if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.READ_GROUP_NOT_FOUND,
@@ -2078,10 +2078,10 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         }
         // TODO(mccowan): Is this asking "is this the primary alignment"?
         if (this.getReadLength() == 0 && !this.isSecondaryAlignment()) {
-            final Object fz = getAttribute(SAMTagUtil.FZ);
+            final Object fz = getAttribute(SAMTag.FZ.getBinaryTag());
             if (fz == null) {
-                final String cq = (String)getAttribute(SAMTagUtil.CQ);
-                final String cs = (String)getAttribute(SAMTagUtil.CS);
+                final String cq = (String)getAttribute(SAMTag.CQ.getBinaryTag());
+                final String cs = (String)getAttribute(SAMTag.CS.getBinaryTag());
                 if (cq == null || cq.isEmpty() || cs == null || cs.isEmpty()) {
                     if (ret == null) ret = new ArrayList<>();
                     ret.add(new SAMValidationError(SAMValidationError.Type.EMPTY_READ,

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -203,7 +203,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
      */
     public void addRecord(final SAMRecord record) {
         if (record.getReadPairedFlag() && !record.getMateUnmappedFlag() &&
-                null == record.getAttribute(SAMTagUtil.getSingleton().MC)) {
+                null == record.getAttribute(SAMTagUtil.MC)) {
             throw new SAMException("Mate Cigar tag (MC) not found in: " + record.getReadName());
         }
         this.records.add(record);

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -203,7 +203,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
      */
     public void addRecord(final SAMRecord record) {
         if (record.getReadPairedFlag() && !record.getMateUnmappedFlag() &&
-                null == record.getAttribute(SAMTagUtil.MC)) {
+                null == record.getAttribute(SAMTag.MC.getBinaryTag())) {
             throw new SAMException("Mate Cigar tag (MC) not found in: " + record.getReadName());
         }
         this.records.add(record);

--- a/src/main/java/htsjdk/samtools/SAMTag.java
+++ b/src/main/java/htsjdk/samtools/SAMTag.java
@@ -31,14 +31,18 @@ public enum SAMTag {
     AS,
     BC,
     BQ,
+    BZ,
+    CB,
     CC,
     CG,
     CM,
     CO,
     CP,
     CQ,
+    CR,
     CS,
     CT,
+    CY,
     E2,
     FI,
     FS,
@@ -55,6 +59,7 @@ public enum SAMTag {
     IH,
     MC,
     MF, // for backwards compatibility
+    MI,
     MD,
     MQ,
     NH,
@@ -64,20 +69,29 @@ public enum SAMTag {
     OC,
     OF,
     OR,
+    OX,
     PG,
     PQ,
     PT,
     PU,
     QT,
     Q2,
+    QX,
     R2,
     RG,
+
+    /**
+     * @deprecated use BC instead
+     */
+    @Deprecated
     RT,
+
+    RX,
     S2, // for backwards compatibility
     SA,
     SM,
     SQ, // for backwards compatibility
     TC,
     U2,
-    UQ
-}
+    UQ,
+    }

--- a/src/main/java/htsjdk/samtools/SAMTag.java
+++ b/src/main/java/htsjdk/samtools/SAMTag.java
@@ -48,9 +48,15 @@ public enum SAMTag {
     FS,
     FT,
     FZ,
-    GC, // for backwards compatibility
+    /** for backwards compatibility only */
+    @Deprecated
+    GC,
+    /** @deprecated for backwards compatibility only */
+    @Deprecated
     GS, // for backwards compatibility
-    GQ, // for backwards compatibility
+    /** @deprecated for backwards compatibility only */
+    @Deprecated
+    GQ,
     LB,
     H0,
     H1,
@@ -58,7 +64,9 @@ public enum SAMTag {
     HI,
     IH,
     MC,
-    MF, // for backwards compatibility
+    /** @deprecated  for backwards compatibility only */
+    @Deprecated
+    MF,
     MI,
     MD,
     MQ,
@@ -79,19 +87,33 @@ public enum SAMTag {
     QX,
     R2,
     RG,
-
     /**
-     * @deprecated use BC instead
+     * @deprecated use BC instead, for backwards compatibilty only
      */
     @Deprecated
     RT,
-
     RX,
+    /** @deprecated for backwards compatibility only */
+    @Deprecated
     S2, // for backwards compatibility
     SA,
     SM,
+    /** @deprecated  for backwards compatibility only */
+    @Deprecated
     SQ, // for backwards compatibility
     TC,
     U2,
-    UQ,
+    UQ;
+
+    private final short shortValue = SAMTagUtil.makeBinaryTag(this.name());
+
+    /**
+     * Get the binary representation of this tag name.
+     * @see SAMTagUtil#makeBinaryTag(String)
+     *
+     * @return the binary representation of this tag name
+     */
+    public short getBinaryTag(){
+        return this.shortValue;
     }
+}

--- a/src/main/java/htsjdk/samtools/SAMTag.java
+++ b/src/main/java/htsjdk/samtools/SAMTag.java
@@ -48,7 +48,7 @@ public enum SAMTag {
     FS,
     FT,
     FZ,
-    /** for backwards compatibility only */
+    /** @deprecated for backwards compatibility only */
     @Deprecated
     GC,
     /** @deprecated for backwards compatibility only */

--- a/src/main/java/htsjdk/samtools/SAMTag.java
+++ b/src/main/java/htsjdk/samtools/SAMTag.java
@@ -105,7 +105,20 @@ public enum SAMTag {
     U2,
     UQ;
 
-    private final short shortValue = SAMTagUtil.makeBinaryTag(this.name());
+    private final short shortValue = SAMTag.makeBinaryTag(this.name());;
+
+    /**
+     * Convert from String representation of tag name to short representation.
+     *
+     * @param tag 2-character String representation of a tag name.
+     * @return Tag name packed as 2 ASCII bytes in a short.
+     */
+    static short makeBinaryTag(String tag) {
+        if (tag.length() != 2) {
+            throw new IllegalArgumentException("String tag does not have length() == 2: " + tag);
+        }
+        return (short)(tag.charAt(1) << 8 | tag.charAt(0));
+    }
 
     /**
      * Get the binary representation of this tag name.

--- a/src/main/java/htsjdk/samtools/SAMTagUtil.java
+++ b/src/main/java/htsjdk/samtools/SAMTagUtil.java
@@ -33,62 +33,105 @@ import htsjdk.samtools.util.StringUtil;
  *
  * @author alecw@broadinstitute.org
  */
-public class SAMTagUtil {
+public final class SAMTagUtil {
+
+    /**
+     * This constructor is public despite being a utility class for backwards compatibility reasons.
+     */
+    public SAMTagUtil(){}
 
     // Standard tags pre-computed for convenience
-    public final short RG = makeBinaryTag(SAMTag.RG.name());
-    public final short LB = makeBinaryTag(SAMTag.LB.name());
-    public final short PU = makeBinaryTag(SAMTag.PU.name());
-    public final short PG = makeBinaryTag(SAMTag.PG.name());
-    public final short AS = makeBinaryTag(SAMTag.AS.name());
-    public final short SQ = makeBinaryTag(SAMTag.SQ.name());
-    public final short MQ = makeBinaryTag(SAMTag.MQ.name());
-    public final short NM = makeBinaryTag(SAMTag.NM.name());
-    public final short H0 = makeBinaryTag(SAMTag.H0.name());
-    public final short H1 = makeBinaryTag(SAMTag.H1.name());
-    public final short H2 = makeBinaryTag(SAMTag.H2.name());
-    public final short UQ = makeBinaryTag(SAMTag.UQ.name());
-    public final short PQ = makeBinaryTag(SAMTag.PQ.name());
-    public final short NH = makeBinaryTag(SAMTag.NH.name());
-    public final short IH = makeBinaryTag(SAMTag.IH.name());
-    public final short HI = makeBinaryTag(SAMTag.HI.name());
-    public final short MD = makeBinaryTag(SAMTag.MD.name());
-    public final short CS = makeBinaryTag(SAMTag.CS.name());
-    public final short CQ = makeBinaryTag(SAMTag.CQ.name());
-    public final short CM = makeBinaryTag(SAMTag.CM.name());
-    public final short R2 = makeBinaryTag(SAMTag.R2.name());
-    public final short Q2 = makeBinaryTag(SAMTag.Q2.name());
-    public final short S2 = makeBinaryTag(SAMTag.S2.name());
-    public final short CC = makeBinaryTag(SAMTag.CC.name());
-    public final short CP = makeBinaryTag(SAMTag.CP.name());
-    public final short SM = makeBinaryTag(SAMTag.SM.name());
-    public final short AM = makeBinaryTag(SAMTag.AM.name());
-    public final short MF = makeBinaryTag(SAMTag.MF.name());
-    public final short E2 = makeBinaryTag(SAMTag.E2.name());
-    public final short U2 = makeBinaryTag(SAMTag.U2.name());
-    public final short OQ = makeBinaryTag(SAMTag.OQ.name());
-    public final short FZ = makeBinaryTag(SAMTag.FZ.name());
-    public final short SA = makeBinaryTag(SAMTag.SA.name());
-    public final short MC = makeBinaryTag(SAMTag.MC.name());
-    public final short CG = makeBinaryTag(SAMTag.CG.name());
+    public static final short AM = SAMTag.AM.getBinaryTag();
+    public static final short AS = SAMTag.AS.getBinaryTag();
+    public static final short BC = SAMTag.BC.getBinaryTag();
+    public static final short BQ = SAMTag.BQ.getBinaryTag();
+    public static final short BZ = SAMTag.BZ.getBinaryTag();
+    public static final short CB = SAMTag.CB.getBinaryTag();
+    public static final short CC = SAMTag.CC.getBinaryTag();
+    public static final short CG = SAMTag.CG.getBinaryTag();
+    public static final short CM = SAMTag.CM.getBinaryTag();
+    public static final short CO = SAMTag.CO.getBinaryTag();
+    public static final short CP = SAMTag.CP.getBinaryTag();
+    public static final short CQ = SAMTag.CQ.getBinaryTag();
+    public static final short CR = SAMTag.CR.getBinaryTag();
+    public static final short CS = SAMTag.CS.getBinaryTag();
+    public static final short CT = SAMTag.CT.getBinaryTag();
+    public static final short CY = SAMTag.CY.getBinaryTag();
+    public static final short E2 = SAMTag.E2.getBinaryTag();
+    public static final short FI = SAMTag.FI.getBinaryTag();
+    public static final short FS = SAMTag.FS.getBinaryTag();
+    public static final short FT = SAMTag.FT.getBinaryTag();
+    public static final short FZ = SAMTag.FZ.getBinaryTag();
+    /** @deprecated reserved tag for backwards compatibility only */
+    @Deprecated
+    public static final short GC = SAMTag.GC.getBinaryTag();
+    /** @deprecated reserved tag for backwards compatibility only */
+    @Deprecated
+    public static final short GS = SAMTag.GS.getBinaryTag();
+    /** @deprecated reserved tag for backwards compatibility only */
+    @Deprecated
+    public static final short GQ = SAMTag.GQ.getBinaryTag();
+    public static final short LB = SAMTag.LB.getBinaryTag();
+    public static final short H0 = SAMTag.H0.getBinaryTag();
+    public static final short H1 = SAMTag.H1.getBinaryTag();
+    public static final short H2 = SAMTag.H2.getBinaryTag();
+    public static final short HI = SAMTag.HI.getBinaryTag();
+    public static final short IH = SAMTag.IH.getBinaryTag();
+    public static final short MC = SAMTag.MC.getBinaryTag();
+    /** @deprecated reserved tag for backwards compatibility only */
+    @Deprecated
+    public static final short MF = SAMTag.MF.getBinaryTag();
+    public static final short MI = SAMTag.MI.getBinaryTag();
+    public static final short MD = SAMTag.MD.getBinaryTag();
+    public static final short MQ = SAMTag.MQ.getBinaryTag();
+    public static final short NH = SAMTag.NH.getBinaryTag();
+    public static final short NM = SAMTag.NM.getBinaryTag();
+    public static final short OQ = SAMTag.OQ.getBinaryTag();
+    public static final short OP = SAMTag.OP.getBinaryTag();
+    public static final short OC = SAMTag.OC.getBinaryTag();
+    public static final short OF = SAMTag.OF.getBinaryTag();
+    public static final short OR = SAMTag.OR.getBinaryTag();
+    public static final short OX = SAMTag.OX.getBinaryTag();
+    public static final short PG = SAMTag.PG.getBinaryTag();
+    public static final short PQ = SAMTag.PQ.getBinaryTag();
+    public static final short PT = SAMTag.PT.getBinaryTag();
+    public static final short PU = SAMTag.PU.getBinaryTag();
+    public static final short QT = SAMTag.QT.getBinaryTag();
+    public static final short Q2 = SAMTag.Q2.getBinaryTag();
+    public static final short QX = SAMTag.QX.getBinaryTag();
+    public static final short R2 = SAMTag.R2.getBinaryTag();
+    public static final short RG = SAMTag.RG.getBinaryTag();
+    /** @deprecated use BC instead */
+    @Deprecated
+    public static final short RT = SAMTag.RT.getBinaryTag();
+    public static final short RX = SAMTag.RX.getBinaryTag();
+    /** @deprecated reserved tag for backwards compatibility only */
+    @Deprecated
+    public static final short S2 = SAMTag.S2.getBinaryTag();
+    public static final short SA = SAMTag.SA.getBinaryTag();
+    public static final short SM = SAMTag.SM.getBinaryTag();
+    /** @deprecated reserved tag for backwards compatibility only */
+    @Deprecated
+    public static final short SQ = SAMTag.SQ.getBinaryTag();
+    public static final short TC = SAMTag.TC.getBinaryTag();
+    public static final short U2 = SAMTag.U2.getBinaryTag();
+    public static final short UQ = SAMTag.UQ.getBinaryTag();
 
-    private static SAMTagUtil singleton;
+    private static final SAMTagUtil singleton = new SAMTagUtil();
 
     // Cache of already-converted tags.  Should speed up SAM text generation.
     // Not synchronized because race condition is not a problem.
-    private final String[] stringTags = new String[Short.MAX_VALUE];
+    private static final String[] stringTags = new String[Short.MAX_VALUE];
 
     /**
      * Despite the fact that this class has state, it should be thread-safe because the cache
      * gets filled with the same values by any thread.
+     * @deprecated All methods on this class have been made static, use them directly
      */
+    @Deprecated
     public static SAMTagUtil getSingleton() {
-        if (singleton == null) {
-            singleton = new SAMTagUtil();
-        }
         return singleton;
     }
-
 
     /**
      * Convert from String representation of tag name to short representation.
@@ -96,7 +139,7 @@ public class SAMTagUtil {
      * @param tag 2-character String representation of a tag name.
      * @return Tag name packed as 2 ASCII bytes in a short.
      */
-    public short makeBinaryTag(final String tag) {
+    public static short makeBinaryTag(final String tag) {
         if (tag.length() != 2) {
             throw new IllegalArgumentException("String tag does not have length() == 2: " + tag);
         }
@@ -109,7 +152,7 @@ public class SAMTagUtil {
      * @param tag Tag name packed as 2 ASCII bytes in a short.
      * @return 2-character String representation of a tag name.
      */
-    public String makeStringTag(final short tag) {
+    public static String makeStringTag(final short tag) {
         String ret = stringTags[tag];
         if (ret == null) {
             final byte[] stringConversionBuf = new byte[2];

--- a/src/main/java/htsjdk/samtools/SAMTagUtil.java
+++ b/src/main/java/htsjdk/samtools/SAMTagUtil.java
@@ -118,7 +118,7 @@ public final class SAMTagUtil {
     public static final short U2 = SAMTag.U2.getBinaryTag();
     public static final short UQ = SAMTag.UQ.getBinaryTag();
 
-    private static final SAMTagUtil singleton = new SAMTagUtil();
+    private static final SAMTagUtil SINGLETON = new SAMTagUtil();
 
     // Cache of already-converted tags.  Should speed up SAM text generation.
     // Not synchronized because race condition is not a problem.

--- a/src/main/java/htsjdk/samtools/SAMTagUtil.java
+++ b/src/main/java/htsjdk/samtools/SAMTagUtil.java
@@ -142,10 +142,7 @@ public final class SAMTagUtil {
      * @return Tag name packed as 2 ASCII bytes in a short.
      */
     public static short makeBinaryTag(final String tag) {
-        if (tag.length() != 2) {
-            throw new IllegalArgumentException("String tag does not have length() == 2: " + tag);
-        }
-        return (short)(tag.charAt(1) << 8 | tag.charAt(0));
+        return SAMTag.makeBinaryTag(tag);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMTagUtil.java
+++ b/src/main/java/htsjdk/samtools/SAMTagUtil.java
@@ -36,8 +36,9 @@ import htsjdk.samtools.util.StringUtil;
 public final class SAMTagUtil {
 
     /**
-     * This constructor is public despite being a utility class for backwards compatibility reasons.
+     * @deprecated This constructor is public despite being a utility class for backwards compatibility reasons.
      */
+    @Deprecated
     public SAMTagUtil(){}
 
     // Standard tags pre-computed for convenience

--- a/src/main/java/htsjdk/samtools/SAMTagUtil.java
+++ b/src/main/java/htsjdk/samtools/SAMTagUtil.java
@@ -118,6 +118,7 @@ public final class SAMTagUtil {
     public static final short U2 = SAMTag.U2.getBinaryTag();
     public static final short UQ = SAMTag.UQ.getBinaryTag();
 
+    @Deprecated
     private static final SAMTagUtil SINGLETON = new SAMTagUtil();
 
     // Cache of already-converted tags.  Should speed up SAM text generation.
@@ -131,7 +132,7 @@ public final class SAMTagUtil {
      */
     @Deprecated
     public static SAMTagUtil getSingleton() {
-        return singleton;
+        return SINGLETON;
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMTextWriter.java
+++ b/src/main/java/htsjdk/samtools/SAMTextWriter.java
@@ -158,9 +158,9 @@ public class SAMTextWriter extends SAMFileWriterImpl {
                 out.write(FIELD_SEPARATOR);
                 final String encodedTag;
                 if (attribute.isUnsignedArray()) {
-                    encodedTag = tagCodec.encodeUnsignedArray(tagUtil.makeStringTag(attribute.tag), attribute.value);
+                    encodedTag = tagCodec.encodeUnsignedArray(SAMTagUtil.makeStringTag(attribute.tag), attribute.value);
                 } else {
-                    encodedTag = tagCodec.encode(tagUtil.makeStringTag(attribute.tag), attribute.value);
+                    encodedTag = tagCodec.encode(SAMTagUtil.makeStringTag(attribute.tag), attribute.value);
                 }
                 out.write(encodedTag);
                 attribute = attribute.getNext();

--- a/src/main/java/htsjdk/samtools/SAMTextWriter.java
+++ b/src/main/java/htsjdk/samtools/SAMTextWriter.java
@@ -43,7 +43,6 @@ public class SAMTextWriter extends SAMFileWriterImpl {
     // For error reporting only.
     private final File file;
     private final TextTagCodec tagCodec = new TextTagCodec();
-    private final SAMTagUtil tagUtil = new SAMTagUtil();
 
     private final SamFlagField samFlagFieldOutput;
     

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -1127,7 +1127,7 @@ public final class SAMUtils {
         if (record == null) throw new IllegalArgumentException("record is null");
         if (record.getHeader() == null) throw new IllegalArgumentException("record.getHeader() is null");
         /* extract value of SA tag */
-        final Object saValue = record.getAttribute(SAMTagUtil.getSingleton().SA);
+        final Object saValue = record.getAttribute(SAMTagUtil.SA);
         if (saValue == null) return Collections.emptyList();
         if (!(saValue instanceof String)) throw new SAMException(
                 "Expected a String for attribute 'SA' but got " + saValue.getClass() + ". Record: " + record);
@@ -1220,7 +1220,7 @@ public final class SAMUtils {
             /* fill NM */
             try {
                 if (!commaStrs[5].equals("*")) {
-                    otherRec.setAttribute(SAMTagUtil.getSingleton().NM, Integer.parseInt(commaStrs[5]));
+                    otherRec.setAttribute(SAMTagUtil.NM, Integer.parseInt(commaStrs[5]));
                 }
             } catch (final NumberFormatException err) {
                 throw new SAMException("bad NM in " + semiColonStr + ". Record: " + record, err);

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -1127,7 +1127,7 @@ public final class SAMUtils {
         if (record == null) throw new IllegalArgumentException("record is null");
         if (record.getHeader() == null) throw new IllegalArgumentException("record.getHeader() is null");
         /* extract value of SA tag */
-        final Object saValue = record.getAttribute(SAMTagUtil.SA);
+        final Object saValue = record.getAttribute(SAMTag.SA.getBinaryTag());
         if (saValue == null) return Collections.emptyList();
         if (!(saValue instanceof String)) throw new SAMException(
                 "Expected a String for attribute 'SA' but got " + saValue.getClass() + ". Record: " + record);
@@ -1220,7 +1220,7 @@ public final class SAMUtils {
             /* fill NM */
             try {
                 if (!commaStrs[5].equals("*")) {
-                    otherRec.setAttribute(SAMTagUtil.NM, Integer.parseInt(commaStrs[5]));
+                    otherRec.setAttribute(SAMTag.NM.getBinaryTag(), Integer.parseInt(commaStrs[5]));
                 }
             } catch (final NumberFormatException err) {
                 throw new SAMException("bad NM in " + semiColonStr + ". Record: " + record, err);

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -409,7 +409,7 @@ public class SamFileValidator {
             addError(new SAMValidationError(Type.CG_TAG_FOUND_IN_ATTRIBUTES,
                     "The CG Tag should only be used in BAM format to hold a large cigar. " +
                             "It was found containing the value: " +
-                            record.getAttribute(SAMTagUtil.getSingleton().CG), record.getReadName(), recordNumber));
+                            record.getAttribute(SAMTagUtil.CG), record.getReadName(), recordNumber));
         }
     }
 

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -409,7 +409,7 @@ public class SamFileValidator {
             addError(new SAMValidationError(Type.CG_TAG_FOUND_IN_ATTRIBUTES,
                     "The CG Tag should only be used in BAM format to hold a large cigar. " +
                             "It was found containing the value: " +
-                            record.getAttribute(SAMTagUtil.CG), record.getReadName(), recordNumber));
+                            record.getAttribute(SAMTag.CG.getBinaryTag()), record.getReadName(), recordNumber));
         }
     }
 

--- a/src/main/java/htsjdk/samtools/cram/digest/ContentDigests.java
+++ b/src/main/java/htsjdk/samtools/cram/digest/ContentDigests.java
@@ -33,7 +33,7 @@ public class ContentDigests {
         final List<Digester> digesters = new LinkedList<ContentDigests.Digester>();
         SAMBinaryTagAndValue binaryTag = binaryTags;
         while (binaryTag != null) {
-            final String tagID = SAMTagUtil.getSingleton().makeStringTag(
+            final String tagID = SAMTagUtil.makeStringTag(
                     binaryTag.tag);
             final KNOWN_DIGESTS hash;
             try {
@@ -131,7 +131,7 @@ public class ContentDigests {
             this.digest = digest;
             this.series = series;
             this.tagID = tagID;
-            this.tagCode = SAMTagUtil.getSingleton().makeBinaryTag(tagID);
+            this.tagCode = SAMTagUtil.makeBinaryTag(tagID);
         }
 
         void add(final SAMRecord record) {

--- a/src/main/java/htsjdk/samtools/cram/encoding/BitCodec.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/BitCodec.java
@@ -26,7 +26,6 @@ import java.io.IOException;
  * An interface that defines requirements for serializing/deserializing objects into and from a bit stream.
  *
  * @param <T> data series type to be read or written
- * @noinspection UnnecessaryInterfaceModifier, UnnecessaryInterfaceModifier, UnnecessaryInterfaceModifier, UnnecessaryInterfaceModifier, UnnecessaryInterfaceModifier, UnnecessaryInterfaceModifier, UnnecessaryInterfaceModifier
  */
 public interface BitCodec<T> {
 

--- a/src/main/java/htsjdk/samtools/cram/encoding/huffman/codec/CanonicalHuffmanByteEncoding.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/huffman/codec/CanonicalHuffmanByteEncoding.java
@@ -49,12 +49,14 @@ public class CanonicalHuffmanByteEncoding implements Encoding<Byte> {
             buf = ByteBuffer.allocate(values.length * 8);
 
         ITF8.writeUnsignedITF8(values.length, buf);
-        for (final byte value : values)
+        for (final byte value : values) {
             buf.put(value);
+        }
 
         ITF8.writeUnsignedITF8(bitLengths.length, buf);
-        for (final int value : bitLengths)
+        for (final int value : bitLengths) {
             ITF8.writeUnsignedITF8(value, buf);
+        }
 
         buf.flip();
         final byte[] array = new byte[buf.limit()];
@@ -71,8 +73,9 @@ public class CanonicalHuffmanByteEncoding implements Encoding<Byte> {
 
         size = ITF8.readUnsignedITF8(buf);
         bitLengths = new int[size];
-        for (int i = 0; i < size; i++)
+        for (int i = 0; i < size; i++) {
             bitLengths[i] = ITF8.readUnsignedITF8(buf);
+        }
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/cram/structure/ReadTag.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ReadTag.java
@@ -19,7 +19,6 @@ package htsjdk.samtools.cram.structure;
 
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMFormatException;
-import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecord.SAMTagAndValue;
 import htsjdk.samtools.SAMTagUtil;
 import htsjdk.samtools.SAMUtils;
@@ -63,7 +62,7 @@ public class ReadTag implements Comparable<ReadTag> {
 
         keyType3BytesAsInt = id;
 
-        code = SAMTagUtil.getSingleton().makeBinaryTag(this.key);
+        code = SAMTagUtil.makeBinaryTag(this.key);
     }
 
     private ReadTag(final String key, final char type, final Object value) {
@@ -87,7 +86,7 @@ public class ReadTag implements Comparable<ReadTag> {
         keyType3Bytes = this.key + this.type;
         keyType3BytesAsInt = nameType3BytesToInt(this.key, this.type);
 
-        code = SAMTagUtil.getSingleton().makeBinaryTag(this.key);
+        code = SAMTagUtil.makeBinaryTag(this.key);
     }
 
     public static int name3BytesToInt(final byte[] name) {

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -206,7 +206,7 @@ public class Slice {
         if (value != null && value.getClass().isArray() && Array.getLength(value) == 0) {
             throw new IllegalArgumentException("Empty value passed for tag " + tag);
         }
-        setAttribute(SAMTagUtil.getSingleton().makeBinaryTag(tag), value);
+        setAttribute(SAMTagUtil.makeBinaryTag(tag), value);
     }
 
     public void setUnsignedArrayAttribute(final String tag, final Object value) {
@@ -216,7 +216,7 @@ public class Slice {
         if (Array.getLength(value) == 0) {
             throw new IllegalArgumentException("Empty array passed to setUnsignedArrayAttribute for tag " + tag);
         }
-        setAttribute(SAMTagUtil.getSingleton().makeBinaryTag(tag), value, true);
+        setAttribute(SAMTagUtil.makeBinaryTag(tag), value, true);
     }
 
     void setAttribute(final short tag, final Object value) {

--- a/src/main/java/htsjdk/samtools/cram/structure/SliceIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/SliceIO.java
@@ -66,7 +66,7 @@ class SliceIO {
 
             SAMBinaryTagAndValue tags = slice.sliceTags;
             while (tags != null) {
-                log.debug(String.format("Found slice tag: %s", SAMTagUtil.getSingleton().makeStringTag(tags.tag)));
+                log.debug(String.format("Found slice tag: %s", SAMTagUtil.makeStringTag(tags.tag)));
                 tags = tags.getNext();
             }
         }
@@ -95,7 +95,7 @@ class SliceIO {
                 final BinaryTagCodec binaryTagCodec = new BinaryTagCodec(binaryCoded);
                 SAMBinaryTagAndValue samBinaryTagAndValue = slice.sliceTags;
                 do {
-                    log.debug("Writing slice tag: " + SAMTagUtil.getSingleton().makeStringTag(samBinaryTagAndValue.tag));
+                    log.debug("Writing slice tag: " + SAMTagUtil.makeStringTag(samBinaryTagAndValue.tag));
                     binaryTagCodec.writeTag(samBinaryTagAndValue.tag, samBinaryTagAndValue.value, samBinaryTagAndValue.isUnsignedArray());
                 } while ((samBinaryTagAndValue = samBinaryTagAndValue.getNext()) != null);
                 // BinaryCodec doesn't seem to cache things.

--- a/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
+++ b/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
@@ -210,7 +210,7 @@ public class SRALazyRecord extends SAMRecord {
     static
     {
         lazyAttributeTags = new HashMap<Short, LazyAttribute>();
-        lazyAttributeTags.put(SAMTagUtil.getSingleton().RG, LazyAttribute.RG);
+        lazyAttributeTags.put(SAMTagUtil.RG, LazyAttribute.RG);
     }
 
     public SRALazyRecord(final SAMFileHeader header, SRAAccession accession, ReadCollection run, AlignmentIterator alignmentIterator, String readId, String alignmentId) {
@@ -673,7 +673,7 @@ public class SRALazyRecord extends SAMRecord {
 
     @Override
     public boolean isUnsignedArrayAttribute(final String tag) {
-        Short binaryTag = SAMTagUtil.getSingleton().makeBinaryTag(tag);
+        Short binaryTag = SAMTagUtil.makeBinaryTag(tag);
         LazyAttribute attr = lazyAttributeTags.get(binaryTag);
         if (attr != null && !initializedAttributes.contains(attr)) {
             getAttribute(binaryTag);

--- a/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
+++ b/src/main/java/htsjdk/samtools/sra/SRALazyRecord.java
@@ -27,13 +27,7 @@
 package htsjdk.samtools.sra;
 
 import gov.nih.nlm.ncbi.ngs.NGS;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMTagUtil;
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.Cigar;
-import htsjdk.samtools.SAMBinaryTagAndValue;
-import htsjdk.samtools.SAMUtils;
-import htsjdk.samtools.SAMValidationError;
+import htsjdk.samtools.*;
 import htsjdk.samtools.util.Log;
 import ngs.ReadCollection;
 import ngs.AlignmentIterator;
@@ -210,7 +204,7 @@ public class SRALazyRecord extends SAMRecord {
     static
     {
         lazyAttributeTags = new HashMap<Short, LazyAttribute>();
-        lazyAttributeTags.put(SAMTagUtil.RG, LazyAttribute.RG);
+        lazyAttributeTags.put(SAMTag.RG.getBinaryTag(), LazyAttribute.RG);
     }
 
     public SRALazyRecord(final SAMFileHeader header, SRAAccession accession, ReadCollection run, AlignmentIterator alignmentIterator, String readId, String alignmentId) {

--- a/src/test/java/htsjdk/samtools/SAMBinaryTagAndValueUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMBinaryTagAndValueUnitTest.java
@@ -39,7 +39,7 @@ public class SAMBinaryTagAndValueUnitTest extends HtsjdkTest {
 
     @Test(dataProvider="allowedAttributeTypes")
     public void test_isAllowedConstructor(final Object value) {
-        Assert.assertNotNull(new SAMBinaryTagAndValue(SAMTagUtil.getSingleton().makeBinaryTag("UI"), value));
+        Assert.assertNotNull(new SAMBinaryTagAndValue(SAMTagUtil.makeBinaryTag("UI"), value));
     }
 
     @DataProvider(name="notAllowedAttributeTypes")
@@ -61,7 +61,7 @@ public class SAMBinaryTagAndValueUnitTest extends HtsjdkTest {
 
     @Test(dataProvider="notAllowedAttributeTypes", expectedExceptions=IllegalArgumentException.class)
     public void test_isNotAllowedConstructor(final Object value) {
-        new SAMBinaryTagAndValue(SAMTagUtil.getSingleton().makeBinaryTag("ZZ"), value);
+        new SAMBinaryTagAndValue(SAMTagUtil.makeBinaryTag("ZZ"), value);
     }
 
     @DataProvider(name="allowedUnsignedArrayTypes")
@@ -75,7 +75,7 @@ public class SAMBinaryTagAndValueUnitTest extends HtsjdkTest {
 
     @Test(dataProvider="allowedUnsignedArrayTypes")
     public void test_isAllowedUnsignedArrayAttribute(final Object value) {
-        final short binaryTag = SAMTagUtil.getSingleton().makeBinaryTag("UI");
+        final short binaryTag = SAMTagUtil.makeBinaryTag("UI");
         Assert.assertNotNull(new SAMBinaryTagAndUnsignedArrayValue(binaryTag, value));
     }
 
@@ -89,13 +89,13 @@ public class SAMBinaryTagAndValueUnitTest extends HtsjdkTest {
 
     @Test(dataProvider="notAllowedUnsignedArrayTypes", expectedExceptions=IllegalArgumentException.class)
     public void test_isNotAllowedUnsignedArrayAttribute(final Object value) {
-        final short binaryTag = SAMTagUtil.getSingleton().makeBinaryTag("UI");
+        final short binaryTag = SAMTagUtil.makeBinaryTag("UI");
         new SAMBinaryTagAndUnsignedArrayValue(binaryTag, value);
     }
 
     @DataProvider(name="hashCopyEquals")
     public Object[][] hashCopyEquals() {
-        final short tag = SAMTagUtil.getSingleton().makeBinaryTag("UI");
+        final short tag = SAMTagUtil.makeBinaryTag("UI");
         return new Object[][] {
                 {new SAMBinaryTagAndValue(tag, new String("a string")), new SAMBinaryTagAndValue(tag, new String("a string")), true, true},
                 {new SAMBinaryTagAndValue(tag, new String("a string")), new SAMBinaryTagAndValue(tag, new String("different string")), false, false},

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -335,7 +335,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     @Test
     public void test_getUnsignedIntegerAttribute_valid() {
         final String stringTag = "UI";
-        final short binaryTag = SAMTagUtil.getSingleton().makeBinaryTag(stringTag);
+        final short binaryTag = SAMTagUtil.makeBinaryTag(stringTag);
         SAMFileHeader header = new SAMFileHeader();
         SAMRecord record = new SAMRecord(header);
         Assert.assertNull(record.getUnsignedIntegerAttribute(stringTag));
@@ -374,7 +374,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
      */
     @Test
     public void test_getUnsignedIntegerAttribute_valid_alternative() {
-        final short tag = SAMTagUtil.getSingleton().makeBinaryTag("UI");
+        final short tag = SAMTagUtil.makeBinaryTag("UI");
         SAMFileHeader header = new SAMFileHeader();
         SAMRecord record;
 
@@ -457,7 +457,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
 
     @Test
     public void test_setAttribute_null_removes_tag() {
-        final short tag = SAMTagUtil.getSingleton().makeBinaryTag("UI");
+        final short tag = SAMTagUtil.makeBinaryTag("UI");
         SAMFileHeader header = new SAMFileHeader();
         SAMRecord record = new SAMRecord(header);
         Assert.assertNull(record.getUnsignedIntegerAttribute(tag));

--- a/src/test/java/htsjdk/samtools/SAMUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/SAMUtilsTest.java
@@ -204,7 +204,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(SAMUtils.getOtherCanonicalAlignments(record).size(),0);
 
 
-        record.setAttribute(SAMTagUtil.getSingleton().SA,
+        record.setAttribute(SAMTagUtil.SA,
                 "2,500,+,3S2=1X2=2S,60,1;" +
                 "1,191,-,8M2S,60,*;");
 
@@ -233,7 +233,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(other.getAlignmentStart(),500);
         Assert.assertFalse(other.getReadNegativeStrandFlag());
         Assert.assertEquals(other.getMappingQuality(), 60);
-        Assert.assertEquals(other.getAttribute(SAMTagUtil.getSingleton().NM),1);
+        Assert.assertEquals(other.getAttribute(SAMTagUtil.NM),1);
         Assert.assertEquals(other.getCigarString(),"3S2=1X2=2S");
         Assert.assertEquals(other.getInferredInsertSize(),0);
 
@@ -244,7 +244,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(other.getAlignmentStart(),191);
         Assert.assertTrue(other.getReadNegativeStrandFlag());
         Assert.assertEquals(other.getMappingQuality(), 60);
-        Assert.assertEquals(other.getAttribute(SAMTagUtil.getSingleton().NM),null);
+        Assert.assertEquals(other.getAttribute(SAMTagUtil.NM),null);
         Assert.assertEquals(other.getCigarString(),"8M2S");
         Assert.assertEquals(other.getInferredInsertSize(),-91);//100(mate) - 191(other)
     }

--- a/src/test/java/htsjdk/samtools/SAMUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/SAMUtilsTest.java
@@ -204,7 +204,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(SAMUtils.getOtherCanonicalAlignments(record).size(),0);
 
 
-        record.setAttribute(SAMTagUtil.SA,
+        record.setAttribute(SAMTag.SA.getBinaryTag(),
                 "2,500,+,3S2=1X2=2S,60,1;" +
                 "1,191,-,8M2S,60,*;");
 
@@ -233,7 +233,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(other.getAlignmentStart(),500);
         Assert.assertFalse(other.getReadNegativeStrandFlag());
         Assert.assertEquals(other.getMappingQuality(), 60);
-        Assert.assertEquals(other.getAttribute(SAMTagUtil.NM),1);
+        Assert.assertEquals(other.getAttribute(SAMTag.NM.getBinaryTag()),1);
         Assert.assertEquals(other.getCigarString(),"3S2=1X2=2S");
         Assert.assertEquals(other.getInferredInsertSize(),0);
 
@@ -244,7 +244,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(other.getAlignmentStart(),191);
         Assert.assertTrue(other.getReadNegativeStrandFlag());
         Assert.assertEquals(other.getMappingQuality(), 60);
-        Assert.assertEquals(other.getAttribute(SAMTagUtil.NM),null);
+        Assert.assertEquals(other.getAttribute(SAMTag.NM.getBinaryTag()),null);
         Assert.assertEquals(other.getCigarString(),"8M2S");
         Assert.assertEquals(other.getInferredInsertSize(),-91);//100(mate) - 191(other)
     }


### PR DESCRIPTION
### Description
This PR does several things:
1.  It updates the list of tags in SAMTags and SAMTagUtils to include all the tags currently in the spec
2.  It deprecates tags that are listed as "for backwards compatibility only", this should hopefully signal to downstream users that they should no longer be generating these tags but may still support them for backwards compatibility.  
3.  It makes all methods in SAMTagUtil static and makes the class final.  This will break any existing subclasses.  Searching github and google for "extends SAMTagUtil" results in 0 results so it's unlikely that anyone will be impacted negatively by this. 
4.  Refactoring to make use of newly static SAMTagUtil methods.

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

