### PR TITLE
adding new overloads to IOUtils with Path for some file only methods

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -691,7 +691,7 @@ public class IOUtil {
      */
     public static OutputStream openFileForWriting(final Path path, OpenOption... openOptions) {
         try {
-            if(hasGzipFileExtension(path)) {
+            if (hasGzipFileExtension(path)) {
                 return openGzipFileForWriting(path, openOptions);
             } else {
                 return Files.newOutputStream(path, openOptions);

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -595,15 +595,15 @@ public class IOUtilTest extends HtsjdkTest {
         final Path jmfsRoot = inMemoryFileSystem.getRootDirectories().iterator().next();
         final Path tmp = Files.createTempFile(jmfsRoot, "test", extension);
         final String expected = "lorem ipswitch, nantucket, bucket";
-        try( final Writer out = IOUtil.openFileForBufferedWriting(tmp)){
+        try (Writer out = IOUtil.openFileForBufferedWriting(tmp)){
             out.write(expected);
         }
 
-        try( final InputStream in = new BufferedInputStream(Files.newInputStream(tmp))){
+        try (InputStream in = new BufferedInputStream(Files.newInputStream(tmp))){
                Assert.assertEquals(IOUtil.isGZIPInputStream(in), gzipped);
         }
 
-        try( final BufferedReader in = IOUtil.openFileForBufferedReading(tmp)){
+        try (BufferedReader in = IOUtil.openFileForBufferedReading(tmp)){
             final String actual = in.readLine();
             Assert.assertEquals(actual, expected);
         }

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -67,7 +67,7 @@ public class IOUtilTest extends HtsjdkTest {
     private static final List<String> SLURP_TEST_LINES = Arrays.asList("bacon   and rice   ", "for breakfast  ", "wont you join me");
     private static final String SLURP_TEST_LINE_SEPARATOR = "\n";
     private static final String TEST_FILE_PREFIX = "htsjdk-IOUtilTest";
-    private static final String TEST_FILE_EXTENSIONS[] = {".txt", ".txt.gz"};
+    private static final String[] TEST_FILE_EXTENSIONS = {".txt", ".txt.gz"};
     private static final String TEST_STRING = "bar!";
 
     private File existingTempFile;
@@ -154,7 +154,7 @@ public class IOUtilTest extends HtsjdkTest {
         File lnToSymlink = new File(lnDir, "symlink.txt");
         lnToSymlink.deleteOnExit();
 
-        File files[] = {actual, symlink, lnToActual, lnToSymlink};
+        File[] files = {actual, symlink, lnToActual, lnToSymlink};
         for (File f : files) {
             Assert.assertEquals(IOUtil.getFullCanonicalPath(f), actual.getCanonicalPath());
         }
@@ -579,6 +579,25 @@ public class IOUtilTest extends HtsjdkTest {
                 Assert.assertTrue(previousSize >= newSize);
             }
             previousSize = newSize;
+        }
+    }
+
+    @DataProvider
+    public Object[][] getExtensions(){
+        return new Object[][]{{".gz"}, {".bfq"}, {".txt"}};
+    }
+
+    @Test(dataProvider = "getExtensions")
+    public void testReadWriteJimfs(String extension) throws IOException {
+        final Path jmfsRoot = inMemoryFileSystem.getRootDirectories().iterator().next();
+        final Path tmp = Files.createTempFile(jmfsRoot, "test", extension);
+        final String expected = "lorem ipswitch, nantucket, bucket";
+        try( final Writer out = IOUtil.openFileForBufferedWriting(tmp)){
+            out.write(expected);
+        }
+        try( final BufferedReader in = IOUtil.openFileForBufferedReading(tmp)){
+            final String actual = in.readLine();
+            Assert.assertEquals(actual, expected);
         }
     }
 

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -584,17 +584,25 @@ public class IOUtilTest extends HtsjdkTest {
 
     @DataProvider
     public Object[][] getExtensions(){
-        return new Object[][]{{".gz"}, {".bfq"}, {".txt"}};
+        return new Object[][]{
+                {".gz", true},
+                {".bfq", true},
+                {".txt", false}};
     }
 
     @Test(dataProvider = "getExtensions")
-    public void testReadWriteJimfs(String extension) throws IOException {
+    public void testReadWriteJimfs(String extension, boolean gzipped) throws IOException {
         final Path jmfsRoot = inMemoryFileSystem.getRootDirectories().iterator().next();
         final Path tmp = Files.createTempFile(jmfsRoot, "test", extension);
         final String expected = "lorem ipswitch, nantucket, bucket";
         try( final Writer out = IOUtil.openFileForBufferedWriting(tmp)){
             out.write(expected);
         }
+
+        try( final InputStream in = new BufferedInputStream(Files.newInputStream(tmp))){
+               Assert.assertEquals(IOUtil.isGZIPInputStream(in), gzipped);
+        }
+
         try( final BufferedReader in = IOUtil.openFileForBufferedReading(tmp)){
             final String actual = in.readLine();
             Assert.assertEquals(actual, expected);


### PR DESCRIPTION
### Description
Add Path overloads of some functions in IOUtil that were missing them.
Fixes #1294
### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

