### PR TITLE
Use Integer.parseInt over Integer.valueOf to avoid unnecessary boxing…

### DIFF
--- a/src/main/java/htsjdk/samtools/SamFlagField.java
+++ b/src/main/java/htsjdk/samtools/SamFlagField.java
@@ -69,7 +69,7 @@ public enum SamFlagField {
         }
         @Override
         protected int parseWithoutValidation(final String flag) {
-            return Integer.valueOf(flag.substring(2), 16);
+            return Integer.parseInt(flag.substring(2), 16);
         }
     },
     OCTAL {
@@ -79,7 +79,7 @@ public enum SamFlagField {
         }
         @Override
         protected int parseWithoutValidation(final String flag) {
-            return Integer.valueOf(flag, 8);
+            return Integer.parseInt(flag, 8);
         }
     },
     STRING {

--- a/src/main/java/htsjdk/samtools/TextTagCodec.java
+++ b/src/main/java/htsjdk/samtools/TextTagCodec.java
@@ -188,7 +188,7 @@ public class TextTagCodec {
         } else if (type.equals("i")) {
             final long lValue;
             try {
-                lValue = Long.valueOf(stringVal);
+                lValue = Long.parseLong(stringVal);
             } catch (NumberFormatException e) {
                 throw new SAMFormatException("Tag of type i should have signed decimal value");
             }

--- a/src/main/java/htsjdk/samtools/cram/common/Version.java
+++ b/src/main/java/htsjdk/samtools/cram/common/Version.java
@@ -18,9 +18,9 @@ public class Version implements Comparable<Version> {
 
     public Version(final String version) {
         final String[] numbers = version.split("[\\.\\-b]");
-        major = Integer.valueOf(numbers[0]);
-        minor = Integer.valueOf(numbers[1]);
-        if (numbers.length > 3) build = Integer.valueOf(numbers[3]);
+        major = Integer.parseInt(numbers[0]);
+        minor = Integer.parseInt(numbers[1]);
+        if (numbers.length > 3) build = Integer.parseInt(numbers[3]);
         else build = 0;
     }
 

--- a/src/main/java/htsjdk/samtools/cram/compression/ExternalCompression.java
+++ b/src/main/java/htsjdk/samtools/cram/compression/ExternalCompression.java
@@ -21,7 +21,7 @@ import java.util.zip.GZIPOutputStream;
  * Methods to provide CRAM external compression/decompression features.
  */
 public class ExternalCompression {
-    private static final int GZIP_COMPRESSION_LEVEL = Integer.valueOf(System.getProperty("gzip.compression.level", "5"));
+    private static final int GZIP_COMPRESSION_LEVEL = Integer.parseInt(System.getProperty("gzip.compression.level", "5"));
 
     /**
      * Compress a byte array into GZIP blob. The method obeys {@link ExternalCompression#GZIP_COMPRESSION_LEVEL} compression level.

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
@@ -156,10 +156,10 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
 
                 // Parse the index line.
                 String contig = tokens.group(1);
-                long size = Long.valueOf(tokens.group(2));
-                long location = Long.valueOf(tokens.group(3));
-                int basesPerLine = Integer.valueOf(tokens.group(4));
-                int bytesPerLine = Integer.valueOf(tokens.group(5));
+                long size = Long.parseLong(tokens.group(2));
+                long location = Long.parseLong(tokens.group(3));
+                int basesPerLine = Integer.parseInt(tokens.group(4));
+                int bytesPerLine = Integer.parseInt(tokens.group(5));
 
                 contig = SAMSequenceRecord.truncateSequenceName(contig);
                 // Build sequence structure

--- a/src/main/java/htsjdk/tribble/example/CountRecords.java
+++ b/src/main/java/htsjdk/tribble/example/CountRecords.java
@@ -68,7 +68,7 @@ public class CountRecords {
             printUsage();
         }
 
-        int optimizeIndex = args.length == 2 ? Integer.valueOf(args[1]) : -1;
+        int optimizeIndex = args.length == 2 ? Integer.parseInt(args[1]) : -1;
 
         // determine the codec
         FeatureCodec codec = getFeatureCodec(featureFile);

--- a/src/main/java/htsjdk/tribble/example/ProfileIndexReading.java
+++ b/src/main/java/htsjdk/tribble/example/ProfileIndexReading.java
@@ -42,7 +42,7 @@ public class ProfileIndexReading {
         if (args.length < 2)
             printUsage();
 
-        int iterations = Integer.valueOf(args[0]);
+        int iterations = Integer.parseInt(args[0]);
         for ( int j = 1; j < args.length; j++  ) {
             String indexFile = args[j];
             System.out.printf("Reading %s%n", indexFile);

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -60,7 +60,7 @@ public class LinearIndex extends AbstractIndex {
     private final static int MAX_BIN_WIDTH = 1 * 1000 * 1000 * 1000; //  widths must be less than 1 billion
 
     // 1MB: we will no merge bins with any features in them beyond this size, no matter how sparse, per chromosome
-    private static final long MAX_BIN_WIDTH_FOR_OCCUPIED_CHR_INDEX = Long.valueOf(System.getProperty("MAX_BIN_WIDTH_FOR_OCCUPIED_CHR_INDEX", "1024000"));
+    private static final long MAX_BIN_WIDTH_FOR_OCCUPIED_CHR_INDEX = Long.parseLong(System.getProperty("MAX_BIN_WIDTH_FOR_OCCUPIED_CHR_INDEX", "1024000"));
 
     public static boolean enableAdaptiveIndexing = true;
 

--- a/src/main/java/htsjdk/tribble/readers/PositionalBufferedStream.java
+++ b/src/main/java/htsjdk/tribble/readers/PositionalBufferedStream.java
@@ -177,7 +177,7 @@ public final class PositionalBufferedStream extends InputStream implements Posit
 
     public static void main(String[] args) throws Exception {
         final File testFile = new File(args[0]);
-        final int iterations = Integer.valueOf(args[1]);
+        final int iterations = Integer.parseInt(args[1]);
         final boolean includeInputStream = Boolean.valueOf(args[2]);
         final boolean doReadFileInChunks = Boolean.valueOf(args[3]);
 

--- a/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
+++ b/src/main/java/htsjdk/variant/variantcontext/CommonInfo.java
@@ -312,7 +312,7 @@ public final class CommonInfo implements Serializable {
         Object x = getAttribute(key);
         if ( x == null || x == VCFConstants.MISSING_VALUE_v4 ) return defaultValue;
         if ( x instanceof Integer ) return (Integer)x;
-        return Integer.valueOf((String)x); // throws an exception if this isn't a string
+        return Integer.parseInt((String)x); // throws an exception if this isn't a string
     }
 
     public double getAttributeAsDouble(String key, double defaultValue) {

--- a/src/main/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Genotype.java
@@ -518,7 +518,7 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
         Object x = getExtendedAttribute(key);
         if ( x == null || x == VCFConstants.MISSING_VALUE_v4 ) return defaultValue;
         if ( x instanceof Integer ) return (Integer)x;
-        return Integer.valueOf((String)x); // throws an exception if this isn't a string
+        return Integer.parseInt((String)x); // throws an exception if this isn't a string
     }
 
     @Deprecated

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1253,7 +1253,7 @@ public class VariantContext implements Feature, Serializable {
 
         // AN
         if (hasAttribute(VCFConstants.ALLELE_NUMBER_KEY)) {
-            final int reportedAN = Integer.valueOf(getAttribute(VCFConstants.ALLELE_NUMBER_KEY).toString());
+            final int reportedAN = Integer.parseInt(getAttribute(VCFConstants.ALLELE_NUMBER_KEY).toString());
             final int observedAN = getCalledChrCount();
             if ( reportedAN != observedAN )
                 throw new TribbleException.InternalCodecException(String.format("the Allele Number (AN) tag is incorrect for the record at position %s:%d, %d vs. %d", getContig(), getStart(), reportedAN, observedAN));
@@ -1277,7 +1277,7 @@ public class VariantContext implements Feature, Serializable {
 
             for (int i = 0; i < observedACs.size(); i++) {
                 // need to cast to int to make sure we don't have an issue below with object equals (earlier bug) - EB
-                final int reportedAC = Integer.valueOf(reportedACs.get(i).toString());
+                final int reportedAC = Integer.parseInt(reportedACs.get(i).toString());
                 if (reportedAC != observedACs.get(i))
                     throw new TribbleException.InternalCodecException(String.format("the Allele Count (AC) tag is incorrect for the record at position %s:%d, %s vs. %d", getContig(), getStart(), reportedAC, observedACs.get(i)));
             }

--- a/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -319,7 +319,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
         builder.chr(chr);
         int pos = -1;
         try {
-            pos = Integer.valueOf(parts[1]);
+            pos = Integer.parseInt(parts[1]);
         } catch (NumberFormatException e) {
             generateException(parts[1] + " is not a valid start position in the VCF format");
         }
@@ -344,7 +344,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
         if ( attrs.containsKey(VCFConstants.END_KEY) ) {
             // update stop with the end key if provided
             try {
-                builder.stop(Integer.valueOf(attrs.get(VCFConstants.END_KEY).toString()));
+                builder.stop(Integer.parseInt(attrs.get(VCFConstants.END_KEY).toString()));
             } catch (Exception e) {
                 generateException("the END value in the INFO field is not valid");
             }
@@ -486,7 +486,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
             return Allele.NO_CALL;
         final int i;
         try {
-            i = Integer.valueOf(index);
+            i = Integer.parseInt(index);
         } catch ( NumberFormatException e ) {
             throw new TribbleException.InternalCodecException("The following invalid GT allele index was encountered in the file: " + index);
         }
@@ -741,7 +741,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
                                 gb.PL(GenotypeLikelihoods.fromGLField(genotypeValues.get(i)).getAsPLs());
                             }
                         } else if (gtKey.equals(VCFConstants.DEPTH_KEY)) {
-                            gb.DP(Integer.valueOf(genotypeValues.get(i)));
+                            gb.DP(Integer.parseInt(genotypeValues.get(i)));
                         } else {
                             gb.attribute(gtKey, genotypeValues.get(i));
                         }

--- a/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
@@ -227,7 +227,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
             countType = VCFHeaderLineCount.UNBOUNDED;
         } else {
             countType = VCFHeaderLineCount.INTEGER;
-            count = Integer.valueOf(numberStr);
+            count = Integer.parseInt(numberStr);
 
         }
 

--- a/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
@@ -79,7 +79,7 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
 	public SAMSequenceRecord getSAMSequenceRecord() {
 		final String lengthString = this.getGenericFieldValue("length");
 		if (lengthString == null) throw new TribbleException("Contig " + this.getID() + " does not have a length field.");
-		final SAMSequenceRecord record = new SAMSequenceRecord(this.getID(), Integer.valueOf(lengthString));
+		final SAMSequenceRecord record = new SAMSequenceRecord(this.getID(), Integer.parseInt(lengthString));
         record.setAssembly(this.getGenericFieldValue("assembly"));
 		record.setSequenceIndex(this.contigIndex);
 		return record;


### PR DESCRIPTION
... as reported by SpotBugs.

See https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#bx-boxing-unboxing-to-parse-a-primitive-dm-boxed-primitive-for-parsing

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

