### PR TITLE
Adding first class Description field to SAMSequenceRecord

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -49,6 +49,7 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
     public static final String ASSEMBLY_TAG = "AS";
     public static final String URI_TAG = "UR";
     public static final String SPECIES_TAG = "SP";
+    public static final String DESCRIPTION_TAG = "DS";
 
     /** If one sequence has this length, and another sequence had a different length, isSameSequence will
      * not complain that they are different sequences. */
@@ -122,6 +123,9 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
 
     public String getMd5() { return (String) getAttribute(MD5_TAG); }
     public void setMd5(final String value) { setAttribute(MD5_TAG, value); }
+
+    public String getDescription() { return getAttribute(DESCRIPTION_TAG);}
+    public void setDescription(final String value) { setAttribute(DESCRIPTION_TAG, value);}
 
     /**
      * @return Index of this record in the sequence dictionary it lives in. 

--- a/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
@@ -83,4 +83,13 @@ public class SAMSequenceRecordTest extends HtsjdkTest {
             Assert.assertEquals(rec1.isSameSequence(rec2), isSame);
         }
     }
+
+    @Test
+    public void testSetAndCheckDescription(){
+        final SAMSequenceRecord record = new SAMSequenceRecord("Test", 1000);
+        Assert.assertNull(record.getDescription());
+        final String description = "A description.";
+        record.setDescription(description);
+        Assert.assertEquals(record.getDescription(), description);
+    }
 }


### PR DESCRIPTION
* The @SQ DS header field was added to the 1.6 bam spec, this adds a getter and setter for it.
* We do not correctly support UTF-8 characters in description due to https://github.com/samtools/htsjdk/issues/1202

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

