### PR TITLE
CRAM: formalize Slice Type with an enum

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -132,7 +132,7 @@ public class CRAMBAIIndexer {
                 /**
                  * Unmapped span must be processed after mapped spans:
                  */
-                AlignmentSpan unmappedSpan = spanMap.remove(ReferenceContext.UNMAPPED);
+                AlignmentSpan unmappedSpan = spanMap.remove(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
                 for (final ReferenceContext refContext : new TreeSet<>(spanMap.keySet())) {
                     final AlignmentSpan span = spanMap.get(refContext);
                     final Slice fakeSlice = new Slice(refContext);
@@ -147,7 +147,7 @@ public class CRAMBAIIndexer {
                 }
 
                 if (unmappedSpan != null) {
-                    final Slice fakeSlice = new Slice(ReferenceContext.UNMAPPED);
+                    final Slice fakeSlice = new Slice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
                     fakeSlice.containerOffset = slice.containerOffset;
                     fakeSlice.offset = slice.offset;
                     fakeSlice.index = slice.index;
@@ -450,10 +450,10 @@ public class CRAMBAIIndexer {
                     final ReferenceContext containerContext = container.getReferenceContext();
                     String sequenceName;
                     switch (containerContext.getType()) {
-                        case UNMAPPED_UNPLACED:
+                        case UNMAPPED_UNPLACED_TYPE:
                             sequenceName = "?";
                             break;
-                        case MULTI_REFERENCE:
+                        case MULTIPLE_REFERENCE_TYPE:
                             sequenceName = "???";
                             break;
                         default:

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -40,6 +40,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.cram.build.ContainerParser;
 import htsjdk.samtools.cram.build.CramIO;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.AlignmentSpan;
 import htsjdk.samtools.cram.structure.Container;
 import htsjdk.samtools.cram.structure.ContainerIO;
@@ -49,7 +50,6 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
-import htsjdk.samtools.util.RuntimeIOException;
 
 import java.io.File;
 import java.io.IOException;
@@ -123,19 +123,19 @@ public class CRAMBAIIndexer {
         for (final Slice slice : container.slices) {
             slice.containerOffset = container.offset;
             slice.index = sliceIndex++;
-            if (slice.isMultiref()) {
+            if (slice.getReferenceContext().isMultiRef()) {
                 final ContainerParser parser = new ContainerParser(indexBuilder.bamHeader);
-                final Map<Integer, AlignmentSpan> refSet = parser.getReferences(container, validationStringency);
-                final Slice fakeSlice = new Slice();
+                final Map<ReferenceContext, AlignmentSpan> spanMap = parser.getReferences(container, validationStringency);
+
                 slice.containerOffset = container.offset;
                 slice.index = sliceIndex++;
                 /**
                  * Unmapped span must be processed after mapped spans:
                  */
-                AlignmentSpan unmappedSpan = refSet.remove(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
-                for (final int refId : new TreeSet<>(refSet.keySet())) {
-                    final AlignmentSpan span = refSet.get(refId);
-                    fakeSlice.sequenceId = refId;
+                AlignmentSpan unmappedSpan = spanMap.remove(ReferenceContext.UNMAPPED);
+                for (final ReferenceContext refContext : new TreeSet<>(spanMap.keySet())) {
+                    final AlignmentSpan span = spanMap.get(refContext);
+                    final Slice fakeSlice = new Slice(refContext);
                     fakeSlice.containerOffset = slice.containerOffset;
                     fakeSlice.offset = slice.offset;
                     fakeSlice.index = slice.index;
@@ -145,16 +145,16 @@ public class CRAMBAIIndexer {
                     fakeSlice.nofRecords = span.getCount();
                     processSingleReferenceSlice(fakeSlice);
                 }
+
                 if (unmappedSpan != null) {
-                    final AlignmentSpan span = unmappedSpan;
-                    fakeSlice.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
+                    final Slice fakeSlice = new Slice(ReferenceContext.UNMAPPED);
                     fakeSlice.containerOffset = slice.containerOffset;
                     fakeSlice.offset = slice.offset;
                     fakeSlice.index = slice.index;
 
                     fakeSlice.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
                     fakeSlice.alignmentSpan = 0;
-                    fakeSlice.nofRecords = span.getCount();
+                    fakeSlice.nofRecords = unmappedSpan.getCount();
                     processSingleReferenceSlice(fakeSlice);
                 }
             } else {
@@ -164,8 +164,8 @@ public class CRAMBAIIndexer {
     }
 
     /**
-     * Record index information for a given CRAM slice that contains either unmapped reads or
-     * reads mapped to a single reference.
+     * Record index information for a given CRAM slice that contains either
+     * unmapped-unplaced reads or reads mapped to a single reference.
      * If this alignment starts a new reference, write out the old reference.
      *
      * @param slice The CRAM slice, single ref or unmapped only.
@@ -173,13 +173,16 @@ public class CRAMBAIIndexer {
      */
     public void processSingleReferenceSlice(final Slice slice) {
         try {
-            final int reference = slice.sequenceId;
-            if (reference == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
+            final ReferenceContext sliceContext = slice.getReferenceContext();
+            if (sliceContext.isUnmappedUnplaced()) {
                 return;
             }
-            if (slice.sequenceId == Slice.MULTI_REFERENCE) {
+
+            if (sliceContext.isMultiRef()) {
                 throw new SAMException("Expecting a single reference slice.");
             }
+
+            final int reference = sliceContext.getSequenceId();
             if (reference != currentReference) {
                 // process any completed references
                 advanceToReference(reference);
@@ -264,13 +267,13 @@ public class CRAMBAIIndexer {
             // metadata
             indexStats.recordMetaData(slice);
 
-            final int alignmentStart = slice.alignmentStart;
-            if (alignmentStart == SAMRecord.NO_ALIGNMENT_START) {
+            final ReferenceContext sliceContext = slice.getReferenceContext();
+            if (! sliceContext.isMappedSingleRef()) {
                 return; // do nothing for records without coordinates, but count them
             }
 
             // various checks
-            final int reference = slice.sequenceId;
+            final int reference = sliceContext.getSequenceId();
             if (reference != currentReference) {
                 throw new SAMException("Unexpected reference " + reference +
                         " when constructing index for " + currentReference + " for record " + slice);
@@ -328,6 +331,7 @@ public class CRAMBAIIndexer {
             // process linear index
 
             // the smallest file offset that appears in the 16k window for this bin
+            final int alignmentStart = slice.alignmentStart;
             final int alignmentEnd = slice.alignmentStart + slice.alignmentSpan;
             int startWindow = LinearIndex.convertToLinearIndexOffset(alignmentStart); // the 16k window
             final int endWindow;
@@ -443,16 +447,17 @@ public class CRAMBAIIndexer {
                 indexer.processContainer(container, validationStringency);
 
                 if (null != log) {
+                    final ReferenceContext containerContext = container.getReferenceContext();
                     String sequenceName;
-                    switch (container.sequenceId) {
-                        case SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX:
+                    switch (containerContext.getType()) {
+                        case UNMAPPED_UNPLACED:
                             sequenceName = "?";
                             break;
-                        case Slice.MULTI_REFERENCE:
+                        case MULTI_REFERENCE:
                             sequenceName = "???";
                             break;
                         default:
-                            sequenceName = cramHeader.getSamFileHeader().getSequence(container.sequenceId).getSequenceName();
+                            sequenceName = cramHeader.getSamFileHeader().getSequence(containerContext.getSequenceId()).getSequenceName();
                             break;
                     }
                     progressLogger.record(sequenceName, container.alignmentStart);

--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -201,7 +201,7 @@ public class CRAMContainerStreamWriter {
             return true;
         }
 
-        if (refSeqIndex == ReferenceContext.REF_ID_MULTIPLE) {
+        if (refSeqIndex == ReferenceContext.MULTIPLE_REFERENCE_ID) {
             return false;
         }
 
@@ -216,7 +216,7 @@ public class CRAMContainerStreamWriter {
         if (samRecords.size() > MIN_SINGLE_REF_RECORDS) {
             return true;
         } else {
-            refSeqIndex = ReferenceContext.REF_ID_MULTIPLE;
+            refSeqIndex = ReferenceContext.MULTIPLE_REFERENCE_ID;
             return false;
         }
     }
@@ -265,13 +265,13 @@ public class CRAMContainerStreamWriter {
         final byte[] referenceBases;
         String refSeqName = null;
         switch (refSeqIndex) {
-            case ReferenceContext.REF_ID_MULTIPLE:
+            case ReferenceContext.MULTIPLE_REFERENCE_ID:
                 if (preservation != null && preservation.areReferenceTracksRequired()) {
                     throw new SAMException("Cannot apply reference-based lossy compression on non-coordinate sorted reads.");
                 }
                 referenceBases = new byte[0];
                 break;
-            case ReferenceContext.REF_ID_UNMAPPED:
+            case ReferenceContext.UNMAPPED_UNPLACED_ID:
                 referenceBases = new byte[0];
                 break;
             default:
@@ -480,14 +480,14 @@ public class CRAMContainerStreamWriter {
      * @param samRecordReferenceIndex index of the new reference sequence
      */
     private void updateReferenceContext(final int samRecordReferenceIndex) {
-        if (refSeqIndex == ReferenceContext.REF_ID_MULTIPLE) {
+        if (refSeqIndex == ReferenceContext.MULTIPLE_REFERENCE_ID) {
             return;
         }
 
         if (refSeqIndex == REF_SEQ_INDEX_NOT_INITIALIZED) {
             refSeqIndex = samRecordReferenceIndex;
         } else if (refSeqIndex != samRecordReferenceIndex) {
-            refSeqIndex = ReferenceContext.REF_ID_MULTIPLE;
+            refSeqIndex = ReferenceContext.MULTIPLE_REFERENCE_ID;
     }
     }
 

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -157,13 +157,13 @@ public class CRAMIterator implements SAMRecordIterator {
 
         final ReferenceContext containerContext = container.getReferenceContext();
         switch (containerContext.getType()) {
-            case UNMAPPED_UNPLACED:
+            case UNMAPPED_UNPLACED_TYPE:
                 referenceBases = new byte[]{};
                 prevSeqId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
                 break;
-            case MULTI_REFERENCE:
+            case MULTIPLE_REFERENCE_TYPE:
                 referenceBases = null;
-                prevSeqId = ReferenceContext.REF_ID_MULTIPLE;
+                prevSeqId = ReferenceContext.MULTIPLE_REFERENCE_ID;
                 break;
             default:
                 if (prevSeqId != containerContext.getSequenceId()) {

--- a/src/main/java/htsjdk/samtools/cram/CRAIEntry.java
+++ b/src/main/java/htsjdk/samtools/cram/CRAIEntry.java
@@ -142,9 +142,9 @@ public class CRAIEntry implements Comparable<CRAIEntry> {
         @Override
         public int compare(CRAIEntry o1, CRAIEntry o2) {
             if (o1.sequenceId != o2.sequenceId) {
-                if (o1.sequenceId == ReferenceContext.REF_ID_UNMAPPED)
+                if (o1.sequenceId == ReferenceContext.UNMAPPED_UNPLACED_ID)
                     return 1;
-                if (o2.sequenceId == ReferenceContext.REF_ID_UNMAPPED)
+                if (o2.sequenceId == ReferenceContext.UNMAPPED_UNPLACED_ID)
                     return -1;
                 return -o2.sequenceId + o1.sequenceId;
             }

--- a/src/main/java/htsjdk/samtools/cram/CRAIEntry.java
+++ b/src/main/java/htsjdk/samtools/cram/CRAIEntry.java
@@ -1,6 +1,6 @@
 package htsjdk.samtools.cram;
 
-import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.util.RuntimeIOException;
 
 import java.io.IOException;
@@ -142,9 +142,9 @@ public class CRAIEntry implements Comparable<CRAIEntry> {
         @Override
         public int compare(CRAIEntry o1, CRAIEntry o2) {
             if (o1.sequenceId != o2.sequenceId) {
-                if (o1.sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX)
+                if (o1.sequenceId == ReferenceContext.REF_ID_UNMAPPED)
                     return 1;
-                if (o2.sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX)
+                if (o2.sequenceId == ReferenceContext.REF_ID_UNMAPPED)
                     return -1;
                 return -o2.sequenceId + o1.sequenceId;
             }

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
@@ -41,8 +41,7 @@ public class ContainerFactory {
     public Container buildContainer(final List<CramCompressionRecord> records) {
         // sets header APDelta
         final boolean coordinateSorted = samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.coordinate;
-        final SubstitutionMatrix substitutionMatrix = null;     // TODO
-        final CompressionHeader header = new CompressionHeaderFactory().build(records, substitutionMatrix, coordinateSorted);
+        final CompressionHeader header = new CompressionHeaderFactory().build(records, null, coordinateSorted);
 
         header.readNamesIncluded = preserveReadNames;
 

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
@@ -39,41 +39,33 @@ public class ContainerFactory {
     }
 
     public Container buildContainer(final List<CramCompressionRecord> records) {
-        return buildContainer(records, null);
-    }
-
-    Container buildContainer(final List<CramCompressionRecord> records,
-                             final SubstitutionMatrix substitutionMatrix) {
-
         // sets header APDelta
         final boolean coordinateSorted = samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.coordinate;
+        final SubstitutionMatrix substitutionMatrix = null;     // TODO
         final CompressionHeader header = new CompressionHeaderFactory().build(records, substitutionMatrix, coordinateSorted);
 
         header.readNamesIncluded = preserveReadNames;
 
         final List<Slice> slices = new ArrayList<>();
 
-        final Container container = new Container();
-        container.header = header;
-        container.nofRecords = records.size();
-        container.globalRecordCounter = globalRecordCounter;
-        container.bases = 0;
-        container.blockCount = 0;
-
-        long lastGlobalRecordCounter = container.globalRecordCounter;
+        int baseCount = 0;
+        long lastGlobalRecordCounter = globalRecordCounter;
         for (int i = 0; i < records.size(); i += recordsPerSlice) {
             final List<CramCompressionRecord> sliceRecords = records.subList(i,
                     Math.min(records.size(), i + recordsPerSlice));
             final Slice slice = Slice.buildSlice(sliceRecords, header);
-            slice.globalRecordCounter = lastGlobalRecordCounter;
-            lastGlobalRecordCounter += slice.nofRecords;
-            container.bases += slice.bases;
+            slice.globalRecordCounter = globalRecordCounter;
+            globalRecordCounter += slice.nofRecords;
+            baseCount += slice.bases;
             slices.add(slice);
         }
 
-        container.finalizeContainerState(slices.toArray(new Slice[0]));
-
-        globalRecordCounter += records.size();
+        final Container container = Container.initializeFromSlices(slices);
+        container.header = header;
+        container.nofRecords = records.size();
+        container.globalRecordCounter = lastGlobalRecordCounter;
+        container.blockCount = 0;
+        container.bases += baseCount;
         return container;
     }
 

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
@@ -87,10 +87,10 @@ public class ContainerParser {
         final Map<ReferenceContext, AlignmentSpan> spanMap = new HashMap<>();
         final ReferenceContext sliceContext = slice.getReferenceContext();
         switch (sliceContext.getType()) {
-            case UNMAPPED_UNPLACED:
-                spanMap.put(ReferenceContext.UNMAPPED, AlignmentSpan.UNMAPPED_SPAN);
+            case UNMAPPED_UNPLACED_TYPE:
+                spanMap.put(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, AlignmentSpan.UNMAPPED_SPAN);
                 break;
-            case MULTI_REFERENCE:
+            case MULTIPLE_REFERENCE_TYPE:
                 final Map<ReferenceContext, AlignmentSpan> spans = slice.getMultiRefAlignmentSpans(header, validationStringency);
                 addAllSpans(spanMap, spans);
                 break;

--- a/src/main/java/htsjdk/samtools/cram/build/Cram2SamRecordFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/Cram2SamRecordFactory.java
@@ -74,13 +74,13 @@ public class Cram2SamRecordFactory {
         if (samRecord.getReadPairedFlag()) {
             samRecord.setMateReferenceIndex(cramRecord.mateSequenceID);
             samRecord
-                    .setMateAlignmentStart(cramRecord.mateAlignmentStart > 0 ? cramRecord.mateAlignmentStart : SAMRecord
-                            .NO_ALIGNMENT_START);
+                    .setMateAlignmentStart(cramRecord.mateAlignmentStart > 0 ?
+                            cramRecord.mateAlignmentStart :
+                            SAMRecord.NO_ALIGNMENT_START);
             samRecord.setMateNegativeStrandFlag(cramRecord.isMateNegativeStrand());
             samRecord.setMateUnmappedFlag(cramRecord.isMateUnmapped());
         } else {
-            samRecord
-                    .setMateReferenceIndex(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+            samRecord.setMateReferenceIndex(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
             samRecord.setMateAlignmentStart(SAMRecord.NO_ALIGNMENT_START);
         }
 

--- a/src/main/java/htsjdk/samtools/cram/build/CramIO.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramIO.java
@@ -23,6 +23,7 @@ import htsjdk.samtools.cram.common.CramVersions;
 import htsjdk.samtools.cram.common.Version;
 import htsjdk.samtools.cram.io.CountingInputStream;
 import htsjdk.samtools.cram.io.InputStreamUtils;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.block.Block;
 import htsjdk.samtools.cram.structure.Container;
 import htsjdk.samtools.cram.structure.ContainerIO;
@@ -257,17 +258,14 @@ public class CramIO {
         System.arraycopy(data, 0, blockContent, 0, Math.min(data.length, length));
         final Block block = Block.createRawFileHeaderBlock(blockContent);
 
-        final Container container = new Container();
+        final Container container = new Container(new ReferenceContext(0));
         container.blockCount = 1;
         container.blocks = new Block[]{block};
         container.landmarks = new int[0];
         container.slices = new Slice[0];
-        container.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
-        container.alignmentStart = Slice.NO_ALIGNMENT_START;
         container.bases = 0;
         container.globalRecordCounter = 0;
         container.nofRecords = 0;
-        container.sequenceId = 0;
 
         final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         block.write(major, byteArrayOutputStream);

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
@@ -59,7 +59,7 @@ public class MultiRefSliceAlignmentSpanReader extends CramRecordReader {
                                             final ValidationStringency validationStringency,
                                             final int initialAlignmentStart,
                                             final int recordCount) {
-        super(coreInputStream, externalInputMap, header, ReferenceContext.MULTIPLE, validationStringency);
+        super(coreInputStream, externalInputMap, header, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, validationStringency);
 
         this.prevAlignmentStart = initialAlignmentStart;
 

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
@@ -19,7 +19,6 @@ import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.cram.io.BitInputStream;
 import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.*;
-import htsjdk.samtools.cram.structure.Slice;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
@@ -17,7 +17,9 @@ package htsjdk.samtools.cram.encoding.reader;
 
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.cram.io.BitInputStream;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.*;
+import htsjdk.samtools.cram.structure.Slice;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
@@ -39,7 +41,7 @@ public class MultiRefSliceAlignmentSpanReader extends CramRecordReader {
     /**
      * Detected sequence spans
      */
-    private final Map<Integer, AlignmentSpan> spans = new HashMap<>();
+    private final Map<ReferenceContext, AlignmentSpan> spans = new HashMap<>();
 
     /**
      * Initializes a Multiple Reference Sequence ID Reader.
@@ -58,7 +60,7 @@ public class MultiRefSliceAlignmentSpanReader extends CramRecordReader {
                                             final ValidationStringency validationStringency,
                                             final int initialAlignmentStart,
                                             final int recordCount) {
-        super(coreInputStream, externalInputMap, header, Slice.MULTI_REFERENCE, validationStringency);
+        super(coreInputStream, externalInputMap, header, ReferenceContext.MULTIPLE, validationStringency);
 
         this.prevAlignmentStart = initialAlignmentStart;
 
@@ -67,7 +69,7 @@ public class MultiRefSliceAlignmentSpanReader extends CramRecordReader {
         }
     }
 
-    public Map<Integer, AlignmentSpan> getReferenceSpans() {
+    public Map<ReferenceContext, AlignmentSpan> getReferenceSpans() {
         return Collections.unmodifiableMap(spans);
     }
 
@@ -76,10 +78,11 @@ public class MultiRefSliceAlignmentSpanReader extends CramRecordReader {
 
         prevAlignmentStart = super.read(cramRecord, prevAlignmentStart);
 
-        if (!spans.containsKey(cramRecord.sequenceId)) {
-            spans.put(cramRecord.sequenceId, new AlignmentSpan(cramRecord.alignmentStart, cramRecord.readLength));
+        final ReferenceContext recordContext = new ReferenceContext(cramRecord.sequenceId);
+        if (!spans.containsKey(recordContext)) {
+            spans.put(recordContext, new AlignmentSpan(prevAlignmentStart, cramRecord.readLength));
         } else {
-            spans.get(cramRecord.sequenceId).addSingle(cramRecord.alignmentStart, cramRecord.readLength);
+            spans.get(recordContext).addSingle(prevAlignmentStart, cramRecord.readLength);
         }
     }
 }

--- a/src/main/java/htsjdk/samtools/cram/encoding/writer/CramRecordWriter.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/writer/CramRecordWriter.java
@@ -19,7 +19,9 @@ package htsjdk.samtools.cram.encoding.writer;
 
 import htsjdk.samtools.cram.encoding.readfeatures.*;
 import htsjdk.samtools.cram.io.BitOutputStream;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.*;
+import htsjdk.samtools.cram.structure.Slice;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
@@ -60,7 +62,7 @@ public class CramRecordWriter {
     private final Charset charset = Charset.forName("UTF8");
 
     private final boolean captureReadNames;
-    private final int refId;
+    private final ReferenceContext refContext;
     private final SubstitutionMatrix substitutionMatrix;
     private final boolean AP_delta;
     
@@ -74,14 +76,14 @@ public class CramRecordWriter {
      * @param coreOutputStream Core data block bit stream, to be written by non-external Encodings
      * @param externalOutputMap External data block byte stream map, to be written by external Encodings
      * @param header the associated Cram Compression Header
-     * @param refId the reference sequence ID to assign to these records
+     * @param refContext the reference context to assign to these records
      */
     public CramRecordWriter(final BitOutputStream coreOutputStream,
                             final Map<Integer, ByteArrayOutputStream> externalOutputMap,
                             final CompressionHeader header,
-                            final int refId) {
+                            final ReferenceContext refContext) {
         this.captureReadNames = header.readNamesIncluded;
-        this.refId = refId;
+        this.refContext = refContext;
         this.substitutionMatrix = header.substitutionMatrix;
         this.AP_delta = header.APDelta;
 
@@ -165,7 +167,7 @@ public class CramRecordWriter {
     private void writeRecord(final CramCompressionRecord r, final int prevAlignmentStart) {
         bitFlagsC.writeData(r.flags);
         compBitFlagsC.writeData(r.getCompressionFlags());
-        if (refId == Slice.MULTI_REFERENCE) {
+        if (refContext.isMultiRef()) {
             refIdCodec.writeData(r.sequenceId);
         }
 

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceContext.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceContext.java
@@ -6,19 +6,19 @@ import htsjdk.samtools.cram.CRAMException;
 /**
  * Represents the current state of reference sequence processing.
  *
- * Are we handling MULTI_REFERENCE records (-2, from the CRAM spec)?
+ * Are we handling MULTIPLE_REFERENCE_TYPE records (-2, from the CRAM spec)?
  *
- * Are we handling UNMAPPED_UNPLACED records (-1, from the CRAM spec)?
+ * Are we handling UNMAPPED_UNPLACED_TYPE records (-1, from the CRAM spec)?
  *
- * Or are we handing a known SINGLE_REFERENCE sequence (0 or higher, from the CRAM spec))?
+ * Or are we handing a known SINGLE_REFERENCE_TYPE sequence (0 or higher, from the CRAM spec))?
  *
  */
 public class ReferenceContext implements Comparable<ReferenceContext> {
-    public static final int REF_ID_MULTIPLE = -2;
-    public static final int REF_ID_UNMAPPED = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX; // -1
+    public static final int MULTIPLE_REFERENCE_ID = -2;
+    public static final int UNMAPPED_UNPLACED_ID = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX; // -1
 
-    public static final ReferenceContext MULTIPLE = new ReferenceContext(REF_ID_MULTIPLE);
-    public static final ReferenceContext UNMAPPED = new ReferenceContext(REF_ID_UNMAPPED);
+    public static final ReferenceContext MULTIPLE_REFERENCE_CONTEXT = new ReferenceContext(MULTIPLE_REFERENCE_ID);
+    public static final ReferenceContext UNMAPPED_UNPLACED_CONTEXT = new ReferenceContext(UNMAPPED_UNPLACED_ID);
 
     private final ReferenceContextType type;
     private final int serializableSequenceId;
@@ -35,15 +35,15 @@ public class ReferenceContext implements Comparable<ReferenceContext> {
         this.serializableSequenceId = serializableSequenceId;
 
         switch (serializableSequenceId) {
-            case REF_ID_MULTIPLE:
-                this.type = ReferenceContextType.MULTI_REFERENCE;
+            case MULTIPLE_REFERENCE_ID:
+                this.type = ReferenceContextType.MULTIPLE_REFERENCE_TYPE;
                 break;
-            case REF_ID_UNMAPPED:
-                this.type = ReferenceContextType.UNMAPPED_UNPLACED;
+            case UNMAPPED_UNPLACED_ID:
+                this.type = ReferenceContextType.UNMAPPED_UNPLACED_TYPE;
                 break;
             default:
                 if (serializableSequenceId >= 0) {
-                    this.type = ReferenceContextType.SINGLE_REFERENCE;
+                    this.type = ReferenceContextType.SINGLE_REFERENCE_TYPE;
                 } else {
                     throw new CRAMException("Invalid Reference Sequence ID: " + serializableSequenceId);
                 }
@@ -51,7 +51,7 @@ public class ReferenceContext implements Comparable<ReferenceContext> {
     }
 
     /**
-     * Get the ReferenceContext type: SINGLE_REFERENCE, UNMAPPED_UNPLACED, or MULTI_REFERENCE
+     * Get the ReferenceContext type: SINGLE_REFERENCE_TYPE, UNMAPPED_UNPLACED_TYPE, or MULTIPLE_REFERENCE_TYPE
      * @return the {@link ReferenceContextType} enum
      */
     public ReferenceContextType getType() {
@@ -75,7 +75,7 @@ public class ReferenceContext implements Comparable<ReferenceContext> {
      * @return the sequence ID
      */
     public int getSequenceId() {
-        if (type != ReferenceContextType.SINGLE_REFERENCE) {
+        if (type != ReferenceContextType.SINGLE_REFERENCE_TYPE) {
             final String msg = "This ReferenceContext does not have a valid reference sequence ID because its type is " +
                     type.toString();
             throw new CRAMException(msg);
@@ -93,7 +93,7 @@ public class ReferenceContext implements Comparable<ReferenceContext> {
      * @return true if the ReferenceContext refers only to unmapped-unplaced reads
      */
     public boolean isUnmappedUnplaced() {
-        return type == ReferenceContextType.UNMAPPED_UNPLACED;
+        return type == ReferenceContextType.UNMAPPED_UNPLACED_TYPE;
     }
 
     /**
@@ -104,7 +104,7 @@ public class ReferenceContext implements Comparable<ReferenceContext> {
      * or a combination of placed and unplaced reads
      */
     public boolean isMultiRef() {
-        return type == ReferenceContextType.MULTI_REFERENCE;
+        return type == ReferenceContextType.MULTIPLE_REFERENCE_TYPE;
     }
 
     /**
@@ -112,7 +112,7 @@ public class ReferenceContext implements Comparable<ReferenceContext> {
      * @return true if all reads referred to by this ReferenceContext are placed on a single reference
      */
     public boolean isMappedSingleRef() {
-        return type == ReferenceContextType.SINGLE_REFERENCE;
+        return type == ReferenceContextType.SINGLE_REFERENCE_TYPE;
     }
 
     @Override
@@ -141,12 +141,12 @@ public class ReferenceContext implements Comparable<ReferenceContext> {
     @Override
     public String toString() {
         switch (serializableSequenceId) {
-            case REF_ID_MULTIPLE:
-                return "MULTIPLE";
-            case REF_ID_UNMAPPED:
-                return "UNMAPPED";
+            case MULTIPLE_REFERENCE_ID:
+                return "MULTIPLE_REFERENCE_CONTEXT";
+            case UNMAPPED_UNPLACED_ID:
+                return "UNMAPPED_UNPLACED_CONTEXT";
             default:
-                return "" + serializableSequenceId;
+                return "SINGLE_REFERENCE_CONTEXT: " + serializableSequenceId;
         }
     }
 }

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceContext.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceContext.java
@@ -88,7 +88,7 @@ public class ReferenceContext implements Comparable<ReferenceContext> {
      * Does this ReferenceContext refer to only unmapped-unplaced reads?
      *
      * Note: not a guarantee that the unmapped flag is set for all records
-     * @see htsjdk.samtools.cram.structure.CramCompressionRecord#isPlaced(boolean)
+     * @see htsjdk.samtools.cram.structure.CramCompressionRecord#isPlaced()
      *
      * @return true if the ReferenceContext refers only to unmapped-unplaced reads
      */

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceContext.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceContext.java
@@ -1,0 +1,152 @@
+package htsjdk.samtools.cram.ref;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.cram.CRAMException;
+
+/**
+ * Represents the current state of reference sequence processing.
+ *
+ * Are we handling MULTI_REFERENCE records (-2, from the CRAM spec)?
+ *
+ * Are we handling UNMAPPED_UNPLACED records (-1, from the CRAM spec)?
+ *
+ * Or are we handing a known SINGLE_REFERENCE sequence (0 or higher, from the CRAM spec))?
+ *
+ */
+public class ReferenceContext implements Comparable<ReferenceContext> {
+    public static final int REF_ID_MULTIPLE = -2;
+    public static final int REF_ID_UNMAPPED = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX; // -1
+
+    public static final ReferenceContext MULTIPLE = new ReferenceContext(REF_ID_MULTIPLE);
+    public static final ReferenceContext UNMAPPED = new ReferenceContext(REF_ID_UNMAPPED);
+
+    private final ReferenceContextType type;
+    private final int serializableSequenceId;
+
+    /**
+     * Create a ReferenceContext from a serializable sequence ID
+     * 0 or greater for single reference
+     * -1 for unmapped-unplaced
+     * -2 for multiple reference
+     *
+     * @param serializableSequenceId the sequence ID or sentinel value for constructing this ReferenceContext
+     */
+    public ReferenceContext(final int serializableSequenceId) {
+        this.serializableSequenceId = serializableSequenceId;
+
+        switch (serializableSequenceId) {
+            case REF_ID_MULTIPLE:
+                this.type = ReferenceContextType.MULTI_REFERENCE;
+                break;
+            case REF_ID_UNMAPPED:
+                this.type = ReferenceContextType.UNMAPPED_UNPLACED;
+                break;
+            default:
+                if (serializableSequenceId >= 0) {
+                    this.type = ReferenceContextType.SINGLE_REFERENCE;
+                } else {
+                    throw new CRAMException("Invalid Reference Sequence ID: " + serializableSequenceId);
+                }
+        }
+    }
+
+    /**
+     * Get the ReferenceContext type: SINGLE_REFERENCE, UNMAPPED_UNPLACED, or MULTI_REFERENCE
+     * @return the {@link ReferenceContextType} enum
+     */
+    public ReferenceContextType getType() {
+        return type;
+    }
+
+    /**
+     * Get the ReferenceContext sequence ID or sentinel value, suitable for serialization:
+     * 0 or greater for single reference
+     * -1 for unmapped
+     * -2 for multiple reference
+     * @return the sequence ID
+     */
+    public int getSerializableId() {
+        return serializableSequenceId;
+    }
+
+    /**
+     * Get the valid sequence ID, if single-reference
+     * @throws CRAMException if this is not single-ref
+     * @return the sequence ID
+     */
+    public int getSequenceId() {
+        if (type != ReferenceContextType.SINGLE_REFERENCE) {
+            final String msg = "This ReferenceContext does not have a valid reference sequence ID because its type is " +
+                    type.toString();
+            throw new CRAMException(msg);
+        }
+
+        return serializableSequenceId;
+    }
+
+    /**
+     * Does this ReferenceContext refer to only unmapped-unplaced reads?
+     *
+     * Note: not a guarantee that the unmapped flag is set for all records
+     * @see htsjdk.samtools.cram.structure.CramCompressionRecord#isPlaced(boolean)
+     *
+     * @return true if the ReferenceContext refers only to unmapped-unplaced reads
+     */
+    public boolean isUnmappedUnplaced() {
+        return type == ReferenceContextType.UNMAPPED_UNPLACED;
+    }
+
+    /**
+     * Does this ReferenceContext refer to:
+     * - reads placed on multiple references
+     * - or a combination of placed and unplaced reads?
+     * @return true if the ReferenceContext relates to reads placed on multiple references
+     * or a combination of placed and unplaced reads
+     */
+    public boolean isMultiRef() {
+        return type == ReferenceContextType.MULTI_REFERENCE;
+    }
+
+    /**
+     * Does this ReferenceContext refer to reads placed on a single reference (whether their unmapped flags are set or not)?
+     * @return true if all reads referred to by this ReferenceContext are placed on a single reference
+     */
+    public boolean isMappedSingleRef() {
+        return type == ReferenceContextType.SINGLE_REFERENCE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ReferenceContext that = (ReferenceContext) o;
+
+        if (serializableSequenceId != that.serializableSequenceId) return false;
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + serializableSequenceId;
+        return result;
+    }
+
+    @Override
+    public int compareTo(final ReferenceContext o) {
+        return Integer.compare(this.serializableSequenceId, o.serializableSequenceId);
+    }
+
+    @Override
+    public String toString() {
+        switch (serializableSequenceId) {
+            case REF_ID_MULTIPLE:
+                return "MULTIPLE";
+            case REF_ID_UNMAPPED:
+                return "UNMAPPED";
+            default:
+                return "" + serializableSequenceId;
+        }
+    }
+}

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceContextType.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceContextType.java
@@ -1,0 +1,16 @@
+package htsjdk.samtools.cram.ref;
+
+/**
+ * Is this {@link ReferenceContext} Single Reference,
+ * Multiple Reference, or Unmapped?
+ *
+ * Section 8.5 of the CRAM spec defines the following values for the Slice Header sequence ID field:
+ *      -2: Multiple Reference Slice
+ *      -1: Unmapped-Unplaced Slice
+ *      Any positive integer (including zero): Single Reference Slice
+ */
+public enum ReferenceContextType {
+    MULTI_REFERENCE,
+    UNMAPPED_UNPLACED,
+    SINGLE_REFERENCE
+}

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceContextType.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceContextType.java
@@ -10,7 +10,7 @@ package htsjdk.samtools.cram.ref;
  *      Any positive integer (including zero): Single Reference Slice
  */
 public enum ReferenceContextType {
-    MULTI_REFERENCE,
-    UNMAPPED_UNPLACED,
-    SINGLE_REFERENCE
+    MULTIPLE_REFERENCE_TYPE,
+    UNMAPPED_UNPLACED_TYPE,
+    SINGLE_REFERENCE_TYPE
 }

--- a/src/main/java/htsjdk/samtools/cram/structure/Container.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Container.java
@@ -81,11 +81,11 @@ public class Container {
      * - set the Container's Alignment Start and Span to cover all slices
      *
      * A Multiple Reference Container contains only Multiple Reference Slices.
-     * - set the Container's ReferenceContext to MULTIPLE
+     * - set the Container's ReferenceContext to MULTIPLE_REFERENCE_CONTEXT
      * - unset the Container's Alignment Start and Span
      *
      * An Unmapped Container contains only Unmapped Slices.
-     * - set the Container's ReferenceContext to UNMAPPED
+     * - set the Container's ReferenceContext to UNMAPPED_UNPLACED_CONTEXT
      * - unset the Container's Alignment Start and Span
      *
      * Any other combination is invalid.

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
@@ -56,13 +56,7 @@ public class ContainerIO {
      * @return a new {@link Container} object with container header values filled out but empty body (no slices and blocks).
      */
     public static Container readContainerHeader(final int major, final InputStream inputStream) {
-        final Container container = new Container();
-        final ContainerHeaderIO containerHeaderIO = new ContainerHeaderIO();
-        if (!containerHeaderIO.readContainerHeader(major, container, inputStream)) {
-            containerHeaderIO.readContainerHeader(container, new ByteArrayInputStream((major >= 3 ? CramIO.ZERO_F_EOF_MARKER : CramIO.ZERO_B_EOF_MARKER)));
-            return container;
-        }
-        return container;
+        return ContainerHeaderIO.readContainerHeader(major, inputStream);
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -86,8 +80,7 @@ public class ContainerIO {
 
         final List<Slice> slices = new ArrayList<Slice>();
         for (int sliceCount = fromSlice; sliceCount < howManySlices - fromSlice; sliceCount++) {
-            final Slice slice = new Slice();
-            SliceIO.read(major, slice, inputStream);
+            final Slice slice = SliceIO.read(major, inputStream);
             slice.index = sliceCount;
             slices.add(slice);
         }
@@ -126,7 +119,7 @@ public class ContainerIO {
      * @return the number of bytes written
      */
     public static int writeContainerHeader(final int major, final Container container, final OutputStream outputStream) {
-        return new ContainerHeaderIO().writeContainerHeader(major, container, outputStream);
+        return ContainerHeaderIO.writeContainerHeader(major, container, outputStream);
     }
 
     /**
@@ -149,7 +142,7 @@ public class ContainerIO {
                     firstBlock.write(version.major, byteArrayOutputStream);
                     container.containerByteSize = byteArrayOutputStream.size();
 
-                    final int containerHeaderByteSize = new ContainerHeaderIO().writeContainerHeader(version.major, container, outputStream);
+                    final int containerHeaderByteSize = ContainerHeaderIO.writeContainerHeader(version.major, container, outputStream);
                     try {
                         outputStream.write(byteArrayOutputStream.toByteArray(), 0, byteArrayOutputStream.size());
                     } catch (final IOException e) {
@@ -182,7 +175,7 @@ public class ContainerIO {
         container.containerByteSize = byteArrayOutputStream.size();
         calculateSliceOffsetsAndSizes(container);
 
-        int length = new ContainerHeaderIO().writeContainerHeader(version.major, container, outputStream);
+        int length = ContainerHeaderIO.writeContainerHeader(version.major, container, outputStream);
         try {
             outputStream.write(byteArrayOutputStream.toByteArray(), 0, byteArrayOutputStream.size());
         } catch (final IOException e) {

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -28,7 +28,9 @@ import htsjdk.samtools.cram.encoding.writer.CramRecordWriter;
 import htsjdk.samtools.cram.io.BitInputStream;
 import htsjdk.samtools.cram.io.DefaultBitInputStream;
 import htsjdk.samtools.cram.io.DefaultBitOutputStream;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.block.Block;
+import htsjdk.samtools.cram.ref.ReferenceContextType;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.SequenceUtil;
@@ -38,26 +40,23 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * CRAM slice is a logical union of blocks into for example alignment slices.
  */
 public class Slice {
-    public static final int MULTI_REFERENCE = -2;
     public static final int NO_ALIGNMENT_START = -1;
     public static final int NO_ALIGNMENT_SPAN = 0;
     public static final int NO_ALIGNMENT_END = SAMRecord.NO_ALIGNMENT_START; // 0
     private static final Log log = Log.getInstance(Slice.class);
 
-    // as defined in the specs:
-    public int sequenceId = -1;
-    public int alignmentStart = -1;
-    public int alignmentSpan = -1;
+    private final ReferenceContext referenceContext;
+
+    // header values as defined in the specs, in addition to sequenceId from ReferenceContext
+    public int alignmentStart = NO_ALIGNMENT_START;
+    public int alignmentSpan = NO_ALIGNMENT_SPAN;
     public int nofRecords = -1;
     public long globalRecordCounter = -1;
     public int nofBlocks = -1;
@@ -89,27 +88,47 @@ public class Slice {
 
     public SAMBinaryTagAndValue sliceTags;
 
+    /**
+     * Construct this Slice by providing its {@link ReferenceContext}
+     * @param refContext the reference context associated with this slice
+     */
+    public Slice(final ReferenceContext refContext) {
+        this.referenceContext = refContext;
+    }
+
+    public ReferenceContext getReferenceContext() {
+        return referenceContext;
+    }
+
     private void alignmentBordersSanityCheck(final byte[] ref) {
-        if (sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) return ;
-        if (alignmentStart > 0 && sequenceId >= 0 && ref == null) throw new IllegalArgumentException ("Mapped slice reference is null.");
+        if (referenceContext.isUnmappedUnplaced()) {
+            return;
+        }
+
+        if (alignmentStart > 0 && referenceContext.isMappedSingleRef() && ref == null) {
+            throw new IllegalArgumentException ("Mapped slice reference is null.");
+        }
 
         if (alignmentStart > ref.length) {
-            log.error(String.format("Slice mapped outside of reference: seqID=%d, start=%d, counter=%d.", sequenceId, alignmentStart,
-                    globalRecordCounter));
+            log.error(String.format("Slice mapped outside of reference: seqID=%s, start=%d, counter=%d.",
+                    referenceContext, alignmentStart, globalRecordCounter));
             throw new RuntimeException("Slice mapped outside of the reference.");
         }
 
         if (alignmentStart - 1 + alignmentSpan > ref.length) {
-            log.warn(String.format("Slice partially mapped outside of reference: seqID=%d, start=%d, span=%d, counter=%d.",
-                    sequenceId, alignmentStart, alignmentSpan, globalRecordCounter));
+            log.warn(String.format("Slice partially mapped outside of reference: seqID=%s, start=%d, span=%d, counter=%d.",
+                    referenceContext, alignmentStart, alignmentSpan, globalRecordCounter));
         }
     }
 
     public boolean validateRefMD5(final byte[] ref) {
-        if(sequenceId == Slice.MULTI_REFERENCE)
+        if (referenceContext.isMultiRef()) {
             throw new SAMException("Cannot verify a slice with multiple references on a single reference.");
+        }
 
-        if (sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) return true;
+        if (referenceContext.isUnmappedUnplaced()) {
+            return true;
+        }
 
         alignmentBordersSanityCheck(ref);
 
@@ -118,12 +137,14 @@ public class Slice {
             final String excerpt = getBrief(alignmentStart, alignmentSpan, ref, shoulderLength);
 
             if (validateRefMD5(ref, alignmentStart, alignmentSpan - 1, refMD5)) {
-                log.warn(String.format("Reference MD5 matches partially for slice %d:%d-%d, %s", sequenceId, alignmentStart,
+                log.warn(String.format("Reference MD5 matches partially for slice %s:%d-%d, %s",
+                        referenceContext, alignmentStart,
                         alignmentStart + alignmentSpan - 1, excerpt));
                 return true;
             }
 
-            log.error(String.format("Reference MD5 mismatch for slice %d:%d-%d, %s", sequenceId, alignmentStart, alignmentStart +
+            log.error(String.format("Reference MD5 mismatch for slice %s:%d-%d, %s",
+                    referenceContext, alignmentStart, alignmentStart +
                     alignmentSpan - 1, excerpt));
             return false;
         }
@@ -160,13 +181,14 @@ public class Slice {
 
     @Override
     public String toString() {
-        return String.format("slice: seqID %d, start %d, span %d, records %d.", sequenceId, alignmentStart, alignmentSpan, nofRecords);
+        return String.format("slice: seqID %s, start %d, span %d, records %d.",
+                referenceContext, alignmentStart, alignmentSpan, nofRecords);
     }
 
     public void setRefMD5(final byte[] ref) {
         alignmentBordersSanityCheck(ref);
 
-        if (sequenceId < 0 && alignmentStart < 1) {
+        if (! referenceContext.isMappedSingleRef() && alignmentStart < 1) {
             refMD5 = new byte[16];
             Arrays.fill(refMD5, (byte) 0);
 
@@ -190,9 +212,9 @@ public class Slice {
                     sb.append(getBrief(alignmentStart, alignmentSpan, ref, shoulder));
                 }
 
-                log.debug(String.format("Slice md5: %s for %d:%d-%d, %s",
+                log.debug(String.format("Slice md5: %s for %s:%d-%d, %s",
                         String.format("%032x", new BigInteger(1, refMD5)),
-                        sequenceId, alignmentStart, alignmentStart + span - 1,
+                        referenceContext, alignmentStart, alignmentStart + span - 1,
                         sb.toString()));
             }
         }
@@ -257,32 +279,6 @@ public class Slice {
         }
     }
 
-    /**
-     * Does this Slice contain only unplaced reads (whether their unmapped flags are set or not)?
-     * @return true if the Slice is designated as Unmapped
-     */
-    public boolean isUnmapped() {
-        return sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-    }
-
-    /**
-     * Does this Slice contain either:
-     * - reads placed on multiple references
-     * - or a combination of placed and unplaced reads?
-     * @return true if the Slice contains reads places on multiple references or are a combination of placed and unplaced
-     */
-    public boolean isMultiref() {
-        return sequenceId == Slice.MULTI_REFERENCE;
-    }
-
-    /**
-     * Does this Slice contain reads placed on a single reference (whether their unmapped flags are set or not)?
-     * @return true if all reads in the Slice are placed on a single reference
-     */
-    public boolean isMappedSingleRef() {
-        return ! isUnmapped() && ! isMultiref();
-    }
-
     private BitInputStream getCoreBlockInputStream() {
         return new DefaultBitInputStream(new ByteArrayInputStream(coreBlock.getUncompressedContent()));
     }
@@ -306,7 +302,7 @@ public class Slice {
         return new CramRecordReader(getCoreBlockInputStream(),
                 getExternalBlockInputMap(),
                 header,
-                sequenceId,
+                referenceContext,
                 validationStringency);
     }
 
@@ -317,7 +313,7 @@ public class Slice {
      * @param header               the associated Cram Compression Header
      * @param validationStringency how strict to be when reading CRAM records
      */
-    public Map<Integer, AlignmentSpan> getMultiRefAlignmentSpans(final CompressionHeader header,
+    public Map<ReferenceContext, AlignmentSpan> getMultiRefAlignmentSpans(final CompressionHeader header,
                                                                  final ValidationStringency validationStringency) {
         final MultiRefSliceAlignmentSpanReader reader = new MultiRefSliceAlignmentSpanReader(getCoreBlockInputStream(),
                 getExternalBlockInputMap(),
@@ -333,7 +329,7 @@ public class Slice {
      * @return a new CRAI Index Entry
      */
     public CRAIEntry getCRAIEntry() {
-        return new CRAIEntry(sequenceId, alignmentStart, alignmentSpan, containerOffset, offset, size);
+        return new CRAIEntry(referenceContext.getSerializableId(), alignmentStart, alignmentSpan, containerOffset, offset, size);
     }
     /**
      * Generate a CRAI Index entry from this Slice and the container offset.
@@ -345,7 +341,7 @@ public class Slice {
      * @return a new CRAI Index Entry
      */
     public CRAIEntry getCRAIEntry(final long containerStartOffset) {
-        return new CRAIEntry(sequenceId, alignmentStart, alignmentSpan, containerStartOffset, offset, size);
+        return new CRAIEntry(referenceContext.getSerializableId(), alignmentStart, alignmentSpan, containerStartOffset, offset, size);
     }
 
     /**
@@ -359,78 +355,17 @@ public class Slice {
      */
     public static Slice buildSlice(final List<CramCompressionRecord> records,
                                    final CompressionHeader header) {
+        final Slice slice = initializeFromRecords(records);
+
         final Map<Integer, ByteArrayOutputStream> externalBlockMap = new HashMap<>();
         for (final int id : header.externalIds) {
             externalBlockMap.put(id, new ByteArrayOutputStream());
         }
 
-        final Slice slice = new Slice();
-        slice.nofRecords = records.size();
-
-        int minAlStart = Integer.MAX_VALUE;
-        int maxAlEnd = SAMRecord.NO_ALIGNMENT_START;
-        {
-            // @formatter:off
-            /*
-             * 1) Count slice bases.
-             * 2) Decide if the slice is single ref, unmapped or multi reference.
-             * 3) Detect alignment boundaries for the slice if not multi reference.
-             */
-            // @formatter:on
-
-            // Valid Slice states, by individual record contents:
-            //
-            // Single Reference: all records have valid placements/alignments on the same reference sequence
-            //      * records can be unmapped-but-placed
-            //      * reference can be external or embedded
-            // Multiple Reference: records may be placed or not, and may have differing reference sequences
-            //      * reference must not be embedded (not checked here)
-            // Unmapped: all records are unmapped and unplaced
-
-            final CramCompressionRecord firstRecord = records.get(0);
-            slice.sequenceId = firstRecord.isPlaced() ?
-                    firstRecord.sequenceId :
-                    SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-
-            final ContentDigests hasher = ContentDigests.create(ContentDigests.ALL);
-            for (final CramCompressionRecord record : records) {
-                slice.bases += record.readLength;
-                hasher.add(record);
-
-                // flip an unmapped slice to multi-ref if the record is placed
-                if (slice.isUnmapped() && record.isPlaced()) {
-                    slice.sequenceId = MULTI_REFERENCE;
-                }
-                else if (slice.isMappedSingleRef()) {
-                    // flip a single-ref slice to multi-ref if the record is unplaced or on a different ref
-                    if (!record.isPlaced() || slice.sequenceId != record.sequenceId) {
-                        slice.sequenceId = MULTI_REFERENCE;
-                    }
-                    else {
-                        // calculate single ref slice alignment
-
-                        minAlStart = Math.min(record.alignmentStart, minAlStart);
-                        maxAlEnd = Math.max(record.getAlignmentEnd(), maxAlEnd);
-                    }
-                }
-            }
-
-            slice.sliceTags = hasher.getAsTags();
-        }
-
-        if (slice.isMappedSingleRef()) {
-            slice.alignmentStart = minAlStart;
-            slice.alignmentSpan = maxAlEnd - minAlStart + 1;
-        }
-        else {
-            slice.alignmentStart = NO_ALIGNMENT_START;
-            slice.alignmentSpan = NO_ALIGNMENT_SPAN;
-        }
-
         try (final ByteArrayOutputStream bitBAOS = new ByteArrayOutputStream();
              final DefaultBitOutputStream bitOutputStream = new DefaultBitOutputStream(bitBAOS)) {
 
-            final CramRecordWriter writer = new CramRecordWriter(bitOutputStream, externalBlockMap, header, slice.sequenceId);
+            final CramRecordWriter writer = new CramRecordWriter(bitOutputStream, externalBlockMap, header, slice.referenceContext);
             writer.writeCramCompressionRecords(records, slice.alignmentStart);
 
             bitOutputStream.close();
@@ -458,4 +393,75 @@ public class Slice {
         return slice;
     }
 
+    /**
+     * Using a collection of {@link CramCompressionRecord}s,
+     * determine whether the slice is single ref, unmapped or multi reference.
+     * Derive alignment boundaries for the slice if single ref.
+     *
+     * Valid Slice states, by individual record contents:
+     *
+     * Single Reference: all records have valid placements/alignments on the same reference sequence
+     * - records can be unmapped-but-placed
+     * - reference can be external or embedded
+     *
+     * Multiple Reference: records may be placed or not, and may have differing reference sequences
+     * - reference must not be embedded (not checked here)
+     *
+     * Unmapped: all records are unmapped and unplaced
+     * - note however that we do not actually check mapping flags for unplaced reads.
+     * @see CramCompressionRecord#isPlaced()
+     *
+     * @see ReferenceContextType
+     * @param records the input records
+     * @return the initialized Slice
+     */
+    private static Slice initializeFromRecords(final Collection<CramCompressionRecord> records) {
+        final ContentDigests hasher = ContentDigests.create(ContentDigests.ALL);
+        int baseCount = 0;
+        final Set<ReferenceContext> referenceContexts = new HashSet<>();
+        // ignore these values if we later determine this Slice is not single-ref
+        int singleRefAlignmentStart = Integer.MAX_VALUE;
+        int singleRefAlignmentEnd = SAMRecord.NO_ALIGNMENT_START;
+
+        for (final CramCompressionRecord record : records) {
+            hasher.add(record);
+            baseCount += record.readLength;
+
+            if (record.isPlaced()) {
+                referenceContexts.add(new ReferenceContext(record.sequenceId));
+                singleRefAlignmentStart = Math.min(record.alignmentStart, singleRefAlignmentStart);
+                singleRefAlignmentEnd = Math.max(record.getAlignmentEnd(), singleRefAlignmentEnd);
+            }
+            else {
+                referenceContexts.add(ReferenceContext.UNMAPPED);
+            }
+        }
+
+        ReferenceContext sliceRefContext;
+        switch (referenceContexts.size()) {
+            case 0:
+                sliceRefContext = ReferenceContext.UNMAPPED;
+                break;
+            case 1:
+                // SINGLE REF: all reads placed on the same reference
+                // or UNMAPPED_UNPLACED: all reads unplaced
+                sliceRefContext = referenceContexts.iterator().next();
+                break;
+            default:
+                // placed reads on multiple references and/or a combination of placed and unplaced reads
+                sliceRefContext = ReferenceContext.MULTIPLE;
+        }
+
+        final Slice slice = new Slice(sliceRefContext);
+        if (sliceRefContext.isMappedSingleRef()) {
+            slice.alignmentStart = singleRefAlignmentStart;
+            slice.alignmentSpan = singleRefAlignmentEnd - singleRefAlignmentStart + 1;
+        }
+
+        slice.sliceTags = hasher.getAsTags();
+        slice.bases = baseCount;
+        slice.nofRecords = records.size();
+
+        return slice;
+    }
 }

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -433,23 +433,23 @@ public class Slice {
                 singleRefAlignmentEnd = Math.max(record.getAlignmentEnd(), singleRefAlignmentEnd);
             }
             else {
-                referenceContexts.add(ReferenceContext.UNMAPPED);
+                referenceContexts.add(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
             }
         }
 
         ReferenceContext sliceRefContext;
         switch (referenceContexts.size()) {
             case 0:
-                sliceRefContext = ReferenceContext.UNMAPPED;
+                sliceRefContext = ReferenceContext.UNMAPPED_UNPLACED_CONTEXT;
                 break;
             case 1:
-                // SINGLE REF: all reads placed on the same reference
-                // or UNMAPPED_UNPLACED: all reads unplaced
+                // SINGLE_REFERENCE_TYPE context: all reads placed on the same reference
+                // or UNMAPPED_UNPLACED_CONTEXT: all reads unplaced
                 sliceRefContext = referenceContexts.iterator().next();
                 break;
             default:
                 // placed reads on multiple references and/or a combination of placed and unplaced reads
-                sliceRefContext = ReferenceContext.MULTIPLE;
+                sliceRefContext = ReferenceContext.MULTIPLE_REFERENCE_CONTEXT;
         }
 
         final Slice slice = new Slice(sliceRefContext);

--- a/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
@@ -10,7 +10,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +36,7 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
         return record;
     }
     @Test
-    public void test_processMultiContainer() throws IOException, IllegalAccessException {
+    public void test_processMultiContainer() {
         SAMFileHeader samFileHeader = new SAMFileHeader();
         samFileHeader.addSequence(new SAMSequenceRecord("1", 10));
         samFileHeader.addSequence(new SAMSequenceRecord("2", 10));
@@ -54,7 +53,7 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
         final Container container1 = containerFactory.buildContainer(records);
         Assert.assertNotNull(container1);
         Assert.assertEquals(container1.nofRecords, records.size());
-        Assert.assertEquals(container1.sequenceId, Slice.MULTI_REFERENCE);
+        Assert.assertTrue(container1.getReferenceContext().isMultiRef());
 
         indexer.processContainer(container1, ValidationStringency.STRICT);
 
@@ -62,10 +61,10 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
         records.add(createRecord(3, 1, 3));
         records.add(createRecord(4, 2, 3));
         records.add(createRecord(5, 2, 4));
-        final Container  container2 = containerFactory.buildContainer(records);
+        final Container container2 = containerFactory.buildContainer(records);
         Assert.assertNotNull(container2);
         Assert.assertEquals(container2.nofRecords, records.size());
-        Assert.assertEquals(container2.sequenceId, Slice.MULTI_REFERENCE);
+        Assert.assertTrue(container2.getReferenceContext().isMultiRef());
 
         indexer.processContainer(container2, ValidationStringency.STRICT);
 

--- a/src/test/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
@@ -3,6 +3,7 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.cram.build.ContainerParser;
 import htsjdk.samtools.cram.build.CramContainerIterator;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.cram.structure.AlignmentSpan;
 import htsjdk.samtools.cram.structure.Container;
@@ -173,23 +174,23 @@ public class CRAMFileBAIIndexTest extends HtsjdkTest {
     }
 
     @Test
-    public void testIteratorFromFileSpan_SecondContainer() throws IOException, IllegalAccessException {
+    public void testIteratorFromFileSpan_SecondContainer() throws IOException {
         CramContainerIterator it = new CramContainerIterator(new ByteArrayInputStream(cramBytes));
         it.hasNext();
         it.next();
         it.hasNext();
         Container secondContainer = it.next();
         Assert.assertNotNull(secondContainer);
-        final Map<Integer, AlignmentSpan> references = new ContainerParser(it.getCramHeader().getSamFileHeader()).getReferences(secondContainer, ValidationStringency.STRICT);
+        final Map<ReferenceContext, AlignmentSpan> references = new ContainerParser(it.getCramHeader().getSamFileHeader()).getReferences(secondContainer, ValidationStringency.STRICT);
         it.close();
-        int refId = new TreeSet<Integer>(references.keySet()).iterator().next();
-        final AlignmentSpan alignmentSpan = references.get(refId);
+        final ReferenceContext referenceContext = new TreeSet<>(references.keySet()).iterator().next();
+        final AlignmentSpan alignmentSpan = references.get(referenceContext);
 
         CRAMFileReader reader = new CRAMFileReader(new ByteArraySeekableStream(cramBytes), new ByteArraySeekableStream(baiBytes), source, ValidationStringency.SILENT);
         reader.setValidationStringency(ValidationStringency.SILENT);
 
         final BAMIndex index = reader.getIndex();
-        final SAMFileSpan spanOfSecondContainer = index.getSpanOverlapping(refId, alignmentSpan.getStart(), alignmentSpan.getStart()+ alignmentSpan.getSpan());
+        final SAMFileSpan spanOfSecondContainer = index.getSpanOverlapping(referenceContext.getSequenceId(), alignmentSpan.getStart(), alignmentSpan.getStart()+ alignmentSpan.getSpan());
         Assert.assertNotNull(spanOfSecondContainer);
         Assert.assertFalse(spanOfSecondContainer.isEmpty());
         Assert.assertTrue(spanOfSecondContainer instanceof BAMFileSpan);
@@ -200,7 +201,7 @@ public class CRAMFileBAIIndexTest extends HtsjdkTest {
         boolean matchFound = false;
         while (iterator.hasNext()) {
             final SAMRecord record = iterator.next();
-            if (record.getReferenceIndex().intValue() == refId) {
+            if (record.getReferenceIndex() == referenceContext.getSequenceId()) {
                 boolean overlaps = CoordMath.overlaps(record.getAlignmentStart(), record.getAlignmentEnd(), alignmentSpan.getStart(), alignmentSpan.getStart()+ alignmentSpan.getSpan());
                 if (overlaps) matchFound = true;
             }

--- a/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
@@ -39,7 +39,7 @@ public class CramContainerHeaderIteratorTest extends HtsjdkTest {
             Container fullContainer = fullContainers.get(i);
             Container headerOnlyContainer = headerOnlyContainers.get(i);
             Assert.assertEquals(headerOnlyContainer.containerByteSize, fullContainer.containerByteSize);
-            Assert.assertEquals(headerOnlyContainer.sequenceId, fullContainer.sequenceId);
+            Assert.assertEquals(headerOnlyContainer.getReferenceContext(), fullContainer.getReferenceContext());
             Assert.assertEquals(headerOnlyContainer.alignmentStart, fullContainer.alignmentStart);
             Assert.assertEquals(headerOnlyContainer.alignmentSpan, fullContainer.alignmentSpan);
             Assert.assertEquals(headerOnlyContainer.nofRecords, fullContainer.nofRecords);

--- a/src/test/java/htsjdk/samtools/cram/CRAIEntryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAIEntryTest.java
@@ -1,6 +1,7 @@
 package htsjdk.samtools.cram;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.Container;
 import htsjdk.samtools.cram.structure.Slice;
 import org.testng.Assert;
@@ -16,23 +17,22 @@ import java.util.List;
 public class CRAIEntryTest extends HtsjdkTest {
     @Test
     public void testFromContainer() {
-        final Container container = new Container();
-        final Slice slice = new Slice();
-        slice.sequenceId = 1;
+        final Slice slice = new Slice(new ReferenceContext(1));
         slice.alignmentStart = 2;
         slice.alignmentSpan = 3;
         slice.containerOffset = 4;
         slice.offset = 5;
         slice.size = 6;
+
+        final Container container = Container.initializeFromSlices(Collections.singletonList(slice));
         container.landmarks = new int[]{7};
-        container.slices = new Slice[]{slice};
 
         final List<CRAIEntry> entries = container.getCRAIEntries();
         Assert.assertNotNull(entries);
         Assert.assertEquals(entries.size(), 1);
         final CRAIEntry entry = entries.get(0);
 
-        Assert.assertEquals(entry.getSequenceId(), slice.sequenceId);
+        Assert.assertEquals(entry.getSequenceId(), slice.getReferenceContext().getSequenceId());
         Assert.assertEquals(entry.getAlignmentStart(), slice.alignmentStart);
         Assert.assertEquals(entry.getAlignmentSpan(), slice.alignmentSpan);
         Assert.assertEquals(entry.getContainerStartByteOffset(), slice.containerOffset);

--- a/src/test/java/htsjdk/samtools/cram/build/ContainerFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/ContainerFactoryTest.java
@@ -1,307 +1,111 @@
 package htsjdk.samtools.cram.build;
 
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMRecord;
-import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.Container;
 import htsjdk.samtools.cram.structure.CramCompressionRecord;
+import htsjdk.samtools.cram.structure.CramCompressionRecordUtil;
 import htsjdk.samtools.cram.structure.Slice;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
  * Created by vadim on 15/12/2015.
  */
 public class ContainerFactoryTest extends HtsjdkTest {
-    static final int TEST_RECORD_COUNT = 10;
-    static final int READ_LENGTH_FOR_TEST_RECORDS = 123;
+    private static final int TEST_RECORD_COUNT = 10;
 
-    private static final SAMFileHeader header = initializeSAMFileHeaderForTests();
+    @DataProvider(name = "containerStateTests")
+    private Object[][] containerStateTests() {
+        final int mappedSequenceId = 0;  // arbitrary
+        final ReferenceContext mappedRefContext = new ReferenceContext(mappedSequenceId);
+        final int mappedAlignmentStart = 1;
+        final int mappedAlignmentSpan = CramCompressionRecordUtil.READ_LENGTH_FOR_TEST_RECORDS + TEST_RECORD_COUNT - 1;
 
-    private static SAMFileHeader initializeSAMFileHeaderForTests() {
-        final SAMFileHeader header = new SAMFileHeader();
+        return new Object[][]{
+                {
+                        CramCompressionRecordUtil.getSingleRefRecords(TEST_RECORD_COUNT, mappedSequenceId),
+                        mappedRefContext, mappedAlignmentStart, mappedAlignmentSpan
+                },
+                {
+                        CramCompressionRecordUtil.getMultiRefRecords(TEST_RECORD_COUNT),
+                        ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                },
+                {
+                        CramCompressionRecordUtil.getUnmappedRecords(TEST_RECORD_COUNT),
+                        ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                },
 
-        // arbitrary names and length.  Just ensure we have 10 different valid refs.
+                // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
+                // but not both.  We treat these weird edge cases as unplaced.
 
-        header.addSequence(new SAMSequenceRecord("0", 10));
-        header.addSequence(new SAMSequenceRecord("1", 10));
-        header.addSequence(new SAMSequenceRecord("2", 10));
-        header.addSequence(new SAMSequenceRecord("3", 10));
-        header.addSequence(new SAMSequenceRecord("4", 10));
-        header.addSequence(new SAMSequenceRecord("5", 10));
-        header.addSequence(new SAMSequenceRecord("6", 10));
-        header.addSequence(new SAMSequenceRecord("7", 10));
-        header.addSequence(new SAMSequenceRecord("8", 10));
-        header.addSequence(new SAMSequenceRecord("9", 10));
+                {
+                        CramCompressionRecordUtil.getHalfUnmappedNoRefRecords(TEST_RECORD_COUNT),
+                        ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                },
+                {
+                        CramCompressionRecordUtil.getHalfUnmappedNoStartRecords(TEST_RECORD_COUNT, mappedSequenceId),
+                        ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                },
 
-        return header;
+                // show that unmapped-unplaced reads cause a single ref slice/container to become multiref
+
+                {
+                        CramCompressionRecordUtil.getSingleRefRecordsWithOneUnmapped(TEST_RECORD_COUNT, mappedSequenceId),
+                        ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                },
+
+                // show that unmapped-unplaced reads don't change the state of a multi-ref slice/container
+
+                {
+                        CramCompressionRecordUtil.getMultiRefRecordsWithOneUnmapped(TEST_RECORD_COUNT),
+                        ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                },
+        };
     }
 
-    static SAMFileHeader getSAMFileHeaderForTests() {
-        return header;
-    }
-
-    static List<CramCompressionRecord> getSingleRefRecords(final int recordCount) {
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < recordCount; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-
-            if (i % 2 == 0) {
-                record.setSegmentUnmapped(true);
-            }
-
-            records.add(record);
-        }
-        return records;
-    }
-
-    static List<CramCompressionRecord> getUnmappedRecords() {
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-            record.setSegmentUnmapped(true);
-            record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
-            record.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-            records.add(record);
-        }
-        return records;
-    }
-
-    // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
-    // but not both.  We treat these weird edge cases as unplaced.
-
-    static List<CramCompressionRecord> getUnmappedNoRefRecords() {
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-            record.setSegmentUnmapped(true);
-            record.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-            records.add(record);
-        }
-        return records;
-    }
-
-    static List<CramCompressionRecord> getUnmappedNoStartRecords() {
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-            record.setSegmentUnmapped(true);
-            record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
-            record.setLastSegment(true);
-            records.add(record);
-        }
-        return records;
-    }
-
-    static List<CramCompressionRecord> getMultiRefRecords() {
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-            record.sequenceId = i;
-
-            if (i % 2 == 0) {
-                record.setSegmentUnmapped(true);
-            }
-
-            records.add(record);
-        }
-        return records;
-    }
-
-    static List<Container> getMultiRefContainersForStateTest() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final List<Container> testContainers = new ArrayList<>(3);
-
-        final List<CramCompressionRecord> records = new ArrayList<>();
-
-        final CramCompressionRecord record0 = createMappedRecord(0);
-        record0.sequenceId = 0;
-        records.add(record0);
-        final Container container0 = factory.buildContainer(records);
-
-        final CramCompressionRecord record1 = createMappedRecord(1);
-        record1.sequenceId = 1;
-        records.add(record1);
-        final Container container1 = factory.buildContainer(records);
-
-        final CramCompressionRecord unmapped = createMappedRecord(2);
-        unmapped.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
-        unmapped.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-        unmapped.setSegmentUnmapped(true);
-        records.add(unmapped);
-        final Container container2 = factory.buildContainer(records);
-
-        testContainers.add(container0);
-        testContainers.add(container1);
-        testContainers.add(container2);
-        return testContainers;
-    }
-
-    private static CramCompressionRecord createMappedRecord(int i) {
-        final CramCompressionRecord record = new CramCompressionRecord();
-        record.readBases = "AAA".getBytes();
-        record.qualityScores = "!!!".getBytes();
-        record.readLength = READ_LENGTH_FOR_TEST_RECORDS;
-        record.readName = "" + i;
-        record.sequenceId = 0;
-        record.alignmentStart = i + 1;
-        record.setLastSegment(true);
-        record.setSegmentUnmapped(false);
-        record.readFeatures = Collections.emptyList();
-        return record;
+    @Test(dataProvider = "containerStateTests")
+    public void testContainerState(final List<CramCompressionRecord> records,
+                                   final ReferenceContext expectedReferenceContext,
+                                   final int expectedAlignmentStart,
+                                   final int expectedAlignmentSpan) {
+        final Container container = buildFromNewFactory(records);
+        assertContainerState(container, expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan);
     }
 
     @Test
-    public void testMapped() {
-        final ReferenceContext refContext = new ReferenceContext(0);
-        final int alignmentStart = 1;
-        final int alignmentSpan = READ_LENGTH_FOR_TEST_RECORDS + TEST_RECORD_COUNT - 1;
-
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final Container container = factory.buildContainer(getSingleRefRecords(TEST_RECORD_COUNT));
-        assertContainerState(container, refContext, alignmentStart, alignmentSpan);
-    }
-
-    @Test
-    public void testUnmapped() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final Container container = factory.buildContainer(getUnmappedRecords());
-        assertContainerState(container, ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
-    }
-
-    // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
-    // but not both.  We treat these weird edge cases as unplaced.
-
-    @Test
-    public void testUnmappedNoReferenceId() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final Container container = factory.buildContainer(getUnmappedNoRefRecords());
-        assertContainerState(container, ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
-    }
-
-    @Test
-    public void testUnmappedNoAlignmentStart() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final Container container = factory.buildContainer(getUnmappedNoStartRecords());
-        assertContainerState(container, ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
-    }
-
-    @Test
-    public void testMultiref() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final Container container = factory.buildContainer(getMultiRefRecords());
-        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
-    }
-
-    @Test
-    public void testMultirefWithStateTransitions() {
-        final List<Container> containers = getMultiRefContainersForStateTest();
+    public void testMultiRefWithStateTransitions() {
+        final List<Container> containers = CramCompressionRecordUtil.getMultiRefContainersForStateTest();
 
         // first container is single-ref
 
         final ReferenceContext refContext = new ReferenceContext(0);
         final int alignmentStart = 1;
-        final int alignmentSpan = READ_LENGTH_FOR_TEST_RECORDS;
+        final int alignmentSpan = CramCompressionRecordUtil.READ_LENGTH_FOR_TEST_RECORDS;
         int recordCount = 1;
         int globalRecordCount = 0; // first container - no records yet
         assertContainerState(containers.get(0), refContext, alignmentStart, alignmentSpan,
-                globalRecordCount, recordCount, READ_LENGTH_FOR_TEST_RECORDS * recordCount);
+                globalRecordCount, recordCount, CramCompressionRecordUtil.READ_LENGTH_FOR_TEST_RECORDS * recordCount);
 
         // when other refs are added, subsequent containers are multiref
 
         recordCount++;  // this container has 2 records
         globalRecordCount = containers.get(0).nofRecords;   // we've seen 1 record before this container
         assertContainerState(containers.get(1), ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
-                globalRecordCount, recordCount, READ_LENGTH_FOR_TEST_RECORDS * recordCount);
+                globalRecordCount, recordCount, CramCompressionRecordUtil.READ_LENGTH_FOR_TEST_RECORDS * recordCount);
 
         recordCount++;  // this container has 3 records
         globalRecordCount = containers.get(0).nofRecords + containers.get(1).nofRecords;    // we've seen 3 records before this container
         assertContainerState(containers.get(2), ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
-                globalRecordCount, recordCount, READ_LENGTH_FOR_TEST_RECORDS * recordCount);
+                globalRecordCount, recordCount, CramCompressionRecordUtil.READ_LENGTH_FOR_TEST_RECORDS * recordCount);
     }
 
-    // show that unmapped-unplaced reads cause a single ref slice/container to become multiref
-
-    @Test
-    public void singleRefWithUnmappedNoRef() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-
-            if (i % 2 == 0) {
-                record.setSegmentUnmapped(true);
-                record.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-            }
-
-            records.add(record);
-        }
-
-        final Container container = factory.buildContainer(records);
-        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
-    }
-
-    @Test
-    public void singleRefWithUnmappedNoStart() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-
-            if (i % 2 == 0) {
-                record.setSegmentUnmapped(true);
-                record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
-            }
-
-            records.add(record);
-        }
-
-        final Container container = factory.buildContainer(records);
-        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
-    }
-
-    // show that unmapped-unplaced reads don't change the state of a multi-ref slice/container
-
-    @Test
-    public void multiRefWithUnmappedNoRef() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-
-            if (i % 2 == 0) {
-                record.setSegmentUnmapped(true);
-                record.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-            }
-            records.add(record);
-        }
-
-        final Container container = factory.buildContainer(records);
-        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
-    }
-
-    @Test
-    public void multiRefWithUnmappedNoStart() {
-        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
-        final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord record = createMappedRecord(i);
-
-            if (i % 2 == 0) {
-                record.setSegmentUnmapped(true);
-                record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
-            }
-            records.add(record);
-        }
-
-        final Container container = factory.buildContainer(records);
-        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+    private Container buildFromNewFactory(final List<CramCompressionRecord> records) {
+        final ContainerFactory factory = new ContainerFactory(CramCompressionRecordUtil.getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
+        return factory.buildContainer(records);
     }
 
     private void assertContainerState(final Container container,
@@ -309,7 +113,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                                       final int alignmentStart,
                                       final int alignmentSpan) {
         final int globalRecordCounter = 0; // first Container
-        final int baseCount = TEST_RECORD_COUNT * READ_LENGTH_FOR_TEST_RECORDS;
+        final int baseCount = TEST_RECORD_COUNT * CramCompressionRecordUtil.READ_LENGTH_FOR_TEST_RECORDS;
 
         assertContainerState(container, referenceContext, alignmentStart, alignmentSpan, globalRecordCounter, TEST_RECORD_COUNT, baseCount);
     }

--- a/src/test/java/htsjdk/samtools/cram/build/ContainerFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/ContainerFactoryTest.java
@@ -172,7 +172,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
     public void testUnmapped() {
         final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
         final Container container = factory.buildContainer(getUnmappedRecords());
-        assertContainerState(container, ReferenceContext.UNMAPPED, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertContainerState(container, ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
@@ -182,21 +182,21 @@ public class ContainerFactoryTest extends HtsjdkTest {
     public void testUnmappedNoReferenceId() {
         final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
         final Container container = factory.buildContainer(getUnmappedNoRefRecords());
-        assertContainerState(container, ReferenceContext.UNMAPPED, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertContainerState(container, ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
     public void testUnmappedNoAlignmentStart() {
         final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
         final Container container = factory.buildContainer(getUnmappedNoStartRecords());
-        assertContainerState(container, ReferenceContext.UNMAPPED, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertContainerState(container, ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
     public void testMultiref() {
         final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
         final Container container = factory.buildContainer(getMultiRefRecords());
-        assertContainerState(container, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
@@ -217,12 +217,12 @@ public class ContainerFactoryTest extends HtsjdkTest {
 
         recordCount++;  // this container has 2 records
         globalRecordCount = containers.get(0).nofRecords;   // we've seen 1 record before this container
-        assertContainerState(containers.get(1), ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
+        assertContainerState(containers.get(1), ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
                 globalRecordCount, recordCount, READ_LENGTH_FOR_TEST_RECORDS * recordCount);
 
         recordCount++;  // this container has 3 records
         globalRecordCount = containers.get(0).nofRecords + containers.get(1).nofRecords;    // we've seen 3 records before this container
-        assertContainerState(containers.get(2), ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
+        assertContainerState(containers.get(2), ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
                 globalRecordCount, recordCount, READ_LENGTH_FOR_TEST_RECORDS * recordCount);
     }
 
@@ -244,7 +244,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
         }
 
         final Container container = factory.buildContainer(records);
-        assertContainerState(container, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
@@ -263,7 +263,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
         }
 
         final Container container = factory.buildContainer(records);
-        assertContainerState(container, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     // show that unmapped-unplaced reads don't change the state of a multi-ref slice/container
@@ -283,7 +283,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
         }
 
         final Container container = factory.buildContainer(records);
-        assertContainerState(container, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
@@ -301,7 +301,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
         }
 
         final Container container = factory.buildContainer(records);
-        assertContainerState(container, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertContainerState(container, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     private void assertContainerState(final Container container,

--- a/src/test/java/htsjdk/samtools/cram/build/ContainerParserTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/ContainerParserTest.java
@@ -2,14 +2,11 @@ package htsjdk.samtools.cram.build;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMFileHeader;
-import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.cram.common.CramVersions;
 import htsjdk.samtools.cram.common.Version;
-import htsjdk.samtools.cram.structure.AlignmentSpan;
-import htsjdk.samtools.cram.structure.Container;
-import htsjdk.samtools.cram.structure.ContainerIO;
-import htsjdk.samtools.cram.structure.CramCompressionRecord;
+import htsjdk.samtools.cram.ref.ReferenceContext;
+import htsjdk.samtools.cram.structure.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -23,8 +20,8 @@ import java.util.*;
  * Created by vadim on 11/01/2016.
  */
 public class ContainerParserTest extends HtsjdkTest {
-
-    static private final int TEST_RECORD_COUNT = 10;
+    private static final int TEST_RECORD_COUNT = ContainerFactoryTest.TEST_RECORD_COUNT;
+    private static final int READ_LENGTH_FOR_TEST_RECORDS = ContainerFactoryTest.READ_LENGTH_FOR_TEST_RECORDS;
 
     @DataProvider(name = "eof")
     private Object[][] eofData() {
@@ -50,15 +47,11 @@ public class ContainerParserTest extends HtsjdkTest {
         return new Object[][] {
                 {
                         ContainerFactoryTest.getSingleRefRecords(TEST_RECORD_COUNT),
-                        new HashSet<Integer>() {{
-                            add(0);
-                        }}
+                        Collections.singleton(new ReferenceContext(0))
                 },
                 {
                         ContainerFactoryTest.getUnmappedRecords(),
-                        new HashSet<Integer>() {{
-                            add(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
-                        }}
+                        Collections.singleton(ReferenceContext.UNMAPPED)
                 },
 
                 // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
@@ -66,28 +59,24 @@ public class ContainerParserTest extends HtsjdkTest {
 
                 {
                         ContainerFactoryTest.getUnmappedNoRefRecords(),
-                        new HashSet<Integer>() {{
-                            add(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
-                        }}
+                        Collections.singleton(ReferenceContext.UNMAPPED)
                 },
                 {
                         ContainerFactoryTest.getUnmappedNoStartRecords(),
-                        new HashSet<Integer>() {{
-                            add(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
-                        }}
+                        Collections.singleton(ReferenceContext.UNMAPPED)
                 },
         };
     }
 
     @Test(dataProvider = "containersForRefTests")
-    public void paramTest(final List<CramCompressionRecord> records, final Set<Integer> expectedKeys) {
+    public void paramTest(final List<CramCompressionRecord> records, final Set<ReferenceContext> expectedKeys) {
         final ContainerFactory factory = new ContainerFactory(ContainerFactoryTest.getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
         final Container container = factory.buildContainer(records);
 
         final ContainerParser parser = new ContainerParser(ContainerFactoryTest.getSAMFileHeaderForTests());
 
-        final Map<Integer, AlignmentSpan> referenceSet = parser.getReferences(container, ValidationStringency.STRICT);
-        Assert.assertEquals(referenceSet.keySet(), expectedKeys);
+        final Map<ReferenceContext, AlignmentSpan> spanMap = parser.getReferences(container, ValidationStringency.STRICT);
+        Assert.assertEquals(spanMap.keySet(), expectedKeys);
 
         final List<CramCompressionRecord> roundTripRecords = parser.getRecords(container, null, ValidationStringency.STRICT);
         // TODO this fails.  return to this when refactoring Container and CramCompressionRecord
@@ -97,9 +86,9 @@ public class ContainerParserTest extends HtsjdkTest {
 
    @Test
     public void testMultirefContainer() {
-       final Map<Integer, AlignmentSpan> expectedSpans = new HashMap<>();
-       for (int i = 0; i < 10; i++) {
-           expectedSpans.put(i, new AlignmentSpan(i + 1, 3, 1));
+       final Map<ReferenceContext, AlignmentSpan> expectedSpans = new HashMap<>();
+       for (int i = 0; i < TEST_RECORD_COUNT; i++) {
+           expectedSpans.put(new ReferenceContext(i), new AlignmentSpan(i + 1, READ_LENGTH_FOR_TEST_RECORDS, 1));
        }
 
        final ContainerFactory factory = new ContainerFactory(ContainerFactoryTest.getSAMFileHeaderForTests(), TEST_RECORD_COUNT);
@@ -107,15 +96,15 @@ public class ContainerParserTest extends HtsjdkTest {
 
        final ContainerParser parser = new ContainerParser(ContainerFactoryTest.getSAMFileHeaderForTests());
 
-       final Map<Integer, AlignmentSpan> referenceSet = parser.getReferences(container, ValidationStringency.STRICT);
-       Assert.assertEquals(referenceSet, expectedSpans);
+       final Map<ReferenceContext, AlignmentSpan> spanMap = parser.getReferences(container, ValidationStringency.STRICT);
+       Assert.assertEquals(spanMap, expectedSpans);
    }
 
     @Test
     public void testMultirefContainerWithUnmapped() {
         final List<AlignmentSpan> expectedSpans = new ArrayList<>();
-        expectedSpans.add(new AlignmentSpan(1, 3, 1));
-        expectedSpans.add(new AlignmentSpan(2, 3, 1));
+        expectedSpans.add(new AlignmentSpan(1, READ_LENGTH_FOR_TEST_RECORDS, 1));
+        expectedSpans.add(new AlignmentSpan(2, READ_LENGTH_FOR_TEST_RECORDS, 1));
 
 
         final SAMFileHeader samFileHeader = ContainerFactoryTest.getSAMFileHeaderForTests();
@@ -125,39 +114,33 @@ public class ContainerParserTest extends HtsjdkTest {
 
         // first container is single-ref
 
-        final Map<Integer, AlignmentSpan> referenceSet0 = parser.getReferences(containers.get(0), ValidationStringency.STRICT);
-        Assert.assertNotNull(referenceSet0);
-        Assert.assertEquals(referenceSet0.size(), 1);
+        final Map<ReferenceContext, AlignmentSpan> spanMap0 = parser.getReferences(containers.get(0), ValidationStringency.STRICT);
+        Assert.assertNotNull(spanMap0);
+        Assert.assertEquals(spanMap0.size(), 1);
 
-        Assert.assertTrue(referenceSet0.containsKey(0));
-        Assert.assertEquals(referenceSet0.get(0), expectedSpans.get(0));
+        Assert.assertEquals(spanMap0.get(new ReferenceContext(0)), expectedSpans.get(0));
 
         // when other refs are added, subsequent containers are multiref
 
-        final Map<Integer, AlignmentSpan> referenceSet1 = parser.getReferences(containers.get(1), ValidationStringency.STRICT);
-        Assert.assertNotNull(referenceSet1);
-        Assert.assertEquals(referenceSet1.size(), 2);
+        final Map<ReferenceContext, AlignmentSpan> spanMap1 = parser.getReferences(containers.get(1), ValidationStringency.STRICT);
+        Assert.assertNotNull(spanMap1);
+        Assert.assertEquals(spanMap1.size(), 2);
 
         // contains the span we checked earlier
-        Assert.assertTrue(referenceSet1.containsKey(0));
-        Assert.assertEquals(referenceSet1.get(0), expectedSpans.get(0));
-
-        Assert.assertTrue(referenceSet1.containsKey(1));
-        Assert.assertEquals(referenceSet1.get(1), expectedSpans.get(1));
+        Assert.assertEquals(spanMap1.get(new ReferenceContext(0)), expectedSpans.get(0));
+        Assert.assertEquals(spanMap1.get(new ReferenceContext(1)), expectedSpans.get(1));
 
 
-        final Map<Integer, AlignmentSpan> referenceSet2 = parser.getReferences(containers.get(2), ValidationStringency.STRICT);
-        Assert.assertNotNull(referenceSet2);
-        Assert.assertEquals(referenceSet2.size(), 3);
+        final Map<ReferenceContext, AlignmentSpan> spanMap2 = parser.getReferences(containers.get(2), ValidationStringency.STRICT);
+        Assert.assertNotNull(spanMap2);
+        Assert.assertEquals(spanMap2.size(), 3);
 
         // contains the spans we checked earlier
-        Assert.assertTrue(referenceSet2.containsKey(0));
-        Assert.assertEquals(referenceSet2.get(0), expectedSpans.get(0));
-        Assert.assertTrue(referenceSet2.containsKey(1));
-        Assert.assertEquals(referenceSet2.get(1), expectedSpans.get(1));
+        Assert.assertEquals(spanMap2.get(new ReferenceContext(0)), expectedSpans.get(0));
+        Assert.assertEquals(spanMap2.get(new ReferenceContext(1)), expectedSpans.get(1));
 
-        Assert.assertTrue(referenceSet2.containsKey(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX));
-        final AlignmentSpan unmappedSpan = referenceSet2.get(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+        Assert.assertTrue(spanMap2.containsKey(ReferenceContext.UNMAPPED));
+        final AlignmentSpan unmappedSpan = spanMap2.get(ReferenceContext.UNMAPPED);
 
         // only checking count here because start and span aren't meaningful
         Assert.assertEquals(unmappedSpan.getCount(), 1);

--- a/src/test/java/htsjdk/samtools/cram/build/ContainerParserTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/ContainerParserTest.java
@@ -51,7 +51,7 @@ public class ContainerParserTest extends HtsjdkTest {
                 },
                 {
                         ContainerFactoryTest.getUnmappedRecords(),
-                        Collections.singleton(ReferenceContext.UNMAPPED)
+                        Collections.singleton(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT)
                 },
 
                 // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
@@ -59,11 +59,11 @@ public class ContainerParserTest extends HtsjdkTest {
 
                 {
                         ContainerFactoryTest.getUnmappedNoRefRecords(),
-                        Collections.singleton(ReferenceContext.UNMAPPED)
+                        Collections.singleton(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT)
                 },
                 {
                         ContainerFactoryTest.getUnmappedNoStartRecords(),
-                        Collections.singleton(ReferenceContext.UNMAPPED)
+                        Collections.singleton(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT)
                 },
         };
     }
@@ -139,8 +139,8 @@ public class ContainerParserTest extends HtsjdkTest {
         Assert.assertEquals(spanMap2.get(new ReferenceContext(0)), expectedSpans.get(0));
         Assert.assertEquals(spanMap2.get(new ReferenceContext(1)), expectedSpans.get(1));
 
-        Assert.assertTrue(spanMap2.containsKey(ReferenceContext.UNMAPPED));
-        final AlignmentSpan unmappedSpan = spanMap2.get(ReferenceContext.UNMAPPED);
+        Assert.assertTrue(spanMap2.containsKey(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT));
+        final AlignmentSpan unmappedSpan = spanMap2.get(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
 
         // only checking count here because start and span aren't meaningful
         Assert.assertEquals(unmappedSpan.getCount(), 1);

--- a/src/test/java/htsjdk/samtools/cram/encoding/CramRecordTestHelper.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/CramRecordTestHelper.java
@@ -8,6 +8,7 @@ import htsjdk.samtools.cram.build.Sam2CramRecordFactory;
 import htsjdk.samtools.cram.common.CramVersions;
 import htsjdk.samtools.cram.encoding.writer.CramRecordWriter;
 import htsjdk.samtools.cram.io.*;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.*;
 
 import java.io.ByteArrayInputStream;
@@ -126,12 +127,12 @@ public abstract class CramRecordTestHelper extends HtsjdkTest {
     public byte[] write(final List<CramCompressionRecord> records,
                         final Map<Integer, ByteArrayOutputStream> outputMap,
                         final CompressionHeader header,
-                        final int refId,
+                        final ReferenceContext refContext,
                         final int initialAlignmentStart) throws IOException {
         try (final ByteArrayOutputStream os = new ByteArrayOutputStream();
              final BitOutputStream bos = new DefaultBitOutputStream(os)) {
 
-            final CramRecordWriter writer = new CramRecordWriter(bos, outputMap, header, refId);
+            final CramRecordWriter writer = new CramRecordWriter(bos, outputMap, header, refContext);
             writer.writeCramCompressionRecords(records, initialAlignmentStart);
 
             return os.toByteArray();

--- a/src/test/java/htsjdk/samtools/cram/encoding/CramRecordWriterReaderTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/CramRecordWriterReaderTest.java
@@ -72,14 +72,14 @@ public class CramRecordWriterReaderTest extends CramRecordTestHelper {
 
         final Map<Integer, ByteArrayOutputStream> outputMap = createOutputMap(header);
         int initialAlignmentStart = initialRecords.get(0).alignmentStart;
-        final byte[] written = write(initialRecords, outputMap, header, ReferenceContext.MULTIPLE, initialAlignmentStart);
+        final byte[] written = write(initialRecords, outputMap, header, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, initialAlignmentStart);
 
         final Map<Integer, ByteArrayInputStream> inputMap = createInputMap(outputMap);
         final List<CramCompressionRecord> roundTripRecords = new ArrayList<>(initialRecords.size());
 
         int prevAlignmentStart = initialAlignmentStart;
         for (int i = 0; i < initialRecords.size(); i++) {
-            final CramCompressionRecord newRecord = read(written, inputMap, header, ReferenceContext.MULTIPLE, prevAlignmentStart);
+            final CramCompressionRecord newRecord = read(written, inputMap, header, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, prevAlignmentStart);
             prevAlignmentStart = newRecord.alignmentStart;
             roundTripRecords.add(newRecord);
         }

--- a/src/test/java/htsjdk/samtools/cram/encoding/MultiRefSliceAlignmentSpanReaderTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/MultiRefSliceAlignmentSpanReaderTest.java
@@ -76,7 +76,7 @@ public class MultiRefSliceAlignmentSpanReaderTest extends CramRecordTestHelper {
 
         final CompressionHeader header = createHeader(initialRecords, coordinateSorted);
 
-        final ReferenceContext refId = ReferenceContext.MULTIPLE;
+        final ReferenceContext refId = ReferenceContext.MULTIPLE_REFERENCE_CONTEXT;
         final Map<Integer, ByteArrayOutputStream> outputMap = createOutputMap(header);
         int initialAlignmentStart = initialRecords.get(0).alignmentStart;
         final byte[] written = write(initialRecords, outputMap, header, refId, initialAlignmentStart);
@@ -91,7 +91,7 @@ public class MultiRefSliceAlignmentSpanReaderTest extends CramRecordTestHelper {
             Assert.assertEquals(spans.size(), 3);
             Assert.assertEquals(spans.get(new ReferenceContext(1)), new AlignmentSpan(1, 5, 2));
             Assert.assertEquals(spans.get(new ReferenceContext(2)), new AlignmentSpan(2, 3, 1));
-            Assert.assertNotNull(spans.get(ReferenceContext.UNMAPPED));
+            Assert.assertNotNull(spans.get(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT));
         }
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/encoding/MultiRefSliceAlignmentSpanReaderTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/MultiRefSliceAlignmentSpanReaderTest.java
@@ -5,10 +5,10 @@ import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.cram.encoding.reader.MultiRefSliceAlignmentSpanReader;
 import htsjdk.samtools.cram.io.BitInputStream;
 import htsjdk.samtools.cram.io.DefaultBitInputStream;
+import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.AlignmentSpan;
 import htsjdk.samtools.cram.structure.CompressionHeader;
 import htsjdk.samtools.cram.structure.CramCompressionRecord;
-import htsjdk.samtools.cram.structure.Slice;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -76,7 +76,7 @@ public class MultiRefSliceAlignmentSpanReaderTest extends CramRecordTestHelper {
 
         final CompressionHeader header = createHeader(initialRecords, coordinateSorted);
 
-        final int refId = Slice.MULTI_REFERENCE;
+        final ReferenceContext refId = ReferenceContext.MULTIPLE;
         final Map<Integer, ByteArrayOutputStream> outputMap = createOutputMap(header);
         int initialAlignmentStart = initialRecords.get(0).alignmentStart;
         final byte[] written = write(initialRecords, outputMap, header, refId, initialAlignmentStart);
@@ -86,15 +86,12 @@ public class MultiRefSliceAlignmentSpanReaderTest extends CramRecordTestHelper {
             final BitInputStream bis = new DefaultBitInputStream(is)) {
 
             final MultiRefSliceAlignmentSpanReader reader = new MultiRefSliceAlignmentSpanReader(bis, inputMap, header, ValidationStringency.DEFAULT_STRINGENCY, initialAlignmentStart, initialRecords.size());
-            final Map<Integer, AlignmentSpan> spans = reader.getReferenceSpans();
+            final Map<ReferenceContext, AlignmentSpan> spans = reader.getReferenceSpans();
 
             Assert.assertEquals(spans.size(), 3);
-            Assert.assertTrue(spans.containsKey(1));
-            Assert.assertTrue(spans.containsKey(2));
-            Assert.assertTrue(spans.containsKey(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX));
-            Assert.assertEquals(spans.get(1), new AlignmentSpan(1, 5, 2));
-            Assert.assertEquals(spans.get(2), new AlignmentSpan(2, 3, 1));
-            Assert.assertNotNull(spans.get(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX));
+            Assert.assertEquals(spans.get(new ReferenceContext(1)), new AlignmentSpan(1, 5, 2));
+            Assert.assertEquals(spans.get(new ReferenceContext(2)), new AlignmentSpan(2, 3, 1));
+            Assert.assertNotNull(spans.get(ReferenceContext.UNMAPPED));
         }
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
@@ -16,7 +16,7 @@ public class ReferenceContextTest extends HtsjdkTest {
         Assert.assertTrue(refContext0.isMappedSingleRef());
         Assert.assertFalse(refContext0.isUnmappedUnplaced());
         Assert.assertFalse(refContext0.isMultiRef());
-        Assert.assertEquals(refContext0.getType(), ReferenceContextType.SINGLE_REFERENCE);
+        Assert.assertEquals(refContext0.getType(), ReferenceContextType.SINGLE_REFERENCE_TYPE);
         Assert.assertEquals(refContext0.getSequenceId(), 0);
         Assert.assertEquals(refContext0.getSerializableId(), 0);
 
@@ -24,29 +24,29 @@ public class ReferenceContextTest extends HtsjdkTest {
         Assert.assertTrue(refContext1.isMappedSingleRef());
         Assert.assertFalse(refContext1.isUnmappedUnplaced());
         Assert.assertFalse(refContext1.isMultiRef());
-        Assert.assertEquals(refContext1.getType(), ReferenceContextType.SINGLE_REFERENCE);
+        Assert.assertEquals(refContext1.getType(), ReferenceContextType.SINGLE_REFERENCE_TYPE);
         Assert.assertEquals(refContext1.getSequenceId(), 1);
         Assert.assertEquals(refContext1.getSerializableId(), 1);
 
-        final ReferenceContext unmapped = new ReferenceContext(ReferenceContext.REF_ID_UNMAPPED);
-        final ReferenceContext unmappedStatic = ReferenceContext.UNMAPPED;
+        final ReferenceContext unmapped = new ReferenceContext(ReferenceContext.UNMAPPED_UNPLACED_ID);
+        final ReferenceContext unmappedStatic = ReferenceContext.UNMAPPED_UNPLACED_CONTEXT;
         Assert.assertEquals(unmappedStatic, unmapped);
 
         Assert.assertFalse(unmapped.isMappedSingleRef());
         Assert.assertTrue(unmapped.isUnmappedUnplaced());
         Assert.assertFalse(unmapped.isMultiRef());
-        Assert.assertEquals(unmapped.getType(), ReferenceContextType.UNMAPPED_UNPLACED);
-        Assert.assertEquals(unmapped.getSerializableId(), ReferenceContext.REF_ID_UNMAPPED);
+        Assert.assertEquals(unmapped.getType(), ReferenceContextType.UNMAPPED_UNPLACED_TYPE);
+        Assert.assertEquals(unmapped.getSerializableId(), ReferenceContext.UNMAPPED_UNPLACED_ID);
 
-        final ReferenceContext multi = new ReferenceContext(ReferenceContext.REF_ID_MULTIPLE);
-        final ReferenceContext multiStatic = ReferenceContext.MULTIPLE;
+        final ReferenceContext multi = new ReferenceContext(ReferenceContext.MULTIPLE_REFERENCE_ID);
+        final ReferenceContext multiStatic = ReferenceContext.MULTIPLE_REFERENCE_CONTEXT;
         Assert.assertEquals(multiStatic, multi);
 
         Assert.assertFalse(multi.isMappedSingleRef());
         Assert.assertFalse(multi.isUnmappedUnplaced());
         Assert.assertTrue(multi.isMultiRef());
-        Assert.assertEquals(multi.getType(), ReferenceContextType.MULTI_REFERENCE);
-        Assert.assertEquals(multi.getSerializableId(), ReferenceContext.REF_ID_MULTIPLE);
+        Assert.assertEquals(multi.getType(), ReferenceContextType.MULTIPLE_REFERENCE_TYPE);
+        Assert.assertEquals(multi.getSerializableId(), ReferenceContext.MULTIPLE_REFERENCE_ID);
     }
 
     @Test(expectedExceptions = CRAMException.class)
@@ -57,8 +57,8 @@ public class ReferenceContextTest extends HtsjdkTest {
     @DataProvider(name = "sentinels")
     private static Object[][] sentinels() {
         return new Object[][] {
-                {ReferenceContext.REF_ID_MULTIPLE},
-                {ReferenceContext.REF_ID_UNMAPPED}
+                {ReferenceContext.MULTIPLE_REFERENCE_ID},
+                {ReferenceContext.UNMAPPED_UNPLACED_ID}
         };
     }
 

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
@@ -9,44 +9,57 @@ import org.testng.annotations.Test;
 public class ReferenceContextTest extends HtsjdkTest {
 
     // test constructors and basic identity methods
-    
-    @Test
-    public void basicTest() {
-        final ReferenceContext refContext0 = new ReferenceContext(0);
-        Assert.assertTrue(refContext0.isMappedSingleRef());
-        Assert.assertFalse(refContext0.isUnmappedUnplaced());
-        Assert.assertFalse(refContext0.isMultiRef());
-        Assert.assertEquals(refContext0.getType(), ReferenceContextType.SINGLE_REFERENCE_TYPE);
-        Assert.assertEquals(refContext0.getSequenceId(), 0);
-        Assert.assertEquals(refContext0.getSerializableId(), 0);
 
-        final ReferenceContext refContext1 = new ReferenceContext(1);
-        Assert.assertTrue(refContext1.isMappedSingleRef());
-        Assert.assertFalse(refContext1.isUnmappedUnplaced());
-        Assert.assertFalse(refContext1.isMultiRef());
-        Assert.assertEquals(refContext1.getType(), ReferenceContextType.SINGLE_REFERENCE_TYPE);
-        Assert.assertEquals(refContext1.getSequenceId(), 1);
-        Assert.assertEquals(refContext1.getSerializableId(), 1);
+    @DataProvider(name = "validRefContexts")
+    private static Object[][] refContexts() {
+        return new Object[][] {
+                //context, expectedType, isSingle, isUnplaced, isMultiple, serializableID
+                {
+                        new ReferenceContext(0),
+                        ReferenceContextType.SINGLE_REFERENCE_TYPE,
+                        true, false, false, 0
+                },
+                {
+                        new ReferenceContext(1),
+                        ReferenceContextType.SINGLE_REFERENCE_TYPE,
+                        true, false, false, 1
+                },
+                {
+                        new ReferenceContext(ReferenceContext.UNMAPPED_UNPLACED_ID),
+                        ReferenceContextType.UNMAPPED_UNPLACED_TYPE,
+                        false, true, false, ReferenceContext.UNMAPPED_UNPLACED_ID
+                },
+                {
+                        ReferenceContext.UNMAPPED_UNPLACED_CONTEXT,
+                        ReferenceContextType.UNMAPPED_UNPLACED_TYPE,
+                        false, true, false, ReferenceContext.UNMAPPED_UNPLACED_ID
+                },
+                {
+                        new ReferenceContext(ReferenceContext.MULTIPLE_REFERENCE_ID),
+                        ReferenceContextType.MULTIPLE_REFERENCE_TYPE,
+                        false, false, true, ReferenceContext.MULTIPLE_REFERENCE_ID
+                },
+                {
+                        ReferenceContext.MULTIPLE_REFERENCE_CONTEXT,
+                        ReferenceContextType.MULTIPLE_REFERENCE_TYPE,
+                        false, false, true, ReferenceContext.MULTIPLE_REFERENCE_ID
+                },
+        };
+    }
 
-        final ReferenceContext unmapped = new ReferenceContext(ReferenceContext.UNMAPPED_UNPLACED_ID);
-        final ReferenceContext unmappedStatic = ReferenceContext.UNMAPPED_UNPLACED_CONTEXT;
-        Assert.assertEquals(unmappedStatic, unmapped);
-
-        Assert.assertFalse(unmapped.isMappedSingleRef());
-        Assert.assertTrue(unmapped.isUnmappedUnplaced());
-        Assert.assertFalse(unmapped.isMultiRef());
-        Assert.assertEquals(unmapped.getType(), ReferenceContextType.UNMAPPED_UNPLACED_TYPE);
-        Assert.assertEquals(unmapped.getSerializableId(), ReferenceContext.UNMAPPED_UNPLACED_ID);
-
-        final ReferenceContext multi = new ReferenceContext(ReferenceContext.MULTIPLE_REFERENCE_ID);
-        final ReferenceContext multiStatic = ReferenceContext.MULTIPLE_REFERENCE_CONTEXT;
-        Assert.assertEquals(multiStatic, multi);
-
-        Assert.assertFalse(multi.isMappedSingleRef());
-        Assert.assertFalse(multi.isUnmappedUnplaced());
-        Assert.assertTrue(multi.isMultiRef());
-        Assert.assertEquals(multi.getType(), ReferenceContextType.MULTIPLE_REFERENCE_TYPE);
-        Assert.assertEquals(multi.getSerializableId(), ReferenceContext.MULTIPLE_REFERENCE_ID);
+    @Test(dataProvider = "validRefContexts")
+    public void referenceContextTest(
+            final ReferenceContext refContext,
+            final ReferenceContextType expectedType,
+            final boolean expectedSingle,
+            final boolean expectedUnplaced,
+            final boolean expectedMulti,
+            final int expectedID) {
+        Assert.assertEquals(refContext.getType(), expectedType);
+        Assert.assertEquals(refContext.isMappedSingleRef(), expectedSingle);
+        Assert.assertEquals(refContext.isUnmappedUnplaced(), expectedUnplaced);
+        Assert.assertEquals(refContext.isMultiRef(), expectedMulti);
+        Assert.assertEquals(refContext.getSerializableId(), expectedID);
     }
 
     @Test(expectedExceptions = CRAMException.class)

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
@@ -62,12 +62,15 @@ public class ReferenceContextTest extends HtsjdkTest {
         };
     }
 
-    @Test(dataProvider = "sentinels", expectedExceptions = CRAMException.class)
-    public void testInvalidGetSequenceId(final int seqId) {
+    @Test(dataProvider = "sentinels")
+    public void testSentinelsGetSerializableId(final int seqId) {
         final ReferenceContext context = new ReferenceContext(seqId);
-        // works
         Assert.assertEquals(context.getSerializableId(), seqId);
-        // throws
+    }
+
+    @Test(dataProvider = "sentinels", expectedExceptions = CRAMException.class)
+    public void testSentinelsGetSequenceId(final int seqId) {
+        final ReferenceContext context = new ReferenceContext(seqId);
         context.getSequenceId();
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
@@ -55,10 +55,10 @@ public class ReferenceContextTest extends HtsjdkTest {
     }
 
     @DataProvider(name = "sentinels")
-    private static Object[][] invalidGet() {
+    private static Object[][] sentinels() {
         return new Object[][] {
-                {-2},
-                {-1}
+                {ReferenceContext.REF_ID_MULTIPLE},
+                {ReferenceContext.REF_ID_UNMAPPED}
         };
     }
 

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceContextTest.java
@@ -1,0 +1,73 @@
+package htsjdk.samtools.cram.ref;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.cram.CRAMException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ReferenceContextTest extends HtsjdkTest {
+
+    // test constructors and basic identity methods
+    
+    @Test
+    public void basicTest() {
+        final ReferenceContext refContext0 = new ReferenceContext(0);
+        Assert.assertTrue(refContext0.isMappedSingleRef());
+        Assert.assertFalse(refContext0.isUnmappedUnplaced());
+        Assert.assertFalse(refContext0.isMultiRef());
+        Assert.assertEquals(refContext0.getType(), ReferenceContextType.SINGLE_REFERENCE);
+        Assert.assertEquals(refContext0.getSequenceId(), 0);
+        Assert.assertEquals(refContext0.getSerializableId(), 0);
+
+        final ReferenceContext refContext1 = new ReferenceContext(1);
+        Assert.assertTrue(refContext1.isMappedSingleRef());
+        Assert.assertFalse(refContext1.isUnmappedUnplaced());
+        Assert.assertFalse(refContext1.isMultiRef());
+        Assert.assertEquals(refContext1.getType(), ReferenceContextType.SINGLE_REFERENCE);
+        Assert.assertEquals(refContext1.getSequenceId(), 1);
+        Assert.assertEquals(refContext1.getSerializableId(), 1);
+
+        final ReferenceContext unmapped = new ReferenceContext(ReferenceContext.REF_ID_UNMAPPED);
+        final ReferenceContext unmappedStatic = ReferenceContext.UNMAPPED;
+        Assert.assertEquals(unmappedStatic, unmapped);
+
+        Assert.assertFalse(unmapped.isMappedSingleRef());
+        Assert.assertTrue(unmapped.isUnmappedUnplaced());
+        Assert.assertFalse(unmapped.isMultiRef());
+        Assert.assertEquals(unmapped.getType(), ReferenceContextType.UNMAPPED_UNPLACED);
+        Assert.assertEquals(unmapped.getSerializableId(), ReferenceContext.REF_ID_UNMAPPED);
+
+        final ReferenceContext multi = new ReferenceContext(ReferenceContext.REF_ID_MULTIPLE);
+        final ReferenceContext multiStatic = ReferenceContext.MULTIPLE;
+        Assert.assertEquals(multiStatic, multi);
+
+        Assert.assertFalse(multi.isMappedSingleRef());
+        Assert.assertFalse(multi.isUnmappedUnplaced());
+        Assert.assertTrue(multi.isMultiRef());
+        Assert.assertEquals(multi.getType(), ReferenceContextType.MULTI_REFERENCE);
+        Assert.assertEquals(multi.getSerializableId(), ReferenceContext.REF_ID_MULTIPLE);
+    }
+
+    @Test(expectedExceptions = CRAMException.class)
+    public void testInvalidSetSequenceId() {
+        new ReferenceContext(-3);
+    }
+
+    @DataProvider(name = "sentinels")
+    private static Object[][] invalidGet() {
+        return new Object[][] {
+                {-2},
+                {-1}
+        };
+    }
+
+    @Test(dataProvider = "sentinels", expectedExceptions = CRAMException.class)
+    public void testInvalidGetSequenceId(final int seqId) {
+        final ReferenceContext context = new ReferenceContext(seqId);
+        // works
+        Assert.assertEquals(context.getSerializableId(), seqId);
+        // throws
+        context.getSequenceId();
+    }
+}

--- a/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
@@ -1,149 +1,104 @@
 package htsjdk.samtools.cram.structure;
 
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.cram.CRAMException;
+import htsjdk.samtools.cram.ref.ReferenceContext;
+import htsjdk.samtools.cram.ref.ReferenceContextType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-public class ContainerTest extends HtsjdkTest {
+import java.util.Arrays;
 
+public class ContainerTest extends HtsjdkTest {
     @Test
     public static void singleRefSliceStateTest() {
-        final Slice slice = new Slice();
-        slice.sequenceId = 5;
+        final Slice slice = new Slice(new ReferenceContext(5));
         slice.alignmentStart = 10;
         slice.alignmentSpan = 15;
 
-        final Container container = new Container();
-        container.finalizeContainerState(slice);
+        final Container container = Container.initializeFromSlices(Arrays.asList(slice));
 
-        Assert.assertEquals(container.sequenceId, slice.sequenceId);
+        Assert.assertTrue(container.getReferenceContext().isMappedSingleRef());
+        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.SINGLE_REFERENCE);
+        Assert.assertEquals(container.getReferenceContext(), slice.getReferenceContext());
         Assert.assertEquals(container.alignmentStart, slice.alignmentStart);
         Assert.assertEquals(container.alignmentSpan, slice.alignmentSpan);
     }
 
     @Test
     public static void singleRefSliceMultipleStateTest() {
-        final Slice slice1 = new Slice();
-        slice1.sequenceId = 5;
+        final Slice slice1 = new Slice(new ReferenceContext(5));
         slice1.alignmentStart = 10;
         slice1.alignmentSpan = 15;
 
-        final Slice slice2 = new Slice();
-        slice2.sequenceId = slice1.sequenceId;
+        final Slice slice2 = new Slice(slice1.getReferenceContext());
         slice2.alignmentStart = 20;
         slice2.alignmentSpan = 20;
 
-        final Container container = new Container();
-        container.finalizeContainerState(slice1, slice2);
+        final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2));
 
-        Assert.assertEquals(container.sequenceId, slice1.sequenceId);
+        Assert.assertTrue(container.getReferenceContext().isMappedSingleRef());
+        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.SINGLE_REFERENCE);
+        Assert.assertEquals(container.getReferenceContext(), slice1.getReferenceContext());
         Assert.assertEquals(container.alignmentStart, 10);
         Assert.assertEquals(container.alignmentSpan, 30);      // 20 + 20 - 10
     }
 
     @Test
     public static void multiRefSliceStateTest() {
-        final Slice slice1 = new Slice();
-        slice1.sequenceId = Slice.MULTI_REFERENCE;
-        slice1.alignmentStart = Slice.NO_ALIGNMENT_START;
-        slice1.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
+        final Slice slice1 = new Slice(ReferenceContext.MULTIPLE);
+        final Slice slice2 = new Slice(ReferenceContext.MULTIPLE);
 
-        final Slice slice2 = new Slice();
-        slice2.sequenceId = Slice.MULTI_REFERENCE;
-        slice2.alignmentStart = Slice.NO_ALIGNMENT_START;
-        slice2.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
+        final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2));
 
-        final Container container = new Container();
-        container.finalizeContainerState(slice1, slice2);
-
-        Assert.assertEquals(container.sequenceId, slice1.sequenceId);
-        Assert.assertEquals(container.alignmentStart, slice1.alignmentStart);
-        Assert.assertEquals(container.alignmentSpan, slice1.alignmentSpan);
+        Assert.assertTrue(container.getReferenceContext().isMultiRef());
+        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.MULTI_REFERENCE);
+        Assert.assertEquals(container.alignmentStart, Slice.NO_ALIGNMENT_START);
+        Assert.assertEquals(container.alignmentSpan, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
     public static void unmappedSliceStateTest() {
-        final Slice slice1 = new Slice();
-        slice1.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-        slice1.alignmentStart = Slice.NO_ALIGNMENT_START;
-        slice1.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
+        final Slice slice1 = new Slice(ReferenceContext.UNMAPPED);
+        final Slice slice2 = new Slice(ReferenceContext.UNMAPPED);
 
-        final Slice slice2 = new Slice();
-        slice2.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-        slice2.alignmentStart = Slice.NO_ALIGNMENT_START;
-        slice2.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
+        final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2));
 
-        final Container container = new Container();
-        container.finalizeContainerState(slice1, slice2);
-
-        Assert.assertEquals(container.sequenceId, slice1.sequenceId);
-        Assert.assertEquals(container.alignmentStart, slice1.alignmentStart);
-        Assert.assertEquals(container.alignmentSpan, slice1.alignmentSpan);
+        Assert.assertTrue(container.getReferenceContext().isUnmappedUnplaced());
+        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.UNMAPPED_UNPLACED);
+        Assert.assertEquals(container.alignmentStart, Slice.NO_ALIGNMENT_START);
+        Assert.assertEquals(container.alignmentSpan, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test(expectedExceptions = CRAMException.class)
     public static void differentReferencesStateTest() {
-        final Slice one = new Slice();
-        one.sequenceId = 5;
-        one.alignmentStart = 10;
-        one.alignmentSpan = 15;
+        final Slice one = new Slice(new ReferenceContext(5));
+        final Slice another = new Slice(new ReferenceContext(2));
 
-        final Slice another = new Slice();
-        another.sequenceId = 2;
-        another.alignmentStart = 1;
-        another.alignmentSpan = 10;
-
-        final Container container = new Container();
-        container.finalizeContainerState(one, another);
+        Container.initializeFromSlices(Arrays.asList(one, another));
     }
 
     @Test(expectedExceptions = CRAMException.class)
     public static void singleAndUnmappedStateTest() {
-        final Slice single = new Slice();
-        single.sequenceId = 5;
-        single.alignmentStart = 10;
-        single.alignmentSpan = 15;
+        final Slice single = new Slice(new ReferenceContext(5));
+        final Slice unmapped = new Slice(ReferenceContext.UNMAPPED);
 
-        final Slice unmapped = new Slice();
-        unmapped.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-        unmapped.alignmentStart = Slice.NO_ALIGNMENT_START;
-        unmapped.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
-
-        final Container container = new Container();
-        container.finalizeContainerState(single, unmapped);
+        Container.initializeFromSlices(Arrays.asList(single, unmapped));
     }
 
     @Test(expectedExceptions = CRAMException.class)
     public static void multiAndSingleStateTest() {
-        final Slice multi = new Slice();
-        multi.sequenceId = Slice.MULTI_REFERENCE;
-        multi.alignmentStart = Slice.NO_ALIGNMENT_START;
-        multi.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
+        final Slice multi = new Slice(ReferenceContext.MULTIPLE);
+        final Slice single = new Slice(new ReferenceContext(5));
 
-        final Slice single = new Slice();
-        single.sequenceId = 5;
-        single.alignmentStart = 10;
-        single.alignmentSpan = 15;
-
-        final Container container = new Container();
-        container.finalizeContainerState(multi, single);
+        Container.initializeFromSlices(Arrays.asList(multi, single));
     }
 
     @Test(expectedExceptions = CRAMException.class)
     public static void multiAndUnmappedStateTest() {
-        final Slice multi = new Slice();
-        multi.sequenceId = Slice.MULTI_REFERENCE;
-        multi.alignmentStart = Slice.NO_ALIGNMENT_START;
-        multi.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
+        final Slice multi = new Slice(ReferenceContext.MULTIPLE);
+        final Slice unmapped = new Slice(ReferenceContext.UNMAPPED);
 
-        final Slice unmapped = new Slice();
-        unmapped.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-        unmapped.alignmentStart = Slice.NO_ALIGNMENT_START;
-        unmapped.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
-
-        final Container container = new Container();
-        container.finalizeContainerState(multi, unmapped);
+        Container.initializeFromSlices(Arrays.asList(multi, unmapped));
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
@@ -19,7 +19,7 @@ public class ContainerTest extends HtsjdkTest {
         final Container container = Container.initializeFromSlices(Arrays.asList(slice));
 
         Assert.assertTrue(container.getReferenceContext().isMappedSingleRef());
-        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.SINGLE_REFERENCE);
+        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.SINGLE_REFERENCE_TYPE);
         Assert.assertEquals(container.getReferenceContext(), slice.getReferenceContext());
         Assert.assertEquals(container.alignmentStart, slice.alignmentStart);
         Assert.assertEquals(container.alignmentSpan, slice.alignmentSpan);
@@ -38,7 +38,7 @@ public class ContainerTest extends HtsjdkTest {
         final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2));
 
         Assert.assertTrue(container.getReferenceContext().isMappedSingleRef());
-        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.SINGLE_REFERENCE);
+        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.SINGLE_REFERENCE_TYPE);
         Assert.assertEquals(container.getReferenceContext(), slice1.getReferenceContext());
         Assert.assertEquals(container.alignmentStart, slice1.alignmentStart);
         Assert.assertEquals(container.alignmentSpan, slice2.alignmentStart + slice2.alignmentSpan - slice1.alignmentStart);      // 20 + 20 - 10
@@ -46,26 +46,26 @@ public class ContainerTest extends HtsjdkTest {
 
     @Test
     public static void multiRefSliceStateTest() {
-        final Slice slice1 = new Slice(ReferenceContext.MULTIPLE);
-        final Slice slice2 = new Slice(ReferenceContext.MULTIPLE);
+        final Slice slice1 = new Slice(ReferenceContext.MULTIPLE_REFERENCE_CONTEXT);
+        final Slice slice2 = new Slice(ReferenceContext.MULTIPLE_REFERENCE_CONTEXT);
 
         final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2));
 
         Assert.assertTrue(container.getReferenceContext().isMultiRef());
-        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.MULTI_REFERENCE);
+        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.MULTIPLE_REFERENCE_TYPE);
         Assert.assertEquals(container.alignmentStart, Slice.NO_ALIGNMENT_START);
         Assert.assertEquals(container.alignmentSpan, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
     public static void unmappedSliceStateTest() {
-        final Slice slice1 = new Slice(ReferenceContext.UNMAPPED);
-        final Slice slice2 = new Slice(ReferenceContext.UNMAPPED);
+        final Slice slice1 = new Slice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
+        final Slice slice2 = new Slice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
 
         final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2));
 
         Assert.assertTrue(container.getReferenceContext().isUnmappedUnplaced());
-        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.UNMAPPED_UNPLACED);
+        Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.UNMAPPED_UNPLACED_TYPE);
         Assert.assertEquals(container.alignmentStart, Slice.NO_ALIGNMENT_START);
         Assert.assertEquals(container.alignmentSpan, Slice.NO_ALIGNMENT_SPAN);
     }
@@ -81,14 +81,14 @@ public class ContainerTest extends HtsjdkTest {
     @Test(expectedExceptions = CRAMException.class)
     public static void singleAndUnmappedStateTest() {
         final Slice single = new Slice(new ReferenceContext(5));
-        final Slice unmapped = new Slice(ReferenceContext.UNMAPPED);
+        final Slice unmapped = new Slice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
 
         Container.initializeFromSlices(Arrays.asList(single, unmapped));
     }
 
     @Test(expectedExceptions = CRAMException.class)
     public static void multiAndSingleStateTest() {
-        final Slice multi = new Slice(ReferenceContext.MULTIPLE);
+        final Slice multi = new Slice(ReferenceContext.MULTIPLE_REFERENCE_CONTEXT);
         final Slice single = new Slice(new ReferenceContext(5));
 
         Container.initializeFromSlices(Arrays.asList(multi, single));
@@ -96,8 +96,8 @@ public class ContainerTest extends HtsjdkTest {
 
     @Test(expectedExceptions = CRAMException.class)
     public static void multiAndUnmappedStateTest() {
-        final Slice multi = new Slice(ReferenceContext.MULTIPLE);
-        final Slice unmapped = new Slice(ReferenceContext.UNMAPPED);
+        final Slice multi = new Slice(ReferenceContext.MULTIPLE_REFERENCE_CONTEXT);
+        final Slice unmapped = new Slice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
 
         Container.initializeFromSlices(Arrays.asList(multi, unmapped));
     }

--- a/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
@@ -40,8 +40,8 @@ public class ContainerTest extends HtsjdkTest {
         Assert.assertTrue(container.getReferenceContext().isMappedSingleRef());
         Assert.assertEquals(container.getReferenceContext().getType(), ReferenceContextType.SINGLE_REFERENCE);
         Assert.assertEquals(container.getReferenceContext(), slice1.getReferenceContext());
-        Assert.assertEquals(container.alignmentStart, 10);
-        Assert.assertEquals(container.alignmentSpan, 30);      // 20 + 20 - 10
+        Assert.assertEquals(container.alignmentStart, slice1.alignmentStart);
+        Assert.assertEquals(container.alignmentSpan, slice2.alignmentStart + slice2.alignmentSpan - slice1.alignmentStart);      // 20 + 20 - 10
     }
 
     @Test

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -1,6 +1,5 @@
 package htsjdk.samtools.cram.structure;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMRecord;

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordUtil.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordUtil.java
@@ -1,0 +1,161 @@
+package htsjdk.samtools.cram.structure;
+
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.cram.build.ContainerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CramCompressionRecordUtil {
+    public static final int READ_LENGTH_FOR_TEST_RECORDS = 123;
+
+    private static final SAMFileHeader header = initializeSAMFileHeaderForTests();
+
+    private static SAMFileHeader initializeSAMFileHeaderForTests() {
+        final SAMFileHeader header = new SAMFileHeader();
+
+        // arbitrary names and length.  Just ensure we have 10 different valid refs.
+
+        header.addSequence(new SAMSequenceRecord("0", 10));
+        header.addSequence(new SAMSequenceRecord("1", 10));
+        header.addSequence(new SAMSequenceRecord("2", 10));
+        header.addSequence(new SAMSequenceRecord("3", 10));
+        header.addSequence(new SAMSequenceRecord("4", 10));
+        header.addSequence(new SAMSequenceRecord("5", 10));
+        header.addSequence(new SAMSequenceRecord("6", 10));
+        header.addSequence(new SAMSequenceRecord("7", 10));
+        header.addSequence(new SAMSequenceRecord("8", 10));
+        header.addSequence(new SAMSequenceRecord("9", 10));
+
+        return header;
+    }
+
+    public static SAMFileHeader getSAMFileHeaderForTests() {
+        return header;
+    }
+
+    private static CramCompressionRecord createMappedRecord(final int alignmentStart, final int sequenceId) {
+        final CramCompressionRecord record = new CramCompressionRecord();
+        record.readBases = "AAA".getBytes();
+        record.qualityScores = "!!!".getBytes();
+        record.readLength = READ_LENGTH_FOR_TEST_RECORDS;
+        record.readName = "A READ NAME";
+        record.sequenceId = sequenceId;
+        record.alignmentStart = alignmentStart + 1;
+        record.setLastSegment(true);
+        record.setSegmentUnmapped(false);
+        record.readFeatures = Collections.emptyList();
+        return record;
+    }
+
+    public static List<CramCompressionRecord> getSingleRefRecords(final int recordCount, final int sequenceId) {
+        final List<CramCompressionRecord> records = new ArrayList<>();
+        for (int i = 0; i < recordCount; i++) {
+            final CramCompressionRecord record = createMappedRecord(i, sequenceId);
+
+            // set half unmapped-but-placed, to show that it does not make a difference
+            if (i % 2 == 0) {
+                record.setSegmentUnmapped(true);
+            }
+
+            records.add(record);
+        }
+        return records;
+    }
+
+    public static List<CramCompressionRecord> getMultiRefRecords(final int recordCount) {
+        final List<CramCompressionRecord> records = new ArrayList<>();
+        for (int i = 0; i < recordCount; i++) {
+            final CramCompressionRecord record = createMappedRecord(i, i);
+
+            // set half unmapped-but-placed, to show that it does not make a difference
+            if (i % 2 == 0) {
+                record.setSegmentUnmapped(true);
+            }
+
+            records.add(record);
+        }
+        return records;
+    }
+
+    public static List<CramCompressionRecord> getUnmappedRecords(final int recordCount) {
+        final List<CramCompressionRecord> records = new ArrayList<>();
+        for (int i = 0; i < recordCount; i++) {
+            final CramCompressionRecord record = createMappedRecord(i, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+            record.setSegmentUnmapped(true);
+            record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
+            records.add(record);
+        }
+        return records;
+    }
+
+    // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
+    // but not both.  We treat these weird edge cases as unplaced.
+
+    public static List<CramCompressionRecord> getHalfUnmappedNoRefRecords(final int recordCount) {
+        final List<CramCompressionRecord> records = new ArrayList<>();
+        for (int i = 0; i < recordCount; i++) {
+            final CramCompressionRecord record = createMappedRecord(i, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+            record.setSegmentUnmapped(true);
+            records.add(record);
+        }
+        return records;
+    }
+
+    public static List<CramCompressionRecord> getHalfUnmappedNoStartRecords(final int recordCount, final int sequenceId) {
+        final List<CramCompressionRecord> records = new ArrayList<>();
+        for (int i = 0; i < recordCount; i++) {
+            final CramCompressionRecord record = createMappedRecord(i, sequenceId);
+            record.setSegmentUnmapped(true);
+            record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
+            record.setLastSegment(true);
+            records.add(record);
+        }
+        return records;
+    }
+
+    public static List<CramCompressionRecord> getSingleRefRecordsWithOneUnmapped(final int testRecordCount, final int mappedSequenceId) {
+        final List<CramCompressionRecord> retval = getSingleRefRecords(testRecordCount, mappedSequenceId);
+        retval.get(0).setSegmentUnmapped(true);
+        retval.get(0).alignmentStart = SAMRecord.NO_ALIGNMENT_START;
+        retval.get(0).sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
+        return retval;
+    }
+
+    public static List<CramCompressionRecord> getMultiRefRecordsWithOneUnmapped(final int testRecordCount) {
+        final List<CramCompressionRecord> retval = getMultiRefRecords(testRecordCount);
+        retval.get(0).setSegmentUnmapped(true);
+        retval.get(0).alignmentStart = SAMRecord.NO_ALIGNMENT_START;
+        retval.get(0).sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
+        return retval;
+    }
+
+    public static List<Container> getMultiRefContainersForStateTest() {
+        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), 10);
+        final List<Container> testContainers = new ArrayList<>(3);
+
+        final List<CramCompressionRecord> records = new ArrayList<>();
+
+        final CramCompressionRecord record0 = createMappedRecord(0, 0);
+        records.add(record0);
+        final Container container0 = factory.buildContainer(records);
+
+        final CramCompressionRecord record1 = createMappedRecord(1, 1);
+        records.add(record1);
+        final Container container1 = factory.buildContainer(records);
+
+        final CramCompressionRecord unmapped = createMappedRecord(2, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+        unmapped.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
+        unmapped.setSegmentUnmapped(true);
+        records.add(unmapped);
+        final Container container2 = factory.buildContainer(records);
+
+        testContainers.add(container0);
+        testContainers.add(container1);
+        testContainers.add(container2);
+        return testContainers;
+    }
+}

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -128,7 +128,6 @@ public class SliceTests extends HtsjdkTest {
                           final int expectedAlignmentStart,
                           final int expectedAlignmentSpan) {
         final CompressionHeader header = new CompressionHeaderFactory().build(records, null, coordinateSorted);
-        final int globalRecordCounter = 12345;   // arbitrary
         final Slice slice = Slice.buildSlice(records, header);
         final int expectedBaseCount = TEST_RECORD_COUNT * READ_LENGTH_FOR_TEST_RECORDS;
         assertSliceState(slice, expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan,
@@ -179,9 +178,8 @@ public class SliceTests extends HtsjdkTest {
 
         final CompressionHeader header = new CompressionHeaderFactory().build(records, null, true);
 
-        final int globalRecordCounter = 98765;   // arbitrary
         final Slice slice = Slice.buildSlice(records, header);
-        final int expectedBaseCount = 20 + 35;
+        final int expectedBaseCount = single.readLength + unmapped.readLength;
         assertSliceState(slice, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
                 records.size(), expectedBaseCount);
     }
@@ -192,7 +190,6 @@ public class SliceTests extends HtsjdkTest {
                                                  final int expectedAlignmentSpan) {
         final CompressionHeader header = new CompressionHeaderFactory().build(records, null, true);
         final Slice slice = Slice.buildSlice(records, header);
-        final int expectedGlobalRecordCounter = 0;   // first Slice
         final int expectedBaseCount = records.size() * READ_LENGTH_FOR_TEST_RECORDS;
         assertSliceState(slice, expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan,
                 records.size(), expectedBaseCount);

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -29,7 +29,7 @@ public class SliceTests extends HtsjdkTest {
 
     @Test
     public void testUnmappedValidateRef() {
-        final Slice slice = new Slice(ReferenceContext.UNMAPPED);
+        final Slice slice = new Slice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
 
         Assert.assertTrue(slice.validateRefMD5(null));
         Assert.assertTrue(slice.validateRefMD5(new byte[0]));
@@ -90,13 +90,13 @@ public class SliceTests extends HtsjdkTest {
                 {
                         getMultiRefRecords(),
                         coordSorted,
-                        ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                        ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
                 });
             retval.add(new Object[]
                 {
                         getUnplacedRecords(),
                         coordSorted,
-                        ReferenceContext.UNMAPPED, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                        ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
                 });
 
 
@@ -107,14 +107,14 @@ public class SliceTests extends HtsjdkTest {
                 {
                         getNoRefRecords(),
                         coordSorted,
-                        ReferenceContext.UNMAPPED, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                        ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
                 });
 
             retval.add(new Object[]
                 {
                         getNoStartRecords(),
                         coordSorted,
-                        ReferenceContext.UNMAPPED, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                        ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
                 });
         }
 
@@ -148,17 +148,17 @@ public class SliceTests extends HtsjdkTest {
 
         final CramCompressionRecord record2 = createRecord(1, 1);
         records.add(record2);
-        assertSliceStateFromTestRecords(records, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertSliceStateFromTestRecords(records, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
 
         final CramCompressionRecord record3 = createRecord(2, 2);
         records.add(record3);
-        assertSliceStateFromTestRecords(records, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertSliceStateFromTestRecords(records, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
 
         final CramCompressionRecord unmapped = createRecord(3, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
         unmapped.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
         unmapped.setSegmentUnmapped(true);
         records.add(unmapped);
-        assertSliceStateFromTestRecords(records, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertSliceStateFromTestRecords(records, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class SliceTests extends HtsjdkTest {
 
         final Slice slice = Slice.buildSlice(records, header);
         final int expectedBaseCount = single.readLength + unmapped.readLength;
-        assertSliceState(slice, ReferenceContext.MULTIPLE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
+        assertSliceState(slice, ReferenceContext.MULTIPLE_REFERENCE_CONTEXT, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN,
                 records.size(), expectedBaseCount);
     }
 


### PR DESCRIPTION
### Description

Add a ReferenceContext member to Slice and Container, based on the discussion at https://github.com/samtools/hts-specs/issues/370 and the related spec update at https://github.com/samtools/hts-specs/pull/372.  

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

