### PR TITLE
Load BlockCompressedIndexedFastaSequenceFile and GZIIndex from streams

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
@@ -78,6 +78,14 @@ public class BlockCompressedIndexedFastaSequenceFile extends AbstractIndexedFast
         }
     }
 
+    /**
+     * Initialize the given indexed fasta sequence file stream.
+     * @param source The named source of the reference file (used in error messages).
+     * @param in The input stream to read the fasta file from; should not be decompressed already.
+     * @param index The fasta index.
+     * @param dictionary The sequence dictionary, or null if there isn't one.
+     * @param gziIndex The GZI index; may not be null.
+     */
     public BlockCompressedIndexedFastaSequenceFile(final String source, final SeekableStream in, final FastaSequenceIndex index, final SAMSequenceDictionary dictionary, final GZIIndex gziIndex) {
         super(source, index, dictionary);
         if (gziIndex == null) {

--- a/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
@@ -25,7 +25,10 @@
 package htsjdk.samtools.reference;
 
 import htsjdk.samtools.SAMException;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.seekablestream.ReadableSeekableStreamByteChannel;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
+import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.GZIIndex;
 import htsjdk.samtools.util.IOUtil;
@@ -73,6 +76,15 @@ public class BlockCompressedIndexedFastaSequenceFile extends AbstractIndexedFast
         } catch (IOException e) {
             throw new SAMException("Fasta file should be readable but is not: " + path, e);
         }
+    }
+
+    public BlockCompressedIndexedFastaSequenceFile(final String source, final SeekableStream in, final FastaSequenceIndex index, final SAMSequenceDictionary dictionary, final GZIIndex gziIndex) {
+        super(source, index, dictionary);
+        if (gziIndex == null) {
+            throw new IllegalArgumentException("null gzi index");
+        }
+        stream = new BlockCompressedInputStream(in);
+        gzindex = gziIndex;
     }
 
     private static GZIIndex loadFastaGziIndex(final Path path) {

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -269,6 +269,7 @@ public final class GZIIndex {
     /**
      * Loads the index from the provided input stream.
      *
+     * @param source The named source of the reference file (used in error messages). May be null if unknown.
      * @param indexIn the input stream for the index to load.
      *
      * @return loaded index.
@@ -284,6 +285,16 @@ public final class GZIIndex {
         }
     }
 
+    /**
+     * Loads the index from the provided channel.
+     *
+     * @param source The named source of the reference file (used in error messages). May be null if unknown.
+     * @param channel the channel to read the index from.
+     *
+     * @return loaded index.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
     public static final GZIIndex loadIndex(final String source, final ReadableByteChannel channel) throws IOException {
         // allocate a buffer for re-use for read each byte
         ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -25,9 +25,12 @@
 package htsjdk.samtools.util;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.ByteChannel;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -258,66 +261,88 @@ public final class GZIIndex {
         if (indexPath == null) {
             throw new IllegalArgumentException("null input path");
         }
+        try (final ReadableByteChannel channel = Files.newByteChannel(indexPath)) {
+            return loadIndex(indexPath.toUri().toString(), channel);
+        }
+    }
+
+    /**
+     * Loads the index from the provided input stream.
+     *
+     * @param indexIn the input stream for the index to load.
+     *
+     * @return loaded index.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
+    public static final GZIIndex loadIndex(final String source, final InputStream indexIn) throws IOException {
+        if (indexIn == null) {
+            throw new IllegalArgumentException("null input stream");
+        }
+        try (final ReadableByteChannel channel = Channels.newChannel(indexIn)) {
+            return loadIndex(source, channel);
+        }
+    }
+
+    public static final GZIIndex loadIndex(final String source, final ReadableByteChannel channel) throws IOException {
         // allocate a buffer for re-use for read each byte
         ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
 
-        try (final ByteChannel channel = Files.newByteChannel(indexPath)) {
-            if (Long.BYTES != channel.read(buffer)) {
-                throw getCorruptedIndexException(indexPath, "less than " + Long.BYTES+ "bytes", null);
-            }
-            buffer.flip();
-
-            final int numberOfEntries;
-            try {
-                numberOfEntries = Math.toIntExact(buffer.getLong());
-            } catch (ArithmeticException e) {
-                buffer.flip();
-                throw getCorruptedIndexException(indexPath,
-                        String.format("HTSJDK cannot handle more than %d entries in .gzi index, but found %s",
-                                Integer.MAX_VALUE, buffer.getLong()),
-                        e);
-            }
-
-            // allocate array with the entries and add the first one
-            final List<IndexEntry> entries = new ArrayList<>(numberOfEntries);
-
-            // create a new buffer with the correct size and read into it
-            buffer = allocateBuffer(numberOfEntries, false);
-            channel.read(buffer);
-            buffer.flip();
-
-            for (int i = 0; i < numberOfEntries; i++) {
-                final IndexEntry entry;
-                try {
-                    entry = new IndexEntry(buffer.getLong(), buffer.getLong());
-                } catch (IllegalArgumentException e) {
-                    throw getCorruptedIndexException(indexPath, e.getMessage(), e);
-                }
-                // check if the entry is increasing in order
-                if (i == 0) {
-                    if (entry.getUncompressedOffset() == 0 && entry.getCompressedOffset() == 0) {
-                        throw getCorruptedIndexException(indexPath, "first block index entry should not be present", null);
-                    }
-                } else if (entries.get(i - 1).getCompressedOffset() >= entry.getCompressedOffset()
-                        || entries.get(i - 1).getUncompressedOffset() >= entry.getUncompressedOffset()) {
-                    throw getCorruptedIndexException(indexPath,
-                            String.format("index entries in misplaced order - %s vs %s",
-                                    entries.get(i - 1), entry),
-                            null);
-                }
-
-                entries.add(entry);
-            }
-
-            return new GZIIndex(entries);
+        if (Long.BYTES != channel.read(buffer)) {
+            throw getCorruptedIndexException(source, "less than " + Long.BYTES+ "bytes", null);
         }
+        buffer.flip();
+
+        final int numberOfEntries;
+        try {
+            numberOfEntries = Math.toIntExact(buffer.getLong());
+        } catch (ArithmeticException e) {
+            buffer.flip();
+            throw getCorruptedIndexException(source,
+                    String.format("HTSJDK cannot handle more than %d entries in .gzi index, but found %s",
+                            Integer.MAX_VALUE, buffer.getLong()),
+                    e);
+        }
+
+        // allocate array with the entries and add the first one
+        final List<IndexEntry> entries = new ArrayList<>(numberOfEntries);
+
+        // create a new buffer with the correct size and read into it
+        buffer = allocateBuffer(numberOfEntries, false);
+        channel.read(buffer);
+        buffer.flip();
+
+        for (int i = 0; i < numberOfEntries; i++) {
+            final IndexEntry entry;
+            try {
+                entry = new IndexEntry(buffer.getLong(), buffer.getLong());
+            } catch (IllegalArgumentException e) {
+                throw getCorruptedIndexException(source, e.getMessage(), e);
+            }
+            // check if the entry is increasing in order
+            if (i == 0) {
+                if (entry.getUncompressedOffset() == 0 && entry.getCompressedOffset() == 0) {
+                    throw getCorruptedIndexException(source, "first block index entry should not be present", null);
+                }
+            } else if (entries.get(i - 1).getCompressedOffset() >= entry.getCompressedOffset()
+                    || entries.get(i - 1).getUncompressedOffset() >= entry.getUncompressedOffset()) {
+                throw getCorruptedIndexException(source,
+                        String.format("index entries in misplaced order - %s vs %s",
+                                entries.get(i - 1), entry),
+                        null);
+            }
+
+            entries.add(entry);
+        }
+
+        return new GZIIndex(entries);
     }
 
-    private static final IOException getCorruptedIndexException(final Path indexPath, final String msg, final Exception e) {
+    private static final IOException getCorruptedIndexException(final String source, final String msg, final Exception e) {
         return new IOException(String.format("Corrupted index file: %s (%s)",
                 msg,
-                indexPath == null ? "unknown" : indexPath.toUri()),
+                source == null ? "unknown" : source),
                 e);
     }
 

--- a/src/test/java/htsjdk/samtools/util/GZIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/util/GZIIndexTest.java
@@ -30,6 +30,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -53,6 +55,14 @@ public class GZIIndexTest extends HtsjdkTest {
         // test reading of the input file
         final GZIIndex index = GZIIndex.loadIndex(indexFile.toPath());
         Assert.assertEquals(index.getNumberOfBlocks(), expectedBlocks);
+    }
+
+    @Test(dataProvider = "indexFiles")
+    public void testLoadIndexFromStream(final File indexFile, final int expectedBlocks) throws Exception {
+        try (InputStream in = new FileInputStream(indexFile)) {
+            final GZIIndex index = GZIIndex.loadIndex(indexFile.toString(), in);
+            Assert.assertEquals(index.getNumberOfBlocks(), expectedBlocks);
+        }
     }
 
     @Test(dataProvider = "indexFiles")


### PR DESCRIPTION
### Description

This enables fasta.gz files to be loaded from streams (not just path objects), which is needed for https://github.com/disq-bio/disq/issues/75.

See original bug report in https://github.com/broadinstitute/gatk/issues/5547 

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Is not backward compatible (breaks binary or source compatibility)

