### PR TITLE
Deprecate TestUtil.deleteRecursively

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1318,20 +1318,21 @@ public class IOUtil {
     }
 
     /**
-     * Little test utility to help tests that create multiple levels of subdirectories
-     * clean up after themselves.
+     * Delete a directory and all files in it.
      *
      * @param directory The directory to be deleted (along with its subdirectories)
      */
-    public static void recursiveDelete(final Path directory) throws IOException {
-
+    public static void recursiveDelete(final Path directory) {
+        
         final SimpleFileVisitor<Path> simpleFileVisitor = new SimpleFileVisitor<Path>() {
+            @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 super.visitFile(file, attrs);
                 Files.deleteIfExists(file);
                 return FileVisitResult.CONTINUE;
             }
 
+            @Override
             public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
                 super.postVisitDirectory(dir, exc);
                 Files.deleteIfExists(dir);
@@ -1339,6 +1340,10 @@ public class IOUtil {
             }
         };
 
-        Files.walkFileTree(directory, simpleFileVisitor);
+        try {
+            Files.walkFileTree(directory, simpleFileVisitor);
+        } catch (final IOException e){
+            throw new RuntimeIOException(e);
+        }
     }
 }

--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -94,11 +94,13 @@ public class TestUtil {
      * clean up after themselves.
      *
      * @param directory The directory to be deleted (along with its subdirectories)
+     * @deprecated Since 3/19, prefer {@link IOUtil#recursiveDelete(Path)}
      */
+    @Deprecated
     public static void recursiveDelete(final File directory) {
         try {
             IOUtil.recursiveDelete(directory.toPath());
-        } catch (IOException e) {
+        } catch (RuntimeIOException e) {
             // bury exception
         }
     }


### PR DESCRIPTION
* I deprecated this method since it's been replaced.  

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

