### PR TITLE
Fix bug when loading indexed bgzip fasta file.

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
@@ -100,8 +100,8 @@ public class BlockCompressedIndexedFastaSequenceFile extends AbstractIndexedFast
     private static void assertIsBlockCompressed(final Path path) {
         try {
             // check if the it is a valid block-compressed file and if the .gzi index exits
-            if(!IOUtil.isBlockCompressed(path, true)){
-              throw new SAMException("Invalid block-compressed Fasta file: " + path);
+            if (!IOUtil.isBlockCompressed(path, true)) {
+                throw new SAMException("Invalid block-compressed Fasta file: " + path);
             }
         } catch (IOException e) {
             throw new SAMException("Invalid block-compressed Fasta file: " + path, e);

--- a/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/BlockCompressedIndexedFastaSequenceFile.java
@@ -26,19 +26,15 @@ package htsjdk.samtools.reference;
 
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.seekablestream.ReadableSeekableStreamByteChannel;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.GZIIndex;
 import htsjdk.samtools.util.IOUtil;
 
-import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -55,7 +51,7 @@ public class BlockCompressedIndexedFastaSequenceFile extends AbstractIndexedFast
 
     public BlockCompressedIndexedFastaSequenceFile(final Path path)
             throws FileNotFoundException {
-        this(path,new FastaSequenceIndex((findRequiredFastaIndexFile(path))));
+        this(path, new FastaSequenceIndex((findRequiredFastaIndexFile(path))));
     }
 
     public BlockCompressedIndexedFastaSequenceFile(final Path path, final FastaSequenceIndex index) {
@@ -67,9 +63,7 @@ public class BlockCompressedIndexedFastaSequenceFile extends AbstractIndexedFast
         if (gziIndex == null) {
             throw new IllegalArgumentException("null gzi index");
         }
-        if (!canCreateBlockCompresedIndexedFastaSequence(path)) {
-            throw new SAMException("Invalid block-compressed Fasta file");
-        }
+        assertIsBlockCompressed(path);
         try {
             stream = new BlockCompressedInputStream(new SeekablePathStream(path));
             gzindex = gziIndex;
@@ -103,12 +97,14 @@ public class BlockCompressedIndexedFastaSequenceFile extends AbstractIndexedFast
         }
     }
 
-    private static boolean canCreateBlockCompresedIndexedFastaSequence(final Path path) {
+    private static void assertIsBlockCompressed(final Path path) {
         try {
             // check if the it is a valid block-compressed file and if the .gzi index exits
-            return IOUtil.isBlockCompressed(path, true) && Files.exists(GZIIndex.resolveIndexNameForBgzipFile(path));
+            if(!IOUtil.isBlockCompressed(path, true)){
+              throw new SAMException("Invalid block-compressed Fasta file: " + path);
+            }
         } catch (IOException e) {
-            return false;
+            throw new SAMException("Invalid block-compressed Fasta file: " + path, e);
         }
     }
 

--- a/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
+++ b/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
@@ -360,10 +360,10 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
         final Path moved = Files.createTempFile("moved", ".fasta.gz");
         Files.copy(SEQUENCE_FILE_BGZ.toPath(), moved, StandardCopyOption.REPLACE_EXISTING);
         IOUtil.deleteOnExit(moved);
-        try( ReferenceSequenceFile withNoAdacentIndex = new BlockCompressedIndexedFastaSequenceFile(moved, new FastaSequenceIndex(SEQUENCE_FILE_INDEX), GZIIndex.loadIndex(SEQUENCE_FILE_GZI.toPath()));
+        try (ReferenceSequenceFile withNoAdacentIndex = new BlockCompressedIndexedFastaSequenceFile(moved, new FastaSequenceIndex(SEQUENCE_FILE_INDEX), GZIIndex.loadIndex(SEQUENCE_FILE_GZI.toPath()));
              ReferenceSequenceFile withFilesAdjacent = new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ.toPath())){
             Assert.assertEquals(withNoAdacentIndex.getSubsequenceAt("chrM", 100, 1000).getBases(),
-            withFilesAdjacent.getSubsequenceAt("chrM", 100, 1000).getBases());
+                withFilesAdjacent.getSubsequenceAt("chrM", 100, 1000).getBases());
         }
     }
 }

--- a/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
+++ b/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
@@ -27,7 +27,11 @@ package htsjdk.samtools.reference;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
-import htsjdk.samtools.util.*;
+import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.GZIIndex;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.samtools.util.StringUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -46,7 +50,6 @@ import java.nio.file.StandardCopyOption;
 public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
     private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/reference");
     private static final File SEQUENCE_FILE = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta");
-    private static final File SEQUENCE_FILE_DICT = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.dict");
     private static final File SEQUENCE_FILE_INDEX = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta.fai");
     private static final File SEQUENCE_FILE_BGZ = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta.gz");
     private static final File SEQUENCE_FILE_GZI = new File(TEST_DATA_DIR,"Homo_sapiens_assembly18.trimmed.fasta.gz.gzi");
@@ -361,9 +364,9 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
         Files.copy(SEQUENCE_FILE_BGZ.toPath(), moved, StandardCopyOption.REPLACE_EXISTING);
         IOUtil.deleteOnExit(moved);
         try (ReferenceSequenceFile withNoAdacentIndex = new BlockCompressedIndexedFastaSequenceFile(moved, new FastaSequenceIndex(SEQUENCE_FILE_INDEX), GZIIndex.loadIndex(SEQUENCE_FILE_GZI.toPath()));
-             ReferenceSequenceFile withFilesAdjacent = new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ.toPath())){
+             ReferenceSequenceFile withFilesAdjacent = new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ.toPath())) {
             Assert.assertEquals(withNoAdacentIndex.getSubsequenceAt("chrM", 100, 1000).getBases(),
-                withFilesAdjacent.getSubsequenceAt("chrM", 100, 1000).getBases());
+                    withFilesAdjacent.getSubsequenceAt("chrM", 100, 1000).getBases());
         }
     }
 }


### PR DESCRIPTION
* There was a bug that prevented loading an indexed bgzip fasta file if the index location was specified but wasn't next to the fasta in the file system.
* Fixes #1290

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

