### PR TITLE
Makes IntervalKeepPairFilter filter out single ended reads

### DIFF
--- a/src/main/java/htsjdk/samtools/filter/IntervalKeepPairFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/IntervalKeepPairFilter.java
@@ -58,8 +58,8 @@ public class IntervalKeepPairFilter implements SamRecordFilter {
      * overlaps the current interval using overlap detector. If yes, return
      * false -> don't filter it out.
      *
-     * If a read is secondary or supplementary, filter read out. Use
-     * {@link IntervalFilter} if you want to keep these reads, but NOTE: the
+     * If a read is secondary, supplementary, or single ended, filter read out.
+     * Use {@link IntervalFilter} if you want to keep these reads, but NOTE: the
      * resulting bam may not be valid.
      *
      * @param record the SAMRecord to evaluate
@@ -67,7 +67,7 @@ public class IntervalKeepPairFilter implements SamRecordFilter {
      */
     @Override
     public boolean filterOut(final SAMRecord record) {
-        if (record.isSecondaryOrSupplementary()) {
+        if (record.isSecondaryOrSupplementary() || !record.getReadPairedFlag()) {
            return true;
         }
 

--- a/src/test/java/htsjdk/samtools/filter/IntervalKeepPairFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/IntervalKeepPairFilterTest.java
@@ -48,6 +48,8 @@ public class IntervalKeepPairFilterTest extends HtsjdkTest {
         builder.addFrag("mapped_pair_chr1", 0, 1, false, false, "151M", null, -1, true, false);
         // Supplementary alignment are never kept by the interval filter.
         builder.addFrag("mapped_pair_chr1", 0, 1, false, false, "151M", null, -1, false, true);
+        // Single ended read should never be kept by the interval filter.
+        builder.addFrag("single_ended", 0, 1, false);
     }
 
     @Test(dataProvider = "testData")
@@ -94,6 +96,21 @@ public class IntervalKeepPairFilterTest extends HtsjdkTest {
                 .anyMatch(rec -> rec.isSecondaryAlignment() || rec.getSupplementaryAlignmentFlag());
 
         Assert.assertFalse(notPrimary);
+    }
+
+    @Test
+    public void testSingleEndedReads() {
+        final List<Interval> intervalList = new ArrayList<>();
+        final Interval interval1 = new Interval("chr1", 1, 999);
+        intervalList.add(interval1);
+
+        final IntervalKeepPairFilter filter = new IntervalKeepPairFilter(intervalList);
+
+        boolean singleEnded = StreamSupport.stream(builder.spliterator(), false)
+                .filter(rec -> !filter.filterOut(rec))
+                .anyMatch(rec -> rec.getReadName().equals("single_ended"));
+
+        Assert.assertFalse(singleEnded);
     }
 
     @DataProvider(name = "testData")


### PR DESCRIPTION
### Description

When a BAM contains both single ended and paired ended reads this filter throws an exception (`java.lang.IllegalStateException: Inappropriate call if not paired read`). Since the filter is only meant to keep paired reads it now also filters out single ended reads and doesn't throw an exception.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

