### PR TITLE
Deprecated htsjdk.samtools.apps package.

### DIFF
--- a/src/main/java/htsjdk/samtools/apps/TimeChannel.java
+++ b/src/main/java/htsjdk/samtools/apps/TimeChannel.java
@@ -29,7 +29,9 @@ import java.nio.channels.FileChannel;
 
 /**
  * @author alecw@broadinstitute.org
+ * @deprecated This is deprecated with no replacement.  1/19
  */
+@Deprecated
 public class TimeChannel {
     public static void main(String[] args) throws Exception {
         long fileSize = new File(args[0]).length();

--- a/src/main/java/htsjdk/samtools/apps/TimeRandomAccessFile.java
+++ b/src/main/java/htsjdk/samtools/apps/TimeRandomAccessFile.java
@@ -28,7 +28,9 @@ import java.io.RandomAccessFile;
 
 /**
  * @author alecw@broadinstitute.org
+ * @deprecated This is deprecated with no replacement. 1/19
  */
+@Deprecated
 public class TimeRandomAccessFile {
     public static void main(String[] args) throws Exception {
         RandomAccessFile raf = new RandomAccessFile(new File(args[0]), "r");


### PR DESCRIPTION
* deprecated TimeChannel and TimeRandomAccesFile
* these are two tools which were probably used for testing at some point but should not be part of the htsjdk distribution

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

