### PR TITLE
CRAM: correct CT and MF encoding datatypes from byte to int

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/encoding/reader/CramRecordReader.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/reader/CramRecordReader.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 
 public class CramRecordReader {
     private final DataSeriesReader<Integer> bitFlagsCodec;
-    private final DataSeriesReader<Byte> compressionBitFlagsCodec;
+    private final DataSeriesReader<Integer> compressionBitFlagsCodec;
     private final DataSeriesReader<Integer> readLengthCodec;
     private final DataSeriesReader<Integer> alignmentStartCodec;
     private final DataSeriesReader<Integer> readGroupCodec;
@@ -54,7 +54,7 @@ public class CramRecordReader {
     private final DataSeriesReader<Integer> paddingCodec;
     private final DataSeriesReader<Integer> deletionLengthCodec;
     private final DataSeriesReader<Integer> mappingScoreCodec;
-    private final DataSeriesReader<Byte> mateBitFlagCodec;
+    private final DataSeriesReader<Integer> mateBitFlagCodec;
     private final DataSeriesReader<Integer> mateReferenceIdCodec;
     private final DataSeriesReader<Integer> mateAlignmentStartCodec;
     private final DataSeriesReader<Integer> insertSizeCodec;

--- a/src/main/java/htsjdk/samtools/cram/encoding/writer/CramRecordWriter.java
+++ b/src/main/java/htsjdk/samtools/cram/encoding/writer/CramRecordWriter.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 
 public class CramRecordWriter {
     private final DataSeriesWriter<Integer> bitFlagsC;
-    private final DataSeriesWriter<Byte> compBitFlagsC;
+    private final DataSeriesWriter<Integer> compBitFlagsC;
     private final DataSeriesWriter<Integer> readLengthC;
     private final DataSeriesWriter<Integer> alStartC;
     private final DataSeriesWriter<Integer> readGroupC;
@@ -51,7 +51,7 @@ public class CramRecordWriter {
     private final DataSeriesWriter<Integer> paddingCodec;
     private final DataSeriesWriter<Integer> deletionLengthCodec;
     private final DataSeriesWriter<Integer> mappingQualityScoreCodec;
-    private final DataSeriesWriter<Byte> mateBitFlagsCodec;
+    private final DataSeriesWriter<Integer> mateBitFlagsCodec;
     private final DataSeriesWriter<Integer> nextFragmentReferenceSequenceIDCodec;
     private final DataSeriesWriter<Integer> nextFragmentAlignmentStart;
     private final DataSeriesWriter<Integer> templateSize;

--- a/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CramCompressionRecord.java
@@ -99,12 +99,12 @@ public class CramCompressionRecord {
 
     public int sliceIndex = 0;
 
-    public byte getMateFlags() {
-        return (byte) (0xFF & mateFlags);
+    public int getMateFlags() {
+        return (0xFF & mateFlags);
     }
 
-    public byte getCompressionFlags() {
-        return (byte) (0xFF & compressionFlags);
+    public int getCompressionFlags() {
+        return (0xFF & compressionFlags);
     }
 
     @SuppressWarnings("SimplifiableIfStatement")

--- a/src/main/java/htsjdk/samtools/cram/structure/DataSeries.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/DataSeries.java
@@ -36,7 +36,7 @@ public enum DataSeries {
     // Main
 
     BF_BitFlags                         (DataSeriesType.INT,        "BF",  1),
-    CF_CompressionBitFlags              (DataSeriesType.BYTE,       "CF",  2),
+    CF_CompressionBitFlags              (DataSeriesType.INT,        "CF",  2),
 
     // Positional
 
@@ -52,7 +52,7 @@ public enum DataSeries {
     // Mate Record
 
     NF_RecordsToNextFragment            (DataSeriesType.INT,        "NF",  8),
-    MF_MateBitFlags                     (DataSeriesType.BYTE,       "MF",  9),
+    MF_MateBitFlags                     (DataSeriesType.INT,        "MF",  9),
     NS_NextFragmentReferenceSequenceID  (DataSeriesType.INT,        "NS", 10),
     NP_NextFragmentAlignmentStart       (DataSeriesType.INT,        "NP", 11),
     TS_InsertSize                       (DataSeriesType.INT,        "TS", 12),

--- a/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
@@ -14,6 +14,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Motivation for this test: we were incorrectly encoding a few CRAM record
+ * fields using the wrong data type.  This was surprising, since we would
+ * expect catastrophic "frame shift" type failures from this.
+ *
+ * Instead, we noticed that this conflict causes no problems under the following conditions:
+ *
+ * 1. External Byte, External Integer, and External Long Encodings
+ * create identical output streams when values are limited to the
+ * range 0 to 0x7F because the respective underlying encodings
+ * (raw bytes, ITF8, and LTF8 respectively) result in byte-for-byte
+ * identical outputs.
+ *
+ * 2. External Integer and External Long Encodings also create identical
+ * output streams when values are limited to 28 unsigned bits
+ * (0 to 0x0F FF FF FF) because ITF8 ands LTF8 are equivalent over that range.
+ *
+ * Demonstrate that these conditions do in fact create identical streams.
+ *
+ */
 public class ExternalCodecEquivalenceTest extends HtsjdkTest {
     // show that External codecs are equivalent within certain ranges
 

--- a/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
@@ -42,8 +42,8 @@ public class ExternalCodecEquivalenceTest extends HtsjdkTest {
 
     @Test(dataProvider = "testPositiveByteLists", dataProviderClass = IOTestCases.class)
     public void byteEquivalenceTest(final List<Byte> values) {
-        codecPairTest(values, this::externalByteCodecWrite,      this::externalIntegerCodecRead);
-        codecPairTest(values, this::externalByteCodecWrite,      this::externalLongCodecRead);
+        codecPairTest(values, this::externalByteCodecWrite,     this::externalIntegerCodecRead);
+        codecPairTest(values, this::externalByteCodecWrite,     this::externalLongCodecRead);
         codecPairTest(values, this::externalIntegerCodecWrite,  this::externalByteCodecRead);
         codecPairTest(values, this::externalIntegerCodecWrite,  this::externalLongCodecRead);
         codecPairTest(values, this::externalLongCodecWrite,     this::externalByteCodecRead);
@@ -60,7 +60,7 @@ public class ExternalCodecEquivalenceTest extends HtsjdkTest {
         codecPairTest(values, this::externalLongCodecWrite,     this::externalIntegerCodecRead);
     }
 
-    private <T extends Number> void codecPairTest(final List<T> values, Writer<T> writer, Reader reader) {
+    private <T extends Number> void codecPairTest(final List<T> values, CodecTestWriter<T> writer, CodecTestReader reader) {
         byte[] written = writer.write(values);
         final List<Long> read = reader.read(written, values.size());
 
@@ -72,12 +72,12 @@ public class ExternalCodecEquivalenceTest extends HtsjdkTest {
         Assert.assertEquals(read, expected);
     }
 
-    private interface Writer<T> {
+    private interface CodecTestWriter<T> {
         byte[] write(final List<T> toWrite);
     }
 
     // byte, integer, and long can all be read as Long
-    private interface Reader {
+    private interface CodecTestReader {
         List<Long> read(final byte[] toRead, final int count);
     }
 

--- a/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
@@ -1,0 +1,224 @@
+package htsjdk.samtools.cram.encoding.external;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.cram.encoding.CRAMCodec;
+import htsjdk.samtools.cram.io.IOTestCases;
+import htsjdk.samtools.util.RuntimeIOException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExternalCodecEquivalenceTest extends HtsjdkTest {
+    // show that External codecs are equivalent within certain ranges
+
+    // if all values are 0 <= v <= 0x7F (high bit 7)
+    // ExternalByteCodec, ExternalIntegerCodec, and ExternalLongCodec streams are identical
+    // because raw bytes, ITF8 and LTF8 are identical
+
+    @Test(dataProvider = "testPositiveByteLists", dataProviderClass = IOTestCases.class)
+    public void byteEquivalenceTest(final List<Byte> values) {
+        codecPairTestForByte(values, this::writeByteForByte, this::readIntegerForByte);
+        codecPairTestForByte(values, this::writeByteForByte, this::readLongForByte);
+        codecPairTestForByte(values, this::writeIntegerForByte, this::readByteForByte);
+        codecPairTestForByte(values, this::writeIntegerForByte, this::readLongForByte);
+        codecPairTestForByte(values, this::writeLongForByte, this::readByteForByte);
+        codecPairTestForByte(values, this::writeLongForByte, this::readIntegerForByte);
+    }
+
+    private void codecPairTestForByte(final List<Byte> values, ByteWriter writer, ByteReader reader) {
+        byte[] written = writer.write(values);
+        final List<Byte> read = reader.read(written, values.size());
+        Assert.assertEquals(read, values);
+    }
+
+    // if all values are 0 <= v <= 0x0F FF FF FF (high bit 28)
+    // ExternalIntegerCodec, and ExternalLongCodec streams are identical
+    // because ITF8 and LTF8 are identical
+
+    @Test(dataProvider = "testUint28Lists", dataProviderClass = IOTestCases.class)
+    public void intEquivalenceTest(final List<Integer> values) {
+        codecPairTestForInteger(values, this::writeIntegerForInteger, this::readLongForInteger);
+        codecPairTestForInteger(values, this::writeLongForInteger, this::readIntegerForInteger);
+    }
+
+    private void codecPairTestForInteger(final List<Integer> values, IntegerWriter writer, IntegerReader reader) {
+        byte[] written = writer.write(values);
+        final List<Integer> read = reader.read(written, values.size());
+        Assert.assertEquals(read, values);
+    }
+
+    private interface ByteWriter {
+        byte[] write(final List<Byte> toWrite);
+    }
+
+    private interface ByteReader {
+        List<Byte> read(final byte[] toRead, final int count);
+    }
+
+    private byte[] writeByteForByte(List<Byte> values) {
+        byte[] written;
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            final CRAMCodec<Byte> writeCodec = new ExternalByteCodec(null, os);
+
+            for (final byte value : values) {
+                writeCodec.write(value);
+            }
+            os.flush();
+            written = os.toByteArray();
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return written;
+    }
+
+    private byte[] writeIntegerForByte(List<Byte> values) {
+        byte[] written;
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            final CRAMCodec<Integer> writeCodec = new ExternalIntegerCodec(null, os);
+
+            for (final byte value : values) {
+                writeCodec.write((int)value);
+            }
+            os.flush();
+            written = os.toByteArray();
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return written;
+    }
+
+
+    private byte[] writeLongForByte(List<Byte> values) {
+        byte[] written;
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            final CRAMCodec<Long> writeCodec = new ExternalLongCodec(null, os);
+
+            for (final byte value : values) {
+                writeCodec.write((long)value);
+            }
+            os.flush();
+            written = os.toByteArray();
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return written;
+    }
+
+    private List<Byte> readByteForByte(byte[] written, final int length) {
+        final List<Byte> actual = new ArrayList<>(length);
+        try (final ByteArrayInputStream is = new ByteArrayInputStream(written)) {
+            final CRAMCodec<Byte> readCodec = new ExternalByteCodec(is, null);
+
+            for (int i = 0; i < length; i++) {
+                actual.add(readCodec.read());
+            }
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return actual;
+    }
+
+    private List<Byte> readIntegerForByte(byte[] written, final int length) {
+        final List<Byte> actual = new ArrayList<>(length);
+        try (final ByteArrayInputStream is = new ByteArrayInputStream(written)) {
+            final CRAMCodec<Integer> readCodec = new ExternalIntegerCodec(is, null);
+
+            for (int i = 0; i < length; i++) {
+                actual.add(readCodec.read().byteValue());
+            }
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return actual;
+    }
+
+    private List<Byte> readLongForByte(byte[] written, final int length) {
+        final List<Byte> actual = new ArrayList<>(length);
+        try (final ByteArrayInputStream is = new ByteArrayInputStream(written)) {
+            final CRAMCodec<Long> readCodec = new ExternalLongCodec(is, null);
+
+            for (int i = 0; i < length; i++) {
+                actual.add(readCodec.read().byteValue());
+            }
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return actual;
+    }
+
+    private interface IntegerWriter {
+        byte[] write(final List<Integer> toWrite);
+    }
+
+    private interface IntegerReader {
+        List<Integer> read(final byte[] toRead, final int count);
+    }
+
+    private byte[] writeIntegerForInteger(List<Integer> values) {
+        byte[] written;
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            final CRAMCodec<Integer> writeCodec = new ExternalIntegerCodec(null, os);
+
+            for (final int value : values) {
+                writeCodec.write(value);
+            }
+            os.flush();
+            written = os.toByteArray();
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return written;
+    }
+
+
+    private byte[] writeLongForInteger(List<Integer> values) {
+        byte[] written;
+        try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            final CRAMCodec<Long> writeCodec = new ExternalLongCodec(null, os);
+
+            for (final int value : values) {
+                writeCodec.write((long)value);
+            }
+            os.flush();
+            written = os.toByteArray();
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return written;
+    }
+
+
+    private List<Integer> readIntegerForInteger(byte[] written, final int length) {
+        final List<Integer> actual = new ArrayList<>(length);
+        try (final ByteArrayInputStream is = new ByteArrayInputStream(written)) {
+            final CRAMCodec<Integer> readCodec = new ExternalIntegerCodec(is, null);
+
+            for (int i = 0; i < length; i++) {
+                actual.add(readCodec.read());
+            }
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return actual;
+    }
+
+    private List<Integer> readLongForInteger(byte[] written, final int length) {
+        final List<Integer> actual = new ArrayList<>(length);
+        try (final ByteArrayInputStream is = new ByteArrayInputStream(written)) {
+            final CRAMCodec<Long> readCodec = new ExternalLongCodec(is, null);
+
+            for (int i = 0; i < length; i++) {
+                actual.add(readCodec.read().intValue());
+            }
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+        return actual;
+    }
+
+}

--- a/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
@@ -131,15 +131,15 @@ public class ExternalCodecEquivalenceTest extends HtsjdkTest {
     }
 
     private List<Long> externalByteCodecRead(byte[] written, final int length) {
-        return read(written, length, this::externalByteCodecReaderConstructor);
+        return read(written, length, (is -> new ExternalByteCodec(is, null)));
     }
 
     private List<Long> externalIntegerCodecRead(byte[] written, final int length) {
-        return read(written, length, this::externalIntegerCodecReaderConstructor);
+        return read(written, length, (is -> new ExternalIntegerCodec(is, null)));
     }
 
     private List<Long> externalLongCodecRead(byte[] written, final int length) {
-        return read(written, length, this::externalLongCodecReaderConstructor);
+        return read(written, length, (is -> new ExternalLongCodec(is, null)));
     }
 
     private <T extends Number> List<Long> read(byte[] written, final int length, final ReadCodecConstructor<T> readCC) {
@@ -160,17 +160,5 @@ public class ExternalCodecEquivalenceTest extends HtsjdkTest {
 
     private interface ReadCodecConstructor<T> {
         CRAMCodec<T> reader(final ByteArrayInputStream is);
-    }
-
-    private CRAMCodec<Byte> externalByteCodecReaderConstructor(final ByteArrayInputStream is) {
-        return new ExternalByteCodec(is, null);
-    }
-
-    private CRAMCodec<Integer> externalIntegerCodecReaderConstructor(final ByteArrayInputStream is) {
-        return new ExternalIntegerCodec(is, null);
-    }
-
-    private CRAMCodec<Long> externalLongCodecReaderConstructor(final ByteArrayInputStream is) {
-        return new ExternalLongCodec(is, null);
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
+++ b/src/test/java/htsjdk/samtools/cram/encoding/external/ExternalCodecEquivalenceTest.java
@@ -24,12 +24,11 @@ import java.util.stream.Collectors;
  * 1. External Byte, External Integer, and External Long Encodings
  * create identical output streams when values are limited to the
  * range 0 to 0x7F because the respective underlying encodings
- * (raw bytes, ITF8, and LTF8 respectively) result in byte-for-byte
- * identical outputs.
+ * (raw bytes, ITF8, and LTF8) result in byte-for-byte identical outputs.
  *
  * 2. External Integer and External Long Encodings also create identical
  * output streams when values are limited to 28 unsigned bits
- * (0 to 0x0F FF FF FF) because ITF8 ands LTF8 are equivalent over that range.
+ * (0 to 0x0F FF FF FF) because ITF8 and LTF8 are equivalent over that range.
  *
  * Demonstrate that these conditions do in fact create identical streams.
  *
@@ -43,8 +42,8 @@ public class ExternalCodecEquivalenceTest extends HtsjdkTest {
 
     @Test(dataProvider = "testPositiveByteLists", dataProviderClass = IOTestCases.class)
     public void byteEquivalenceTest(final List<Byte> values) {
-        codecPairTest(values, this::externalByteCodeWrite,      this::externalIntegerCodecRead);
-        codecPairTest(values, this::externalByteCodeWrite,      this::externalLongCodecRead);
+        codecPairTest(values, this::externalByteCodecWrite,      this::externalIntegerCodecRead);
+        codecPairTest(values, this::externalByteCodecWrite,      this::externalLongCodecRead);
         codecPairTest(values, this::externalIntegerCodecWrite,  this::externalByteCodecRead);
         codecPairTest(values, this::externalIntegerCodecWrite,  this::externalLongCodecRead);
         codecPairTest(values, this::externalLongCodecWrite,     this::externalByteCodecRead);
@@ -82,7 +81,7 @@ public class ExternalCodecEquivalenceTest extends HtsjdkTest {
         List<Long> read(final byte[] toRead, final int count);
     }
 
-    private <T extends Number> byte[] externalByteCodeWrite(List<T> values) {
+    private <T extends Number> byte[] externalByteCodecWrite(List<T> values) {
         byte[] written;
         try (final ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             final CRAMCodec<Byte> writeCodec = new ExternalByteCodec(null, os);

--- a/src/test/java/htsjdk/samtools/cram/io/IOTestCases.java
+++ b/src/test/java/htsjdk/samtools/cram/io/IOTestCases.java
@@ -1,14 +1,17 @@
 package htsjdk.samtools.cram.io;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.TestUtil;
 import org.testng.annotations.DataProvider;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 public class IOTestCases extends HtsjdkTest {
+    private static final Random RANDOM = new Random(TestUtil.RANDOM_SEED);
 
     @DataProvider(name = "littleEndianTests32")
     public static Object[][] littleEndianTests32() {
@@ -65,7 +68,7 @@ public class IOTestCases extends HtsjdkTest {
     public static Object[][] testByteValues() {
         final List<Byte> byteTests = IOTestCases.byteTests();
         final List<Byte> shuffled = new ArrayList<>(byteTests);
-        Collections.shuffle(shuffled);
+        Collections.shuffle(shuffled, RANDOM);
 
         return new Object[][]{
                 {byteTests},
@@ -81,7 +84,7 @@ public class IOTestCases extends HtsjdkTest {
                 .collect(Collectors.toList());
 
         final List<Byte> shuffled = new ArrayList<>(positiveByteTests);
-        Collections.shuffle(shuffled);
+        Collections.shuffle(shuffled, RANDOM);
 
         return new Object[][]{
                 {positiveByteTests},
@@ -93,7 +96,7 @@ public class IOTestCases extends HtsjdkTest {
     public static Object[][] testByteArrayValues() {
         final List<Byte> byteTestsList = IOTestCases.byteTests();
         final List<Byte> shuffledList = new ArrayList<>(byteTestsList);
-        Collections.shuffle(shuffledList);
+        Collections.shuffle(shuffledList, RANDOM);
 
         final byte[] byteTests = new byte[byteTestsList.size()];
         for(int i = 0; i < byteTestsList.size(); i++) {
@@ -149,7 +152,7 @@ public class IOTestCases extends HtsjdkTest {
     public static Object[][] testValues32() {
         final List<Integer> int32Tests = IOTestCases.int32Tests();
         final List<Integer> shuffled = new ArrayList<>(int32Tests);
-        Collections.shuffle(shuffled);
+        Collections.shuffle(shuffled, RANDOM);
 
         return new Object[][]{
                 {int32Tests},
@@ -179,7 +182,7 @@ public class IOTestCases extends HtsjdkTest {
     public static Object[][] testValuesU28() {
         final List<Integer> uint28Tests = IOTestCases.uint28Tests();
         final List<Integer> shuffled = new ArrayList<>(uint28Tests);
-        Collections.shuffle(shuffled);
+        Collections.shuffle(shuffled, RANDOM);
 
         return new Object[][]{
                 {uint28Tests},
@@ -231,7 +234,7 @@ public class IOTestCases extends HtsjdkTest {
     public static Object[][] testValues64() {
         final List<Long> int64Tests = IOTestCases.int64Tests();
         final List<Long> shuffled = new ArrayList<>(int64Tests);
-        Collections.shuffle(shuffled);
+        Collections.shuffle(shuffled, RANDOM);
 
         return new Object[][]{
                 {int64Tests},

--- a/src/test/java/htsjdk/samtools/cram/io/IOTestCases.java
+++ b/src/test/java/htsjdk/samtools/cram/io/IOTestCases.java
@@ -6,6 +6,7 @@ import org.testng.annotations.DataProvider;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class IOTestCases extends HtsjdkTest {
 
@@ -68,6 +69,22 @@ public class IOTestCases extends HtsjdkTest {
 
         return new Object[][]{
                 {byteTests},
+                {shuffled}
+        };
+    }
+
+    @DataProvider(name = "testPositiveByteLists")
+    public static Object[][] testPositiveByteValues() {
+        final List<Byte> positiveByteTests = IOTestCases.byteTests()
+                .stream()
+                .filter(b -> b >= 0)
+                .collect(Collectors.toList());
+
+        final List<Byte> shuffled = new ArrayList<>(positiveByteTests);
+        Collections.shuffle(shuffled);
+
+        return new Object[][]{
+                {positiveByteTests},
                 {shuffled}
         };
     }
@@ -136,6 +153,28 @@ public class IOTestCases extends HtsjdkTest {
 
         return new Object[][]{
                 {int32Tests},
+                {shuffled}
+        };
+    }
+
+    // for testing ITF8 and LTF8 equivalence: only true in the range 0 - (high bit = 28)
+
+    private static List<Integer> uint28Tests() {
+        final int max = 1 << 28;
+        return int32Tests()
+                .stream()
+                .filter(i -> i >= 0 && i < max)
+                .collect(Collectors.toList());
+    }
+
+    @DataProvider(name = "testUint28Lists")
+    public static Object[][] testValuesU28() {
+        final List<Integer> uint28Tests = IOTestCases.uint28Tests();
+        final List<Integer> shuffled = new ArrayList<>(uint28Tests);
+        Collections.shuffle(shuffled);
+
+        return new Object[][]{
+                {uint28Tests},
                 {shuffled}
         };
     }

--- a/src/test/java/htsjdk/samtools/cram/io/IOTestCases.java
+++ b/src/test/java/htsjdk/samtools/cram/io/IOTestCases.java
@@ -157,13 +157,21 @@ public class IOTestCases extends HtsjdkTest {
         };
     }
 
-    // for testing ITF8 and LTF8 equivalence: only true in the range 0 - (high bit = 28)
+    // Motivation for this test case: we were incorrectly encoding a few CRAM record
+    // fields using the wrong data type.  This was surprising, since we would
+    // expect catastrophic "frame shift" type failures from this.
+    //
+    // Instead, we noticed that this conflict would cause no problems in a few specific
+    // cases, including:
+    //
+    // External Integer vs. External Long, if all values are in the range (0 to 0x0F FF FF FF)
+    // because ITF8 and LTF8 are equivalent over that range.
 
     private static List<Integer> uint28Tests() {
         final int max = 1 << 28;
         return int32Tests()
                 .stream()
-                .filter(i -> i >= 0 && i < max)
+                .filter(i -> i >= 0 && i < max)  // valid range is (0 to 0x0F FF FF FF)
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/htsjdk/samtools/cram/io/ITF8Test.java
+++ b/src/test/java/htsjdk/samtools/cram/io/ITF8Test.java
@@ -71,6 +71,9 @@ public class ITF8Test extends HtsjdkTest {
     @DataProvider(name = "predefined")
     public static Object[][] predefinedProvider() {
         return new Object[][]{
+                // 0x7F has highest bit 7
+                // write out as-is
+                {0x7F, new byte[]{0x7F}},
                 // 0x454F46 has highest bit 23
                 // set 3 high bits + bits 25-28 (all 0) -> 0xE0
                 // write 3 bytes as-is -> 0x45, 0x4F, 0x46

--- a/src/test/java/htsjdk/samtools/cram/io/LTF8Test.java
+++ b/src/test/java/htsjdk/samtools/cram/io/LTF8Test.java
@@ -33,6 +33,9 @@ public class LTF8Test extends HtsjdkTest {
     @DataProvider(name = "predefined")
     public static Object[][] predefinedProvider() {
         return new Object[][]{
+                // 0x7F has highest bit 7
+                // write out as-is
+                {0x7F, new byte[]{0x7F}},
                 // 0x454F46 has highest bit 23
                 // set 3 high bits + bits 25-28 (all 0) -> 0xE0
                 // write 3 bytes as-is -> 0x45, 0x4F, 0x46


### PR DESCRIPTION
Also add a test demonstrating that the old byte-based code did not cause problems because byte and int codecs are identical for the full range of the fields 

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

