### PR TITLE
Getter for generic fields in VCFSimpleHeaderLine

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
@@ -126,4 +126,8 @@ public class VCFSimpleHeaderLine extends VCFHeaderLine implements VCFIDHeaderLin
     public String getID() {
         return name;
     }
-}
+	
+    public String getGenericFields() {
+	return genericFields;    
+    }	    
+ }

--- a/src/main/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFSimpleHeaderLine.java
@@ -25,6 +25,7 @@
 
 package htsjdk.variant.vcf;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -126,8 +127,12 @@ public class VCFSimpleHeaderLine extends VCFHeaderLine implements VCFIDHeaderLin
     public String getID() {
         return name;
     }
-	
-    public String getGenericFields() {
-	return genericFields;    
-    }	    
+
+
+    /**
+     * @return a map of all pairs of fields and values in this header line
+     */
+    public Map<String, String> getGenericFields() {
+        return Collections.unmodifiableMap(genericFields);
+    }
  }

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -260,6 +260,16 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     }
 
     @Test
+    public void testVCFSimpleHeaderLineGenericFieldGetter() {
+        VCFHeader header = createHeader(VCF4headerStrings);
+        List<VCFFilterHeaderLine> filters = header.getFilterLines();
+        VCFFilterHeaderLine filterHeaderLine = filters.get(0);
+        Map<String,String> genericFields = filterHeaderLine.getGenericFields();
+        Assert.assertEquals(genericFields.get("ID"),"NoQCALL");
+        Assert.assertEquals(genericFields.get("Description"),"Variant called by Dindel but not confirmed by QCALL");
+    }
+
+    @Test
     public void testVCFHeaderAddOtherLine() {
         final VCFHeader header = getHiSeqVCFHeader();
         final VCFHeaderLine otherLine = new VCFHeaderLine("TestOtherLine", "val");


### PR DESCRIPTION
### Description

Setting a getter for accessing to values like "Description" 

### Checklist

- [] Code compiles correctly
- [] New tests covering changes and new functionality
- [] All tests passing
- [] Extended the README / documentation, if necessary
- [] Is not backward compatible (breaks binary or source compatibility)

