### PR TITLE
Changing the team name/url in the maven pom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,13 +178,13 @@ publishing {
                 name = 'HTSJDK'
                 packaging = 'jar'
                 description = 'A Java API for high-throughput sequencing data (HTS) formats'
-                url = 'http://samtools.github.io/htsjdk/'
+                url = 'https://samtools.github.io/htsjdk/'
 
                 developers {
                     developer {
-                        id = 'picard'
-                        name = 'Picard Team'
-                        url = 'http://broadinstitute.github.io/picard'
+                        id = 'htsjdk'
+                        name = 'Htsjdk Team'
+                        url = 'https://github.com/samtools/htsjdk'
                     }
                 }
 


### PR DESCRIPTION
Htsjdk is no longer a subproject of the Picard team and it's published pom should reflect that it has it's own team of developers.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

