### PR TITLE
moving HttpUtilsTest to externalApi test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ test {
         exclude "broken"
         exclude "defaultReference"
         exclude "ftp"
+        exclude "http"
         exclude "sra"
         exclude "ena"
 
@@ -127,11 +128,12 @@ task testFTP(type: Test) {
 }
 
 task testExternalApis(type: Test) {
-    description = "Run the SRA and ENA tests (tests that interact with external APIs)"
+    description = "Run the SRA, ENA, and HTTP tests (tests that interact with external APIs)"
     jvmArgs += '-Dsamjdk.sra_libraries_download=true'
 
     tags {
         include "sra"
+        include "http"
         include "ena"
         exclude "slow"
         exclude "broken"

--- a/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/util/HttpUtilsTest.java
@@ -8,12 +8,13 @@ import org.testng.annotations.Test;
 
 import htsjdk.HtsjdkTest;
 
+@Test(groups = "http")
 public class HttpUtilsTest extends HtsjdkTest {
     @DataProvider(name = "existing_urls")
     public Object[][] testExistingURLsData() {
         return new Object[][]{
             {"http://broadinstitute.github.io/picard/testdata/index_test.bam"},
-            {"http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/current.tree"}
+            {"http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/README_using_1000genomes_cram.md"}
         };
     }
 


### PR DESCRIPTION
* HttpUtilsTest is flakey because it connects to remote web servers.
Moved it to the testExternalAPIs test task
* changed a broken link so that the tests pass again

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

