### PR TITLE
Add isRefOnlyBlock function...

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -126,14 +126,14 @@ public class Allele implements Comparable<Allele>, Serializable {
     private byte[] bases = null;
 
     /** A generic static NO_CALL allele for use */
-    public final static String NO_CALL_STRING = ".";
+    public static final String NO_CALL_STRING = ".";
 
     /** A generic static SPAN_DEL allele for use */
-    public final static String SPAN_DEL_STRING = "*";
+    public static final String SPAN_DEL_STRING = "*";
 
     /** Non ref allele representations */
-    public final static String NON_REF_STRING = "<NON_REF>";
-    public final static String UNSPECIFIED_ALTERNATE_ALLELE_STRING = "<*>";
+    public static final String NON_REF_STRING = "<NON_REF>";
+    public static final String UNSPECIFIED_ALTERNATE_ALLELE_STRING = "<*>";
 
     // no public way to create an allele
     protected Allele(final byte[] bases, final boolean isRef) {
@@ -185,32 +185,31 @@ public class Allele implements Comparable<Allele>, Serializable {
         this.isSymbolic = allele.isSymbolic;
     }
 
-
-    private final static Allele REF_A = new Allele("A", true);
-    private final static Allele ALT_A = new Allele("A", false);
-    private final static Allele REF_C = new Allele("C", true);
-    private final static Allele ALT_C = new Allele("C", false);
-    private final static Allele REF_G = new Allele("G", true);
-    private final static Allele ALT_G = new Allele("G", false);
-    private final static Allele REF_T = new Allele("T", true);
-    private final static Allele ALT_T = new Allele("T", false);
-    private final static Allele REF_N = new Allele("N", true);
-    private final static Allele ALT_N = new Allele("N", false);
-    public final static Allele SPAN_DEL = new Allele(SPAN_DEL_STRING, false);
-    public final static Allele NO_CALL = new Allele(NO_CALL_STRING, false);
-    public final static Allele NON_REF_ALLELE = new Allele(NON_REF_STRING, false);
-    public final static Allele UNSPECIFIED_ALTERNATE_ALLELE = new Allele(UNSPECIFIED_ALTERNATE_ALLELE_STRING, false);
+    private static final Allele REF_A = new Allele("A", true);
+    private static final Allele ALT_A = new Allele("A", false);
+    private static final Allele REF_C = new Allele("C", true);
+    private static final Allele ALT_C = new Allele("C", false);
+    private static final Allele REF_G = new Allele("G", true);
+    private static final Allele ALT_G = new Allele("G", false);
+    private static final Allele REF_T = new Allele("T", true);
+    private static final Allele ALT_T = new Allele("T", false);
+    private static final Allele REF_N = new Allele("N", true);
+    private static final Allele ALT_N = new Allele("N", false);
+    public static final Allele SPAN_DEL = new Allele(SPAN_DEL_STRING, false);
+    public static final Allele NO_CALL = new Allele(NO_CALL_STRING, false);
+    public static final Allele NON_REF_ALLELE = new Allele(NON_REF_STRING, false);
+    public static final Allele UNSPECIFIED_ALTERNATE_ALLELE = new Allele(UNSPECIFIED_ALTERNATE_ALLELE_STRING, false);
 
     // for simple deletion, e.g. "ALT==<DEL>" (note that the spec allows, for now at least, alt alleles like <DEL:ME>)
-    public final static Allele SV_SIMPLE_DEL = StructuralVariantType.DEL.toSymbolicAltAllele();
+    public static final Allele SV_SIMPLE_DEL = StructuralVariantType.DEL.toSymbolicAltAllele();
     // for simple insertion, e.g. "ALT==<INS>"
-    public final static Allele SV_SIMPLE_INS = StructuralVariantType.INS.toSymbolicAltAllele();
+    public static final Allele SV_SIMPLE_INS = StructuralVariantType.INS.toSymbolicAltAllele();
     // for simple inversion, e.g. "ALT==<INV>"
-    public final static Allele SV_SIMPLE_INV = StructuralVariantType.INV.toSymbolicAltAllele();
+    public static final Allele SV_SIMPLE_INV = StructuralVariantType.INV.toSymbolicAltAllele();
     // for simple generic cnv, e.g. "ALT==<CNV>"
-    public final static Allele SV_SIMPLE_CNV = StructuralVariantType.CNV.toSymbolicAltAllele();
+    public static final Allele SV_SIMPLE_CNV = StructuralVariantType.CNV.toSymbolicAltAllele();
     // for simple duplication, e.g. "ALT==<DUP>"
-    public final static Allele SV_SIMPLE_DUP = StructuralVariantType.DUP.toSymbolicAltAllele();
+    public static final Allele SV_SIMPLE_DUP = StructuralVariantType.DUP.toSymbolicAltAllele();
 
     // ---------------------------------------------------------------------------------------------------------
     //
@@ -562,9 +561,9 @@ public class Allele implements Comparable<Allele>, Serializable {
     }
 
     /**
-     *  @return true if Allele is either "<NON_REF>" or "<*>"
+     *  @return true if Allele is either {@code <NON_REF>} or {@code <*>}
      */
     public boolean isNonRefAllele() {
-        return this.equals(Allele.NON_REF_ALLELE) || this.equals(Allele.UNSPECIFIED_ALTERNATE_ALLELE);
+        return equals(NON_REF_ALLELE) || equals(UNSPECIFIED_ALTERNATE_ALLELE);
     }
 }

--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -134,6 +134,8 @@ public class Allele implements Comparable<Allele>, Serializable {
     /** A generic static NON_REF allele for use */
     public final static String NON_REF_STRING = "<NON_REF>";
 
+    public final static String UNSPECIFIED_ALTERNATE_ALLELE_STRING = "<*>";
+
     // no public way to create an allele
     protected Allele(final byte[] bases, final boolean isRef) {
         // null alleles are no longer allowed
@@ -198,6 +200,7 @@ public class Allele implements Comparable<Allele>, Serializable {
     public final static Allele SPAN_DEL = new Allele(SPAN_DEL_STRING, false);
     public final static Allele NO_CALL = new Allele(NO_CALL_STRING, false);
     public final static Allele NON_REF_ALLELE = new Allele(NON_REF_STRING, false);
+    public final static Allele UNSPECIFIED_ALTERNATE_ALLELE = new Allele(UNSPECIFIED_ALTERNATE_ALLELE_STRING, false);
 
     // for simple deletion, e.g. "ALT==<DEL>" (note that the spec allows, for now at least, alt alleles like <DEL:ME>)
     public final static Allele SV_SIMPLE_DEL = StructuralVariantType.DEL.toSymbolicAltAllele();
@@ -557,5 +560,12 @@ public class Allele implements Comparable<Allele>, Serializable {
     private static boolean firstIsPrefixOfSecond(final Allele a1, final Allele a2) {
         String a1String = a1.getBaseString();
         return a2.getBaseString().substring(0, a1String.length()).equals(a1String);
+    }
+
+    /**
+     *  @return true if Allele is either "<NON_REF>" or "<*>"
+     */
+    public boolean isValidRefBlockAllele() {
+        return this.equals(Allele.NON_REF_ALLELE) || this.equals(Allele.UNSPECIFIED_ALTERNATE_ALLELE);
     }
 }

--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -131,9 +131,8 @@ public class Allele implements Comparable<Allele>, Serializable {
     /** A generic static SPAN_DEL allele for use */
     public final static String SPAN_DEL_STRING = "*";
 
-    /** A generic static NON_REF allele for use */
+    /** Non ref allele representations */
     public final static String NON_REF_STRING = "<NON_REF>";
-
     public final static String UNSPECIFIED_ALTERNATE_ALLELE_STRING = "<*>";
 
     // no public way to create an allele
@@ -565,7 +564,7 @@ public class Allele implements Comparable<Allele>, Serializable {
     /**
      *  @return true if Allele is either "<NON_REF>" or "<*>"
      */
-    public boolean isValidRefBlockAllele() {
+    public boolean isNonRefAllele() {
         return this.equals(Allele.NON_REF_ALLELE) || this.equals(Allele.UNSPECIFIED_ALTERNATE_ALLELE);
     }
 }

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -25,7 +25,6 @@
 
 package htsjdk.variant.variantcontext;
 
-import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.util.ParsingUtils;
@@ -1689,7 +1688,7 @@ public class VariantContext implements Feature, Serializable {
      */
     public boolean isRefOnlyBlock(){
         return getAlternateAlleles().size() == 1
-                && getAlternateAllele(0).isValidRefBlockAllele()
+                && getAlternateAllele(0).isNonRefAllele()
                 && getAttribute(VCFConstants.END_KEY) != null;
     }
 

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1684,11 +1684,13 @@ public class VariantContext implements Feature, Serializable {
 
     /**
      *
-     * @return whether the variant context meets the requirements to be a REF-only block
+     * @return whether the variant context meets the requirements to be a REF-only block or not
      *
      */
     public boolean isRefOnlyBlock(){
-        return getAlternateAlleles().size() == 1 && getAlternateAllele(0).isSymbolic() && getAttribute(VCFConstants.END_KEY) != null;
+        return getAlternateAlleles().size() == 1
+                && getAlternateAllele(0).isValidRefBlockAllele()
+                && getAttribute(VCFConstants.END_KEY) != null;
     }
 
     public boolean hasSymbolicAlleles() {

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1682,6 +1682,15 @@ public class VariantContext implements Feature, Serializable {
         return (int)stop;
     }
 
+    /**
+     *
+     * @return whether the variant context meets the requirements to be a REF-only block
+     *
+     */
+    public boolean isRefOnlyBlock(){
+        return getAlternateAlleles().size() == 1 && getAlternateAllele(0).isSymbolic() && getAttribute(VCFConstants.END_KEY) != null;
+    }
+
     public boolean hasSymbolicAlleles() {
         return hasSymbolicAlleles(getAlleles());
     }

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1247,11 +1247,11 @@ public class VariantContext implements Feature, Serializable {
         validateAttributeIsExpectedSize(VCFConstants.ALLELE_COUNT_KEY, numberOfAlternateAlleles);
         validateAttributeIsExpectedSize(VCFConstants.ALLELE_FREQUENCY_KEY, numberOfAlternateAlleles);
 
-        if ( !hasGenotypes() )
+        if (!hasGenotypes())
             return;
 
         // AN
-        if ( hasAttribute(VCFConstants.ALLELE_NUMBER_KEY) ) {
+        if (hasAttribute(VCFConstants.ALLELE_NUMBER_KEY)) {
             final int reportedAN = Integer.valueOf(getAttribute(VCFConstants.ALLELE_NUMBER_KEY).toString());
             final int observedAN = getCalledChrCount();
             if ( reportedAN != observedAN )
@@ -1259,12 +1259,12 @@ public class VariantContext implements Feature, Serializable {
         }
 
         // AC
-        if ( hasAttribute(VCFConstants.ALLELE_COUNT_KEY) ) {
+        if (hasAttribute(VCFConstants.ALLELE_COUNT_KEY)) {
             final ArrayList<Integer> observedACs = new ArrayList<>();
 
             // if there are alternate alleles, record the relevant tags
-            if ( numberOfAlternateAlleles > 0 ) {
-                for ( Allele allele : getAlternateAlleles() ) {
+            if (numberOfAlternateAlleles > 0) {
+                for (Allele allele : getAlternateAlleles()) {
                     observedACs.add(getCalledChrCount(allele));
                 }
             }
@@ -1277,7 +1277,7 @@ public class VariantContext implements Feature, Serializable {
             for (int i = 0; i < observedACs.size(); i++) {
                 // need to cast to int to make sure we don't have an issue below with object equals (earlier bug) - EB
                 final int reportedAC = Integer.valueOf(reportedACs.get(i).toString());
-                if ( reportedAC != observedACs.get(i) )
+                if (reportedAC != observedACs.get(i))
                     throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag is incorrect for the record at position %s:%d, %s vs. %d", getContig(), getStart(), reportedAC, observedACs.get(i)));
             }
         }

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1683,10 +1683,10 @@ public class VariantContext implements Feature, Serializable {
 
     /**
      *
-     * @return whether the variant context meets the requirements to be a REF-only block or not
+     * @return true if the variant context is a REF-only block
      *
      */
-    public boolean isRefOnlyBlock(){
+    public boolean isRefOnlyBlock() {
         return getAlternateAlleles().size() == 1
                 && getAlternateAllele(0).isNonRefAllele()
                 && getAttribute(VCFConstants.END_KEY) != null;
@@ -1696,7 +1696,7 @@ public class VariantContext implements Feature, Serializable {
         return hasSymbolicAlleles(getAlleles());
     }
 
-    public static boolean hasSymbolicAlleles( final List<Allele> alleles ) {
+    public static boolean hasSymbolicAlleles(final List<Allele> alleles) {
         return alleles.stream().anyMatch(Allele::isSymbolic);
     }
 

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1683,10 +1683,10 @@ public class VariantContext implements Feature, Serializable {
 
     /**
      *
-     * @return true if the variant context is a REF-only block
+     * @return true if the variant context is a reference block
      *
      */
-    public boolean isRefOnlyBlock() {
+    public boolean isReferenceBlock() {
         return getAlternateAlleles().size() == 1
                 && getAlternateAllele(0).isNonRefAllele()
                 && getAttribute(VCFConstants.END_KEY) != null;

--- a/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
@@ -29,7 +29,6 @@ package htsjdk.variant.variantcontext;
 // the imports for unit testing.
 
 import htsjdk.variant.VariantBaseTest;
-import htsjdk.variant.variantcontext.Allele;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
@@ -48,7 +47,7 @@ import org.testng.annotations.Test;
  * Basic unit test for RecalData
  */
 public class AlleleUnitTest extends VariantBaseTest {
-    Allele ARef, A, T, ATIns, ATCIns, NoCall, SpandDel;
+    Allele ARef, A, T, ATIns, ATCIns, NoCall, SpandDel, NonRef, UnspecifiedAlternate;
     
     @BeforeSuite
     public void before() {
@@ -62,6 +61,9 @@ public class AlleleUnitTest extends VariantBaseTest {
         NoCall = Allele.create(Allele.NO_CALL_STRING);
 
         SpandDel = Allele.create(Allele.SPAN_DEL_STRING);
+
+        NonRef = Allele.create(Allele.NON_REF_STRING);
+        UnspecifiedAlternate = Allele.create(Allele.UNSPECIFIED_ALTERNATE_ALLELE_STRING);
     }
 
     @Test
@@ -188,6 +190,22 @@ public class AlleleUnitTest extends VariantBaseTest {
         Assert.assertTrue(a.isSymbolic());
         Assert.assertEquals("<SYMBOLIC>", a.getDisplayString());
     }
+
+    @Test
+    public void testNonRefAllele() {
+        Assert.assertTrue(NonRef.isNonRefAllele());
+        Assert.assertTrue(UnspecifiedAlternate.isNonRefAllele());
+
+        Assert.assertFalse(T.isNonRefAllele());
+        Assert.assertFalse(ATIns.isNonRefAllele());
+
+        Assert.assertTrue(Allele.NON_REF_ALLELE.isNonRefAllele());
+        Assert.assertTrue(Allele.UNSPECIFIED_ALTERNATE_ALLELE.isNonRefAllele());
+
+        Allele a = Allele.create("<*>");
+        Assert.assertTrue(a.isNonRefAllele());
+    }
+
 
     @Test
     public void testEquals() {

--- a/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
@@ -47,7 +47,7 @@ import org.testng.annotations.Test;
  * Basic unit test for RecalData
  */
 public class AlleleUnitTest extends VariantBaseTest {
-    Allele ARef, A, T, ATIns, ATCIns, NoCall, SpandDel, NonRef, UnspecifiedAlternate;
+    private Allele ARef, A, T, ATIns, ATCIns, NoCall, SpandDel, NonRef, UnspecifiedAlternate;
     
     @BeforeSuite
     public void before() {

--- a/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
@@ -202,7 +202,7 @@ public class AlleleUnitTest extends VariantBaseTest {
         Assert.assertTrue(Allele.NON_REF_ALLELE.isNonRefAllele());
         Assert.assertTrue(Allele.UNSPECIFIED_ALTERNATE_ALLELE.isNonRefAllele());
 
-        Allele a = Allele.create("<*>");
+        Allele a = Allele.create(new String("<*>"));
         Assert.assertTrue(a.isNonRefAllele());
     }
 

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1552,41 +1552,28 @@ public class VariantContextUnitTest extends VariantBaseTest {
         }
     }
 
-    @Test
-    public void testRefOnlyBlock(){
-        VariantContextBuilder builder = new VariantContextBuilder();
+    @DataProvider(name = "refOnlyBlockData")
+    public Object[][] refOnlyBlockData() {
+        List<Object[]> tests = new ArrayList<>();
 
-        // create a context with the only alt allele being symbolic and no "END" attribute
-        VariantContext context = builder
-                .source("test")
-                .loc(snpLoc, snpLocStart, snpLocStop)
-                .alleles("A", "<*>")
-                .make();
-        Assert.assertFalse(context.isRefOnlyBlock());
+        tests.add(new Object[]{Arrays.asList(Aref, Allele.UNSPECIFIED_ALTERNATE_ALLELE), false, false});
+        tests.add(new Object[]{Arrays.asList(Aref, Allele.UNSPECIFIED_ALTERNATE_ALLELE), true, true});
+        tests.add(new Object[]{Arrays.asList(Aref, Allele.NON_REF_ALLELE), true, true});
+        tests.add(new Object[]{Arrays.asList(Aref, C, Allele.UNSPECIFIED_ALTERNATE_ALLELE), true, false});
+        tests.add(new Object[]{Arrays.asList(Aref, C), false, false});
 
-        // add end attribute to context
-        context = builder
-                .attribute("END", snpLocStop)
-                .make();
-        Assert.assertTrue(context.isRefOnlyBlock());
+        return tests.toArray(new Object[][]{});
+    }
 
-        // use a different symbolic alt allele
-        context = builder
-                .alleles("A", "<NON_REF>")
-                .make();
-        Assert.assertTrue(context.isRefOnlyBlock());
-
-        // add a second alt allele to the context
-        context = builder
-                .alleles("A", "G", "<*>")
-                .make();
-        Assert.assertFalse(context.isRefOnlyBlock());
-
-        // context with no symbolic alt allele
-        context = builder
-                .alleles("A", "G")
-                .make();
-        Assert.assertFalse(context.isRefOnlyBlock());
+    @Test(dataProvider = "refOnlyBlockData")
+    public void testRefOnlyBlock(List<Allele> alleles, boolean addEndAttribute, boolean isRefBlock){
+        // create a context builder/context based on inputs provided
+        final VariantContextBuilder builder =
+                new VariantContextBuilder("test", snpLoc,snpLocStart, snpLocStop, alleles);
+        if (addEndAttribute){
+            builder.attribute("END", 10);
+        }
+        Assert.assertEquals(builder.make().isRefOnlyBlock(), isRefBlock);
     }
 
     @Test

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1553,6 +1553,43 @@ public class VariantContextUnitTest extends VariantBaseTest {
     }
 
     @Test
+    public void testRefOnlyBlock(){
+        VariantContextBuilder builder = new VariantContextBuilder();
+
+        // create a context with the only alt allele being symbolic and no "END" attribute
+        VariantContext context = builder
+                .source("test")
+                .loc(snpLoc, snpLocStart, snpLocStop)
+                .alleles("A", "<*>")
+                .make();
+        Assert.assertFalse(context.isRefOnlyBlock());
+
+        // add end attribute to context
+        context = builder
+                .attribute("END", 10)
+                .make();
+        Assert.assertTrue(context.isRefOnlyBlock());
+
+        // use a different symbolic alt allele
+        context = builder
+                .alleles("A", "<NON_REF>")
+                .make();
+        Assert.assertTrue(context.isRefOnlyBlock());
+
+        // add a second alt allele to the context
+        context = builder
+                .alleles("A", "G", "<*>")
+                .make();
+        Assert.assertFalse(context.isRefOnlyBlock());
+
+        // context with no symbolic alt allele
+        context = builder
+                .alleles("A", "G")
+                .make();
+        Assert.assertFalse(context.isRefOnlyBlock());
+    }
+
+    @Test
     public void testGetAttributeAsIntList() {
         final VariantContext context = basicBuilder
                 .attribute("Empty", new int[0])

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1552,8 +1552,8 @@ public class VariantContextUnitTest extends VariantBaseTest {
         }
     }
 
-    @DataProvider(name = "refOnlyBlockData")
-    public Object[][] refOnlyBlockData() {
+    @DataProvider(name = "referenceBlockData")
+    public Object[][] referenceBlockData() {
         return new Object[][]{
                 {Arrays.asList(Aref, Allele.UNSPECIFIED_ALTERNATE_ALLELE), false, false},
                 {Arrays.asList(Aref, Allele.UNSPECIFIED_ALTERNATE_ALLELE), true, true},
@@ -1563,15 +1563,15 @@ public class VariantContextUnitTest extends VariantBaseTest {
         };
     }
 
-    @Test(dataProvider = "refOnlyBlockData")
-    public void testRefOnlyBlock(List<Allele> alleles, boolean addEndAttribute, boolean isRefBlock) {
+    @Test(dataProvider = "referenceBlockData")
+    public void testReferenceBlock(List<Allele> alleles, boolean addEndAttribute, boolean isRefBlock) {
         // create a context builder/context based on inputs provided
         final VariantContextBuilder builder =
                 new VariantContextBuilder("test", snpLoc,snpLocStart, snpLocStop, alleles);
         if (addEndAttribute) {
             builder.attribute("END", 10);
         }
-        Assert.assertEquals(builder.make().isRefOnlyBlock(), isRefBlock);
+        Assert.assertEquals(builder.make().isReferenceBlock(), isRefBlock);
     }
 
     @Test

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1566,7 +1566,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
         // add end attribute to context
         context = builder
-                .attribute("END", 10)
+                .attribute("END", snpLocStop)
                 .make();
         Assert.assertTrue(context.isRefOnlyBlock());
 

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1554,23 +1554,21 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "refOnlyBlockData")
     public Object[][] refOnlyBlockData() {
-        List<Object[]> tests = new ArrayList<>();
-
-        tests.add(new Object[]{Arrays.asList(Aref, Allele.UNSPECIFIED_ALTERNATE_ALLELE), false, false});
-        tests.add(new Object[]{Arrays.asList(Aref, Allele.UNSPECIFIED_ALTERNATE_ALLELE), true, true});
-        tests.add(new Object[]{Arrays.asList(Aref, Allele.NON_REF_ALLELE), true, true});
-        tests.add(new Object[]{Arrays.asList(Aref, C, Allele.UNSPECIFIED_ALTERNATE_ALLELE), true, false});
-        tests.add(new Object[]{Arrays.asList(Aref, C), false, false});
-
-        return tests.toArray(new Object[][]{});
+        return new Object[][]{
+                {Arrays.asList(Aref, Allele.UNSPECIFIED_ALTERNATE_ALLELE), false, false},
+                {Arrays.asList(Aref, Allele.UNSPECIFIED_ALTERNATE_ALLELE), true, true},
+                {Arrays.asList(Aref, Allele.NON_REF_ALLELE), true, true},
+                {Arrays.asList(Aref, C, Allele.UNSPECIFIED_ALTERNATE_ALLELE), true, false},
+                {Arrays.asList(Aref, C), false, false}
+        };
     }
 
     @Test(dataProvider = "refOnlyBlockData")
-    public void testRefOnlyBlock(List<Allele> alleles, boolean addEndAttribute, boolean isRefBlock){
+    public void testRefOnlyBlock(List<Allele> alleles, boolean addEndAttribute, boolean isRefBlock) {
         // create a context builder/context based on inputs provided
         final VariantContextBuilder builder =
                 new VariantContextBuilder("test", snpLoc,snpLocStart, snpLocStop, alleles);
-        if (addEndAttribute){
+        if (addEndAttribute) {
             builder.attribute("END", 10);
         }
         Assert.assertEquals(builder.make().isRefOnlyBlock(), isRefBlock);


### PR DESCRIPTION
### Description

to VariantContext so we can check whether or not it is a ref block according the VCF v4.3 spec.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

