### PR TITLE
Revert singletonList optimization in SamRecordSetBuilder

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -615,7 +615,10 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord(READ_GROUP_ID);
             readGroupRecord.setSample(SAMPLE);
             readGroupRecord.setPlatform(PlatformValue.ILLUMINA.name());
-            final List<SAMReadGroupRecord> readGroups = Collections.singletonList(readGroupRecord);
+            //This must be a mutable list because setReadGroups doesn't perform a copy and tests expect to be able
+            //to modify it.
+            final List<SAMReadGroupRecord> readGroups = new ArrayList<>();
+            readGroups.add(readGroupRecord);
             header.setReadGroups(readGroups);
         }
         return header;


### PR DESCRIPTION
* A trivial optimization to use a singletonList instead of an ArrayList in SamRecordSet builder broke downstream tests because SamFileHeader.setReadGroups explicitly doesn't copy the list.
* Tests downstream expect the list to be mutable.
* Fixes https://github.com/samtools/htsjdk/issues/1316
