### PR TITLE
Fixed memory leak in VCFCodec

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -300,10 +300,36 @@ public class Allele implements Comparable<Allele>, Serializable {
     	if ( bases.length <= 1 )
             return false;
         else {
-            final String strBases = new String(bases);
-            return (bases[0] == '<' || bases[bases.length-1] == '>') || // symbolic or large insertion
-            		(bases[0] == '.' || bases[bases.length-1] == '.') || // single breakend
-                    (strBases.contains("[") || strBases.contains("]")); // mated breakend
+            return bases[0] == '<' || bases[bases.length - 1] == '>' ||
+                    wouldBeBreakpoint(bases) ||
+                    wouldBeSingleBreakend(bases);
+        }
+    }
+    /**
+     * @param bases  bases representing an allele
+     * @return true if the bases represent a symbolic allele in breakpoint notation
+     */
+    public static boolean wouldBeBreakpoint(final byte[] bases) {
+        if ( bases.length <= 1 )
+            return false;
+        else {
+            for (int i = 0; i < bases.length; i++) {
+                if (bases[i] == '[' || bases[i] == ']') {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+    /**
+     * @param bases  bases representing an allele
+     * @return true if the bases represent a symbolic allele in single breakend notation
+     */
+    public static boolean wouldBeSingleBreakend(final byte[] bases) {
+        if ( bases.length <= 1 )
+            return false;
+        else {
+            return bases[0] == '.' || bases[bases.length - 1] == '.';
         }
     }
 
@@ -420,6 +446,10 @@ public class Allele implements Comparable<Allele>, Serializable {
 
     // Returns true if this Allele is symbolic (i.e. no well-defined base sequence)
     public boolean isSymbolic()         { return isSymbolic; }
+
+    public boolean isBreakpoint()         { return wouldBeBreakpoint(bases); }
+
+    public boolean isSingleBreakend()         { return wouldBeSingleBreakend(bases); }
 
     // Returns a nice string representation of this object
     public String toString() {

--- a/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
@@ -277,4 +277,34 @@ public class AlleleUnitTest extends VariantBaseTest {
         Assert.assertEquals("ATCGA", Allele.extend(Allele.create("AT"), "CGA".getBytes()).toString());
         Assert.assertEquals("ATCGA", Allele.extend(Allele.create("ATC"), "GA".getBytes()).toString());
     }
+    @Test
+    public void testWouldBeSymbolic() {
+        Assert.assertTrue(Allele.wouldBeSymbolicAllele("<DEL>".getBytes()));
+        Assert.assertTrue(Allele.wouldBeSymbolicAllele("AAAAAA[chr1:1234[".getBytes()));
+        Assert.assertTrue(Allele.wouldBeSymbolicAllele("AAAAAA]chr1:1234]".getBytes()));
+        Assert.assertTrue(Allele.wouldBeSymbolicAllele("A.".getBytes()));
+        Assert.assertTrue(Allele.wouldBeSymbolicAllele(".A".getBytes()));
+        Assert.assertFalse(Allele.wouldBeSymbolicAllele("AA".getBytes()));
+        Assert.assertFalse(Allele.wouldBeSymbolicAllele("A".getBytes()));
+    }
+    @Test
+    public void testWouldBeBreakpoint() {
+        Assert.assertFalse(Allele.wouldBeBreakpoint("<DEL>".getBytes()));
+        Assert.assertTrue(Allele.wouldBeBreakpoint("AAAAAA[chr1:1234[".getBytes()));
+        Assert.assertTrue(Allele.wouldBeBreakpoint("AAAAAA]chr1:1234]".getBytes()));
+        Assert.assertFalse(Allele.wouldBeBreakpoint("A.".getBytes()));
+        Assert.assertFalse(Allele.wouldBeBreakpoint(".A".getBytes()));
+        Assert.assertFalse(Allele.wouldBeBreakpoint("AA".getBytes()));
+        Assert.assertFalse(Allele.wouldBeBreakpoint("A".getBytes()));
+    }
+    @Test
+    public void testWouldBeBreakend() {
+        Assert.assertFalse(Allele.wouldBeSingleBreakend("<DEL>".getBytes()));
+        Assert.assertFalse(Allele.wouldBeSingleBreakend("AAAAAA[chr1:1234[".getBytes()));
+        Assert.assertFalse(Allele.wouldBeSingleBreakend("AAAAAA]chr1:1234]".getBytes()));
+        Assert.assertTrue(Allele.wouldBeSingleBreakend("A.".getBytes()));
+        Assert.assertTrue(Allele.wouldBeSingleBreakend(".A".getBytes()));
+        Assert.assertFalse(Allele.wouldBeSingleBreakend("AA".getBytes()));
+        Assert.assertFalse(Allele.wouldBeSingleBreakend("A".getBytes()));
+    }
 }


### PR DESCRIPTION
### Description

VCFCodec caches previously seen allele strings which I presume is so that the millions of identical allele strings (e.g A, AA, AT, T) are weakly interned in the string HashMap<>. Unfortunately, when parsing large VCF with SV alleles, this causes a memory leak.

Since each allele string is retained until the VCFCodec is GCed, streaming a VCF containing SVs (e.g just counting # records) results in a continual increase in memory usage even when the VCF records are no longer used. For SVs, the allele string can easily be thousands of bytes in size.

Changes:
- Excluding breakpoint, single breakend allele strings from the cache.
- Excluding ALT allele strings containing multiple alleles from the cache (String.split() gets called so there's no point in caching these at all)
- I also put a safety check to exclude long alleles from the cache since they're very likely to be unique and not benefit from the caching at all.

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

