### PR TITLE
CRAM: Only calculate alignmentDelta as needed for records

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -317,7 +317,6 @@ public class CRAMContainerStreamWriter {
         containerFactory.setPreserveReadNames(preserveReadNames);
 
         int index = 0;
-        int prevAlStart = start;
         for (final SAMRecord samRecord : samRecords) {
             if (samRecord.getReferenceIndex() != SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX && refSeqIndex != samRecord.getReferenceIndex()) {
                 // this may load all ref sequences into memory:
@@ -325,10 +324,7 @@ public class CRAMContainerStreamWriter {
             }
             final CramCompressionRecord cramRecord = sam2CramRecordFactory.createCramRecord(samRecord);
             cramRecord.index = ++index;
-            cramRecord.alignmentDelta = samRecord.getAlignmentStart() - prevAlStart;
             cramRecord.alignmentStart = samRecord.getAlignmentStart();
-            prevAlStart = samRecord.getAlignmentStart();
-
             cramRecords.add(cramRecord);
 
             if (preservation != null) preservation.addQualityScores(samRecord, cramRecord, tracks);
@@ -379,8 +375,7 @@ public class CRAMContainerStreamWriter {
                     while (last.next != null) last = last.next;
 
                     if (cramRecord.isFirstSegment() && last.isLastSegment()) {
-                        final boolean coordinateSorted = (samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.coordinate);
-                        final int templateLength = CramNormalizer.computeInsertSize(cramRecord, last, coordinateSorted);
+                        final int templateLength = CramNormalizer.computeInsertSize(cramRecord, last);
 
                         if (cramRecord.templateSize == templateLength) {
                             last = cramRecord.next;

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
@@ -125,8 +125,8 @@ public class ContainerParser {
             record.sliceIndex = slice.index;
             record.index = i;
 
-            reader.read(record, prevAlignmentStart);
-            prevAlignmentStart = record.alignmentStart;
+            // read the new record and update the running prevAlignmentStart
+            prevAlignmentStart = reader.read(record, prevAlignmentStart);
 
             if (record.sequenceId == slice.sequenceId) {
                 record.sequenceName = seqName;

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
@@ -119,13 +119,14 @@ public class ContainerParser {
 
         final ArrayList<CramCompressionRecord> records = new ArrayList<>(slice.nofRecords);
 
-        int prevStart = slice.alignmentStart;
+        int prevAlignmentStart = slice.alignmentStart;
         for (int i = 0; i < slice.nofRecords; i++) {
             final CramCompressionRecord record = new CramCompressionRecord();
             record.sliceIndex = slice.index;
             record.index = i;
 
-            reader.read(record);
+            reader.read(record, prevAlignmentStart);
+            prevAlignmentStart = record.alignmentStart;
 
             if (record.sequenceId == slice.sequenceId) {
                 record.sequenceName = seqName;
@@ -140,11 +141,6 @@ public class ContainerParser {
             }
 
             records.add(record);
-
-            if (header.APDelta) {
-                prevStart += record.alignmentDelta;
-                record.alignmentStart = prevStart;
-            }
         }
 
         return records;

--- a/src/main/java/htsjdk/samtools/cram/build/CramNormalizer.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramNormalizer.java
@@ -94,8 +94,7 @@ public class CramNormalizer {
             for (final CramCompressionRecord record : records) {
                 if (record.previous != null) continue;
                 if (record.next == null) continue;
-                final boolean usePositionDeltaEncoding = header.getSortOrder() == SAMFileHeader.SortOrder.coordinate;
-                restoreMateInfo(record, usePositionDeltaEncoding);
+                restoreMateInfo(record);
             }
         }
 
@@ -138,8 +137,7 @@ public class CramNormalizer {
         restoreQualityScores(defaultQualityScore, records);
     }
 
-    private static void restoreMateInfo(final CramCompressionRecord record,
-                                        final boolean usePositionDeltaEncoding) {
+    private static void restoreMateInfo(final CramCompressionRecord record) {
         if (record.next == null) {
 
             return;
@@ -157,7 +155,7 @@ public class CramNormalizer {
 //        record.setFirstSegment(true);
 //        last.setLastSegment(true);
 
-        final int templateLength = computeInsertSize(record, last, usePositionDeltaEncoding);
+        final int templateLength = computeInsertSize(record, last);
         record.templateSize = templateLength;
         last.templateSize = -templateLength;
     }
@@ -328,12 +326,10 @@ public class CramNormalizer {
      *
      * @param firstEnd  first mate of the pair
      * @param secondEnd second mate of the pair
-     * @param usePositionDeltaEncoding do these records delta-encode their alignment starts?
      * @return template length
      */
     public static int computeInsertSize(final CramCompressionRecord firstEnd,
-                                        final CramCompressionRecord secondEnd,
-                                        final boolean usePositionDeltaEncoding) {
+                                        final CramCompressionRecord secondEnd) {
         if (firstEnd.isSegmentUnmapped() || secondEnd.isSegmentUnmapped()) {
             return 0;
         }
@@ -341,8 +337,8 @@ public class CramNormalizer {
             return 0;
         }
 
-        final int firstEnd5PrimePosition = firstEnd.isNegativeStrand() ? firstEnd.getAlignmentEnd(usePositionDeltaEncoding) : firstEnd.alignmentStart;
-        final int secondEnd5PrimePosition = secondEnd.isNegativeStrand() ? secondEnd.getAlignmentEnd(usePositionDeltaEncoding) : secondEnd.alignmentStart;
+        final int firstEnd5PrimePosition = firstEnd.isNegativeStrand() ? firstEnd.getAlignmentEnd() : firstEnd.alignmentStart;
+        final int secondEnd5PrimePosition = secondEnd.isNegativeStrand() ? secondEnd.getAlignmentEnd() : secondEnd.alignmentStart;
 
         final int adjustment = (secondEnd5PrimePosition >= firstEnd5PrimePosition) ? +1 : -1;
         return secondEnd5PrimePosition - firstEnd5PrimePosition + adjustment;

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/CramRecordReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/CramRecordReader.java
@@ -162,7 +162,7 @@ public class CramRecordReader {
      *
      * @param cramRecord the Cram Compression Record to read into
      */
-    public void read(final CramCompressionRecord cramRecord) {
+    public void read(final CramCompressionRecord cramRecord, final int prevAlignmentStart) {
         try {
             // int mark = testCodec.readData();
             // if (Writer.TEST_MARK != mark) {
@@ -181,8 +181,9 @@ public class CramRecordReader {
 
             cramRecord.readLength = readLengthCodec.readData();
             if (APDelta) {
-                cramRecord.alignmentDelta = alignmentStartCodec.readData();
-            } else {
+                cramRecord.alignmentStart = prevAlignmentStart + alignmentStartCodec.readData();
+            }
+            else {
                 cramRecord.alignmentStart = alignmentStartCodec.readData();
             }
 
@@ -330,4 +331,5 @@ public class CramRecordReader {
             throw new RuntimeIOException(e);
         }
     }
+
 }

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/CramRecordReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/CramRecordReader.java
@@ -161,8 +161,10 @@ public class CramRecordReader {
      * Read a Cram Compression Record, using this class's Encodings
      *
      * @param cramRecord the Cram Compression Record to read into
+     * @param prevAlignmentStart the alignmentStart of the previous record, for delta calculation
+     * @return the alignmentStart of the newly-read record
      */
-    public void read(final CramCompressionRecord cramRecord, final int prevAlignmentStart) {
+    public int read(final CramCompressionRecord cramRecord, final int prevAlignmentStart) {
         try {
             // int mark = testCodec.readData();
             // if (Writer.TEST_MARK != mark) {
@@ -182,8 +184,7 @@ public class CramRecordReader {
             cramRecord.readLength = readLengthCodec.readData();
             if (APDelta) {
                 cramRecord.alignmentStart = prevAlignmentStart + alignmentStartCodec.readData();
-            }
-            else {
+            } else {
                 cramRecord.alignmentStart = alignmentStartCodec.readData();
             }
 
@@ -330,6 +331,8 @@ public class CramRecordReader {
             }
             throw new RuntimeIOException(e);
         }
+
+        return cramRecord.alignmentStart;
     }
 
 }

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
@@ -73,8 +73,8 @@ public class MultiRefSliceAlignmentSpanReader extends CramRecordReader {
 
     private void readCramRecord() {
         final CramCompressionRecord cramRecord = new CramCompressionRecord();
-        super.read(cramRecord, prevAlignmentStart);
-        prevAlignmentStart = cramRecord.alignmentStart;
+
+        prevAlignmentStart = super.read(cramRecord, prevAlignmentStart);
 
         if (!spans.containsKey(cramRecord.sequenceId)) {
             spans.put(cramRecord.sequenceId, new AlignmentSpan(cramRecord.alignmentStart, cramRecord.readLength));

--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/MultiRefSliceAlignmentSpanReader.java
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class MultiRefSliceAlignmentSpanReader extends CramRecordReader {
     /**
-     * Alignment start to of the previous record, for delta-encoding if necessary
+     * Alignment start of the previous record, for delta-encoding if necessary
      */
     private int prevAlignmentStart;
 

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -264,7 +264,9 @@ public class CramCompressionRecord {
      * @return true if the record is placed
      */
     boolean isPlaced() {
-        boolean placed = isPlacedInternal();
+        // placement requires a valid sequence ID and alignment start coordinate
+        boolean placed = sequenceId != SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX &&
+                alignmentStart != SAMRecord.NO_ALIGNMENT_START;
 
         if (!placed && !isSegmentUnmapped()) {
             final String warning = String.format(
@@ -275,17 +277,6 @@ public class CramCompressionRecord {
         }
 
         return placed;
-    }
-
-    // check placement without regard to mapping; helper method for isPlaced()
-    private boolean isPlacedInternal() {
-        // placement requires a valid sequence ID
-        if (sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
-            return false;
-        }
-
-        // an alignment start coordinate is required for placement too
-        return ! (alignmentStart == SAMRecord.NO_ALIGNMENT_START);
     }
 
     public boolean isFirstSegment() {

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -59,7 +59,6 @@ public class CramCompressionRecord {
     // sequential index of the record in a stream:
     public int index = 0;
     public int alignmentStart;
-    public int alignmentDelta;
     private int alignmentEnd = UNINITIALIZED_END;
     private int alignmentSpan = UNINITIALIZED_SPAN;
 
@@ -129,7 +128,6 @@ public class CramCompressionRecord {
 
         if (!Arrays.equals(readBases, cramRecord.readBases)) return false;
         return Arrays.equals(qualityScores, cramRecord.qualityScores) && areEqual(flags, cramRecord.flags) && areEqual(readName, cramRecord.readName);
-
     }
 
     private boolean areEqual(final Object o1, final Object o2) {
@@ -156,7 +154,7 @@ public class CramCompressionRecord {
         final StringBuilder stringBuilder = new StringBuilder("[");
         if (readName != null) stringBuilder.append(readName).append("; ");
         stringBuilder.append("flags=").append(flags)
-                .append("; alignmentOffset=").append(alignmentDelta)
+                .append("; alignmentStart=").append(alignmentStart)
                 .append("; mateOffset=").append(recordsToNextFragment)
                 .append("; mappingQuality=").append(mappingQuality);
 
@@ -172,24 +170,22 @@ public class CramCompressionRecord {
 
     /**
      * Check whether alignmentSpan has been initialized, and do so if it has not
-     * @param usePositionDeltaEncoding is this record's position delta-encoded? used to call isPlaced()
      * @return the initialized alignmentSpan
      */
-    public int getAlignmentSpan(final boolean usePositionDeltaEncoding) {
+    public int getAlignmentSpan() {
         if (alignmentSpan == UNINITIALIZED_SPAN) {
-            intializeAlignmentBoundaries(usePositionDeltaEncoding);
+            intializeAlignmentBoundaries();
         }
         return alignmentSpan;
     }
 
     /**
      * Check whether alignmentEnd has been initialized, and do so if it has not
-     * @param usePositionDeltaEncoding is this record's position delta-encoded? used to call isPlaced()
      * @return the initialized alignmentEnd
      */
-    public int getAlignmentEnd(final boolean usePositionDeltaEncoding) {
+    public int getAlignmentEnd() {
         if (alignmentEnd == UNINITIALIZED_END) {
-            intializeAlignmentBoundaries(usePositionDeltaEncoding);
+            intializeAlignmentBoundaries();
         }
         return alignmentEnd;
     }
@@ -197,8 +193,8 @@ public class CramCompressionRecord {
     // https://github.com/samtools/htsjdk/issues/1301
     // does not update alignmentSpan/alignmentEnd when the record changes
 
-    private void intializeAlignmentBoundaries(final boolean usePositionDeltaEncoding) {
-        if (!isPlaced(usePositionDeltaEncoding)) {
+    private void intializeAlignmentBoundaries() {
+        if (!isPlaced()) {
             alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
             alignmentEnd = Slice.NO_ALIGNMENT_END;
             return;
@@ -244,7 +240,7 @@ public class CramCompressionRecord {
      * Unmapped records may be stored in the same {@link Slice}s and {@link Container}s as mapped
      * records if they are placed.
      *
-     * @see #isPlaced(boolean)
+     * @see #isPlaced()
      * @return true if the record is unmapped
      */
     public boolean isSegmentUnmapped() {
@@ -258,19 +254,17 @@ public class CramCompressionRecord {
     /**
      * Does this record have a valid placement/alignment location?
      *
-     * It must have a valid reference sequence ID to be considered placed.
-     * In the case of absolute (non-delta) position encoding, it must also have a
-     * valid alignment start position, so we need to know if it is delta-encoded.
+     * It must have a valid reference sequence ID and a valid alignment start position
+     * to be considered placed.
      *
      * Normally we expect to see that the unmapped flag is set for unplaced reads,
      * so we log a WARNING here if the read is unplaced yet somehow mapped.
      *
      * @see #isSegmentUnmapped()
-     * @param usePositionDeltaEncoding is this read's position delta-encoded?  if not, check alignment Start.
      * @return true if the record is placed
      */
-    public boolean isPlaced(final boolean usePositionDeltaEncoding) {
-        boolean placed = isPlacedInternal(!usePositionDeltaEncoding);
+    boolean isPlaced() {
+        boolean placed = isPlacedInternal();
 
         if (!placed && !isSegmentUnmapped()) {
             final String warning = String.format(
@@ -284,14 +278,14 @@ public class CramCompressionRecord {
     }
 
     // check placement without regard to mapping; helper method for isPlaced()
-    private boolean isPlacedInternal(final boolean useAbsolutePositionEncoding) {
+    private boolean isPlacedInternal() {
         // placement requires a valid sequence ID
         if (sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
             return false;
         }
 
-        // if an absolute alignment start coordinate is required but we have none, it's unplaced
-        return ! (useAbsolutePositionEncoding && alignmentStart == SAMRecord.NO_ALIGNMENT_START);
+        // an alignment start coordinate is required for placement too
+        return ! (alignmentStart == SAMRecord.NO_ALIGNMENT_START);
     }
 
     public boolean isFirstSegment() {
@@ -407,5 +401,4 @@ public class CramCompressionRecord {
     public void setSupplementary(final boolean supplementary) {
         flags = supplementary ? flags | SUPPLEMENTARY_FLAG : flags & ~SUPPLEMENTARY_FLAG;
     }
-
 }

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -388,7 +388,7 @@ public class Slice {
             // Unmapped: all records are unmapped and unplaced
 
             final CramCompressionRecord firstRecord = records.get(0);
-            slice.sequenceId = firstRecord.isPlaced(header.APDelta) ?
+            slice.sequenceId = firstRecord.isPlaced() ?
                     firstRecord.sequenceId :
                     SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX;
 
@@ -398,19 +398,19 @@ public class Slice {
                 hasher.add(record);
 
                 // flip an unmapped slice to multi-ref if the record is placed
-                if (slice.isUnmapped() && record.isPlaced(header.APDelta)) {
+                if (slice.isUnmapped() && record.isPlaced()) {
                     slice.sequenceId = MULTI_REFERENCE;
                 }
                 else if (slice.isMappedSingleRef()) {
                     // flip a single-ref slice to multi-ref if the record is unplaced or on a different ref
-                    if (!record.isPlaced(header.APDelta) || slice.sequenceId != record.sequenceId) {
+                    if (!record.isPlaced() || slice.sequenceId != record.sequenceId) {
                         slice.sequenceId = MULTI_REFERENCE;
                     }
                     else {
                         // calculate single ref slice alignment
 
                         minAlStart = Math.min(record.alignmentStart, minAlStart);
-                        maxAlEnd = Math.max(record.getAlignmentEnd(header.APDelta), maxAlEnd);
+                        maxAlEnd = Math.max(record.getAlignmentEnd(), maxAlEnd);
                     }
                 }
             }

--- a/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
@@ -28,7 +28,7 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
         record.setSegmentUnmapped(false);
         record.setMultiFragment(false);
         record.sequenceId = seqId;
-        record.alignmentStart =start;
+        record.alignmentStart = start;
         record.readBases = record.qualityScores = bases;
         record.readName = Integer.toString(recordIndex);
         record.readLength = readLength;

--- a/src/test/java/htsjdk/samtools/cram/encoding/CramRecordTestHelper.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/CramRecordTestHelper.java
@@ -22,8 +22,8 @@ public abstract class CramRecordTestHelper extends HtsjdkTest {
 
     // attempt at minimal initialization for tests
 
-    CompressionHeader createHeader(final List<CramCompressionRecord> records, final boolean coordinateSorter) {
-        return new CompressionHeaderFactory().build(records, new SubstitutionMatrix(new long[256][256]), coordinateSorter);
+    CompressionHeader createHeader(final List<CramCompressionRecord> records, final boolean coordinateSorted) {
+        return new CompressionHeaderFactory().build(records, new SubstitutionMatrix(new long[256][256]), coordinateSorted);
     }
 
     List<CramCompressionRecord> createRecords() {

--- a/src/test/java/htsjdk/samtools/cram/encoding/CramRecordTestHelper.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/CramRecordTestHelper.java
@@ -22,8 +22,8 @@ public abstract class CramRecordTestHelper extends HtsjdkTest {
 
     // attempt at minimal initialization for tests
 
-    CompressionHeader createHeader(final List<CramCompressionRecord> records, final boolean sorted) {
-        return new CompressionHeaderFactory().build(records, new SubstitutionMatrix(new long[256][256]), sorted);
+    CompressionHeader createHeader(final List<CramCompressionRecord> records, final boolean coordinateSorter) {
+        return new CompressionHeaderFactory().build(records, new SubstitutionMatrix(new long[256][256]), coordinateSorter);
     }
 
     List<CramCompressionRecord> createRecords() {
@@ -124,14 +124,15 @@ public abstract class CramRecordTestHelper extends HtsjdkTest {
     }
 
     public byte[] write(final List<CramCompressionRecord> records,
+                        final Map<Integer, ByteArrayOutputStream> outputMap,
                         final CompressionHeader header,
                         final int refId,
-                        final Map<Integer, ByteArrayOutputStream> outputMap) throws IOException {
+                        final int initialAlignmentStart) throws IOException {
         try (final ByteArrayOutputStream os = new ByteArrayOutputStream();
              final BitOutputStream bos = new DefaultBitOutputStream(os)) {
 
             final CramRecordWriter writer = new CramRecordWriter(bos, outputMap, header, refId);
-            writer.writeCramCompressionRecords(records, 0);
+            writer.writeCramCompressionRecords(records, initialAlignmentStart);
 
             return os.toByteArray();
         }

--- a/src/test/java/htsjdk/samtools/cram/encoding/CramRecordWriterReaderTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/CramRecordWriterReaderTest.java
@@ -8,6 +8,7 @@ import htsjdk.samtools.cram.structure.CompressionHeader;
 import htsjdk.samtools.cram.structure.CramCompressionRecord;
 import htsjdk.samtools.cram.structure.Slice;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -19,15 +20,16 @@ import java.util.Map;
 
 public class CramRecordWriterReaderTest extends CramRecordTestHelper {
     private CramCompressionRecord read(final byte[] dataBytes,
+                                       final Map<Integer, ByteArrayInputStream> inputMap,
                                        final CompressionHeader header,
                                        final int refId,
-                                       final Map<Integer, ByteArrayInputStream> inputMap) throws IOException {
+                                       final int prevAlignmentStart) throws IOException {
         try (final ByteArrayInputStream is = new ByteArrayInputStream(dataBytes);
             final BitInputStream bis = new DefaultBitInputStream(is)) {
 
             final CramRecordReader reader = new CramRecordReader(bis, inputMap, header, refId, ValidationStringency.DEFAULT_STRINGENCY);
             final CramCompressionRecord recordToRead = new CramCompressionRecord();
-            reader.read(recordToRead);
+            reader.read(recordToRead, prevAlignmentStart);
             return recordToRead;
         }
     }
@@ -52,8 +54,13 @@ public class CramRecordWriterReaderTest extends CramRecordTestHelper {
         return records;
     }
 
-    @Test
-    public void roundTripTest() throws IOException {
+    @DataProvider(name = "coordSortedTrueFalse")
+    private Object[][] tf() {
+        return new Object[][] { {true}, {false}};
+    }
+
+    @Test(dataProvider = "coordSortedTrueFalse")
+    public void roundTripTest(final boolean coordinateSorted) throws IOException {
         final List<CramCompressionRecord> initialRecords = initRTRecords();
 
         // note for future refactoring
@@ -61,17 +68,21 @@ public class CramRecordWriterReaderTest extends CramRecordTestHelper {
         // which is the only way to set a record's tagIdsIndex
         // which would otherwise be null
 
-        final boolean sorted = true;
-        final CompressionHeader header = createHeader(initialRecords, sorted);
+        final CompressionHeader header = createHeader(initialRecords, coordinateSorted);
 
         final int refId = Slice.MULTI_REFERENCE;
         final Map<Integer, ByteArrayOutputStream> outputMap = createOutputMap(header);
-        final byte[] written = write(initialRecords, header, refId, outputMap);
+        int initialAlignmentStart = initialRecords.get(0).alignmentStart;
+        final byte[] written = write(initialRecords, outputMap, header, refId, initialAlignmentStart);
 
         final Map<Integer, ByteArrayInputStream> inputMap = createInputMap(outputMap);
         final List<CramCompressionRecord> roundTripRecords = new ArrayList<>(initialRecords.size());
+
+        int prevAlignmentStart = initialAlignmentStart;
         for (int i = 0; i < initialRecords.size(); i++) {
-            roundTripRecords.add(read(written, header, refId, inputMap));
+            final CramCompressionRecord newRecord = read(written, inputMap, header, refId, prevAlignmentStart);
+            prevAlignmentStart = newRecord.alignmentStart;
+            roundTripRecords.add(newRecord);
         }
 
         Assert.assertEquals(roundTripRecords, initialRecords);

--- a/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CramCompressionRecordTest.java
@@ -16,13 +16,8 @@ import java.util.List;
  * Created by vadim on 28/09/2015.
  */
 public class CramCompressionRecordTest extends HtsjdkTest {
-    @DataProvider(name = "deltaEncodingTrueFalse")
-    private Object[][] tf() {
-        return new Object[][] { {true}, {false}};
-    }
-
-    @Test(dataProvider = "deltaEncodingTrueFalse")
-    public void test_getAlignmentSpanAndEnd(final boolean usePositionDeltaEncoding) {
+    @Test
+    public void test_getAlignmentSpanAndEnd() {
         CramCompressionRecord r = new CramCompressionRecord();
         int readLength = 100;
         r.alignmentStart = 5;
@@ -30,7 +25,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.setSegmentUnmapped(false);
 
         int expectedSpan = r.readLength;
-        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
+        assertSpanAndEnd(r, expectedSpan);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 10;
@@ -41,7 +36,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures.add(new SoftClip(1, softClip.getBytes()));
 
         expectedSpan = r.readLength - softClip.length();
-        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
+        assertSpanAndEnd(r, expectedSpan);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 20;
@@ -52,7 +47,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures.add(new Deletion(1, deletionLength));
 
         expectedSpan = r.readLength + deletionLength;
-        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
+        assertSpanAndEnd(r, expectedSpan);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 30;
@@ -63,7 +58,7 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures.add(new Insertion(1, insertion.getBytes()));
 
         expectedSpan = r.readLength - insertion.length();
-        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
+        assertSpanAndEnd(r, expectedSpan);
 
         r = new CramCompressionRecord();
         r.alignmentStart = 40;
@@ -73,15 +68,14 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readFeatures.add(new InsertBase(1, (byte) 'A'));
 
         expectedSpan = r.readLength - 1;
-        assertSpanAndEnd(r, usePositionDeltaEncoding, expectedSpan);
+        assertSpanAndEnd(r, expectedSpan);
     }
 
     private void assertSpanAndEnd(final CramCompressionRecord r,
-                                  final boolean usePositionDeltaEncoding,
                                   final int expectedSpan) {
         final int expectedEnd = expectedSpan + r.alignmentStart - 1;
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), expectedSpan);
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), expectedEnd);
+        Assert.assertEquals(r.getAlignmentSpan(), expectedSpan);
+        Assert.assertEquals(r.getAlignmentEnd(), expectedEnd);
     }
 
     // https://github.com/samtools/htsjdk/issues/1301
@@ -89,28 +83,28 @@ public class CramCompressionRecordTest extends HtsjdkTest {
     // demonstrate the bug: alignmentEnd and alignmentSpan are set once only
     // and do not update to reflect the state of the record
 
-    @Test(dataProvider = "deltaEncodingTrueFalse")
-    public void demonstrateBug1301(final boolean usePositionDeltaEncoding) {
+    @Test
+    public void demonstrateBug1301() {
         final CramCompressionRecord r = new CramCompressionRecord();
         final int alignmentStart = 5;
         final int readLength = 100;
         r.alignmentStart = alignmentStart;
         r.readLength = readLength;
         r.setSegmentUnmapped(false);
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), readLength + alignmentStart - 1);
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), readLength);
+        Assert.assertEquals(r.getAlignmentEnd(), readLength + alignmentStart - 1);
+        Assert.assertEquals(r.getAlignmentSpan(), readLength);
 
         // matches original values, not the new ones
 
         r.alignmentStart++;
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), readLength + alignmentStart - 1);
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), readLength);
-        Assert.assertNotEquals(r.getAlignmentEnd(usePositionDeltaEncoding), readLength + r.alignmentStart - 1);
+        Assert.assertEquals(r.getAlignmentEnd(), readLength + alignmentStart - 1);
+        Assert.assertEquals(r.getAlignmentSpan(), readLength);
+        Assert.assertNotEquals(r.getAlignmentEnd(), readLength + r.alignmentStart - 1);
 
         r.readLength++;
-        Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), readLength + alignmentStart - 1);
-        Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), readLength);
-        Assert.assertNotEquals(r.getAlignmentSpan(usePositionDeltaEncoding), r.readLength);
+        Assert.assertEquals(r.getAlignmentEnd(), readLength + alignmentStart - 1);
+        Assert.assertEquals(r.getAlignmentSpan(), readLength);
+        Assert.assertNotEquals(r.getAlignmentSpan(), r.readLength);
     }
 
     @DataProvider(name = "placedTests")
@@ -121,35 +115,33 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         final int[] sequenceIds = new int[]{ SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX, validSeqId };
         final int validAlignmentStart = 1;
         final int[] starts = new int[]{ SAMRecord.NO_ALIGNMENT_START, validAlignmentStart };
-        final boolean[] deltas = new boolean[] { true, false };
         final boolean[] mappeds = new boolean[] { true, false };
 
         for (final int sequenceId : sequenceIds) {
             for (final int start : starts) {
-                for (final boolean delta : deltas) {
-                    for (final boolean mapped : mappeds) {
+                for (final boolean mapped : mappeds) {
 
-                        // logically, unplaced reads should never be mapped.
-                        // when isPlaced() sees an unplaced-mapped read, it returns false and emits a log warning.
-                        // it does not affect expectations here.
+                    // logically, unplaced reads should never be mapped.
+                    // when isPlaced() sees an unplaced-mapped read, it returns false and emits a log warning.
+                    // it does not affect expectations here.
 
-                        boolean placementExpectation = true;
+                    boolean placementExpectation = true;
 
-                        // we also expect that read sequenceIds and alignmentStart are both valid or both invalid.
-                        // however: we do handle the edge case where only one of the pair is valid
-                        // by marking it as unplaced.
+                    // we also expect that read sequenceIds and alignmentStart are both valid or both invalid.
+                    // however: we do handle the edge case where only one of the pair is valid
+                    // by marking it as unplaced.
 
-                        if (sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
-                            placementExpectation = false;
-                        }
-
-                        if (!delta && start == SAMRecord.NO_ALIGNMENT_START) {
-                            placementExpectation = false;
-                        }
-
-                        retval.add(new Object[]{sequenceId, start, mapped, delta, placementExpectation});
+                    if (sequenceId == SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX) {
+                        placementExpectation = false;
                     }
+
+                    if (start == SAMRecord.NO_ALIGNMENT_START) {
+                        placementExpectation = false;
+                    }
+
+                    retval.add(new Object[]{sequenceId, start, mapped, placementExpectation});
                 }
+
             }
         }
 
@@ -160,20 +152,18 @@ public class CramCompressionRecordTest extends HtsjdkTest {
     public void test_isPlaced(final int sequenceId,
                               final int alignmentStart,
                               final boolean mapped,
-                              final boolean usePositionDeltaEncoding,
                               final boolean placementExpectation) {
         final CramCompressionRecord r = new CramCompressionRecord();
         r.sequenceId = sequenceId;
         r.alignmentStart = alignmentStart;
         r.setSegmentUnmapped(!mapped);
-        Assert.assertEquals(r.isPlaced(usePositionDeltaEncoding), placementExpectation);
+        Assert.assertEquals(r.isPlaced(), placementExpectation);
     }
 
     @Test(dataProvider = "placedTests")
     public void test_placementForAlignmentSpanAndEnd(final int sequenceId,
                                                      final int alignmentStart,
                                                      final boolean mapped,
-                                                     final boolean usePositionDeltaEncoding,
                                                      final boolean placementExpectation) {
         final CramCompressionRecord r = new CramCompressionRecord();
         r.sequenceId = sequenceId;
@@ -183,12 +173,12 @@ public class CramCompressionRecordTest extends HtsjdkTest {
         r.readLength = readLength;
 
         if (placementExpectation) {
-            Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), readLength);
-            Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), alignmentStart + readLength - 1);
+            Assert.assertEquals(r.getAlignmentSpan(), readLength);
+            Assert.assertEquals(r.getAlignmentEnd(), alignmentStart + readLength - 1);
         }
         else {
-            Assert.assertEquals(r.getAlignmentSpan(usePositionDeltaEncoding), Slice.NO_ALIGNMENT_SPAN);
-            Assert.assertEquals(r.getAlignmentEnd(usePositionDeltaEncoding), Slice.NO_ALIGNMENT_END);
+            Assert.assertEquals(r.getAlignmentSpan(), Slice.NO_ALIGNMENT_SPAN);
+            Assert.assertEquals(r.getAlignmentEnd(), Slice.NO_ALIGNMENT_END);
         }
     }
 

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -77,49 +77,47 @@ public class SliceTests extends HtsjdkTest {
 
     @DataProvider(name = "forBuildTests")
     private Object[][] forBuildTests() {
-        return new Object[][] {
+        final List<Object[]> retval = new ArrayList<>();
+        final boolean[] coordinateSorteds = new boolean[] { true, false };
+        for (final boolean coordSorted : coordinateSorteds) {
+            retval.add(new Object[]
                 {
                         getSingleRefRecords(),
-                        true,
+                        coordSorted,
                         TEST_RECORD_COUNT, 0, 1, 12
-                },
+                });
+            retval.add(new Object[]
                 {
                         getMultiRefRecords(),
-                        true,
+                        coordSorted,
                         TEST_RECORD_COUNT, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
-                },
+                });
+            retval.add(new Object[]
                 {
                         getUnplacedRecords(),
-                        true,
+                        coordSorted,
                         TEST_RECORD_COUNT, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
-                },
+                });
 
 
                 // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
                 // but not both.  We treat these weird edge cases as unplaced.
 
+            retval.add(new Object[]
                 {
                         getNoRefRecords(),
-                        true,
+                        coordSorted,
                         TEST_RECORD_COUNT, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
-                },
-
-                // show that not having a valid alignment start does nothing
-                // in the Coordinate-Sorted case (so it remains a Multi-Ref Slice)
-                // but causes the reads to be marked as Unplaced otherwise (so it becomes an Unmapped Slice)
-
+                });
+            retval.add(new Object[]
                 {
                         getNoStartRecords(),
-                        true,
-                        TEST_RECORD_COUNT, Slice.MULTI_REFERENCE, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
-                },
-                {
-                        getNoStartRecords(),
-                        false,
+                        coordSorted,
                         TEST_RECORD_COUNT, SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX, Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN
-                },
+                });
+        }
 
-        };
+        return retval.toArray(new Object[0][0]);
     }
 
     @Test(dataProvider = "forBuildTests")


### PR DESCRIPTION
Use alignmentStart as the sole source of truth, avoiding messy APDelta logic for isPlaced() and elsewhere.

Largely a reversion of and better solution to #1284 

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

