### PR TITLE
Adding back a removed method

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -257,10 +257,20 @@ public class IntervalList implements Iterable<Interval> {
     /**
      * Merges list of intervals and reduces them like htsjdk.samtools.util.IntervalList#getUniqueIntervals()
      *
-     * @param combineAbuttingIntervals   If true, intervals that are abutting will be combined into one interval.
      * @param concatenateNames   If false, the merged interval has the name of the earlier interval.  This keeps name shorter.
      * @param enforceSameStrands enforce that merged intervals have the same strand, otherwise ignore.
      */
+    public static List<Interval> getUniqueIntervals(final IntervalList list, final boolean concatenateNames, final boolean enforceSameStrands) {
+        return getUniqueIntervals(list, true, concatenateNames,  enforceSameStrands);
+    }
+
+        /**
+         * Merges list of intervals and reduces them like htsjdk.samtools.util.IntervalList#getUniqueIntervals()
+         *
+         * @param combineAbuttingIntervals   If true, intervals that are abutting will be combined into one interval.
+         * @param concatenateNames   If false, the merged interval has the name of the earlier interval.  This keeps name shorter.
+         * @param enforceSameStrands enforce that merged intervals have the same strand, otherwise ignore.
+         */
     public static List<Interval> getUniqueIntervals(final IntervalList list, final boolean combineAbuttingIntervals, final boolean concatenateNames, final boolean enforceSameStrands) {
 
         final List<Interval> intervals;


### PR DESCRIPTION
* Adding back an accidentally removed an overload of IntervalList.getUniqueIntervals().
* This fixes a compatibility problem revealed in the pre-release checks.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

