### PR TITLE
CRAM: Be explicit about spec IDs instead of using ordinal()

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/encoding/ByteArrayLenEncoding.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/ByteArrayLenEncoding.java
@@ -47,11 +47,11 @@ public class ByteArrayLenEncoding implements Encoding<byte[]> {
                                          final EncodingParams byteParams) {
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         try {
-            byteArrayOutputStream.write((byte) lenParams.id.ordinal());
+            byteArrayOutputStream.write((byte) lenParams.id.getSpecId());
             ITF8.writeUnsignedITF8(lenParams.params.length, byteArrayOutputStream);
             byteArrayOutputStream.write(lenParams.params);
 
-            byteArrayOutputStream.write((byte) byteParams.id.ordinal());
+            byteArrayOutputStream.write((byte) byteParams.id.getSpecId());
             ITF8.writeUnsignedITF8(byteParams.params.length, byteArrayOutputStream);
             byteArrayOutputStream.write(byteParams.params);
         } catch (final IOException e) {
@@ -64,12 +64,12 @@ public class ByteArrayLenEncoding implements Encoding<byte[]> {
     public byte[] toByteArray() {
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         try {
-            byteArrayOutputStream.write((byte) lenEncoding.id().ordinal());
+            byteArrayOutputStream.write((byte) lenEncoding.id().getSpecId());
             final byte[] lenBytes = lenEncoding.toByteArray();
             ITF8.writeUnsignedITF8(lenBytes.length, byteArrayOutputStream);
             byteArrayOutputStream.write(lenBytes);
 
-            byteArrayOutputStream.write((byte) byteEncoding.id().ordinal());
+            byteArrayOutputStream.write((byte) byteEncoding.id().getSpecId());
             final byte[] byteBytes = byteEncoding.toByteArray();
             ITF8.writeUnsignedITF8(byteBytes.length, byteArrayOutputStream);
             byteArrayOutputStream.write(byteBytes);

--- a/src/main/java/htsjdk/samtools/cram/encoding/ByteArrayLenEncoding.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/ByteArrayLenEncoding.java
@@ -47,11 +47,11 @@ public class ByteArrayLenEncoding implements Encoding<byte[]> {
                                          final EncodingParams byteParams) {
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         try {
-            byteArrayOutputStream.write((byte) lenParams.id.getSpecId());
+            byteArrayOutputStream.write((byte) lenParams.id.getId());
             ITF8.writeUnsignedITF8(lenParams.params.length, byteArrayOutputStream);
             byteArrayOutputStream.write(lenParams.params);
 
-            byteArrayOutputStream.write((byte) byteParams.id.getSpecId());
+            byteArrayOutputStream.write((byte) byteParams.id.getId());
             ITF8.writeUnsignedITF8(byteParams.params.length, byteArrayOutputStream);
             byteArrayOutputStream.write(byteParams.params);
         } catch (final IOException e) {
@@ -64,12 +64,12 @@ public class ByteArrayLenEncoding implements Encoding<byte[]> {
     public byte[] toByteArray() {
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         try {
-            byteArrayOutputStream.write((byte) lenEncoding.id().getSpecId());
+            byteArrayOutputStream.write((byte) lenEncoding.id().getId());
             final byte[] lenBytes = lenEncoding.toByteArray();
             ITF8.writeUnsignedITF8(lenBytes.length, byteArrayOutputStream);
             byteArrayOutputStream.write(lenBytes);
 
-            byteArrayOutputStream.write((byte) byteEncoding.id().getSpecId());
+            byteArrayOutputStream.write((byte) byteEncoding.id().getId());
             final byte[] byteBytes = byteEncoding.toByteArray();
             ITF8.writeUnsignedITF8(byteBytes.length, byteArrayOutputStream);
             byteArrayOutputStream.write(byteBytes);

--- a/src/main/java/htsjdk/samtools/cram/structure/Block.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Block.java
@@ -283,8 +283,8 @@ public class Block {
         if (!isCompressed()) compress();
         if (!isUncompressed()) uncompress();
 
-        outputStream.write(getMethod().getSpecValue());
-        outputStream.write(getContentType().getSpecTypeId());
+        outputStream.write(getMethod().getMethodId());
+        outputStream.write(getContentType().getContentTypeId());
 
         ITF8.writeUnsignedITF8(getContentId(), outputStream);
         ITF8.writeUnsignedITF8(compressedContentSize, outputStream);

--- a/src/main/java/htsjdk/samtools/cram/structure/Block.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Block.java
@@ -283,8 +283,8 @@ public class Block {
         if (!isCompressed()) compress();
         if (!isUncompressed()) uncompress();
 
-        outputStream.write(getMethod().ordinal());
-        outputStream.write(getContentType().ordinal());
+        outputStream.write(getMethod().getSpecValue());
+        outputStream.write(getContentType().getSpecTypeId());
 
         ITF8.writeUnsignedITF8(getContentId(), outputStream);
         ITF8.writeUnsignedITF8(compressedContentSize, outputStream);

--- a/src/main/java/htsjdk/samtools/cram/structure/BlockCompressionMethod.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/BlockCompressionMethod.java
@@ -17,6 +17,9 @@
  */
 package htsjdk.samtools.cram.structure;
 
+/**
+ * The block compression methods specified by Section 8 of the CRAM spec
+ */
 public enum BlockCompressionMethod {
     RAW(0),
     GZIP(1),
@@ -24,17 +27,17 @@ public enum BlockCompressionMethod {
     LZMA(3),
     RANS(4);
 
-    private final int specValue;
+    private final int methodId;
 
     /**
      * The block compression methods specified by Section 8 of the CRAM spec
-     * @param value the number assigned to each block compression method in the CRAM spec
+     * @param id the number assigned to each block compression method in the CRAM spec
      */
-    BlockCompressionMethod(final int value) {
-        specValue = value;
+    BlockCompressionMethod(final int id) {
+        methodId = id;
     }
 
-    public int getSpecValue() {
-        return specValue;
+    public int getMethodId() {
+        return methodId;
     }
 }

--- a/src/main/java/htsjdk/samtools/cram/structure/BlockCompressionMethod.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/BlockCompressionMethod.java
@@ -37,6 +37,9 @@ public enum BlockCompressionMethod {
         methodId = id;
     }
 
+    /**
+     * @return the number assigned to each block compression method in the CRAM spec
+     */
     public int getMethodId() {
         return methodId;
     }

--- a/src/main/java/htsjdk/samtools/cram/structure/BlockCompressionMethod.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/BlockCompressionMethod.java
@@ -18,5 +18,23 @@
 package htsjdk.samtools.cram.structure;
 
 public enum BlockCompressionMethod {
-    RAW, GZIP, BZIP2, LZMA, RANS
+    RAW(0),
+    GZIP(1),
+    BZIP2(2),
+    LZMA(3),
+    RANS(4);
+
+    private final int specValue;
+
+    /**
+     * The block compression methods specified by Section 8 of the CRAM spec
+     * @param value the number assigned to each block compression method in the CRAM spec
+     */
+    BlockCompressionMethod(final int value) {
+        specValue = value;
+    }
+
+    public int getSpecValue() {
+        return specValue;
+    }
 }

--- a/src/main/java/htsjdk/samtools/cram/structure/BlockContentType.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/BlockContentType.java
@@ -38,6 +38,9 @@ public enum BlockContentType {
         contentTypeId = id;
     }
 
+    /**
+     * @return the ID assigned to each content type in the CRAM spec
+     */
     public int getContentTypeId() {
         return contentTypeId;
     }

--- a/src/main/java/htsjdk/samtools/cram/structure/BlockContentType.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/BlockContentType.java
@@ -17,6 +17,9 @@
  */
 package htsjdk.samtools.cram.structure;
 
+/**
+ * The block content types specified by Section 8.1 of the CRAM spec
+ */
 public enum BlockContentType {
     FILE_HEADER(0),
     COMPRESSION_HEADER(1),
@@ -25,17 +28,17 @@ public enum BlockContentType {
     EXTERNAL(4),
     CORE(5);
 
-    private final int specTypeId;
+    private final int contentTypeId;
 
     /**
-     * The block content type IDs specified by Section 8.1 of the CRAM spec
-     * @param id the number assigned to each content type ID in the CRAM spec
+     * The block content types specified by Section 8.1 of the CRAM spec
+     * @param id the ID assigned to each content type in the CRAM spec
      */
     BlockContentType(final int id) {
-        specTypeId = id;
+        contentTypeId = id;
     }
 
-    public int getSpecTypeId() {
-        return specTypeId;
+    public int getContentTypeId() {
+        return contentTypeId;
     }
 }

--- a/src/main/java/htsjdk/samtools/cram/structure/BlockContentType.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/BlockContentType.java
@@ -18,5 +18,24 @@
 package htsjdk.samtools.cram.structure;
 
 public enum BlockContentType {
-    FILE_HEADER, COMPRESSION_HEADER, MAPPED_SLICE, RESERVED, EXTERNAL, CORE
+    FILE_HEADER(0),
+    COMPRESSION_HEADER(1),
+    MAPPED_SLICE(2),
+    RESERVED(3),
+    EXTERNAL(4),
+    CORE(5);
+
+    private final int specTypeId;
+
+    /**
+     * The block content type IDs specified by Section 8.1 of the CRAM spec
+     * @param id the number assigned to each content type ID in the CRAM spec
+     */
+    BlockContentType(final int id) {
+        specTypeId = id;
+    }
+
+    public int getSpecTypeId() {
+        return specTypeId;
+    }
 }

--- a/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
@@ -264,7 +264,7 @@ public class CompressionHeader {
                 mapBuffer.put((byte) encodingKey.name().charAt(1));
 
                 final EncodingParams params = encodingMap.get(encodingKey);
-                mapBuffer.put((byte) (0xFF & params.id.getSpecId()));
+                mapBuffer.put((byte) (0xFF & params.id.getId()));
                 ITF8.writeUnsignedITF8(params.params.length, mapBuffer);
                 mapBuffer.put(params.params);
             }
@@ -283,7 +283,7 @@ public class CompressionHeader {
                 ITF8.writeUnsignedITF8(encodingKey, mapBuffer);
 
                 final EncodingParams params = tMap.get(encodingKey);
-                mapBuffer.put((byte) (0xFF & params.id.getSpecId()));
+                mapBuffer.put((byte) (0xFF & params.id.getId()));
                 ITF8.writeUnsignedITF8(params.params.length, mapBuffer);
                 mapBuffer.put(params.params);
             }

--- a/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
@@ -264,7 +264,7 @@ public class CompressionHeader {
                 mapBuffer.put((byte) encodingKey.name().charAt(1));
 
                 final EncodingParams params = encodingMap.get(encodingKey);
-                mapBuffer.put((byte) (0xFF & params.id.ordinal()));
+                mapBuffer.put((byte) (0xFF & params.id.getSpecId()));
                 ITF8.writeUnsignedITF8(params.params.length, mapBuffer);
                 mapBuffer.put(params.params);
             }
@@ -283,7 +283,7 @@ public class CompressionHeader {
                 ITF8.writeUnsignedITF8(encodingKey, mapBuffer);
 
                 final EncodingParams params = tMap.get(encodingKey);
-                mapBuffer.put((byte) (0xFF & params.id.ordinal()));
+                mapBuffer.put((byte) (0xFF & params.id.getSpecId()));
                 ITF8.writeUnsignedITF8(params.params.length, mapBuffer);
                 mapBuffer.put(params.params);
             }

--- a/src/main/java/htsjdk/samtools/cram/structure/EncodingID.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/EncodingID.java
@@ -72,6 +72,9 @@ public enum EncodingID {
         this.id = id;
     }
 
+    /**
+     * @return the number assigned to each encoding in the CRAM spec
+     */
     public int getId() {
         return id;
     }

--- a/src/main/java/htsjdk/samtools/cram/structure/EncodingID.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/EncodingID.java
@@ -65,7 +65,7 @@ public enum EncodingID {
     private final int specId;
 
     /**
-     * The encodings specified by the CRAM spec
+     * The encodings specified by Section 3 of the CRAM spec
      * @param id the number assigned to each encoding in the CRAM spec
      */
     EncodingID(final int id) {

--- a/src/main/java/htsjdk/samtools/cram/structure/EncodingID.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/EncodingID.java
@@ -18,7 +18,7 @@
 package htsjdk.samtools.cram.structure;
 
 /**
- * Encoding ID as defined in the CRAM specs. These are basically ways to serialize a data series.
+ * Encoding ID as specified by Section 3 of the CRAM spec. These are basically ways to serialize a data series.
  */
 public enum EncodingID {
     /**
@@ -62,17 +62,17 @@ public enum EncodingID {
      */
     GAMMA(9);
 
-    private final int specId;
+    private final int id;
 
     /**
      * The encodings specified by Section 3 of the CRAM spec
      * @param id the number assigned to each encoding in the CRAM spec
      */
     EncodingID(final int id) {
-        specId = id;
+        this.id = id;
     }
 
-    public int getSpecId() {
-        return specId;
+    public int getId() {
+        return id;
     }
 }

--- a/src/main/java/htsjdk/samtools/cram/structure/EncodingID.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/EncodingID.java
@@ -24,41 +24,55 @@ public enum EncodingID {
     /**
      * "Do nothing" encoding. Should throw an exception when trying reading or writing with this encoding.
      */
-    NULL,
+    NULL(0),
     /**
      * Shove the data into a byte array for compressing later with a generic compressor like GZIP.
      */
-    EXTERNAL,
+    EXTERNAL(1),
     /**
      * 'naf said: http://en.wikipedia.org/wiki/Golomb_coding
      */
-    GOLOMB,
+    GOLOMB(2),
     /**
      * http://en.wikipedia.org/wiki/Huffman_coding
      */
-    HUFFMAN,
+    HUFFMAN(3),
     /**
      * A byte array serialized as [length][elements]
      */
-    BYTE_ARRAY_LEN,
+    BYTE_ARRAY_LEN(4),
     /**
      * A byte array serialized as [elements][stop]
      */
-    BYTE_ARRAY_STOP,
+    BYTE_ARRAY_STOP(5),
     /**
      * http://en.wikipedia.org/wiki/Beta_Code
      */
-    BETA,
+    BETA(6),
     /**
      * Subexponential codes, see the CRAM specs for details.
      */
-    SUBEXPONENTIAL,
+    SUBEXPONENTIAL(7),
     /**
      * A variant of GOLOMB encoding: http://en.wikipedia.org/wiki/Golomb_coding
      */
-    GOLOMB_RICE,
+    GOLOMB_RICE(8),
     /**
      * http://en.wikipedia.org/wiki/Elias_gamma_coding
      */
-    GAMMA
+    GAMMA(9);
+
+    private final int specId;
+
+    /**
+     * The encodings specified by the CRAM spec
+     * @param id the number assigned to each encoding in the CRAM spec
+     */
+    EncodingID(final int id) {
+        specId = id;
+    }
+
+    public int getSpecId() {
+        return specId;
+    }
 }


### PR DESCRIPTION
### Description

Using `ordinal()` is brittle because code will break mysteriously if the orders of enums ever change.  These Encoding, Block Compression Method, and BlockContentType IDs are mandated by the spec.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

