### PR TITLE
Relax Beta Encoding requirement to allow 0 bits

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/encoding/core/BetaIntegerEncoding.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/core/BetaIntegerEncoding.java
@@ -36,8 +36,8 @@ public class BetaIntegerEncoding extends CRAMEncoding<Integer> {
     public BetaIntegerEncoding(final int offset, final int bitsPerValue) {
         super(EncodingID.BETA);
 
-        if (bitsPerValue <= 0) {
-            throw new IllegalArgumentException("Number of bits per value must be positive");
+        if (bitsPerValue < 0) {
+            throw new IllegalArgumentException("Number of bits per value must not be negative");
         } else if (bitsPerValue > 32) {
             throw new IllegalArgumentException("Number of bits per value must be 32 or lower");
         }

--- a/src/test/java/htsjdk/samtools/cram/encoding/core/BetaIntegerCodecTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/core/BetaIntegerCodecTest.java
@@ -47,6 +47,8 @@ public class BetaIntegerCodecTest extends HtsjdkTest {
         return new Object[][] {
                 {8, -100, new int[]{100, 101, 102, (1<<8) + 98, (1<<8) + 99}},
                 {4, 10015, new int[]{-10015, -10014, -10001, -10000}},
+                {0, 0, new int[]{0, 0, 0}},
+                {0, 100, new int[]{-100, -100}},
         };
     }
 
@@ -62,6 +64,7 @@ public class BetaIntegerCodecTest extends HtsjdkTest {
         return new Object[][] {
                 {8, new int[]{0, 1, 2, 100, (1 << 8) - 2, (1 << 8) - 1}},
                 {16, new int[]{0, 1, 255, (1 << 16) - 2, (1 << 16) - 1}},
+                {0, new int[]{0, 0, 0}},
         };
     }
 
@@ -77,6 +80,7 @@ public class BetaIntegerCodecTest extends HtsjdkTest {
         // tuples of bitsPerValue and offsets + values which are too big to store
         return new Object[][] {
                 // first with zero offset
+                {0, 0, 1},
                 {1, 0, (1 << 1)},
                 {2, 0, (1 << 2)},
                 {4, 0, (1 << 4)},
@@ -84,6 +88,7 @@ public class BetaIntegerCodecTest extends HtsjdkTest {
                 {16, 0, (1 << 16)},
 
                 // adding offset of 1 will put it over
+                {0, 1, 0},
                 {1, 1, (1 << 1) - 1},
                 {2, 1, (1 << 2) - 1},
                 {4, 1, (1 << 4) - 1},

--- a/src/test/java/htsjdk/samtools/cram/encoding/core/BetaIntegerEncodingTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/core/BetaIntegerEncodingTest.java
@@ -10,6 +10,7 @@ public class BetaIntegerEncodingTest extends HtsjdkTest {
     public Object[][] testData() {
         return new Object[][] {
                 // positive values below the ITF8 single-byte limit (128) are encoded as-is
+                {0, 0, new byte[] { 0, 0 }},
                 {0, 8, new byte[] { 0, 8 }},
                 {127, 32, new byte[] { 127, 32 }},
 
@@ -32,12 +33,11 @@ public class BetaIntegerEncodingTest extends HtsjdkTest {
     }
 
 
-    // sanity checks for bitsPerValue.  Must be > 0 and <= 32
+    // sanity checks for bitsPerValue.  Must be between 0 and 32, inclusive
 
     @DataProvider(name = "bitsPerValue")
     public Object[][] bitsPerValueData() {
         return new Object[][] {
-                {0},
                 {-1},
                 {33}
         };


### PR DESCRIPTION
### Description

I recently added a check to protect against creating Beta Encodings with bitLength 0.  This was mistaken, and causes problems reading CRAMs with this parameter - such as those created by htslib for zero-length or constant data series.

This PR reverts that check.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

