### PR TITLE
making changes to reduce size of giant interval lists

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -531,6 +531,7 @@ public class IntervalList implements Iterable<Interval> {
 
             // Then read in the intervals
             final FormatUtil format = new FormatUtil();
+            String lastSeq = null;
             do {
                 if (line.trim().isEmpty()) {
                     continue; // skip over blank lines
@@ -544,7 +545,12 @@ public class IntervalList implements Iterable<Interval> {
                 }
 
                 // Then parse them out
-                final String seq = fields[SEQUENCE_POS];
+                String seq = fields[SEQUENCE_POS];
+                if (seq.equals(lastSeq)) {
+                    seq = lastSeq;
+                }
+                lastSeq = seq;
+
                 final int start = format.parseInt(fields[START_POS]);
                 final int end = format.parseInt(fields[END_POS]);
                 if (start < 1) {

--- a/src/main/java/htsjdk/samtools/util/IntervalTree.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalTree.java
@@ -60,8 +60,6 @@ public class IntervalTree<V> implements Iterable<IntervalTree.Node<V>>
         mRoot = null;
     }
 
-
-
     /**
      * Put a new interval into the tree (or update the value associated with an existing interval).
      * If the interval is novel, the special sentinel value is returned.
@@ -129,15 +127,17 @@ public class IntervalTree<V> implements Iterable<IntervalTree.Node<V>>
      * @param start interval start position
      * @param end interval end position
      * @param value value to merge into the tree, must not be equal to the sentinel value
-     * @param remappingFunction a function that merges the new value with the existing value for the same start and end position
-     * @return the updated value that is now stored in the tree or sentinel
+     * @param remappingFunction a function that merges the new value with the existing value for the same start and end position,
+     *                          if the function returns the sentinel value then the mapping will be unset
+     * @return the updated value that is stored in the tree after the completion of this merge operation, this will
+     * be the sentinel value if nothing ended up being stored
      */
     public V merge(int start, int end, V value, BiFunction<? super V,  ? super V, ? extends V> remappingFunction) {
         ValidationUtils.validateArg(!Objects.equals(value, mSentinel), "Values equal to the sentinel value may not be merged");
         final V alreadyPresent = put(start, end, value);
         if (!Objects.equals(alreadyPresent, mSentinel)) {
             final V newComputedValue = remappingFunction.apply(value, alreadyPresent);
-            if(Objects.equals(newComputedValue, mSentinel)){
+            if (Objects.equals(newComputedValue, mSentinel)) {
                 remove(start, end);
             } else {
                 put(start, end, newComputedValue);

--- a/src/main/java/htsjdk/samtools/util/IntervalTree.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalTree.java
@@ -23,9 +23,13 @@
  */
 package htsjdk.samtools.util;
 
+import htsjdk.utils.ValidationUtils;
+
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.function.BiFunction;
 
 /**
  * A Red-Black tree with intervals for keys.
@@ -56,6 +60,8 @@ public class IntervalTree<V> implements Iterable<IntervalTree.Node<V>>
         mRoot = null;
     }
 
+
+
     /**
      * Put a new interval into the tree (or update the value associated with an existing interval).
      * If the interval is novel, the special sentinel value is returned.
@@ -64,7 +70,6 @@ public class IntervalTree<V> implements Iterable<IntervalTree.Node<V>>
      * @param value The associated value.
      * @return The old value associated with that interval, or the sentinel.
      */
-    @SuppressWarnings("null")
     public V put( final int start, final int end, final V value )
     {
         if ( start > end )
@@ -112,6 +117,34 @@ public class IntervalTree<V> implements Iterable<IntervalTree.Node<V>>
         }
 
         return result;
+    }
+
+    /**
+     * If the specified start and end positions are not already associated with a value or are
+     * associated with the sentinel ( see {@link #getSentinel()}, associates it with the given (non-sentinel) value.
+     * Otherwise, replaces the associated value with the results of the given
+     * remapping function, or removes if the result is equal to the sentinel value. This
+     * method may be of use when combining multiple values that have the same start and end position.
+     *
+     * @param start interval start position
+     * @param end interval end position
+     * @param value value to merge into the tree, must not be equal to the sentinel value
+     * @param remappingFunction a function that merges the new value with the existing value for the same start and end position
+     * @return the updated value that is now stored in the tree or sentinel
+     */
+    public V merge(int start, int end, V value, BiFunction<? super V,  ? super V, ? extends V> remappingFunction) {
+        ValidationUtils.validateArg(!Objects.equals(value, mSentinel), "Values equal to the sentinel value may not be merged");
+        final V alreadyPresent = put(start, end, value);
+        if (!Objects.equals(alreadyPresent, mSentinel)) {
+            final V newComputedValue = remappingFunction.apply(value, alreadyPresent);
+            if(Objects.equals(newComputedValue, mSentinel)){
+                remove(start, end);
+            } else {
+                put(start, end, newComputedValue);
+            }
+            return newComputedValue;
+        }
+        return value;
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/OverlapDetector.java
+++ b/src/main/java/htsjdk/samtools/util/OverlapDetector.java
@@ -84,9 +84,7 @@ public class OverlapDetector<T> {
         final int end = interval.getEnd() - this.lhsBuffer;
 
         if (start <= end) {  // Don't put in sequences that have no overlappable bases
-            tree.merge(start, end,
-                                  Collections.singleton(object),
-                                  mergeSetsAccountingForSingletons());
+            tree.merge(start, end, Collections.singleton(object), mergeSetsAccountingForSingletons());
         }
     }
 
@@ -97,16 +95,10 @@ public class OverlapDetector<T> {
         return (newValue, oldValue) -> {
             // Sets of size 1 are immutable SingletonSets so we have to make a new
             // mutable one to add to
-            if (oldValue.size() == 1) {
-                Set<T> newMutableSet = new HashSet<>();
-                newMutableSet.addAll(oldValue);
-                newMutableSet.addAll(newValue);
-                return newMutableSet;
-                // otherwise it's already a HashSet and we can just add values to it
-            } else {
-                oldValue.addAll(newValue);
-                return oldValue;
-            }
+            final Set<T> mutableSet = oldValue.size() == 1 ? new HashSet<>() : oldValue;
+            mutableSet.addAll(oldValue);
+            mutableSet.addAll(newValue);
+            return mutableSet;
         };
     }
 

--- a/src/main/java/htsjdk/samtools/util/OverlapDetector.java
+++ b/src/main/java/htsjdk/samtools/util/OverlapDetector.java
@@ -82,13 +82,19 @@ public class OverlapDetector<T> {
         final int start = interval.getStart() + this.lhsBuffer;
         final int end   = interval.getEnd()   - this.lhsBuffer;
 
-        final Set<T> objects = new HashSet<>(1);
-        objects.add(object);
+        final Set<T> newValue = Collections.singleton(object);
         if (start <= end) {  // Don't put in sequences that have no overlappable bases
-            final Set<T> alreadyThere = tree.put(start, end, objects);
+            final Set<T> alreadyThere = tree.put(start, end, newValue);
             if (alreadyThere != null) {
-                alreadyThere.add(object);
-                tree.put(start, end, alreadyThere);
+                if( alreadyThere.size() == 1){
+                    Set<T> mutableSet = new HashSet<>(2);
+                    mutableSet.addAll(alreadyThere);
+                    mutableSet.add(object);
+                    tree.put(start, end, mutableSet);
+                } else {
+                    alreadyThere.add(object);
+                    tree.put(start, end, alreadyThere);
+                }
             }
         }
     }

--- a/src/test/java/htsjdk/samtools/util/OverlapDetectorTest.java
+++ b/src/test/java/htsjdk/samtools/util/OverlapDetectorTest.java
@@ -1,6 +1,7 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.tribble.SimpleFeature;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -237,5 +238,42 @@ public class OverlapDetectorTest extends HtsjdkTest {
         final Set<Locatable> overlaps = detector.getOverlaps(new Interval("1", 50, 200));
         Assert.assertEquals(overlaps.size(), 1);
         Assert.assertEquals(overlaps, Collections.singleton(new Interval("1",10,100)));
+    }
+
+    @Test
+    public void testMultipleIntervalsSameCoordinates(){
+        final List<Locatable> input = Arrays.asList(
+                new IntervalWithNameInEquals("1", 10, 100, false, "same coords 1"),
+                new IntervalWithNameInEquals("1",10,100, true, "same coords 2"),
+                new IntervalWithNameInEquals("1", 10, 100, true, "same coords 3"),
+                new IntervalWithNameInEquals("1", 150, 250, false, "not same coordinates")
+        );
+        final OverlapDetector<Locatable> detector = OverlapDetector.create(input);
+        final Set<Locatable> overlaps = detector.getOverlaps(new Interval("1", 50, 200));
+        Assert.assertEquals(overlaps.size(), 4);
+        Assert.assertEquals(overlaps, new HashSet<>(input));
+    }
+
+    /**
+     * small class to allow creating intervals that have the same coordinates but don't evaluate as equal to each other
+     */
+    private static class IntervalWithNameInEquals extends Interval{
+
+        public IntervalWithNameInEquals(String sequence, int start, int end, boolean negative, String name) {
+            super(sequence, start, end, negative, name);
+        }
+
+        @Override
+        public boolean equals(Object other){
+            if (super.equals(other)) {
+                return getName().equals(((Interval)other).getName());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode(){
+            return super.hashCode() * getName().hashCode();
+        }
     }
 }


### PR DESCRIPTION
### Description
Two separate changes which should reduce the in-memory size of IntervalList and OverlapDetector.

1: Cache the last seen contig name when loading IntervalLists and reuse the same String to avoid keeping many duplicate copies of "chr1" in memory. This should have very minor overhead since interval files are sorted it should be about as effective as a more complicated caching scheme.

2.  Use SingletonSets as the leaf objects in OverlapDetector when constructing it.  These are substantially smaller than HashSets of the same size.  Change to HashSet only when we find 2 or more identically positioned elements.  This will have a minor performance cost while constructing the OverlapDetector but should result in dramatically decreased size in memory.  

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

