### PR TITLE
Add support for Sam Header Readgroup Barcode field

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
@@ -26,11 +26,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.Iso8601Date;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Header information about a read group.
@@ -51,6 +47,13 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
     public static final String PLATFORM_MODEL_TAG = "PM";
     public static final String PLATFORM_UNIT_TAG = "PU";
     public static final String READ_GROUP_SAMPLE_TAG = "SM";
+    public static final String BARCODE_TAG = "BC";
+
+    /**
+     * The recommended separator for the {@link #BARCODE_TAG} when there are multiple bar codes associated with this read group.
+     */
+    public static final String BARCODE_SEPARATOR = "-";
+
 
     /* Platform values for the @RG-PL tag */
     public enum PlatformValue {
@@ -89,6 +92,36 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
 
     public String getPlatform() { return getAttribute(PLATFORM_TAG); }
     public void setPlatform(final String platform) { setAttribute(PLATFORM_TAG, platform); }
+
+    /**
+     * @return the List of barcodes associated with this read group or null
+     */
+    public List<String> getBarcodes() {
+        final String barcodeString = getAttribute(BARCODE_TAG);
+        if(barcodeString == null){
+            return null;
+        } else if( barcodeString.isEmpty()){
+            return Collections.emptyList();
+        } else {
+            return Arrays.asList( barcodeString.split(BARCODE_SEPARATOR));
+        }
+    }
+
+    /**
+     * Set the barcodes associate with this ReadGroup.
+     * Note that null is treated as unsetting the attribute while an empty list is treated as a value set to have no barcodes.
+     * @param barcodes a list of barcodes to associate with this read group
+     */
+    public void setBarcodes(List<String> barcodes) {
+        if( barcodes == null) {
+            setAttribute(BARCODE_TAG, null);
+        } else {
+            if( barcodes.stream().anyMatch(String::isEmpty)){
+                throw new IllegalArgumentException("A barcode must not be an empty String");
+            }
+           setAttribute(BARCODE_TAG, String.join(BARCODE_SEPARATOR, barcodes));
+        }
+    }
 
     public Date getRunDate() {
         final String dt = getAttribute(DATE_RUN_PRODUCED_TAG);

--- a/src/test/java/htsjdk/samtools/SAMReadGroupRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMReadGroupRecordTest.java
@@ -29,7 +29,10 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -143,6 +146,27 @@ public class SAMReadGroupRecordTest extends HtsjdkTest {
         if (isEqual) {
             Assert.assertEquals(rg.hashCode(), other.hashCode());
         }
+    }
+
+    @DataProvider
+    public Object[][] getBarcodes(){
+        return new Object[][]{
+                {null, null},
+                {Collections.emptyList(), ""},
+                {Collections.singletonList("aa"), "aa"},
+                {Arrays.asList("aa", "ac"), "aa-ac"},
+                {Arrays.asList("aa", "ca", "gg"), "aa-ca-gg"}
+        };
+    }
+
+    @Test(dataProvider = "getBarcodes")
+    public void testGetAndSetBarcodes(List<String> barcodes, String encoded){
+        final SAMReadGroupRecord readGroup = new SAMReadGroupRecord("ReadGroup");
+        Assert.assertNull(readGroup.getBarcodes());
+        Assert.assertNull(readGroup.getAttribute(SAMReadGroupRecord.BARCODE_TAG));
+        readGroup.setBarcodes(barcodes);
+        Assert.assertEquals(readGroup.getBarcodes(), barcodes);
+        Assert.assertEquals(readGroup.getAttribute(SAMReadGroupRecord.BARCODE_TAG), encoded);
     }
 
 }


### PR DESCRIPTION
* adding support in SAMReadGroupRecord for the BC attribute
* this was added to the 1.6 spec

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

