### PR TITLE
Changes to FastaReferenceWriter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ test {
         exclude "broken"
         exclude "defaultReference"
         exclude "ftp"
+        exclude "http"
         exclude "sra"
         exclude "ena"
 
@@ -127,11 +128,12 @@ task testFTP(type: Test) {
 }
 
 task testExternalApis(type: Test) {
-    description = "Run the SRA and ENA tests (tests that interact with external APIs)"
+    description = "Run the SRA, ENA, and HTTP tests (tests that interact with external APIs)"
     jvmArgs += '-Dsamjdk.sra_libraries_download=true'
 
     tags {
         include "sra"
+        include "http"
         include "ena"
         exclude "slow"
         exclude "broken"

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -25,7 +25,7 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.LineReader;
-import java.io.BufferedWriter;
+
 import java.io.Writer;
 
 /**

--- a/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceDictionaryCodec.java
@@ -26,6 +26,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.LineReader;
 import java.io.BufferedWriter;
+import java.io.Writer;
 
 /**
  * "On the fly" codec SAMSequenceDictionaryCodec.
@@ -67,7 +68,7 @@ public class SAMSequenceDictionaryCodec {
 
     private final SAMTextHeaderCodec codec;
 
-    public SAMSequenceDictionaryCodec(final BufferedWriter writer) {
+    public SAMSequenceDictionaryCodec(final Writer writer) {
         codec = new SAMTextHeaderCodec();
         codec.setmFileHeader(EMPTY_HEADER);
         codec.setWriter(writer);

--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -62,7 +62,7 @@ public class SAMTextHeaderCodec {
     private ValidationStringency validationStringency = ValidationStringency.SILENT;
 
     // These attributes are populated when generating text
-    private BufferedWriter writer;
+    private Writer writer;
 
     private static final String TAG_KEY_VALUE_SEPARATOR = ":";
     private static final char TAG_KEY_VALUE_SEPARATOR_CHAR = ':';
@@ -73,7 +73,7 @@ public class SAMTextHeaderCodec {
     public static final String COMMENT_PREFIX = HEADER_LINE_START + HeaderRecordType.CO.name() + FIELD_SEPARATOR;
     private static final Log log = Log.getInstance(SAMTextHeaderCodec.class);
 
-    void setWriter(final BufferedWriter writer) {
+    void setWriter(final Writer writer) {
         this.writer = writer;
     }
 

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
@@ -26,6 +26,7 @@ package htsjdk.samtools.reference;
 
 import htsjdk.utils.ValidationUtils;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -211,13 +212,13 @@ public class FastaReferenceWriterBuilder {
         checkBasesPerLine(basesPerLine);
 
         if (fastaFile != null) {
-            fastaOutput = Files.newOutputStream(fastaFile);
+            fastaOutput = new BufferedOutputStream(Files.newOutputStream(fastaFile));
         }
         if (indexFile != null) {
-            indexOutput = Files.newOutputStream(indexFile);
+            indexOutput = new BufferedOutputStream(Files.newOutputStream(indexFile));
         }
         if (dictFile != null) {
-            dictOutput = Files.newOutputStream(dictFile);
+            dictOutput = new BufferedOutputStream(Files.newOutputStream(dictFile));
         }
 
         return new FastaReferenceWriter(basesPerLine, fastaOutput, indexOutput, dictOutput);

--- a/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
@@ -8,12 +8,13 @@ import org.testng.annotations.Test;
 
 import htsjdk.HtsjdkTest;
 
+@Test(groups = "http")
 public class HttpUtilsTest extends HtsjdkTest {
     @DataProvider(name = "existing_urls")
     public Object[][] testExistingURLsData() {
         return new Object[][]{
             {"http://broadinstitute.github.io/picard/testdata/index_test.bam"},
-            {"http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/current.tree"}
+            {"http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/README_using_1000genomes_cram.md"}
         };
     }
 


### PR DESCRIPTION
* make sure the OutputStreams are always buffered
* change close behavior to be more likely to close all output streams in
the event of an early shutdown
* loosen restriction from BufferedWriter to Writer in
SAMSequenceDictionaryCodec and SAMTextHeaderCodec
