### PR TITLE
Fix to ensure that SeekableStream#available() never returns a negative value

### DIFF
--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableStream.java
@@ -107,8 +107,13 @@ public abstract class SeekableStream extends InputStream {
             return 0;
         }
         final long remaining = length() - position();
-        // the remaining might be negative if the length is not available (0)
-        return (remaining < 0) ? 0 : (int) remaining;
+        if (remaining < 0) { // remaining might be negative if the length is not available (0)
+            return 0;
+        } else if (remaining > Integer.MAX_VALUE) { // remaining might be bigger than Integer.MAX_VALUE for very large files
+            return Integer.MAX_VALUE;
+        } else {
+            return (int) remaining;
+        }
     }
 
     /**

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamTest.java
@@ -28,6 +28,7 @@ import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.util.Random;
 
 /**
@@ -81,12 +82,67 @@ public class SeekableStreamTest extends HtsjdkTest {
         Assert.assertEquals(stream.available(), 0);
     }
 
+    @Test
+    public void testAvailableDoesNotOverflowInteger() throws Exception {
+        // initiate large stream (longer than Integer.MAX_VALUE)
+        final long length = Integer.MAX_VALUE * 2L;
+        final SeekableStream stream = getLargeSeekableStream(length);
+        // check that available returns Integer.MAX_VALUE (and not a negative number due to overflow)
+        Assert.assertEquals(stream.available(), Integer.MAX_VALUE);
+    }
+
     private static SeekableStream getRandomSeekableStream(final int size) {
         // generate random array
         final byte[] array = new byte[size];
         new Random().nextBytes(array);
         // instantiate the stream
         return new SeekableMemoryStream(array, "test");
+    }
+
+    private static SeekableStream getLargeSeekableStream(final long size) {
+        // a long file of zeros
+        return new SeekableStream() {
+            long pos = 0;
+            @Override
+            public long length() {
+                return size;
+            }
+
+            @Override
+            public long position() throws IOException {
+                return pos;
+            }
+
+            @Override
+            public void seek(long position) throws IOException {
+                pos = position;
+            }
+
+            @Override
+            public int read(byte[] buffer, int offset, int length) throws IOException {
+                return length;
+            }
+
+            @Override
+            public void close() throws IOException {
+
+            }
+
+            @Override
+            public boolean eof() throws IOException {
+                return pos == length();
+            }
+
+            @Override
+            public String getSource() {
+                return null;
+            }
+
+            @Override
+            public int read() throws IOException {
+                return 0;
+            }
+        };
     }
 
 }


### PR DESCRIPTION
### Description

For files that are larger than 2GB (e.g. an uncompressed FASTA) it is possible that
`length - position` in `SeekableStream#available()` overflows an int, resulting in a negative value being returned.

This fixes the problem described here: https://github.com/broadinstitute/gatk/issues/5547

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

