### PR TITLE
Replaced several for-each loops in VariantContext.Make() based on HaplotypeCaller profiling

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Genotype.java
@@ -197,31 +197,33 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
     protected GenotypeType determineType() {
         // TODO -- this code is slow and could be optimized for the diploid case
         final List<Allele> alleles = getAlleles();
-        if ( alleles.isEmpty() )
+        if ( alleles.isEmpty() ) {
             return GenotypeType.UNAVAILABLE;
+        }
 
         boolean sawNoCall = false, sawMultipleAlleles = false;
-        Allele observedAllele = null;
+        Allele firstAllele = null;
 
-        for ( final Allele allele : alleles ) {
-            if ( allele.isNoCall() )
+        for ( int i = 0; i < alleles.size(); i++ ) {
+            final Allele allele = alleles.get(i);
+            if ( allele.isNoCall() ) {
                 sawNoCall = true;
-            else if ( observedAllele == null )
-                observedAllele = allele;
-            else if ( !allele.equals(observedAllele) )
+            } else if ( firstAllele == null ) {
+                firstAllele = allele;
+            } else if ( !allele.equals(firstAllele) )
                 sawMultipleAlleles = true;
         }
 
         if ( sawNoCall ) {
-            if ( observedAllele == null )
+            if ( firstAllele == null )
                 return GenotypeType.NO_CALL;
             return GenotypeType.MIXED;
         }
 
-        if ( observedAllele == null )
+        if ( firstAllele == null )
             throw new IllegalStateException("BUG: there are no alleles present in this genotype but the alleles list is not null");
 
-        return sawMultipleAlleles ? GenotypeType.HET : observedAllele.isReference() ? GenotypeType.HOM_REF : GenotypeType.HOM_VAR;
+        return sawMultipleAlleles ? GenotypeType.HET : firstAllele.isReference() ? GenotypeType.HOM_REF : GenotypeType.HOM_VAR;
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Genotype.java
@@ -202,28 +202,28 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
         }
 
         boolean sawNoCall = false, sawMultipleAlleles = false;
-        Allele firstAllele = null;
+        Allele firstCallAllele = null;
 
         for ( int i = 0; i < alleles.size(); i++ ) {
             final Allele allele = alleles.get(i);
             if ( allele.isNoCall() ) {
                 sawNoCall = true;
-            } else if ( firstAllele == null ) {
-                firstAllele = allele;
-            } else if ( !allele.equals(firstAllele) )
+            } else if ( firstCallAllele == null ) {
+                firstCallAllele = allele;
+            } else if ( !allele.equals(firstCallAllele) )
                 sawMultipleAlleles = true;
         }
 
         if ( sawNoCall ) {
-            if ( firstAllele == null )
+            if ( firstCallAllele == null )
                 return GenotypeType.NO_CALL;
             return GenotypeType.MIXED;
         }
 
-        if ( firstAllele == null )
+        if ( firstCallAllele == null )
             throw new IllegalStateException("BUG: there are no alleles present in this genotype but the alleles list is not null");
 
-        return sawMultipleAlleles ? GenotypeType.HET : firstAllele.isReference() ? GenotypeType.HOM_REF : GenotypeType.HOM_VAR;
+        return sawMultipleAlleles ? GenotypeType.HET : firstCallAllele.isReference() ? GenotypeType.HOM_REF : GenotypeType.HOM_VAR;
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -822,8 +822,9 @@ public class VariantContext implements Feature, Serializable {
             return true;
 
         final List<Allele> allelesToConsider = considerRefAllele ? getAlleles() : getAlternateAlleles();
-        for ( int i = 0; i < allelesToConsider.size(); i++) {
-            if ( allelesToConsider.get(i).equals(allele, ignoreRefState) )
+        for (int i = 0, allelesToConsiderSize = allelesToConsider.size(); i < allelesToConsiderSize; i++) {
+            Allele anAllelesToConsider = allelesToConsider.get(i);
+            if (anAllelesToConsider.equals(allele, ignoreRefState))
                 return true;
         }
 
@@ -1356,7 +1357,7 @@ public class VariantContext implements Feature, Serializable {
             Genotype genotype = genotypes.get(i);
             if ( genotype.isAvailable() ) {
                 final List<Allele> alleles = genotype.getAlleles();
-                for ( int j = 0; j < alleles.size(); j++ ) {
+                for ( int j = 0, size = alleles.size(); j < size; j++ ) {
                     final Allele gAllele = alleles.get(j);
                     if ( ! hasAllele(gAllele) && gAllele.isCalled() )
                         throw new IllegalStateException("Allele in genotype " + gAllele + " not in the variant context " + alleles);
@@ -1487,8 +1488,8 @@ public class VariantContext implements Feature, Serializable {
 
         boolean sawRef = false;
         for ( final Allele a : alleles ) {
-            for ( int i = 0; i < alleleList.size(); i++ ) {
-                if ( a.equals(alleleList.get(i), true) ) {
+            for (int i = 0, alleleListSize = alleleList.size(); i < alleleListSize; i++) {
+                if (a.equals(alleleList.get(i), true)) {
                     throw new IllegalArgumentException("Duplicate allele added to VariantContext: " + a);
                 }
             }
@@ -1701,8 +1702,7 @@ public class VariantContext implements Feature, Serializable {
     }
 
     public static boolean hasSymbolicAlleles( final List<Allele> alleles ) {
-        int size = alleles.size();
-        for (int i = 0; i < size; i++ ) {
+        for (int i = 0, size = alleles.size(); i < size; i++ ) {
             if (alleles.get(i).isSymbolic()) {
                 return true;
             }

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1353,8 +1353,11 @@ public class VariantContext implements Feature, Serializable {
         if ( this.genotypes == null ) throw new IllegalStateException("Genotypes is null");
 
         for ( int i = 0; i < genotypes.size(); i++ ) {
-            if ( genotypes.get(i).isAvailable() ) {
-                for ( Allele gAllele : genotypes.get(i).getAlleles() ) {
+            Genotype genotype = genotypes.get(i);
+            if ( genotype.isAvailable() ) {
+                final List<Allele> alleles = genotype.getAlleles();
+                for ( int j = 0; j < alleles.size(); j++ ) {
+                    final Allele gAllele = alleles.get(j);
                     if ( ! hasAllele(gAllele) && gAllele.isCalled() )
                         throw new IllegalStateException("Allele in genotype " + gAllele + " not in the variant context " + alleles);
                 }
@@ -1698,7 +1701,8 @@ public class VariantContext implements Feature, Serializable {
     }
 
     public static boolean hasSymbolicAlleles( final List<Allele> alleles ) {
-        for (int i = 0; i < alleles.size(); i++ ) {
+        int size = alleles.size();
+        for (int i = 0; i < size; i++ ) {
             if (alleles.get(i).isSymbolic()) {
                 return true;
             }

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -822,8 +822,8 @@ public class VariantContext implements Feature, Serializable {
             return true;
 
         final List<Allele> allelesToConsider = considerRefAllele ? getAlleles() : getAlternateAlleles();
-        for ( Allele a : allelesToConsider ) {
-            if ( a.equals(allele, ignoreRefState) )
+        for ( int i = 0; i < allelesToConsider.size(); i++) {
+            if ( allelesToConsider.get(i).equals(allele, ignoreRefState) )
                 return true;
         }
 
@@ -1352,9 +1352,9 @@ public class VariantContext implements Feature, Serializable {
     private void validateGenotypes() {
         if ( this.genotypes == null ) throw new IllegalStateException("Genotypes is null");
 
-        for ( final Genotype g : this.genotypes ) {
-            if ( g.isAvailable() ) {
-                for ( Allele gAllele : g.getAlleles() ) {
+        for ( int i = 0; i < genotypes.size(); i++ ) {
+            if ( genotypes.get(i).isAvailable() ) {
+                for ( Allele gAllele : genotypes.get(i).getAlleles() ) {
                     if ( ! hasAllele(gAllele) && gAllele.isCalled() )
                         throw new IllegalStateException("Allele in genotype " + gAllele + " not in the variant context " + alleles);
                 }
@@ -1484,9 +1484,10 @@ public class VariantContext implements Feature, Serializable {
 
         boolean sawRef = false;
         for ( final Allele a : alleles ) {
-            for ( final Allele b : alleleList ) {
-                if ( a.equals(b, true) )
+            for ( int i = 0; i < alleleList.size(); i++ ) {
+                if ( a.equals(alleleList.get(i), true) ) {
                     throw new IllegalArgumentException("Duplicate allele added to VariantContext: " + a);
+                }
             }
 
             // deal with the case where the first allele isn't the reference
@@ -1696,8 +1697,13 @@ public class VariantContext implements Feature, Serializable {
         return hasSymbolicAlleles(getAlleles());
     }
 
-    public static boolean hasSymbolicAlleles(final List<Allele> alleles) {
-        return alleles.stream().anyMatch(Allele::isSymbolic);
+    public static boolean hasSymbolicAlleles( final List<Allele> alleles ) {
+        for (int i = 0; i < alleles.size(); i++ ) {
+            if (alleles.get(i).isSymbolic()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Allele getAltAlleleWithHighestAlleleCount() {


### PR DESCRIPTION
These are micro optimizations that add up to a pretty small change in the HaplotypeCaller (Exome +GVCF) profile when they are implemented. Here are some profiling snippets:

Before: 
<img width="586" alt="screen shot 2018-12-03 at 3 45 29 pm" src="https://user-images.githubusercontent.com/16102845/49403113-d4b9f580-f719-11e8-84f7-ef178ac3b3d8.png">

After:
<img width="603" alt="screen shot 2018-12-03 at 3 45 07 pm" src="https://user-images.githubusercontent.com/16102845/49403131-e13e4e00-f719-11e8-9482-3c00eb16fa07.png">


Then some runtime examples on my laptop just chromosome 15 of the same bam:
Before:  `4m26s, 4m16s, 4m18s, 4m15s, 4m28s`
After:     `4m04s, 4m09s, 4m15s, 4m11s, 4m07`