### PR TITLE
Remove redundant and unused BAM_FLAGS from CRAM code.

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -345,25 +345,4 @@ public class CramCompressionRecord {
         flags = supplementary ? flags | SUPPLEMENTARY_FLAG : flags & ~SUPPLEMENTARY_FLAG;
     }
 
-    public static class BAM_FLAGS {
-        public static final int READ_PAIRED_FLAG = 0x1;
-        public static final int PROPER_PAIR_FLAG = 0x2;
-        public static final int READ_UNMAPPED_FLAG = 0x4;
-        public static final int MATE_UNMAPPED_FLAG = 0x8;
-        public static final int READ_STRAND_FLAG = 0x10;
-        public static final int MATE_STRAND_FLAG = 0x20;
-        public static final int FIRST_OF_PAIR_FLAG = 0x40;
-        public static final int SECOND_OF_PAIR_FLAG = 0x80;
-        public static final int NOT_PRIMARY_ALIGNMENT_FLAG = 0x100;
-        public static final int READ_FAILS_VENDOR_QUALITY_CHECK_FLAG = 0x200;
-        public static final int DUPLICATE_READ_FLAG = 0x400;
-        public static final int SUPPLEMENTARY_FLAG = 0x800;
-    }
-
-    public static int getBAMFlags(final int cramFlags, final byte cramMateFlags) {
-        int value = cramFlags;
-        if ((cramMateFlags & MATE_NEG_STRAND_FLAG) != 0) value |= BAM_FLAGS.MATE_STRAND_FLAG;
-        if ((cramMateFlags & MATE_UNMAPPED_FLAG) != 0) value |= BAM_FLAGS.MATE_UNMAPPED_FLAG;
-        return value;
-    }
 }


### PR DESCRIPTION
Minor cleanup/removal of unused of code I noticed during a code review.