### PR TITLE
update CramCompressionRecord.isPlaced() to make it APDelta-aware

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -379,7 +379,7 @@ public class CRAMContainerStreamWriter {
                     while (last.next != null) last = last.next;
 
                     if (cramRecord.isFirstSegment() && last.isLastSegment()) {
-                        final boolean coordinateSorted = (samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.unsorted);
+                        final boolean coordinateSorted = (samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.coordinate);
                         final int templateLength = CramNormalizer.computeInsertSize(cramRecord, last, coordinateSorted);
 
                         if (cramRecord.templateSize == templateLength) {

--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -379,8 +379,8 @@ public class CRAMContainerStreamWriter {
                     while (last.next != null) last = last.next;
 
                     if (cramRecord.isFirstSegment() && last.isLastSegment()) {
-
-                        final int templateLength = CramNormalizer.computeInsertSize(cramRecord, last);
+                        final boolean coordinateSorted = (samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.unsorted);
+                        final int templateLength = CramNormalizer.computeInsertSize(cramRecord, last, coordinateSorted);
 
                         if (cramRecord.templateSize == templateLength) {
                             last = cramRecord.next;

--- a/src/main/java/htsjdk/samtools/cram/build/CramNormalizer.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramNormalizer.java
@@ -94,7 +94,7 @@ public class CramNormalizer {
             for (final CramCompressionRecord record : records) {
                 if (record.previous != null) continue;
                 if (record.next == null) continue;
-                restoreMateInfo(record);
+                restoreMateInfo(record, header.getSortOrder() == SAMFileHeader.SortOrder.coordinate);
             }
         }
 
@@ -137,7 +137,8 @@ public class CramNormalizer {
         restoreQualityScores(defaultQualityScore, records);
     }
 
-    private static void restoreMateInfo(final CramCompressionRecord record) {
+    private static void restoreMateInfo(final CramCompressionRecord record,
+                                        final boolean coordinateSorted) {
         if (record.next == null) {
 
             return;
@@ -155,7 +156,7 @@ public class CramNormalizer {
 //        record.setFirstSegment(true);
 //        last.setLastSegment(true);
 
-        final int templateLength = computeInsertSize(record, last);
+        final int templateLength = computeInsertSize(record, last, coordinateSorted);
         record.templateSize = templateLength;
         last.templateSize = -templateLength;
     }
@@ -326,10 +327,12 @@ public class CramNormalizer {
      *
      * @param firstEnd  first mate of the pair
      * @param secondEnd second mate of the pair
+     * @param coordinateSorted do these records have APDelta set?
      * @return template length
      */
     public static int computeInsertSize(final CramCompressionRecord firstEnd,
-                                        final CramCompressionRecord secondEnd) {
+                                        final CramCompressionRecord secondEnd,
+                                        final boolean coordinateSorted) {
         if (firstEnd.isSegmentUnmapped() || secondEnd.isSegmentUnmapped()) {
             return 0;
         }
@@ -337,8 +340,8 @@ public class CramNormalizer {
             return 0;
         }
 
-        final int firstEnd5PrimePosition = firstEnd.isNegativeStrand() ? firstEnd.getAlignmentEnd() : firstEnd.alignmentStart;
-        final int secondEnd5PrimePosition = secondEnd.isNegativeStrand() ? secondEnd.getAlignmentEnd() : secondEnd.alignmentStart;
+        final int firstEnd5PrimePosition = firstEnd.isNegativeStrand() ? firstEnd.getAlignmentEnd(coordinateSorted) : firstEnd.alignmentStart;
+        final int secondEnd5PrimePosition = secondEnd.isNegativeStrand() ? secondEnd.getAlignmentEnd(coordinateSorted) : secondEnd.alignmentStart;
 
         final int adjustment = (secondEnd5PrimePosition >= firstEnd5PrimePosition) ? +1 : -1;
         return secondEnd5PrimePosition - firstEnd5PrimePosition + adjustment;

--- a/src/main/java/htsjdk/samtools/cram/build/CramNormalizer.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramNormalizer.java
@@ -94,7 +94,8 @@ public class CramNormalizer {
             for (final CramCompressionRecord record : records) {
                 if (record.previous != null) continue;
                 if (record.next == null) continue;
-                restoreMateInfo(record, header.getSortOrder() == SAMFileHeader.SortOrder.coordinate);
+                final boolean usePositionDeltaEncoding = header.getSortOrder() == SAMFileHeader.SortOrder.coordinate;
+                restoreMateInfo(record, usePositionDeltaEncoding);
             }
         }
 
@@ -138,7 +139,7 @@ public class CramNormalizer {
     }
 
     private static void restoreMateInfo(final CramCompressionRecord record,
-                                        final boolean coordinateSorted) {
+                                        final boolean usePositionDeltaEncoding) {
         if (record.next == null) {
 
             return;
@@ -156,7 +157,7 @@ public class CramNormalizer {
 //        record.setFirstSegment(true);
 //        last.setLastSegment(true);
 
-        final int templateLength = computeInsertSize(record, last, coordinateSorted);
+        final int templateLength = computeInsertSize(record, last, usePositionDeltaEncoding);
         record.templateSize = templateLength;
         last.templateSize = -templateLength;
     }
@@ -327,12 +328,12 @@ public class CramNormalizer {
      *
      * @param firstEnd  first mate of the pair
      * @param secondEnd second mate of the pair
-     * @param coordinateSorted do these records have APDelta set?
+     * @param usePositionDeltaEncoding do these records delta-encode their alignment starts?
      * @return template length
      */
     public static int computeInsertSize(final CramCompressionRecord firstEnd,
                                         final CramCompressionRecord secondEnd,
-                                        final boolean coordinateSorted) {
+                                        final boolean usePositionDeltaEncoding) {
         if (firstEnd.isSegmentUnmapped() || secondEnd.isSegmentUnmapped()) {
             return 0;
         }
@@ -340,8 +341,8 @@ public class CramNormalizer {
             return 0;
         }
 
-        final int firstEnd5PrimePosition = firstEnd.isNegativeStrand() ? firstEnd.getAlignmentEnd(coordinateSorted) : firstEnd.alignmentStart;
-        final int secondEnd5PrimePosition = secondEnd.isNegativeStrand() ? secondEnd.getAlignmentEnd(coordinateSorted) : secondEnd.alignmentStart;
+        final int firstEnd5PrimePosition = firstEnd.isNegativeStrand() ? firstEnd.getAlignmentEnd(usePositionDeltaEncoding) : firstEnd.alignmentStart;
+        final int secondEnd5PrimePosition = secondEnd.isNegativeStrand() ? secondEnd.getAlignmentEnd(usePositionDeltaEncoding) : secondEnd.alignmentStart;
 
         final int adjustment = (secondEnd5PrimePosition >= firstEnd5PrimePosition) ? +1 : -1;
         return secondEnd5PrimePosition - firstEnd5PrimePosition + adjustment;

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -272,7 +272,7 @@ public class CramCompressionRecord {
     // check placement without regard to mapping; helper method for isPlaced()
     private boolean isPlacedInternal(final boolean useAbsolutePositionEncoding) {
         // placement requires a valid sequence ID
-        if (sequenceId != SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
+        if (sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
             return false;
         }
 

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -184,8 +184,8 @@ public class CramCompressionRecord {
 
     private void intializeAlignmentBoundaries(final boolean usePositionDeltaEncoding) {
         if (!isPlaced(usePositionDeltaEncoding)) {
-            alignmentSpan = 0;
-            alignmentEnd = SAMRecord.NO_ALIGNMENT_START;
+            alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
+            alignmentEnd = Slice.NO_ALIGNMENT_END;
             return;
         }
 

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -183,7 +183,7 @@ public class CramCompressionRecord {
     }
 
     private void intializeAlignmentBoundaries(final boolean usePositionDeltaEncoding) {
-        if (! isPlaced(usePositionDeltaEncoding)) {
+        if (!isPlaced(usePositionDeltaEncoding)) {
             alignmentSpan = 0;
             alignmentEnd = SAMRecord.NO_ALIGNMENT_START;
             return;
@@ -211,7 +211,6 @@ public class CramCompressionRecord {
                         break;
                 }
             }
-
         }
 
         alignmentEnd = alignmentStart + alignmentSpan - 1;

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -49,12 +49,15 @@ public class CramCompressionRecord {
     private static final int HAS_MATE_DOWNSTREAM_FLAG = 0x4;
     private static final int UNKNOWN_BASES = 0x8;
 
+    private static final int UNINITIALIZED_END = -1;
+    private static final int UNINITIALIZED_SPAN = -1;
+
     // sequential index of the record in a stream:
     public int index = 0;
     public int alignmentStart;
     public int alignmentDelta;
-    private int alignmentEnd = -1;
-    private int alignmentSpan = -1;
+    private int alignmentEnd = UNINITIALIZED_END;
+    private int alignmentSpan = UNINITIALIZED_SPAN;
 
     public int readLength;
 
@@ -152,15 +155,20 @@ public class CramCompressionRecord {
         return stringBuilder.toString();
     }
 
+    /**
+     *
+     * @param usePositionDeltaEncoding
+     * @return
+     */
     public int getAlignmentSpan(final boolean usePositionDeltaEncoding) {
-        if (alignmentSpan < 0) {
+        if (alignmentSpan == UNINITIALIZED_SPAN) {
             calculateAlignmentBoundaries(usePositionDeltaEncoding);
         }
         return alignmentSpan;
     }
 
     public int getAlignmentEnd(final boolean usePositionDeltaEncoding) {
-        if (alignmentEnd < 0) {
+        if (alignmentEnd == UNINITIALIZED_END) {
             calculateAlignmentBoundaries(usePositionDeltaEncoding);
         }
         return alignmentEnd;

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -182,6 +182,9 @@ public class CramCompressionRecord {
         return alignmentEnd;
     }
 
+    // https://github.com/samtools/htsjdk/issues/1301
+    // does not update alignmentSpan/alignmentEnd when the record changes
+
     private void intializeAlignmentBoundaries(final boolean usePositionDeltaEncoding) {
         if (!isPlaced(usePositionDeltaEncoding)) {
             alignmentSpan = Slice.NO_ALIGNMENT_SPAN;

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -152,22 +152,22 @@ public class CramCompressionRecord {
         return stringBuilder.toString();
     }
 
-    public int getAlignmentSpan(final boolean APDelta) {
+    public int getAlignmentSpan(final boolean usePositionDeltaEncoding) {
         if (alignmentSpan < 0) {
-            calculateAlignmentBoundaries(APDelta);
+            calculateAlignmentBoundaries(usePositionDeltaEncoding);
         }
         return alignmentSpan;
     }
 
-    public int getAlignmentEnd(final boolean APDelta) {
+    public int getAlignmentEnd(final boolean usePositionDeltaEncoding) {
         if (alignmentEnd < 0) {
-            calculateAlignmentBoundaries(APDelta);
+            calculateAlignmentBoundaries(usePositionDeltaEncoding);
         }
         return alignmentEnd;
     }
 
-    void calculateAlignmentBoundaries(final boolean APDelta) {
-        if (! isPlaced(APDelta)) {
+    void calculateAlignmentBoundaries(final boolean usePositionDeltaEncoding) {
+        if (! isPlaced(usePositionDeltaEncoding)) {
             alignmentSpan = 0;
             alignmentEnd = SAMRecord.NO_ALIGNMENT_START;
         } else if (readFeatures == null || readFeatures.isEmpty()) {
@@ -225,14 +225,14 @@ public class CramCompressionRecord {
     /**
      * Does this record have a valid placement/alignment location? This is independent of mapping status.
      * It must have a valid reference sequence ID to qualify, as well as a valid alignment start position
-     * in the case of absolute (non-APDelta) position storage.
+     * in the case of absolute (non-usePositionDeltaEncoding) position storage.
      *
      * @see #isSegmentUnmapped()
      * @return true if the record is placed
      */
-    public boolean isPlaced(final boolean APDelta) {
+    public boolean isPlaced(final boolean usePositionDeltaEncoding) {
         // if an absolute alignment start coordinate is required but we have none, it's unplaced
-        if (! APDelta && alignmentStart == SAMRecord.NO_ALIGNMENT_START) {
+        if (! usePositionDeltaEncoding && alignmentStart == SAMRecord.NO_ALIGNMENT_START) {
             return false;
         }
 

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -156,33 +156,39 @@ public class CramCompressionRecord {
     }
 
     /**
-     *
-     * @param usePositionDeltaEncoding
-     * @return
+     * Check whether alignmentSpan has been initialized, and do so if it has not
+     * @param usePositionDeltaEncoding is this record's position delta-encoded? used to call isPlaced()
+     * @return the initialized alignmentSpan
      */
     public int getAlignmentSpan(final boolean usePositionDeltaEncoding) {
         if (alignmentSpan == UNINITIALIZED_SPAN) {
-            calculateAlignmentBoundaries(usePositionDeltaEncoding);
+            intializeAlignmentBoundaries(usePositionDeltaEncoding);
         }
         return alignmentSpan;
     }
 
+    /**
+     * Check whether alignmentEnd has been initialized, and do so if it has not
+     * @param usePositionDeltaEncoding is this record's position delta-encoded? used to call isPlaced()
+     * @return the initialized alignmentEnd
+     */
     public int getAlignmentEnd(final boolean usePositionDeltaEncoding) {
         if (alignmentEnd == UNINITIALIZED_END) {
-            calculateAlignmentBoundaries(usePositionDeltaEncoding);
+            intializeAlignmentBoundaries(usePositionDeltaEncoding);
         }
         return alignmentEnd;
     }
 
-    void calculateAlignmentBoundaries(final boolean usePositionDeltaEncoding) {
+    private void intializeAlignmentBoundaries(final boolean usePositionDeltaEncoding) {
         if (! isPlaced(usePositionDeltaEncoding)) {
             alignmentSpan = 0;
             alignmentEnd = SAMRecord.NO_ALIGNMENT_START;
-        } else if (readFeatures == null || readFeatures.isEmpty()) {
-            alignmentSpan = readLength;
-            alignmentEnd = alignmentStart + alignmentSpan - 1;
-        } else {
-            alignmentSpan = readLength;
+            return;
+        }
+
+        alignmentSpan = readLength;
+
+        if (readFeatures != null) {
             for (final ReadFeature readFeature : readFeatures) {
                 switch (readFeature.getOperator()) {
                     case InsertBase.operator:
@@ -202,8 +208,10 @@ public class CramCompressionRecord {
                         break;
                 }
             }
-            alignmentEnd = alignmentStart + alignmentSpan - 1;
+
         }
+
+        alignmentEnd = alignmentStart + alignmentSpan - 1;
     }
 
     public boolean isMultiFragment() {

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -388,7 +388,7 @@ public class Slice {
             // Unmapped: all records are unmapped and unplaced
 
             final CramCompressionRecord firstRecord = records.get(0);
-            slice.sequenceId = firstRecord.isPlaced() ?
+            slice.sequenceId = firstRecord.isPlaced(header.APDelta) ?
                     firstRecord.sequenceId :
                     SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
 
@@ -398,19 +398,19 @@ public class Slice {
                 hasher.add(record);
 
                 // flip an unmapped slice to multi-ref if the record is placed
-                if (slice.isUnmapped() && record.isPlaced()) {
+                if (slice.isUnmapped() && record.isPlaced(header.APDelta)) {
                     slice.sequenceId = MULTI_REFERENCE;
                 }
                 else if (slice.isMappedSingleRef()) {
                     // flip a single-ref slice to multi-ref if the record is unplaced or on a different ref
-                    if (!record.isPlaced() || slice.sequenceId != record.sequenceId) {
+                    if (!record.isPlaced(header.APDelta) || slice.sequenceId != record.sequenceId) {
                         slice.sequenceId = MULTI_REFERENCE;
                     }
                     else {
                         // calculate single ref slice alignment
 
                         minAlStart = Math.min(record.alignmentStart, minAlStart);
-                        maxAlEnd = Math.max(record.getAlignmentEnd(), maxAlEnd);
+                        maxAlEnd = Math.max(record.getAlignmentEnd(header.APDelta), maxAlEnd);
                     }
                 }
             }

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -52,6 +52,7 @@ public class Slice {
     public static final int MULTI_REFERENCE = -2;
     public static final int NO_ALIGNMENT_START = -1;
     public static final int NO_ALIGNMENT_SPAN = 0;
+    public static final int NO_ALIGNMENT_END = SAMRecord.NO_ALIGNMENT_START; // 0
     private static final Log log = Log.getInstance(Slice.class);
 
     // as defined in the specs:

--- a/src/test/java/htsjdk/samtools/cram/build/ContainerFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/ContainerFactoryTest.java
@@ -57,6 +57,21 @@ public class ContainerFactoryTest extends HtsjdkTest {
         return records;
     }
 
+    static List<CramCompressionRecord> getUnmappedRecords() {
+        final List<CramCompressionRecord> records = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            final CramCompressionRecord record = createMappedRecord(i);
+            record.setSegmentUnmapped(true);
+            record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
+            record.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
+            records.add(record);
+        }
+        return records;
+    }
+
+    // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
+    // but not both.  We treat these weird edge cases as unplaced.
+
     static List<CramCompressionRecord> getUnmappedNoRefRecords() {
         final List<CramCompressionRecord> records = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
@@ -149,6 +164,16 @@ public class ContainerFactoryTest extends HtsjdkTest {
         final Container container = factory.buildContainer(getSingleRefRecords(recordCount));
         assertContainerState(container, recordCount, sequenceId, alignmentStart, alignmentSpan);
     }
+
+    @Test
+    public void testUnmapped() {
+        final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), 10);
+        final Container container = factory.buildContainer(getUnmappedRecords());
+        assertContainerState(container, 10, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+    }
+
+    // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
+    // but not both.  We treat these weird edge cases as unplaced.
 
     @Test
     public void testUnmappedNoReferenceId() {

--- a/src/test/java/htsjdk/samtools/cram/build/ContainerParserTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/ContainerParserTest.java
@@ -55,6 +55,16 @@ public class ContainerParserTest extends HtsjdkTest {
                         }}
                 },
                 {
+                        ContainerFactoryTest.getUnmappedRecords(),
+                        new HashSet<Integer>() {{
+                            add(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+                        }}
+                },
+
+                // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
+                // but not both.  We treat these weird edge cases as unplaced.
+
+                {
                         ContainerFactoryTest.getUnmappedNoRefRecords(),
                         new HashSet<Integer>() {{
                             add(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -133,6 +133,10 @@ public class CramCompressionRecordTest extends HtsjdkTest {
 
                         boolean placementExpectation = true;
 
+                        // we also expect that read sequenceIds and alignmentStart are both valid or both invalid.
+                        // however: we do handle the edge case where only one of the pair is valid
+                        // by marking it as unplaced.
+
                         if (sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
                             placementExpectation = false;
                         }

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -162,4 +162,27 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.setSegmentUnmapped(!mapped);
         Assert.assertEquals(r.isPlaced(usePositionDeltaEncoding), placementExpectation);
     }
+
+    @Test(dataProvider = "placedTests")
+    public void test_placementForAlignmentSpanAndEnd(final int sequenceId,
+                                                     final int alignmentStart,
+                                                     final boolean mapped,
+                                                     final boolean usePositionDeltaEncoding,
+                                                     final boolean placementExpectation) {
+        final CramCompressionRecord r = new CramCompressionRecord();
+        r.sequenceId = sequenceId;
+        r.alignmentStart = alignmentStart;
+        r.setSegmentUnmapped(!mapped);
+        final int readLength = 100;
+        r.readLength = readLength;
+
+        if (placementExpectation) {
+            Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), readLength);
+            Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), alignmentStart + readLength - 1);
+        }
+        else {
+            Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), Slice.NO_ALIGNMENT_SPAN);
+            Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), Slice.NO_ALIGNMENT_END);
+        }
+    }
 }

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -58,59 +58,6 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         String insertion = "CCCCCCCCCC";
         r.readFeatures.add(new Insertion(1, insertion.getBytes()));
         Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - insertion.length());
-        
-        r = new CramCompressionRecord();
-        r.alignmentStart = 1;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<>();
-        r.readFeatures.add(new InsertBase(1, (byte) 'A'));
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - 1);
-    }
-
-    @Test
-    public void test_getAlignmentEndtrue() {
-        final boolean APDelta = true;
-
-        CramCompressionRecord r = new CramCompressionRecord();
-        r.alignmentStart = 1;
-        r.setSegmentUnmapped(true);
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), SAMRecord.NO_ALIGNMENT_START);
-
-        r = new CramCompressionRecord();
-        int readLength = 100;
-        r.alignmentStart = 1;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1);
-
-        r = new CramCompressionRecord();
-        r.alignmentStart = 1;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<>();
-        String softClip = "AAA";
-        r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - softClip.length());
-
-        r = new CramCompressionRecord();
-        r.alignmentStart = 1;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<>();
-        int deletionLength = 5;
-        r.readFeatures.add(new Deletion(1, deletionLength));
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 + deletionLength);
-
-        r = new CramCompressionRecord();
-        r.alignmentStart = 1;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<>();
-        String insertion = "CCCCCCCCCC";
-        r.readFeatures.add(new Insertion(1, insertion.getBytes()));
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - insertion.length());
-
 
         r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -120,7 +67,6 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures.add(new InsertBase(1, (byte) 'A'));
         Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - 1);
     }
-
 
     @DataProvider(name = "placedTests")
     private Object[][] placedTests() {

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -19,18 +19,18 @@ public class CramCompressionRecordTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "tf")
-    public void test_getAlignmentEnd(final boolean APDelta) {
+    public void test_getAlignmentEnd(final boolean usePositionDeltaEncoding) {
         CramCompressionRecord r = new CramCompressionRecord();
         r.alignmentStart = 1;
         r.setSegmentUnmapped(true);
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), SAMRecord.NO_ALIGNMENT_START);
+        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), SAMRecord.NO_ALIGNMENT_START);
 
         r = new CramCompressionRecord();
         int readLength = 100;
         r.alignmentStart = 1;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1);
+        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -39,7 +39,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         String softClip = "AAA";
         r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - softClip.length());
+        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 - softClip.length());
 
         r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -48,7 +48,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         int deletionLength = 5;
         r.readFeatures.add(new Deletion(1, deletionLength));
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 + deletionLength);
+        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 + deletionLength);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -57,7 +57,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         String insertion = "CCCCCCCCCC";
         r.readFeatures.add(new Insertion(1, insertion.getBytes()));
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - insertion.length());
+        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 - insertion.length());
 
         r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -65,21 +65,21 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.setSegmentUnmapped(false);
         r.readFeatures = new ArrayList<>();
         r.readFeatures.add(new InsertBase(1, (byte) 'A'));
-        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - 1);
+        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 - 1);
     }
 
     @DataProvider(name = "placedTests")
     private Object[][] placedTests() {
         return new Object[][] {
-                // APDelta = false.  Must have a valid Start as well as a Reference
+                // usePositionDeltaEncoding = false.  Must have a valid Start as well as a Reference
                 {false, false, false, false},
-                // APDelta = true.  Must have a valid Reference.  Invalid Start is OK because we use the Delta instead
+                // usePositionDeltaEncoding = true.  Must have a valid Reference.  Invalid Start is OK because we use the Delta instead
                 {true, false, false, true}
         };
     }
 
     @Test(dataProvider = "placedTests")
-    public void test_isPlaced(final boolean APDelta,
+    public void test_isPlaced(final boolean usePositionDeltaEncoding,
                               final boolean noRefExpectation,
                               final boolean bothExpectation,
                               final boolean noStartExpectation) {
@@ -89,18 +89,18 @@ public class CramCompressionRecordTest extends HtsjdkTest {
 
         r.sequenceId = 5;
         r.alignmentStart = 10;
-        Assert.assertTrue(r.isPlaced(APDelta));
+        Assert.assertTrue(r.isPlaced(usePositionDeltaEncoding));
 
         r.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-        Assert.assertEquals(r.isPlaced(APDelta), noRefExpectation);
+        Assert.assertEquals(r.isPlaced(usePositionDeltaEncoding), noRefExpectation);
 
         r.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
-        Assert.assertEquals(r.isPlaced(APDelta), bothExpectation);
+        Assert.assertEquals(r.isPlaced(usePositionDeltaEncoding), bothExpectation);
 
         r.sequenceId = 3;
-        Assert.assertEquals(r.isPlaced(APDelta), noStartExpectation);
+        Assert.assertEquals(r.isPlaced(usePositionDeltaEncoding), noStartExpectation);
 
         r.alignmentStart = 15;
-        Assert.assertTrue(r.isPlaced(APDelta));
+        Assert.assertTrue(r.isPlaced(usePositionDeltaEncoding));
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -20,13 +20,15 @@ public class CramCompressionRecordTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "deltaEncodingTrueFalse")
-    public void test_getAlignmentSpan(final boolean usePositionDeltaEncoding) {
+    public void test_getAlignmentSpanAndEnd(final boolean usePositionDeltaEncoding) {
         CramCompressionRecord r = new CramCompressionRecord();
         int readLength = 100;
         r.alignmentStart = 5;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength);
+
+        int expectedSpan = r.readLength;
+        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 10;
@@ -35,7 +37,9 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         String softClip = "AAA";
         r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength - softClip.length());
+
+        expectedSpan = r.readLength - softClip.length();
+        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 20;
@@ -44,7 +48,9 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         int deletionLength = 5;
         r.readFeatures.add(new Deletion(1, deletionLength));
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength + deletionLength);
+
+        expectedSpan = r.readLength + deletionLength;
+        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 30;
@@ -53,7 +59,9 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         String insertion = "CCCCCCCCCC";
         r.readFeatures.add(new Insertion(1, insertion.getBytes()));
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength - insertion.length());
+
+        expectedSpan = r.readLength - insertion.length();
+        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 40;
@@ -61,52 +69,17 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.setSegmentUnmapped(false);
         r.readFeatures = new ArrayList<>();
         r.readFeatures.add(new InsertBase(1, (byte) 'A'));
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength - 1);
+
+        expectedSpan = r.readLength - 1;
+        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
     }
 
-    @Test(dataProvider = "deltaEncodingTrueFalse")
-    public void test_getAlignmentEnd(final boolean usePositionDeltaEncoding) {
-        CramCompressionRecord r = new CramCompressionRecord();
-        int readLength = 100;
-        r.alignmentStart = 5;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1);
-
-        r = new CramCompressionRecord();
-        r.alignmentStart = 10;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<>();
-        String softClip = "AAA";
-        r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 - softClip.length());
-
-        r = new CramCompressionRecord();
-        r.alignmentStart = 20;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<>();
-        int deletionLength = 5;
-        r.readFeatures.add(new Deletion(1, deletionLength));
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 + deletionLength);
-
-        r = new CramCompressionRecord();
-        r.alignmentStart = 30;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<>();
-        String insertion = "CCCCCCCCCC";
-        r.readFeatures.add(new Insertion(1, insertion.getBytes()));
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 - insertion.length());
-
-        r = new CramCompressionRecord();
-        r.alignmentStart = 40;
-        r.readLength = readLength;
-        r.setSegmentUnmapped(false);
-        r.readFeatures = new ArrayList<>();
-        r.readFeatures.add(new InsertBase(1, (byte) 'A'));
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 - 1);
+    private void assertSpanAndEnd(final CramCompressionRecord r,
+                                  final boolean usePositionDeltaEncoding,
+                                  final int expectedSpan) {
+        final int expectedEnd = expectedSpan + r.alignmentStart - 1;
+        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), expectedSpan);
+        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), expectedEnd);
     }
 
     // show that alignmentEnd and alignmentSpan are set once only and do not update

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -13,12 +13,12 @@ import java.util.ArrayList;
  * Created by vadim on 28/09/2015.
  */
 public class CramCompressionRecordTest extends HtsjdkTest {
-    @DataProvider(name = "tf")
+    @DataProvider(name = "deltaEncodingTrueFalse")
     private Object[][] tf() {
         return new Object[][] { {true}, {false}};
     }
 
-    @Test(dataProvider = "tf")
+    @Test(dataProvider = "deltaEncodingTrueFalse")
     public void test_getAlignmentEnd(final boolean usePositionDeltaEncoding) {
         CramCompressionRecord r = new CramCompressionRecord();
         r.alignmentStart = 1;

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -13,10 +13,64 @@ import java.util.ArrayList;
  * Created by vadim on 28/09/2015.
  */
 public class CramCompressionRecordTest extends HtsjdkTest {
+    @DataProvider(name = "tf")
+    private Object[][] tf() {
+        return new Object[][] { {true}, {false}};
+    }
+
+    @Test(dataProvider = "tf")
+    public void test_getAlignmentEnd(final boolean APDelta) {
+        CramCompressionRecord r = new CramCompressionRecord();
+        r.alignmentStart = 1;
+        r.setSegmentUnmapped(true);
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), SAMRecord.NO_ALIGNMENT_START);
+
+        r = new CramCompressionRecord();
+        int readLength = 100;
+        r.alignmentStart = 1;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1);
+
+        r = new CramCompressionRecord();
+        r.alignmentStart = 1;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        r.readFeatures = new ArrayList<>();
+        String softClip = "AAA";
+        r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - softClip.length());
+
+        r = new CramCompressionRecord();
+        r.alignmentStart = 1;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        r.readFeatures = new ArrayList<>();
+        int deletionLength = 5;
+        r.readFeatures.add(new Deletion(1, deletionLength));
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 + deletionLength);
+
+        r = new CramCompressionRecord();
+        r.alignmentStart = 1;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        r.readFeatures = new ArrayList<>();
+        String insertion = "CCCCCCCCCC";
+        r.readFeatures.add(new Insertion(1, insertion.getBytes()));
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - insertion.length());
+        
+        r = new CramCompressionRecord();
+        r.alignmentStart = 1;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        r.readFeatures = new ArrayList<>();
+        r.readFeatures.add(new InsertBase(1, (byte) 'A'));
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - 1);
+    }
+
     @Test
-    public void test_getAlignmentEnd() {
-        // TODO test delta = true
-        final boolean APDelta = false;
+    public void test_getAlignmentEndtrue() {
+        final boolean APDelta = true;
 
         CramCompressionRecord r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -66,6 +120,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures.add(new InsertBase(1, (byte) 'A'));
         Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - 1);
     }
+
 
     @DataProvider(name = "placedTests")
     private Object[][] placedTests() {

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -4,6 +4,7 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.cram.encoding.readfeatures.*;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -14,17 +15,20 @@ import java.util.ArrayList;
 public class CramCompressionRecordTest extends HtsjdkTest {
     @Test
     public void test_getAlignmentEnd() {
+        // TODO test delta = true
+        final boolean APDelta = false;
+
         CramCompressionRecord r = new CramCompressionRecord();
         r.alignmentStart = 1;
         r.setSegmentUnmapped(true);
-        Assert.assertEquals(r.getAlignmentEnd(), SAMRecord.NO_ALIGNMENT_START);
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), SAMRecord.NO_ALIGNMENT_START);
 
         r = new CramCompressionRecord();
         int readLength = 100;
         r.alignmentStart = 1;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
-        Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1);
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -33,7 +37,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         String softClip = "AAA";
         r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
-        Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1 - softClip.length());
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - softClip.length());
 
         r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -42,7 +46,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         int deletionLength = 5;
         r.readFeatures.add(new Deletion(1, deletionLength));
-        Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1 + deletionLength);
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 + deletionLength);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 1;
@@ -51,7 +55,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures = new ArrayList<>();
         String insertion = "CCCCCCCCCC";
         r.readFeatures.add(new Insertion(1, insertion.getBytes()));
-        Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1 - insertion.length());
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - insertion.length());
 
 
         r = new CramCompressionRecord();
@@ -60,29 +64,42 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.setSegmentUnmapped(false);
         r.readFeatures = new ArrayList<>();
         r.readFeatures.add(new InsertBase(1, (byte) 'A'));
-        Assert.assertEquals(r.getAlignmentEnd(), r.readLength + r.alignmentStart - 1 - 1);
+        Assert.assertEquals(r.getAlignmentEnd(APDelta), r.readLength + r.alignmentStart - 1 - 1);
     }
 
-    @Test
-    public void test_isPlaced() {
+    @DataProvider(name = "placedTests")
+    private Object[][] placedTests() {
+        return new Object[][] {
+                // APDelta = false.  Must have a valid Start as well as a Reference
+                {false, false, false, false},
+                // APDelta = true.  Must have a valid Reference.  Invalid Start is OK because we use the Delta instead
+                {true, false, false, true}
+        };
+    }
+
+    @Test(dataProvider = "placedTests")
+    public void test_isPlaced(final boolean APDelta,
+                              final boolean noRefExpectation,
+                              final boolean bothExpectation,
+                              final boolean noStartExpectation) {
         final CramCompressionRecord r = new CramCompressionRecord();
 
         // it's only Placed if both of these are valid
 
         r.sequenceId = 5;
         r.alignmentStart = 10;
-        Assert.assertTrue(r.isPlaced());
+        Assert.assertTrue(r.isPlaced(APDelta));
 
         r.sequenceId = SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
-        Assert.assertFalse(r.isPlaced());
+        Assert.assertEquals(r.isPlaced(APDelta), noRefExpectation);
 
         r.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
-        Assert.assertFalse(r.isPlaced());
+        Assert.assertEquals(r.isPlaced(APDelta), bothExpectation);
 
         r.sequenceId = 3;
-        Assert.assertFalse(r.isPlaced());
+        Assert.assertEquals(r.isPlaced(APDelta), noStartExpectation);
 
         r.alignmentStart = 15;
-        Assert.assertTrue(r.isPlaced());
+        Assert.assertTrue(r.isPlaced(APDelta));
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -82,13 +82,13 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), expectedEnd);
     }
 
-    // show that alignmentEnd and alignmentSpan are set once only and do not update
-    // to reflect the state of the record
+    // https://github.com/samtools/htsjdk/issues/1301
 
-    // TODO: is this the behavior we actually want?
+    // demonstrate the bug: alignmentEnd and alignmentSpan are set once only
+    // and do not update to reflect the state of the record
 
     @Test(dataProvider = "deltaEncodingTrueFalse")
-    public void testNoReinitialization(final boolean usePositionDeltaEncoding) {
+    public void demonstrateBug1301(final boolean usePositionDeltaEncoding) {
         final CramCompressionRecord r = new CramCompressionRecord();
         final int alignmentStart = 5;
         final int readLength = 100;

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -19,21 +19,61 @@ public class CramCompressionRecordTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "deltaEncodingTrueFalse")
-    public void test_getAlignmentEnd(final boolean usePositionDeltaEncoding) {
+    public void test_getAlignmentSpan(final boolean usePositionDeltaEncoding) {
         CramCompressionRecord r = new CramCompressionRecord();
-        r.alignmentStart = 1;
-        r.setSegmentUnmapped(true);
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), SAMRecord.NO_ALIGNMENT_START);
+        int readLength = 100;
+        r.alignmentStart = 5;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength);
 
         r = new CramCompressionRecord();
+        r.alignmentStart = 10;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        r.readFeatures = new ArrayList<>();
+        String softClip = "AAA";
+        r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
+        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength - softClip.length());
+
+        r = new CramCompressionRecord();
+        r.alignmentStart = 20;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        r.readFeatures = new ArrayList<>();
+        int deletionLength = 5;
+        r.readFeatures.add(new Deletion(1, deletionLength));
+        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength + deletionLength);
+
+        r = new CramCompressionRecord();
+        r.alignmentStart = 30;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        r.readFeatures = new ArrayList<>();
+        String insertion = "CCCCCCCCCC";
+        r.readFeatures.add(new Insertion(1, insertion.getBytes()));
+        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength - insertion.length());
+
+        r = new CramCompressionRecord();
+        r.alignmentStart = 40;
+        r.readLength = readLength;
+        r.setSegmentUnmapped(false);
+        r.readFeatures = new ArrayList<>();
+        r.readFeatures.add(new InsertBase(1, (byte) 'A'));
+        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength - 1);
+    }
+
+    @Test(dataProvider = "deltaEncodingTrueFalse")
+    public void test_getAlignmentEnd(final boolean usePositionDeltaEncoding) {
+        CramCompressionRecord r = new CramCompressionRecord();
         int readLength = 100;
-        r.alignmentStart = 1;
+        r.alignmentStart = 5;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
         Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1);
 
         r = new CramCompressionRecord();
-        r.alignmentStart = 1;
+        r.alignmentStart = 10;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
         r.readFeatures = new ArrayList<>();
@@ -42,7 +82,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 - softClip.length());
 
         r = new CramCompressionRecord();
-        r.alignmentStart = 1;
+        r.alignmentStart = 20;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
         r.readFeatures = new ArrayList<>();
@@ -51,7 +91,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 + deletionLength);
 
         r = new CramCompressionRecord();
-        r.alignmentStart = 1;
+        r.alignmentStart = 30;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
         r.readFeatures = new ArrayList<>();
@@ -60,7 +100,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), r.readLength + r.alignmentStart - 1 - insertion.length());
 
         r = new CramCompressionRecord();
-        r.alignmentStart = 1;
+        r.alignmentStart = 40;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
         r.readFeatures = new ArrayList<>();

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -85,8 +85,6 @@ public class CramCompressionRecordTest extends HtsjdkTest {
                               final boolean noStartExpectation) {
         final CramCompressionRecord r = new CramCompressionRecord();
 
-        // it's only Placed if both of these are valid
-
         r.sequenceId = 5;
         r.alignmentStart = 10;
         Assert.assertTrue(r.isPlaced(usePositionDeltaEncoding));

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -200,7 +200,8 @@ public class SliceTests extends HtsjdkTest {
         }
     }
 
-    private CramCompressionRecord createRecord(final int index, final int sequenceId) {
+    private CramCompressionRecord createRecord(final int index,
+                                               final int sequenceId) {
         final CramCompressionRecord record = new CramCompressionRecord();
         record.readBases = "AAA".getBytes();
         record.qualityScores = "!!!".getBytes();
@@ -210,46 +211,57 @@ public class SliceTests extends HtsjdkTest {
         record.alignmentStart = index + 1;
         record.setLastSegment(true);
         record.readFeatures = Collections.emptyList();
+        record.setSegmentUnmapped(false);
+        return record;
+    }
 
+    // set half of the records created as unmapped, alternating by index
+
+    private CramCompressionRecord createRecordHalfUnmapped(final int index,
+                                                           final int sequenceId) {
+        final CramCompressionRecord record = createRecord(index, sequenceId);
         if (index % 2 == 0) {
             record.setSegmentUnmapped(true);
         } else {
             record.setSegmentUnmapped(false);
         }
-
         return record;
     }
 
     private List<CramCompressionRecord> getSingleRefRecords() {
         final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            records.add(createRecord(i, 0));
+        for (int index = 0; index < TEST_RECORD_COUNT; index++) {
+            records.add(createRecordHalfUnmapped(index, 0));
         }
         return records;
     }
 
     private List<CramCompressionRecord> getMultiRefRecords() {
         final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            records.add(createRecord(i, i));
+        for (int index = 0; index < TEST_RECORD_COUNT; index++) {
+            records.add(createRecordHalfUnmapped(index, index));
         }
         return records;
     }
 
+
     private List<CramCompressionRecord> getNoRefRecords() {
         final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            records.add(createRecord(i, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX));
+        for (int index = 0; index < TEST_RECORD_COUNT; index++) {
+            final CramCompressionRecord record = createRecord(index, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+            record.setSegmentUnmapped(true);
+            records.add(record);
         }
         return records;
     }
 
     private List<CramCompressionRecord> getNoStartRecords() {
         final List<CramCompressionRecord> records = new ArrayList<>();
-        for (int i = 0; i < TEST_RECORD_COUNT; i++) {
-            final CramCompressionRecord rec = createRecord(i, i);
-            rec.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
-            records.add(rec);
+        for (int index = 0; index < TEST_RECORD_COUNT; index++) {
+            final CramCompressionRecord record = createRecord(index, index);
+            record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
+            record.setSegmentUnmapped(true);
+            records.add(record);
         }
         return records;
     }

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -134,29 +134,21 @@ public class SliceTests extends HtsjdkTest {
 
         final CramCompressionRecord record1 = createRecord(0, 0);
         records.add(record1);
-        final CompressionHeader header1 = new CompressionHeaderFactory().build(records, null, true);
-        final Slice slice1 = Slice.buildSlice(records, header1);
-        assertSliceState(slice1, 1, 0, 1, 3);
+        assertSliceStateFromRecords(records, 1, 0, 1, 3);
 
         final CramCompressionRecord record2 = createRecord(1, 1);
         records.add(record2);
-        final CompressionHeader header2 = new CompressionHeaderFactory().build(records, null, true);
-        final Slice slice2 = Slice.buildSlice(records, header2);
-        assertSliceState(slice2, 2, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertSliceStateFromRecords(records, 2, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
 
         final CramCompressionRecord record3 = createRecord(2, 2);
         records.add(record3);
-        final CompressionHeader header3 = new CompressionHeaderFactory().build(records, null, true);
-        final Slice slice3 = Slice.buildSlice(records, header3);
-        assertSliceState(slice3, 3, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertSliceStateFromRecords(records, 3, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
 
         final CramCompressionRecord unmapped = createRecord(3, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
         unmapped.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
         unmapped.setSegmentUnmapped(true);
         records.add(unmapped);
-        final CompressionHeader header4 = new CompressionHeaderFactory().build(records, null, true);
-        final Slice slice4 = Slice.buildSlice(records, header4);
-        assertSliceState(slice4, 4, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+        assertSliceStateFromRecords(records, 4, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
     }
 
     @Test
@@ -176,6 +168,16 @@ public class SliceTests extends HtsjdkTest {
 
         final Slice slice = Slice.buildSlice(records, header);
         assertSliceState(slice, 2, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN);
+    }
+
+    private void assertSliceStateFromRecords(final List<CramCompressionRecord> records,
+                                             final int expectedRecordCount,
+                                             final int expectedSequenceId,
+                                             final int expectedAlignmentStart,
+                                             final int expectedAlignmentSpan) {
+        final CompressionHeader header = new CompressionHeaderFactory().build(records, null, true);
+        final Slice slice = Slice.buildSlice(records, header);
+        assertSliceState(slice, expectedRecordCount, expectedSequenceId, expectedAlignmentStart, expectedAlignmentSpan);
     }
 
     private void assertSliceState(final Slice slice,

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -89,6 +89,16 @@ public class SliceTests extends HtsjdkTest {
                         TEST_RECORD_COUNT, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
                 },
                 {
+                        getUnplacedRecords(),
+                        true,
+                        TEST_RECORD_COUNT, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
+                },
+
+
+                // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
+                // but not both.  We treat these weird edge cases as unplaced.
+
+                {
                         getNoRefRecords(),
                         true,
                         TEST_RECORD_COUNT, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
@@ -244,6 +254,19 @@ public class SliceTests extends HtsjdkTest {
         return records;
     }
 
+    private List<CramCompressionRecord> getUnplacedRecords() {
+        final List<CramCompressionRecord> records = new ArrayList<>();
+        for (int index = 0; index < TEST_RECORD_COUNT; index++) {
+            final CramCompressionRecord record = createRecord(index, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
+            record.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
+            record.setSegmentUnmapped(true);
+            records.add(record);
+        }
+        return records;
+    }
+
+    // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
+    // but not both.  We treat these weird edge cases as unplaced.
 
     private List<CramCompressionRecord> getNoRefRecords() {
         final List<CramCompressionRecord> records = new ArrayList<>();


### PR DESCRIPTION
### Description

isPlaced() was not checking for the APDelta flag, thus inappropriately marking some records as unplaced.

Error introduced on 1/30 with #1266

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

