### PR TITLE
Simplify CRAM sequence dictionary extractor to not require a fake reference.

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -32,23 +32,12 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.*;
 
 import htsjdk.samtools.cram.CRAMException;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 
 public class CRAMIterator implements SAMRecordIterator {
-    
-    /** A CRAMReferenceSource that is never invoked . It's used in {@link #extractDictionary(Path)}*/
-    private static final CRAMReferenceSource NIL_CRAM_REFERENCE_SRC = new CRAMReferenceSource() {
-        @Override
-        public byte[] getReferenceBases(final SAMSequenceRecord sequenceRecord, boolean tryNameVariants) {
-            throw new IllegalStateException("CRAMReferenceSource.getReferenceBases shouldn't be called");
-            }
-    };
     
     private final CountingInputStream countingInputStream;
     private final CramHeader cramHeader;
@@ -315,18 +304,4 @@ public class CRAMIterator implements SAMRecordIterator {
         return cramHeader.getSamFileHeader();
     }
 
-    /** extracts a {@link SAMSequenceDictionary} from a cram file.
-     * @return the dictionary of the cram file
-     * @throws SAMException if a dictionary cannot be extracted
-     */
-    public static SAMSequenceDictionary extractDictionary(final Path cramPath) {
-        IOUtil.assertFileIsReadable(cramPath);
-        try (final InputStream in = Files.newInputStream(cramPath)) {
-            try(final CRAMIterator iter= new CRAMIterator(in, NIL_CRAM_REFERENCE_SRC, ValidationStringency.SILENT)) {
-                return iter.getSAMFileHeader().getSequenceDictionary();
-            }
-        } catch (final Exception err) {
-           throw new SAMException("Cannot extract dictionary from "+cramPath, err);
-        }
-    }
 }

--- a/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
+++ b/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
@@ -26,19 +26,20 @@ package htsjdk.variant.utils;
 
 import htsjdk.samtools.*;
 import htsjdk.samtools.cram.build.CramIO;
+import htsjdk.samtools.cram.structure.CramHeader;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
-import htsjdk.samtools.util.BufferedLineReader;
-import htsjdk.samtools.util.CollectionUtil;
-import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.IntervalList;
+import htsjdk.samtools.util.*;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.vcf.VCFFileReader;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Small class for loading a SAMSequenceDictionary from a file
@@ -74,8 +75,18 @@ public class SAMSequenceDictionaryExtractor {
         CRAM(CramIO.CRAM_FILE_EXTENSION) {
             
             @Override
-            SAMSequenceDictionary extractDictionary(final Path cram) {
-                    return CRAMIterator.extractDictionary(cram);
+            SAMSequenceDictionary extractDictionary(final Path cramPath) {
+                IOUtil.assertFileIsReadable(cramPath);
+                try (final InputStream in = Files.newInputStream(cramPath)) {
+                    final CramHeader cramHeader = CramIO.readCramHeader(in);
+                    final Optional<SAMFileHeader> samHeader = Optional.ofNullable(cramHeader.getSamFileHeader());
+                    if (samHeader.isPresent()) {
+                        return samHeader.get().getSequenceDictionary();
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeIOException(e);
+                }
+                throw new SAMException(String.format("Can't retrieve sequence dictionary from %s", cramPath));
             }
         },
         SAM(IOUtil.SAM_FILE_EXTENSION, BamFileIoUtils.BAM_FILE_EXTENSION) {


### PR DESCRIPTION
Slightly more idiomatic CRAM sequence dictionary extractor. Rather than introduce a new method and fake reference in CRAMIterator, this retrieves the CRAM header and sequence dictionary using existing code that doesn't require a reference.
