### PR TITLE
Changing htsjdk to produce sam version 1.6

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -41,7 +41,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     public static final String SORT_ORDER_TAG = "SO";
     public static final String GROUP_ORDER_TAG = "GO";
     public static final String CURRENT_VERSION = "1.6";
-    public static final Set<String> ACCEPTABLE_VERSIONS = CollectionUtil.makeSet("1.0", "1.3", "1.4", "1.5", "1.6");
+    public static final Set<String> ACCEPTABLE_VERSIONS = CollectionUtil.makeSet("1.0", "1.3", "1.4", "1.5", CURRENT_VERSION );
 
     private SortOrder sortOrder = null;
     private GroupOrder groupOrder = null;

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -40,8 +40,8 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     public static final String VERSION_TAG = "VN";
     public static final String SORT_ORDER_TAG = "SO";
     public static final String GROUP_ORDER_TAG = "GO";
-    public static final String CURRENT_VERSION = "1.5";
-    public static final Set<String> ACCEPTABLE_VERSIONS = CollectionUtil.makeSet("1.0", "1.3", "1.4", "1.5");
+    public static final String CURRENT_VERSION = "1.6";
+    public static final Set<String> ACCEPTABLE_VERSIONS = CollectionUtil.makeSet("1.0", "1.3", "1.4", "1.5", "1.6");
 
     private SortOrder sortOrder = null;
     private GroupOrder groupOrder = null;

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -528,7 +528,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
         }
 
         // Test an unacceptable version
-        testHeaderVersion("1.7", false);
+        testHeaderVersion("1.1", false);
     }
 
     @Test(enabled = false)

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -528,7 +528,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
         }
 
         // Test an unacceptable version
-        testHeaderVersion("1.6", false);
+        testHeaderVersion("1.7", false);
     }
 
     @Test(enabled = false)

--- a/src/test/resources/htsjdk/samtools/SamFileHeaderMergerTest/case1/expected_output.sam
+++ b/src/test/resources/htsjdk/samtools/SamFileHeaderMergerTest/case1/expected_output.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.5	GO:none	SO:coordinate
+@HD	VN:1.6	GO:none	SO:coordinate
 @SQ	SN:chrM	LN:16571	AS:HG18	UR:/seq/references/Homo_sapiens_assembly18/v0/Homo_sapiens_assembly18.fasta	M5:d2ed829b8a1628d16cbeee88e88e39eb	SP:Homo sapiens
 @RG	ID:1	PL:ILLUMINA	SM:sample1
 @PG	ID:1	PN:something

--- a/src/test/resources/htsjdk/samtools/SamFileHeaderMergerTest/case2/chr11sub_file1.sam
+++ b/src/test/resources/htsjdk/samtools/SamFileHeaderMergerTest/case2/chr11sub_file1.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.0	GO:none	SO:coordinate
+@HD	VN:1.6	GO:none	SO:coordinate
 @SQ	SN:chrM	LN:16571	AS:HG18	UR:/seq/references/Homo_sapiens_assembly18/v0/Homo_sapiens_assembly18.fasta	M5:d2ed829b8a1628d16cbeee88e88e39eb	SP:Homo sapiens
 @RG	ID:1	SM:sample1	PL:ILLUMINA
 @PG	ID:1	PN:A

--- a/src/test/resources/htsjdk/samtools/SamFileHeaderMergerTest/case2/expected_output.sam
+++ b/src/test/resources/htsjdk/samtools/SamFileHeaderMergerTest/case2/expected_output.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.5	GO:none	SO:coordinate
+@HD	VN:1.6	GO:none	SO:coordinate
 @SQ	SN:chrM	LN:16571	AS:HG18	UR:/seq/references/Homo_sapiens_assembly18/v0/Homo_sapiens_assembly18.fasta	M5:d2ed829b8a1628d16cbeee88e88e39eb	SP:Homo sapiens
 @RG	ID:1	PL:ILLUMINA	SM:sample1
 @RG	ID:1.1	PL:ILLUMINA	SM:sample2

--- a/src/test/resources/htsjdk/samtools/roundtrip.sam
+++ b/src/test/resources/htsjdk/samtools/roundtrip.sam
@@ -1,4 +1,4 @@
-@HD	VN:1.5	SO:unsorted
+@HD	VN:1.6	SO:unsorted
 @SQ	SN:chr1	LN:101
 @SQ	SN:chr2	LN:101
 @SQ	SN:chr3	LN:101


### PR DESCRIPTION
* Htsjdk has techinically been producing Sam version 1.6 since support for long cigars was added.
* Updating that list of acceptable versions to include 1.6 and setting the header version of new bams to 1.6

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

