### PR TITLE
Yf add get reference to sam set builder

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -45,7 +45,7 @@ import java.util.NoSuchElementException;
  * @author vadim
  */
 @SuppressWarnings("UnusedDeclaration")
-public class CRAMFileReader extends SamReader.ReaderImplementation implements SamReader.Indexing {
+public class CRAMFileReader extends SamReader.ReaderImplementation implements SamReader.Indexing, AutoCloseable {
     private File cramFile;
     private final CRAMReferenceSource referenceSource;
     private InputStream inputStream;

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -652,7 +652,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
     public static void writeRandomReference(final SAMFileHeader header, final Path fasta) throws IOException {
         final int MAX_WRITE_AT_A_TIME = 10_000;
         final byte[] buffer = new byte[MAX_WRITE_AT_A_TIME];
-        final FastaReferenceWriterBuilder builder = new FastaReferenceWriterBuilder().setFastaFile(fasta);
+        final FastaReferenceWriterBuilder builder = new FastaReferenceWriterBuilder().setAddMd5(true).setFastaFile(fasta);
 
         try (FastaReferenceWriter writer = builder.build()) {
 

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -611,21 +611,23 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
     }
 
     public void writeRandomReference(final Path fasta) throws IOException {
-        final FastaReferenceWriterBuilder builder = new FastaReferenceWriterBuilder();
-        final FastaReferenceWriter writer = builder.setFastaFile(fasta).build();
+        final FastaReferenceWriterBuilder builder = new FastaReferenceWriterBuilder().setFastaFile(fasta);
 
-        final Random random = new Random();
-        getHeader().getSequenceDictionary()
-                .getSequences()
-                .forEach(seq -> {
-                    try {
-                        writer.startSequence(seq.getSequenceName());
-                        random.setSeed(seq.getSequenceName().hashCode());
-                        writer.appendBases(SequenceUtil.getRandomBases(random, seq.getSequenceLength()));
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                });
+        try (FastaReferenceWriter writer = builder.build()) {
+
+            final Random random = new Random();
+            getHeader().getSequenceDictionary()
+                    .getSequences()
+                    .forEach(seq -> {
+                        try {
+                            writer.startSequence(seq.getSequenceName());
+                            random.setSeed(seq.getSequenceName().hashCode());
+                            writer.appendBases(SequenceUtil.getRandomBases(random, seq.getSequenceLength()));
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    });
+        }
     }
 }
 

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -51,7 +51,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             "chr11", "chr12", "chr13", "chr14", "chr15", "chr16", "chr17", "chr18", "chr19", "chr20",
             "chr21", "chr22", "chrX", "chrY", "chrM"
     };
-    private static final byte[] BASES = {'A', 'C', 'G', 'T'};
+
     private static final String READ_GROUP_ID = "1";
     private static final String SAMPLE = "FREE_SAMPLE";
     private final Random random = new Random(TestUtil.RANDOM_SEED);
@@ -102,7 +102,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
     public SAMRecordSetBuilder(final boolean sortForMe, final SAMFileHeader.SortOrder sortOrder, final boolean addReadGroup,
                                final int defaultChromosomeLength, final ScoringStrategy duplicateScoringStrategy) {
 
-        this.header = makeDefaultHeader(sortOrder, defaultChromosomeLength);
+        this.header = makeDefaultHeader(sortOrder, defaultChromosomeLength,addReadGroup);
 
         final SAMRecordComparator comparator = sortOrder.getComparatorInstance();
 
@@ -110,15 +110,6 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             this.records = new TreeSet<>(comparator);
         } else {
             this.records = new ArrayList<>();
-        }
-
-        if (addReadGroup) {
-            final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord(READ_GROUP_ID);
-            readGroupRecord.setSample(SAMPLE);
-            readGroupRecord.setPlatform("ILLUMINA");
-            final List<SAMReadGroupRecord> readGroups = new ArrayList<>();
-            readGroups.add(readGroupRecord);
-            this.header.setReadGroups(readGroups);
         }
     }
 
@@ -607,17 +598,25 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
      * @param contigLength length of the other contigs
      * @return newly formed header
      */
-    static public SAMFileHeader makeDefaultHeader(final SAMFileHeader.SortOrder sortOrder, final int contigLength) {
+    static public SAMFileHeader makeDefaultHeader(final SAMFileHeader.SortOrder sortOrder, final int contigLength, final boolean addReadGroup) {
         final List<SAMSequenceRecord> sequences = new ArrayList<>();
         for (final String chrom : chroms) {
             final SAMSequenceRecord sequenceRecord = new SAMSequenceRecord(chrom, contigLength);
             sequences.add(sequenceRecord);
         }
 
-
         final SAMFileHeader header = new SAMFileHeader();
         header.setSequenceDictionary(new SAMSequenceDictionary(sequences));
         header.setSortOrder(sortOrder);
+
+        if (addReadGroup) {
+            final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord(READ_GROUP_ID);
+            readGroupRecord.setSample(SAMPLE);
+            readGroupRecord.setPlatform("ILLUMINA");
+            final List<SAMReadGroupRecord> readGroups = new ArrayList<>();
+            readGroups.add(readGroupRecord);
+            header.setReadGroups(readGroups);
+        }
         return header;
     }
 

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -102,7 +102,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
     public SAMRecordSetBuilder(final boolean sortForMe, final SAMFileHeader.SortOrder sortOrder, final boolean addReadGroup,
                                final int defaultChromosomeLength, final ScoringStrategy duplicateScoringStrategy) {
 
-        this.header = makeDefaultHeader(sortOrder, defaultChromosomeLength,addReadGroup);
+        this.header = makeDefaultHeader(sortOrder, defaultChromosomeLength, addReadGroup);
 
         final SAMRecordComparator comparator = sortOrder.getComparatorInstance();
 

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -234,7 +234,7 @@ public class ReferenceSource implements CRAMReferenceSource {
                     log.error(message);
                 }
             }
-            catch (final NoSuchAlgorithmException | IOException e) {
+            catch (final IOException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriter.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriter.java
@@ -450,7 +450,7 @@ public final class FastaReferenceWriter implements AutoCloseable {
     private void writeDictEntry() {
         final SAMSequenceRecord samSequenceRecord = new SAMSequenceRecord(currentSequenceName, (int) currentBasesCount);
         if (md5Digester != null) {
-            SequenceUtil.md5DigestToString(md5Digester.digest());
+            samSequenceRecord.setMd5(SequenceUtil.md5DigestToString(md5Digester.digest()));
         }
         dictCodec.encodeSequenceRecord(samSequenceRecord);
     }

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
@@ -49,7 +49,7 @@ public class FastaReferenceWriterBuilder {
     private Path fastaFile;
     private boolean makeFaiOutput = true;
     private boolean makeDictOutput = true;
-    private boolean addMd5 = true;
+    private boolean emitMd5 = true;
     private int basesPerLine = FastaReferenceWriter.DEFAULT_BASES_PER_LINE;
     private Path indexFile;
     private Path dictFile;
@@ -222,15 +222,23 @@ public class FastaReferenceWriterBuilder {
             dictOutput = new BufferedOutputStream(Files.newOutputStream(dictFile));
         }
 
-        return new FastaReferenceWriter(basesPerLine, addMd5, fastaOutput, indexOutput, dictOutput);
+        return new FastaReferenceWriter(basesPerLine, emitMd5, fastaOutput, indexOutput, dictOutput);
     }
 
-    public boolean getAddMd5() {
-        return addMd5;
+    /**
+     * @return whether the reference builder will emit M5 tag in the header lines
+     */
+    public boolean getEmitMd5() {
+        return emitMd5;
     }
 
-    public FastaReferenceWriterBuilder setAddMd5(final boolean addMd5) {
-        this.addMd5 = addMd5;
+    /**
+     * @param emitMd5 whether the reference builder will emit the M5 tag in the header line
+     *      * (and populate it with the md5 digest of the sequence)
+     * @return this builder
+     */
+    public FastaReferenceWriterBuilder setEmitMd5(final boolean emitMd5) {
+        this.emitMd5 = emitMd5;
         return this;
     }
 }

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
@@ -49,6 +49,7 @@ public class FastaReferenceWriterBuilder {
     private Path fastaFile;
     private boolean makeFaiOutput = true;
     private boolean makeDictOutput = true;
+    private boolean addMd5 = true;
     private int basesPerLine = FastaReferenceWriter.DEFAULT_BASES_PER_LINE;
     private Path indexFile;
     private Path dictFile;
@@ -221,6 +222,14 @@ public class FastaReferenceWriterBuilder {
             dictOutput = new BufferedOutputStream(Files.newOutputStream(dictFile));
         }
 
-        return new FastaReferenceWriter(basesPerLine, fastaOutput, indexOutput, dictOutput);
+        return new FastaReferenceWriter(basesPerLine, addMd5, fastaOutput, indexOutput, dictOutput);
+    }
+
+    public boolean getAddMd5() {
+        return addMd5;
+    }
+
+    public void setAddMd5(final boolean addMd5) {
+        this.addMd5 = addMd5;
     }
 }

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
@@ -229,7 +229,8 @@ public class FastaReferenceWriterBuilder {
         return addMd5;
     }
 
-    public void setAddMd5(final boolean addMd5) {
+    public FastaReferenceWriterBuilder setAddMd5(final boolean addMd5) {
         this.addMd5 = addMd5;
+        return this;
     }
 }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -40,6 +40,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -30,42 +30,17 @@ import htsjdk.samtools.seekablestream.SeekableBufferedStream;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableHTTPStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
-import htsjdk.tribble.Tribble;
 import htsjdk.samtools.util.nio.DeleteOnExitPathHook;
+import htsjdk.tribble.Tribble;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Reader;
-import java.io.Writer;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Scanner;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.Deflater;
@@ -1339,5 +1314,44 @@ public class IOUtil {
             }
         }
         return path;
+    }
+
+    /**
+     * Little test utility to help tests that create multiple levels of subdirectories
+     * clean up after themselves.
+     *
+     * @param directory The directory to be deleted (along with its subdirectories)
+     */
+    public static void recursiveDelete(final Path directory) throws IOException {
+
+        final SimpleFileVisitor<Path> simpleFileVisitor = new SimpleFileVisitor<Path>() {
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                super.visitFile(file, attrs);
+                Files.deleteIfExists(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                super.postVisitDirectory(dir, exc);
+                Files.deleteIfExists(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        };
+
+        Files.walkFileTree(directory, simpleFileVisitor);
+    }
+    /**
+     * Little test utility to help tests that create multiple levels of subdirectories
+     * clean up after themselves.
+     *
+     * @param directory The directory to be deleted (along with its subdirectories)
+     */
+    public static void recursiveDelete(final File directory) {
+        for (final File f : directory.listFiles()) {
+            if (f.isDirectory()) {
+                recursiveDelete(f);
+            }
+            f.delete();
+        }
     }
 }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1341,18 +1341,4 @@ public class IOUtil {
 
         Files.walkFileTree(directory, simpleFileVisitor);
     }
-    /**
-     * Little test utility to help tests that create multiple levels of subdirectories
-     * clean up after themselves.
-     *
-     * @param directory The directory to be deleted (along with its subdirectories)
-     */
-    public static void recursiveDelete(final File directory) {
-        for (final File f : directory.listFiles()) {
-            if (f.isDirectory()) {
-                recursiveDelete(f);
-            }
-            f.delete();
-        }
-    }
 }

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -253,10 +253,10 @@ public class SequenceUtil {
             }
             for (int i = 0; i < sizeToTest; ++i) {
                 if (!s1.get(i).isSameSequence(s2.get(i))) {
-                    String s1Attrs = "";
+                    StringBuilder s1Attrs = new StringBuilder();
                     for (final java.util.Map.Entry<String, String> entry : s1.get(i)
                             .getAttributes()) {
-                        s1Attrs += "/" + entry.getKey() + "=" + entry.getValue();
+                        s1Attrs.append("/").append(entry.getKey()).append("=").append(entry.getValue());
                     }
                     String s2Attrs = "";
                     for (final java.util.Map.Entry<String, String> entry : s2.get(i)
@@ -911,15 +911,24 @@ public class SequenceUtil {
         }
     }
 
-    public static String calculateMD5String(final byte[] data)
-            throws NoSuchAlgorithmException {
+    public static String calculateMD5String(final byte[] data) {
         return SequenceUtil.calculateMD5String(data, 0, data.length);
     }
 
     public static String calculateMD5String(final byte[] data, final int offset, final int len) {
         final byte[] digest = calculateMD5(data, offset, len);
+        return md5DigestToString(digest);
+    }
+
+    /**
+     * Convets the result of an md5Digest to a string
+     * @param digest digest that needs to be converted to a string
+     * @return string representing the md5
+     */
+    public static String md5DigestToString(final byte[] digest) {
         return String.format("%032x", new BigInteger(1, digest));
     }
+
 
     public static byte[] calculateMD5(final byte[] data, final int offset, final int len) {
         final MessageDigest md5_MessageDigest;

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -1084,8 +1084,8 @@ public class SequenceUtil {
      * @return an array of random DNA bases of the requested length.
      */
     static public byte[] getRandomBases(Random random, final int length) {
-        if (length <= 0) {
-            throw new IllegalArgumentException("length must be greater than zero! got " + length);
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be no smaller than zero! got " + length);
         }
         final byte[] bases = new byte[length];
         getRandomBases(random, length, bases);

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -1084,6 +1084,9 @@ public class SequenceUtil {
      * @return an array of random DNA bases of the requested length.
      */
     static public byte[] getRandomBases(Random random, final int length) {
+        if (length <= 0) {
+            throw new IllegalArgumentException("length must be greater than zero! got " + length);
+        }
         final byte[] bases = new byte[length];
         getRandomBases(random, length, bases);
         return bases;

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -1084,13 +1084,27 @@ public class SequenceUtil {
      * @return an array of random DNA bases of the requested length.
      */
     static public byte[] getRandomBases(Random random, final int length) {
-        ValidationUtils.validateArg(length>=0, "length must be positive");
         final byte[] bases = new byte[length];
+        getRandomBases(random, length, bases);
+        return bases;
+    }
+
+    /**
+     * Fills an array of bytes with random DNA bases. Will overwrite
+     * first {@code length} byte with new bases. if {@code length} is
+     * less than the size of the input array, the remaining bases will
+     * not be modified.
+     *
+     * @param random A {@link Random} object to use for drawing random bases
+     * @param length How many bases to return.
+     * @param bases  Array to use for bases (from index 0)
+     */
+    static public void getRandomBases(Random random, final int length, final byte[] bases) {
+        ValidationUtils.validateArg(length >= 0, "length must be positive");
+        ValidationUtils.validateArg(length <= bases.length, "length must no larger than size of input array");
 
         for (int i = 0; i < length; ++i) {
             bases[i] = VALID_BASES_UPPER[random.nextInt(VALID_BASES_UPPER.length)];
         }
-
-        return bases;
     }
 }

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -1084,9 +1084,7 @@ public class SequenceUtil {
      * @return an array of random DNA bases of the requested length.
      */
     static public byte[] getRandomBases(Random random, final int length) {
-        if (length < 0) {
-            throw new IllegalArgumentException("length must be no smaller than zero! got " + length);
-        }
+        ValidationUtils.validateArg(length >= 0, "length must be non-negative");
         final byte[] bases = new byte[length];
         getRandomBases(random, length, bases);
         return bases;
@@ -1103,7 +1101,7 @@ public class SequenceUtil {
      * @param bases  Array to use for bases (from index 0)
      */
     static public void getRandomBases(Random random, final int length, final byte[] bases) {
-        ValidationUtils.validateArg(length >= 0, "length must be positive");
+        ValidationUtils.validateArg(length >= 0, "length must be non-negative");
         ValidationUtils.validateArg(length <= bases.length, "length must no larger than size of input array");
 
         for (int i = 0; i < length; ++i) {

--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -26,8 +26,11 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.SAMException;
 
 import java.io.*;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 public class TestUtil {
 
@@ -60,43 +63,6 @@ public class TestUtil {
     @Deprecated
     public static File getTempDirecory(final String prefix, final String suffix) {
         return getTempDirectory(prefix, suffix);
-    }
-
-    /**
-     * Little test utility to help tests that create multiple levels of subdirectories
-     * clean up after themselves.
-     *
-     * @param directory The directory to be deleted (along with its subdirectories)
-     */
-    public static void recursiveDelete(final Path directory) throws IOException {
-        Files.list(directory).forEach(f->{
-            if (Files.isDirectory(f)){
-                try {
-                    recursiveDelete(f);
-                } catch (IOException e) {
-
-                }
-            }
-            try {
-                Files.delete(f);
-            } catch (IOException e) {
-
-            }
-        } );
-    }
-        /**
-         * Little test utility to help tests that create multiple levels of subdirectories
-         * clean up after themselves.
-         *
-         * @param directory The directory to be deleted (along with its subdirectories)
-         */
-    public static void recursiveDelete(final File directory) {
-        for (final File f : directory.listFiles()) {
-            if (f.isDirectory()) {
-                recursiveDelete(f);
-            }
-            f.delete();
-        }
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -26,6 +26,8 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.SAMException;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class TestUtil {
 
@@ -60,6 +62,28 @@ public class TestUtil {
         return getTempDirectory(prefix, suffix);
     }
 
+    /**
+     * Little test utility to help tests that create multiple levels of subdirectories
+     * clean up after themselves.
+     *
+     * @param directory The directory to be deleted (along with its subdirectories)
+     */
+    public static void recursiveDelete(final Path directory) throws IOException {
+        Files.list(directory).forEach(f->{
+            if (Files.isDirectory(f)){
+                try {
+                    recursiveDelete(f);
+                } catch (IOException e) {
+
+                }
+            }
+            try {
+                Files.delete(f);
+            } catch (IOException e) {
+
+            }
+        } );
+    }
         /**
          * Little test utility to help tests that create multiple levels of subdirectories
          * clean up after themselves.

--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -88,4 +88,18 @@ public class TestUtil {
         in.close();
         return result;
     }
+
+    /**
+     * Little test utility to help tests that create multiple levels of subdirectories
+     * clean up after themselves.
+     *
+     * @param directory The directory to be deleted (along with its subdirectories)
+     */
+    public static void recursiveDelete(final File directory) {
+        try {
+            IOUtil.recursiveDelete(directory.toPath());
+        } catch (IOException e) {
+            // bury exception
+        }
+    }
 }

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
@@ -32,6 +32,7 @@ import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.Log.LogLevel;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -46,9 +47,16 @@ import java.util.List;
 
 public class CRAMFileWriterTest extends HtsjdkTest {
 
+    final LogLevel globalLogLevel = Log.getGlobalLogLevel();
+
     @BeforeClass
     public void initClass() {
         Log.setGlobalLogLevel(LogLevel.ERROR);
+    }
+
+    @AfterClass
+    public void finitClass() {
+        Log.setGlobalLogLevel(globalLogLevel);
     }
 
     @Test(description = "Test for lossy CRAM compression invariants.")
@@ -159,9 +167,6 @@ public class CRAMFileWriterTest extends HtsjdkTest {
     }
 
     private void doTest(final List<SAMRecord> samRecords) {
-
-        //TODO: records come with their own header...best to set it up right with SAMRecordSetBuilder...
-
         final SAMFileHeader header = createSAMHeader(SAMFileHeader.SortOrder.coordinate);
         final ReferenceSource refSource = createReferenceSource();
         final ByteArrayOutputStream os = new ByteArrayOutputStream();

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
@@ -67,8 +67,7 @@ public class CRAMFileWriterTest extends HtsjdkTest {
     }
 
     @Test(description = "Tests a writing records with null SAMFileHeaders")
-    public void writeRecordsWithNullHeader() throws Exception {
-
+    public void writeRecordsWithNullHeader() {
         final List<SAMRecord> samRecs = createRecords(50);
         for (final SAMRecord rec : samRecs) {
             rec.setHeader(null);

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
@@ -166,6 +166,10 @@ public class CRAMFileWriterTest extends HtsjdkTest {
                 Assert.assertEquals(actualRecord.getAttributes().stream().map(s -> s.tag).collect(Collectors.toSet()),
                         actualRecord.getAttributes().stream().map(s -> s.tag).collect(Collectors.toSet()), expectedRecord.getReadName());
 
+                actualRecord.getAttributes().forEach(tv -> {
+                    Assert.assertEquals(tv.value, expectedRecord.getAttribute(tv.tag));
+                });
+
             }
         }
     }

--- a/src/test/java/htsjdk/samtools/SAMReadGroupRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMReadGroupRecordTest.java
@@ -45,7 +45,7 @@ public class SAMReadGroupRecordTest extends HtsjdkTest {
     public void testGetSAMString() {
         SAMReadGroupRecord r = new SAMReadGroupRecord("rg1");
         r.setSample("mysample");
-        r.setPlatform("ILLUMINA");
+        r.setPlatform(SAMReadGroupRecord.PlatformValue.ILLUMINA.name());
         r.setDescription("my description");
         Assert.assertEquals("@RG\tID:rg1\tSM:mysample\tPL:ILLUMINA\tDS:my description", r.getSAMString());
     }

--- a/src/test/java/htsjdk/samtools/SAMRecordSetBuilderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordSetBuilderTest.java
@@ -1,0 +1,84 @@
+package htsjdk.samtools;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.TestUtil;
+import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.stream.Collectors;
+
+public class SAMRecordSetBuilderTest extends HtsjdkTest {
+
+    @Test
+    public void testWriteDefaultReference() throws IOException {
+
+        SAMRecordSetBuilder samRecords = new SAMRecordSetBuilder(true,
+                SAMFileHeader.SortOrder.coordinate,
+                true,
+                50000);
+
+
+        final File dir = TestUtil.getTempDirectory("SAMRecordSetBuilderTest", "testWriteRandomReference");
+        final File fasta = new File(dir, "output.fa");
+        final File dict = new File(dir, "output.dict");
+
+        samRecords.writeRandomReference(fasta.toPath());
+        checkFastaFile(samRecords.getHeader(),fasta,dict);
+        TestUtil.recursiveDelete(dir);
+    }
+
+    @DataProvider
+    Iterator<Object[]> fastaExtensions() {
+        return ReferenceSequenceFileFactory.FASTA_EXTENSIONS.stream()
+                .filter(s -> !s.endsWith(".gz"))
+                .map(s -> new Object[]{s})
+                .collect(Collectors.toList())
+                .iterator();
+    }
+
+    @Test(dataProvider = "fastaExtensions")
+    public void testWriteRandomReference(final String extension) throws IOException {
+        final File dir = TestUtil.getTempDirectory("SAMRecordSetBuilderTest", "testWriteRandomReference");
+
+        try {
+            final SAMFileHeader header = new SAMFileHeader();
+            header.addSequence(new SAMSequenceRecord("contig1", 100));
+            header.addSequence(new SAMSequenceRecord("contig2", 200));
+            header.addSequence(new SAMSequenceRecord("contig3", 300));
+            header.addSequence(new SAMSequenceRecord("chr_order", 50));
+
+            final File fasta = new File(dir, "output" + extension);
+            final File dict = new File(dir, "output.dict");
+            SAMRecordSetBuilder.writeRandomReference(header, fasta.toPath());
+
+            checkFastaFile(header, fasta, dict);
+        } finally {
+            TestUtil.recursiveDelete(dir);
+        }
+    }
+
+    static private void checkFastaFile(final SAMFileHeader header, final File fasta, final File dict) throws IOException {
+        final SAMSequenceDictionary samSequenceDictionary = SAMSequenceDictionaryExtractor.extractDictionary(dict.toPath());
+        Assert.assertTrue(header.getSequenceDictionary().isSameDictionary(samSequenceDictionary));
+
+        try (ReferenceSequenceFile sequenceFile = ReferenceSequenceFileFactory.getReferenceSequenceFile(fasta.toPath())) {
+
+            header.getSequenceDictionary().getSequences().forEach(s -> {
+
+                final ReferenceSequence referenceSequence = sequenceFile.getSequence(s.getSequenceName());
+                Assert.assertTrue(sequenceFile.isIndexed());
+                Assert.assertEquals(referenceSequence.getBases().length, referenceSequence.length());
+                Assert.assertEquals(referenceSequence.length(), s.getSequenceLength());
+                Assert.assertEquals(referenceSequence.getName(), s.getSequenceName());
+            });
+        }
+    }
+}

--- a/src/test/java/htsjdk/samtools/SAMRecordSetBuilderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordSetBuilderTest.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.samtools.util.CollectionUtil;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
@@ -31,7 +32,7 @@ public class SAMRecordSetBuilderTest extends HtsjdkTest {
 
         samRecords.writeRandomReference(fasta);
         checkFastaFile(samRecords.getHeader(), fasta, dict);
-        TestUtil.recursiveDelete(dir);
+        IOUtil.recursiveDelete(dir);
     }
 
     @Test
@@ -59,8 +60,8 @@ public class SAMRecordSetBuilderTest extends HtsjdkTest {
             Assert.assertTrue(SequenceUtil.areSequenceDictionariesEqual(dict1, dict2));
 
         } finally {
-            TestUtil.recursiveDelete(dir1);
-            TestUtil.recursiveDelete(dir2);
+            IOUtil.recursiveDelete(dir1);
+            IOUtil.recursiveDelete(dir2);
         }
     }
 

--- a/src/test/java/htsjdk/samtools/SAMRecordSetBuilderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordSetBuilderTest.java
@@ -58,7 +58,6 @@ public class SAMRecordSetBuilderTest extends HtsjdkTest {
 
             Assert.assertTrue(SequenceUtil.areSequenceDictionariesEqual(dict1, dict2));
 
-
         } finally {
             TestUtil.recursiveDelete(dir1);
             TestUtil.recursiveDelete(dir2);
@@ -79,17 +78,21 @@ public class SAMRecordSetBuilderTest extends HtsjdkTest {
                 Assert.assertEquals(referenceSequence.length(), s.getSequenceLength());
                 Assert.assertEquals(referenceSequence.getName(), s.getSequenceName());
                 if (s.getMd5() != null) {
-                    Assert.assertEquals(s.getMd5(), sequenceFile.getSequenceDictionary().getSequence(referenceSequence.getName()).getMd5());
+                    Assert.assertEquals(sequenceFile.getSequenceDictionary().getSequence(referenceSequence.getName()).getMd5(), s.getMd5());
                 }
             });
             // the md5's should be all different
-            if (header.getSequenceDictionary().size() > 1) {
-                final String md5 = header.getSequence(0).getMd5();
-                header.getSequenceDictionary().getSequences().stream().skip(1).forEach(s -> {
-                    Assert.assertNotEquals(md5, header.getSequence(1).getMd5(),
-                            "md5s of sequence " + header.getSequence(0).getSequenceName() + " and " + s.getSequenceName() + " are the same!");
-                });
+            if (samSequenceDictionary.size() > 1) {
+                final String md5 = samSequenceDictionary.getSequence(0).getMd5();
+
+                if (md5 != null) {
+                    samSequenceDictionary.getSequences().stream().skip(1).forEach(s -> {
+                        Assert.assertNotEquals(md5, s.getMd5(),
+                                "md5s of sequence " + samSequenceDictionary.getSequence(0).getSequenceName() + " and " + s.getSequenceName() + " are the same!");
+                    });
+                }
             }
         }
     }
+
 }

--- a/src/test/java/htsjdk/samtools/SamStreamsTest.java
+++ b/src/test/java/htsjdk/samtools/SamStreamsTest.java
@@ -92,7 +92,6 @@ public class SamStreamsTest extends HtsjdkTest {
         Assert.assertEquals(SamStreams.sourceLikeCram(strm), expected);
     }
 
-
     @DataProvider(name = "sourceLikeBam")
     public Object[][] sourceLikeBamData() {
         return new Object[][] {
@@ -110,7 +109,6 @@ public class SamStreamsTest extends HtsjdkTest {
     {
         sourceLikeBamImpl(resourceName, isFile, expected);
     }
-
 
     @DataProvider(name = "sourceLikeBamRemote")
     public Object[][] sourceLikeBamDataRemote() {
@@ -135,8 +133,6 @@ public class SamStreamsTest extends HtsjdkTest {
     {
         sourceLikeBamImpl(resourceName, isFile, expected);
     }
-
-
 
     public void sourceLikeBamImpl(
             final String resourceName,

--- a/src/test/java/htsjdk/samtools/SamStreamsTest.java
+++ b/src/test/java/htsjdk/samtools/SamStreamsTest.java
@@ -99,10 +99,25 @@ public class SamStreamsTest extends HtsjdkTest {
                 {"cram_with_bai_index.cram", true, false },
                 {"compressed.bam", true, true },
                 {"unsorted.sam", true, false },
+        };
+    }
+
+    @Test(dataProvider = "sourceLikeBam")
+    public void sourceLikeBam(
+            final String resourceName,
+            final boolean isFile,
+            final boolean expected) throws IOException
+    {
+        sourceLikeBamImpl(resourceName, isFile, expected);
+    }
+
+
+    @DataProvider(name = "sourceLikeBamRemote")
+    public Object[][] sourceLikeBamDataRemote() {
+        return new Object[][] {
                 // fails due to a combination of https://github.com/samtools/htsjdk/issues/619 and
                 // https://github.com/samtools/htsjdk/issues/618
-                //{"ftp://ftp.broadinstitute.org/dummy.cram", false, false},
-                {"ftp://ftp.broadinstitute.org/dummy.bam", false, true},
+                //{"ftp://ftp.broadinstitute.org/dummy.cram", false, false},{"ftp://ftp.broadinstitute.org/dummy.bam", false, true},
                 {"http://www.broadinstitute.org/dummy.bam", false, true},
                 {"https://www.broadinstitute.org/dummy.bam", false, true},
                 {"http://www.broadinstitute.org/dummy.bam?alt=media", false, true},
@@ -112,8 +127,18 @@ public class SamStreamsTest extends HtsjdkTest {
         };
     }
 
-    @Test(dataProvider = "sourceLikeBam")
-    public void sourceLikeBam(
+    @Test(dataProvider = "sourceLikeBamRemote",groups = "ftp")
+    public void sourceLikeBamRemote(
+            final String resourceName,
+            final boolean isFile,
+            final boolean expected) throws IOException
+    {
+        sourceLikeBamImpl(resourceName, isFile, expected);
+    }
+
+
+
+    public void sourceLikeBamImpl(
             final String resourceName,
             final boolean isFile,
             final boolean expected) throws IOException

--- a/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
@@ -650,7 +650,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
             SAMRecordSetBuilderTest.checkFastaFile(header, fasta, dict);
         } finally {
-            TestUtil.recursiveDelete(dir);
+            IOUtil.recursiveDelete(dir);
         }
     }
 }


### PR DESCRIPTION
In order to test cram files we need a way to write a reference that agrees with the samDictionary that the SAMRecordSetBuilder has in mind. By default it is quite large, and so this enables us to generate a random one (deterministic) on the fly.