### PR TITLE
Fix signing task in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,14 +159,6 @@ task sourcesJar(type: Jar) {
     archiveClassifier.set('sources')
 }
 
-/**
- * Sign non-snapshot releases with our secret key.  This should never need to be invoked directly.
- */
-signing {
-    required { isRelease && gradle.taskGraph.hasTask("publishHtsjdkPublicationToMavenRepository") }
-    sign configurations.archives
-}
-
 publishing {
     publications {
         htsjdk(MavenPublication) {
@@ -215,6 +207,17 @@ publishing {
             url = isRelease ? release : snapshot
         }
     }
+}
+
+/**
+ * Sign non-snapshot releases with our secret key.  This should never need to be invoked directly.
+ */
+signing {
+    required { isRelease && gradle.taskGraph.hasTask("publishHtsjdkPublicationToMavenRepository") }
+    sign publishing.publications.htsjdk
+}
+gradle.taskGraph.beforeTask { Task task ->
+    println "executing $task ..."
 }
 
 task install(dependsOn:publishToMavenLocal)


### PR DESCRIPTION
* Fix the signing task configuration in build.gradle so that releases are signed.
I had to do this for the 2.19.0 release.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

