### PR TITLE
Follow-up to #1276: Remove multiple versions of Slice/Container getCRAIEntries()

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMIndexMetaData.java
+++ b/src/main/java/htsjdk/samtools/BAMIndexMetaData.java
@@ -159,7 +159,7 @@ public class BAMIndexMetaData {
             unAlignedRecords += slice.unmappedReadsCount;
         }
 
-        final long start = slice.offset;
+        final long start = slice.byteOffsetFromContainer;
 
         if (BlockCompressedFilePointerUtil.compare(start, firstOffset) < 1 || firstOffset == -1) {
             this.firstOffset = start;

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -134,14 +134,12 @@ public class CRAMBAIIndexer {
 
         int sliceIndex = 0;
         for (final Slice slice : container.slices) {
-            slice.containerOffset = container.offset;
             slice.index = sliceIndex++;
             if (slice.getReferenceContext().isMultiRef()) {
                 final Map<ReferenceContext, AlignmentSpan> spanMap = container.getSpans(validationStringency);
 
                 // TODO why are we updating the original slice here?
 
-                slice.containerOffset = container.offset;
                 slice.index = sliceIndex++;
 
                 /**
@@ -151,8 +149,8 @@ public class CRAMBAIIndexer {
                 for (final ReferenceContext refContext : new TreeSet<>(spanMap.keySet())) {
                     final AlignmentSpan span = spanMap.get(refContext);
                     final Slice fakeSlice = new Slice(refContext);
-                    fakeSlice.containerOffset = slice.containerOffset;
-                    fakeSlice.offset = slice.offset;
+                    fakeSlice.containerByteOffset = slice.containerByteOffset;
+                    fakeSlice.byteOffsetFromContainer = slice.byteOffsetFromContainer;
                     fakeSlice.index = slice.index;
 
                     fakeSlice.alignmentStart = span.getStart();
@@ -165,8 +163,8 @@ public class CRAMBAIIndexer {
 
                 if (unmappedSpan != null) {
                     final Slice fakeSlice = new Slice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
-                    fakeSlice.containerOffset = slice.containerOffset;
-                    fakeSlice.offset = slice.offset;
+                    fakeSlice.containerByteOffset = slice.containerByteOffset;
+                    fakeSlice.byteOffsetFromContainer = slice.byteOffsetFromContainer;
                     fakeSlice.index = slice.index;
 
                     fakeSlice.alignmentStart = SAMRecord.NO_ALIGNMENT_START;
@@ -273,7 +271,7 @@ public class CRAMBAIIndexer {
                     break;
                 }
 
-                container.offset = offset;
+                container.setByteOffset(offset);
 
                 indexer.processContainer(container, validationStringency);
 
@@ -368,7 +366,7 @@ public class CRAMBAIIndexer {
          * Record any index information for a given CRAM slice
          *
          * Reads these Slice fields:
-         * sequenceId, alignmentStart, alignmentSpan, containerOffset, index
+         * sequenceId, alignmentStart, alignmentSpan, containerByteOffset, index
          *
          * @param slice CRAM slice, single ref only.
          */
@@ -411,8 +409,8 @@ public class CRAMBAIIndexer {
 
             // process chunks
 
-            final long chunkStart = (slice.containerOffset << 16) | slice.index;
-            final long chunkEnd = ((slice.containerOffset << 16) | slice.index) + 1;
+            final long chunkStart = (slice.containerByteOffset << 16) | slice.index;
+            final long chunkEnd = ((slice.containerByteOffset << 16) | slice.index) + 1;
 
             final Chunk newChunk = new Chunk(chunkStart, chunkEnd);
 

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -74,6 +74,10 @@ import java.util.TreeSet;
  * and proceeds by processing {@link CRAIEntry} elements obtained from
  * {@link CRAMCRAIIndexer#readIndex(InputStream)}.  {@link CRAMBAIIndexer#processAsSingleReferenceSlice(Slice)}
  * is called on each {@link CRAIEntry} and {@link CRAMBAIIndexer#finish()} is called at the end.
+ *
+ * NOTE: a third pattern of building a BAI from a CRAM file is also supported by this class,
+ * but it is unused.  This would be accomplished via {@link #createIndex(SeekableStream, File, Log, ValidationStringency)}.
+ *
  */
 public class CRAMBAIIndexer {
 

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -131,8 +131,6 @@ public class CRAMBAIIndexer {
             return;
         }
 
-        container.distributeIndexingParametersToSlices();
-
         int sliceIndex = 0;
         for (final Slice slice : container.getSlices()) {
             slice.index = sliceIndex++;

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -301,7 +301,7 @@ public class CRAMBAIIndexer {
      * processAlignment is called for each alignment until a new reference is encountered, then
      * processReference is called when all records for the reference have been processed.
      *
-     * TODO: this was copied from {@link htsjdk.samtools.BAMIndexer.BAMIndexBuilder}
+     * TODO: this was copied from BAMIndexer.BAMIndexBuilder
      * so perhaps they should be merged back together
      */
     private class CRAMBAIIndexBuilder {

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -126,10 +126,12 @@ public class CRAMBAIIndexer {
      *
      * @param container container to be indexed
      */
-    public void processContainer(final Container container, final ValidationStringency validationStringency) {
+    void processContainer(final Container container, final ValidationStringency validationStringency) {
         if (container == null || container.isEOF()) {
             return;
         }
+
+        container.distributeIndexingParametersToSlices();
 
         int sliceIndex = 0;
         for (final Slice slice : container.getSlices()) {

--- a/src/main/java/htsjdk/samtools/CRAMCRAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMCRAIIndexer.java
@@ -93,27 +93,19 @@ public class CRAMCRAIIndexer {
      * @param craiStream stream for output index
      */
     public static void writeIndex(final SeekableStream cramStream, OutputStream craiStream) {
-        try {
-            final CramHeader cramHeader = CramIO.readCramHeader(cramStream);
-            final CRAMCRAIIndexer indexer = new CRAMCRAIIndexer(craiStream, cramHeader.getSamFileHeader());
-            final Version cramVersion = cramHeader.getVersion();
+        final CramHeader cramHeader = CramIO.readCramHeader(cramStream);
+        final CRAMCRAIIndexer indexer = new CRAMCRAIIndexer(craiStream, cramHeader.getSamFileHeader());
+        final Version cramVersion = cramHeader.getVersion();
 
-            // get the first container and its offset
-            long offset = cramStream.position();
-            Container container = ContainerIO.readContainer(cramVersion, cramStream);
+        // get the first container
+        Container container = ContainerIO.readContainer(cramVersion, cramStream);
 
-            while (container != null && !container.isEOF()) {
-                container.setByteOffset(offset);
-                indexer.processContainer(container);
-                offset = cramStream.position();
-                container = ContainerIO.readContainer(cramVersion, cramStream);
-            }
-
-            indexer.finish();
+        while (container != null && !container.isEOF()) {
+            indexer.processContainer(container);
+            container = ContainerIO.readContainer(cramVersion, cramStream);
         }
-        catch (IOException e) {
-            throw new RuntimeIOException("Error writing CRAI index to output stream");
-        }
+
+        indexer.finish();
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/CRAMCRAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMCRAIIndexer.java
@@ -13,7 +13,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Scanner;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -104,7 +103,7 @@ public class CRAMCRAIIndexer {
             Container container = ContainerIO.readContainer(cramVersion, cramStream);
 
             while (container != null && !container.isEOF()) {
-                container.offset = offset;
+                container.setByteOffset(offset);
                 indexer.processContainer(container);
                 offset = cramStream.position();
                 container = ContainerIO.readContainer(cramVersion, cramStream);

--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -446,7 +446,7 @@ public class CRAMContainerStreamWriter {
         for (final Slice slice : container.slices) {
             slice.setRefMD5(referenceBases);
         }
-        container.offset = offset;
+        container.setByteOffset(offset);
         offset += ContainerIO.writeContainer(cramVersion, container, outputStream);
         if (indexer != null) {
             /**

--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -442,11 +442,10 @@ public class CRAMContainerStreamWriter {
             }
         }
 
-        final Container container = containerFactory.buildContainer(cramRecords);
-        for (final Slice slice : container.slices) {
+        final Container container = containerFactory.buildContainer(cramRecords, offset);
+        for (final Slice slice : container.getSlices()) {
             slice.setRefMD5(referenceBases);
         }
-        container.setByteOffset(offset);
         offset += ContainerIO.writeContainer(cramVersion, container, outputStream);
         if (indexer != null) {
             /**

--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -21,7 +21,7 @@ import htsjdk.samtools.cram.CRAIIndex;
 import htsjdk.samtools.cram.ref.CRAMReferenceSource;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.cram.structure.Container;
-import htsjdk.samtools.cram.structure.ContainerIO;
+import htsjdk.samtools.cram.structure.ContainerHeaderIO;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.CloseableIterator;
@@ -400,7 +400,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
             seekableStream.seek(0);
             newIterator = new CRAMIterator(seekableStream, referenceSource, validationStringency);
             seekableStream.seek(startOfLastLinearBin >>> 16);
-            final Container container = ContainerIO.readContainerHeader(newIterator.getCramHeader().getVersion().major, seekableStream);
+            final Container container = ContainerHeaderIO.readContainerHeader(newIterator.getCramHeader().getVersion().major, seekableStream);
             seekableStream.seek(seekableStream.position() + container.containerByteSize);
             iterator = newIterator;
             boolean atAlignments;

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -211,8 +211,8 @@ public class CRAMIterator implements SAMRecordIterator {
             samRecord.setValidationStringency(validationStringency);
 
             if (mReader != null) {
-                final long chunkStart = (container.getByteOffset() << 16) | cramRecord.sliceIndex;
-                final long chunkEnd = ((container.getByteOffset() << 16) | cramRecord.sliceIndex) + 1;
+                final long chunkStart = (container.byteOffset << 16) | cramRecord.sliceIndex;
+                final long chunkEnd = ((container.byteOffset << 16) | cramRecord.sliceIndex) + 1;
                 samRecord.setFileSource(new SAMFileSource(mReader, new BAMFileSpan(new Chunk(chunkStart, chunkEnd))));
             }
             

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -212,8 +212,8 @@ public class CRAMIterator implements SAMRecordIterator {
             samRecord.setValidationStringency(validationStringency);
 
             if (mReader != null) {
-                final long chunkStart = (container.offset << 16) | cramRecord.sliceIndex;
-                final long chunkEnd = ((container.offset << 16) | cramRecord.sliceIndex) + 1;
+                final long chunkStart = (container.getByteOffset() << 16) | cramRecord.sliceIndex;
+                final long chunkEnd = ((container.getByteOffset() << 16) | cramRecord.sliceIndex) + 1;
                 samRecord.setFileSource(new SAMFileSource(mReader, new BAMFileSpan(new Chunk(chunkStart, chunkEnd))));
             }
             

--- a/src/main/java/htsjdk/samtools/CRAMIterator.java
+++ b/src/main/java/htsjdk/samtools/CRAMIterator.java
@@ -177,8 +177,7 @@ public class CRAMIterator implements SAMRecordIterator {
                 }
         }
 
-        for (int i = 0; i < container.slices.length; i++) {
-            final Slice slice = container.slices[i];
+        for (final Slice slice : container.getSlices()) {
             final ReferenceContext sliceContext = slice.getReferenceContext();
 
             if (! sliceContext.isMappedSingleRef())

--- a/src/main/java/htsjdk/samtools/cram/CRAIEntry.java
+++ b/src/main/java/htsjdk/samtools/cram/CRAIEntry.java
@@ -16,10 +16,10 @@ public class CRAIEntry implements Comparable<CRAIEntry> {
     private final int alignmentSpan;
 
     // this Slice's Container's offset in bytes from the beginning of the stream
-    // equal to Slice.containerOffset and Container.offset
+    // equal to Slice.containerByteOffset and Container.byteOffset
     private final long containerStartByteOffset;
     // this Slice's offset in bytes from the beginning of its Container
-    // equal to Slice.offset and Container.landmarks[Slice.index]
+    // equal to Slice.byteOffsetFromContainer and Container.landmarks[Slice.index]
     private final int sliceByteOffset;
     private final int sliceByteSize;
 

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
@@ -58,8 +58,7 @@ public class ContainerFactory {
             slices.add(slice);
         }
 
-        final Container container = Container.initializeFromSlices(slices);
-        container.compressionHeader = compressionHeader;
+        final Container container = Container.initializeFromSlices(slices, compressionHeader);
         container.nofRecords = records.size();
         container.globalRecordCounter = lastGlobalRecordCounter;
         container.blockCount = 0;

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
@@ -38,7 +38,13 @@ public class ContainerFactory {
     }
 
     /**
-     * Build a Container (and its constituent Slices) from {@link CramCompressionRecord}s
+     * Build a Container (and its constituent Slices) from {@link CramCompressionRecord}s.
+     * Note that this will always result in a single Container, regardless of how many Slices
+     * are created.  It is up to the caller to divide the records into multiple Containers,
+     * if that is desired.
+     *
+     * TODO: enable a setting to automate this, perhaps "recordsPerContainer"
+     *
      * @param records the records used to build the Container
      * @param containerByteOffset the Container's byte offset from the start of the stream
      * @return the container built from these records

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerFactory.java
@@ -37,7 +37,13 @@ public class ContainerFactory {
         this.recordsPerSlice = recordsPerSlice;
     }
 
-    public Container buildContainer(final List<CramCompressionRecord> records) {
+    /**
+     * Build a Container (and its constituent Slices) from {@link CramCompressionRecord}s
+     * @param records the records used to build the Container
+     * @param containerByteOffset the Container's byte offset from the start of the stream
+     * @return the container built from these records
+     */
+    public Container buildContainer(final List<CramCompressionRecord> records, final long containerByteOffset) {
         // sets header APDelta
         final boolean coordinateSorted = samFileHeader.getSortOrder() == SAMFileHeader.SortOrder.coordinate;
         final CompressionHeader compressionHeader = new CompressionHeaderFactory().build(records, null, coordinateSorted);
@@ -58,7 +64,7 @@ public class ContainerFactory {
             slices.add(slice);
         }
 
-        final Container container = Container.initializeFromSlices(slices, compressionHeader);
+        final Container container = Container.initializeFromSlices(slices, compressionHeader, containerByteOffset);
         container.nofRecords = records.size();
         container.globalRecordCounter = lastGlobalRecordCounter;
         container.blockCount = 0;

--- a/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
+++ b/src/main/java/htsjdk/samtools/cram/build/ContainerParser.java
@@ -50,7 +50,7 @@ public class ContainerParser {
             records = new ArrayList<>(container.nofRecords);
         }
 
-        for (final Slice slice : container.slices) {
+        for (final Slice slice : container.getSlices()) {
             records.addAll(getRecords(slice, container.compressionHeader, validationStringency));
         }
 

--- a/src/main/java/htsjdk/samtools/cram/build/CramContainerHeaderIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramContainerHeaderIterator.java
@@ -1,6 +1,5 @@
 package htsjdk.samtools.cram.build;
 
-import htsjdk.samtools.cram.common.Version;
 import htsjdk.samtools.cram.io.CountingInputStream;
 import htsjdk.samtools.cram.io.InputStreamUtils;
 import htsjdk.samtools.cram.structure.Container;
@@ -26,15 +25,14 @@ public class CramContainerHeaderIterator extends CramContainerIterator {
      * Consume the entirety of the next container from the stream, but retain only the header.
      * This is intended as a performance optimization, because it does not decode block data.
      *
-     * @see CramContainerIterator#containerFromStream(Version, CountingInputStream)
+     * @see CramContainerIterator#containerFromStream(CountingInputStream)
      *
-     * @param cramVersion the expected CRAM version of the stream
      * @param countingStream the {@link CountingInputStream} to read from
      * @return The next Container's header from the stream, returned as a Container.
      */
     @Override
-    protected Container containerFromStream(final Version cramVersion, final CountingInputStream countingStream) {
-        final Container container = ContainerHeaderIO.readContainerHeader(cramVersion.major, countingStream);
+    protected Container containerFromStream(final CountingInputStream countingStream) {
+        final Container container = ContainerHeaderIO.readContainerHeader(getCramHeader().getVersion().major, countingStream);
         InputStreamUtils.skipFully(countingStream, container.containerByteSize);
         return container;
     }

--- a/src/main/java/htsjdk/samtools/cram/build/CramContainerHeaderIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramContainerHeaderIterator.java
@@ -4,7 +4,7 @@ import htsjdk.samtools.cram.common.Version;
 import htsjdk.samtools.cram.io.CountingInputStream;
 import htsjdk.samtools.cram.io.InputStreamUtils;
 import htsjdk.samtools.cram.structure.Container;
-import htsjdk.samtools.cram.structure.ContainerIO;
+import htsjdk.samtools.cram.structure.ContainerHeaderIO;
 
 import java.io.InputStream;
 
@@ -22,8 +22,19 @@ public class CramContainerHeaderIterator extends CramContainerIterator {
       super(inputStream);
     }
 
+    /**
+     * Consume the entirety of the next container from the stream, but retain only the header.
+     * This is intended as a performance optimization, because it does not decode block data.
+     *
+     * @see CramContainerIterator#containerFromStream(Version, CountingInputStream)
+     *
+     * @param cramVersion the expected CRAM version of the stream
+     * @param countingStream the {@link CountingInputStream} to read from
+     * @return The next Container's header from the stream, returned as a Container.
+     */
+    @Override
     protected Container containerFromStream(final Version cramVersion, final CountingInputStream countingStream) {
-        final Container container = ContainerIO.readContainerHeader(cramVersion.major, countingStream);
+        final Container container = ContainerHeaderIO.readContainerHeader(cramVersion.major, countingStream);
         InputStreamUtils.skipFully(countingStream, container.containerByteSize);
         return container;
     }

--- a/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
@@ -17,20 +17,14 @@ public class CramContainerIterator implements Iterator<Container> {
     private CountingInputStream countingInputStream;
     private Container nextContainer;
     private boolean eof = false;
-    private long offset = 0;
 
     public CramContainerIterator(final InputStream inputStream) {
         this.countingInputStream = new CountingInputStream(inputStream);
         cramHeader = CramIO.readCramHeader(countingInputStream);
-        this.offset = countingInputStream.getCount();
     }
 
-    void readNextContainer() {
+    private void readNextContainer() {
         nextContainer = containerFromStream(cramHeader.getVersion(), countingInputStream);
-        final long containerSizeInBytes = countingInputStream.getCount() - offset;
-
-        nextContainer.setByteOffset(offset);
-        offset += containerSizeInBytes;
 
         if (nextContainer.isEOF()) {
             eof = true;
@@ -40,8 +34,11 @@ public class CramContainerIterator implements Iterator<Container> {
 
     /**
      * Consume the entirety of the next container from the stream.
-     * @param cramVersion
-     * @param countingStream
+     *
+     * @see CramContainerHeaderIterator#containerFromStream(Version, CountingInputStream)
+     *
+     * @param cramVersion the expected CRAM version of the stream
+     * @param countingStream the {@link CountingInputStream} to read from
      * @return The next Container from the stream.
      */
     protected Container containerFromStream(final Version cramVersion, final CountingInputStream countingStream) {

--- a/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
@@ -29,7 +29,7 @@ public class CramContainerIterator implements Iterator<Container> {
         nextContainer = containerFromStream(cramHeader.getVersion(), countingInputStream);
         final long containerSizeInBytes = countingInputStream.getCount() - offset;
 
-        nextContainer.offset = offset;
+        nextContainer.setByteOffset(offset);
         offset += containerSizeInBytes;
 
         if (nextContainer.isEOF()) {

--- a/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramContainerIterator.java
@@ -1,6 +1,5 @@
 package htsjdk.samtools.cram.build;
 
-import htsjdk.samtools.cram.common.Version;
 import htsjdk.samtools.cram.io.CountingInputStream;
 import htsjdk.samtools.cram.structure.Container;
 import htsjdk.samtools.cram.structure.ContainerIO;
@@ -24,7 +23,7 @@ public class CramContainerIterator implements Iterator<Container> {
     }
 
     private void readNextContainer() {
-        nextContainer = containerFromStream(cramHeader.getVersion(), countingInputStream);
+        nextContainer = containerFromStream(countingInputStream);
 
         if (nextContainer.isEOF()) {
             eof = true;
@@ -35,20 +34,26 @@ public class CramContainerIterator implements Iterator<Container> {
     /**
      * Consume the entirety of the next container from the stream.
      *
-     * @see CramContainerHeaderIterator#containerFromStream(Version, CountingInputStream)
+     * @see CramContainerIterator#containerFromStream(CountingInputStream)
      *
-     * @param cramVersion the expected CRAM version of the stream
      * @param countingStream the {@link CountingInputStream} to read from
      * @return The next Container from the stream.
      */
-    protected Container containerFromStream(final Version cramVersion, final CountingInputStream countingStream) {
+    protected Container containerFromStream(final CountingInputStream countingStream) {
         return ContainerIO.readContainer(cramHeader.getVersion(), countingStream);
     }
 
     @Override
     public boolean hasNext() {
-        if (eof) return false;
-        if (nextContainer == null) readNextContainer();
+        if (eof) {
+            return false;
+        }
+
+        if (nextContainer == null) {
+            readNextContainer();
+        }
+
+        // readNextContainer() may set eof
         return !eof;
     }
 

--- a/src/main/java/htsjdk/samtools/cram/build/CramIO.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramIO.java
@@ -347,8 +347,8 @@ public class CramIO {
     public static boolean replaceCramHeader(final File file, final CramHeader newHeader) {
         try (final CountingInputStream countingInputStream = new CountingInputStream(new FileInputStream(file));
              final RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw")) {
-            final CramHeader header = readFormatDefinition(countingInputStream);
-            final Container c = ContainerHeaderIO.readContainerHeader(header.getVersion().major, countingInputStream);
+            final CramHeader cramHeader = readFormatDefinition(countingInputStream);
+            final Container c = ContainerHeaderIO.readContainerHeader(cramHeader.getVersion().major, countingInputStream);
             final long pos = countingInputStream.getCount();
             countingInputStream.close();
 

--- a/src/main/java/htsjdk/samtools/cram/build/CramSpanContainerIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramSpanContainerIterator.java
@@ -101,7 +101,7 @@ public class CramSpanContainerIterator implements Iterator<Container> {
                 
                 final long offset = seekableStream.position();
                 final Container c = ContainerIO.readContainer(cramHeader.getVersion(), seekableStream);
-                c.offset = offset;
+                c.setByteOffset(offset);
                 return c;
             } catch (final IOException e) {
                 throw new RuntimeIOException(e);

--- a/src/main/java/htsjdk/samtools/cram/build/CramSpanContainerIterator.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramSpanContainerIterator.java
@@ -99,10 +99,7 @@ public class CramSpanContainerIterator implements Iterator<Container> {
                     throw new RuntimeException("No more containers in this boundary.");
                 }
                 
-                final long offset = seekableStream.position();
-                final Container c = ContainerIO.readContainer(cramHeader.getVersion(), seekableStream);
-                c.setByteOffset(offset);
-                return c;
+                return ContainerIO.readContainer(cramHeader.getVersion(), seekableStream);
             } catch (final IOException e) {
                 throw new RuntimeIOException(e);
             }

--- a/src/main/java/htsjdk/samtools/cram/structure/Container.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Container.java
@@ -76,16 +76,17 @@ public class Container {
     }
 
     /**
-     * Assign {@link Slice}s to this Container.
+     * Assign {@link Slice}s to this Container and set its byteOffset.
      * Also distribute the Container's byte offset to the {@link Slice}s, for indexing.
      * @param slices the Slices belonging to this container
      * @param byteOffset the byte location in the stream where this Container begins
      */
-    void setSlices(final List<Slice> slices, final long byteOffset) {
+    void setSlicesAndByteOffset(final List<Slice> slices, final long byteOffset) {
         for (final Slice slice : slices) {
             slice.containerByteOffset = byteOffset;
         }
         this.slices = slices.toArray(new Slice[0]);
+        this.byteOffset = byteOffset;
     }
 
     /**
@@ -142,7 +143,7 @@ public class Container {
         final ReferenceContext commonRefContext = sliceRefContexts.iterator().next();
 
         final Container container = new Container(commonRefContext);
-        container.setSlices(containerSlices, containerByteOffset);
+        container.setSlicesAndByteOffset(containerSlices, containerByteOffset);
         container.compressionHeader = compressionHeader;
 
         if (commonRefContext.isMappedSingleRef()) {

--- a/src/main/java/htsjdk/samtools/cram/structure/Container.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Container.java
@@ -81,8 +81,8 @@ public class Container {
      * @param slices the Slices belonging to this container
      * @param byteOffset the byte location in the stream where this Container begins
      */
-    void setSlices(final Slice[] slices, final long byteOffset) {
-        this.slices = slices;
+    void setSlices(final List<Slice> slices, final long byteOffset) {
+        this.slices = slices.toArray(new Slice[0]);
         setByteOffsetInSlices(byteOffset);
     }
 
@@ -169,7 +169,7 @@ public class Container {
         final ReferenceContext commonRefContext = sliceRefContexts.iterator().next();
 
         final Container container = new Container(commonRefContext);
-        container.setSlices(containerSlices.toArray(new Slice[0]), containerByteOffset);
+        container.setSlices(containerSlices, containerByteOffset);
         container.compressionHeader = compressionHeader;
 
         if (commonRefContext.isMappedSingleRef()) {

--- a/src/main/java/htsjdk/samtools/cram/structure/Container.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Container.java
@@ -69,7 +69,7 @@ public class Container {
 
     // this Container's byte offset from the the start of the stream.
     // Used for indexing.
-    private long byteOffset;
+    public long byteOffset;
 
     public Slice[] getSlices() {
         return slices;
@@ -82,37 +82,10 @@ public class Container {
      * @param byteOffset the byte location in the stream where this Container begins
      */
     void setSlices(final List<Slice> slices, final long byteOffset) {
-        this.slices = slices.toArray(new Slice[0]);
-        setByteOffsetInSlices(byteOffset);
-    }
-
-    public long getByteOffset() {
-        return byteOffset;
-    }
-
-    /**
-     * Set this Container's byte offset from the the start of the stream.
-     * Also distribute this value to the Container's constituent {@link Slice}s, if present.
-     *
-     * @param byteOffset the byte location in the stream where this Container begins
-     */
-    void setByteOffset(final long byteOffset) {
-        this.byteOffset = byteOffset;
-        if (slices != null) {
-            setByteOffsetInSlices(byteOffset);
-        }
-    }
-
-    /**
-     * Distribute this Container's byte offset to the Container's constituent {@link Slice}s.
-     * For indexing.
-     *
-     * @param byteOffset the byte location in the stream where this Container begins
-     */
-    private void setByteOffsetInSlices(final long byteOffset) {
         for (final Slice slice : slices) {
             slice.containerByteOffset = byteOffset;
         }
+        this.slices = slices.toArray(new Slice[0]);
     }
 
     /**
@@ -190,7 +163,6 @@ public class Container {
             container.alignmentSpan = Slice.NO_ALIGNMENT_SPAN;
         }
 
-        container.setByteOffset(containerByteOffset);
         return container;
     }
 

--- a/src/main/java/htsjdk/samtools/cram/structure/Container.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Container.java
@@ -201,7 +201,7 @@ public class Container {
      *
      * @throws CRAMException when the Container is in an invalid state
      */
-    void distributeIndexingParametersToSlices() {
+    public void distributeIndexingParametersToSlices() {
         if (slices.length == 0) {
             return;
         }

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerHeaderIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerHeaderIO.java
@@ -77,7 +77,7 @@ public class ContainerHeaderIO {
         if (major >= 3)
             container.checksum = CramInt.readInt32(inputStream);
 
-        container.setByteOffset(containerByteOffset);
+        container.byteOffset = containerByteOffset;
         return container;
     }
 

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
@@ -105,7 +105,8 @@ public class ContainerIO {
             slices.add(SliceIO.read(major, inputStream));
         }
 
-        container.populateSlicesAndIndexingParameters(slices, containerByteOffset);
+        container.setSlices(slices.toArray(new Slice[0]), containerByteOffset);
+        container.distributeIndexingParametersToSlices();
 
         log.debug("READ CONTAINER: " + container.toString());
 
@@ -158,8 +159,10 @@ public class ContainerIO {
             container.blockCount += slice.external.size();
         }
         container.landmarks = landmarks.stream().mapToInt(Integer::intValue).toArray();
-
         container.containerByteSize = byteArrayOutputStream.size();
+
+        // Slices require the Container's landmarks and containerByteSize before indexing
+        container.distributeIndexingParametersToSlices();
 
         int length = ContainerHeaderIO.writeContainerHeader(version.major, container, outputStream);
         try {

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
@@ -105,7 +105,7 @@ public class ContainerIO {
             slices.add(SliceIO.read(major, inputStream));
         }
 
-        container.setSlices(slices.toArray(new Slice[0]), containerByteOffset);
+        container.setSlices(slices, containerByteOffset);
         container.distributeIndexingParametersToSlices();
 
         log.debug("READ CONTAINER: " + container.toString());

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
@@ -3,8 +3,10 @@ package htsjdk.samtools.cram.structure;
 import htsjdk.samtools.cram.build.CramIO;
 import htsjdk.samtools.cram.common.CramVersionPolicies;
 import htsjdk.samtools.cram.common.Version;
+import htsjdk.samtools.cram.io.CountingInputStream;
 import htsjdk.samtools.cram.structure.block.Block;
 import htsjdk.samtools.cram.structure.block.BlockContentType;
+import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
 
@@ -19,87 +21,95 @@ public class ContainerIO {
     private static final Log log = Log.getInstance(ContainerIO.class);
 
     /**
-     * Reads a CRAM container from the input stream. Returns an EOF container when there is no more data or the EOF marker found.
+     * Reads a CRAM container from an {@link InputStream}.
+     * Returns an EOF container when there is no more data or the EOF marker found.
      *
      * @param version CRAM version to expect
-     * @param inputStream      the stream to read from
+     * @param inputStream the {@link InputStream} stream to read from
+     * @param containerByteOffset the byte offset from the start of the stream
      * @return a new container object read from the stream
      */
-    public static Container readContainer(final Version version, final InputStream inputStream) {
-        final Container container = readContainer(version.major, inputStream);
+    public static Container readContainer(final Version version,
+                                          final InputStream inputStream,
+                                          final long containerByteOffset) {
+        Container container = readContainerInternal(version.major, inputStream, containerByteOffset);
         if (container == null) {
             // this will cause System.exit(1):
             CramVersionPolicies.eofNotFound(version);
 
-            return readContainer(version.major, new ByteArrayInputStream(CramIO.ZERO_B_EOF_MARKER));
+            return readContainerInternal(version.major, new ByteArrayInputStream(CramIO.ZERO_B_EOF_MARKER), containerByteOffset);
         }
-        if (container.isEOF()) log.debug("EOF marker found, file/stream is complete.");
+
+        if (container.isEOF()) {
+            log.debug("EOF marker found, file/stream is complete.");
+        }
 
         return container;
+    }
+
+    // convenience methods for SeekableStream and CountingInputStream
+    // TODO: merge these two classes?
+
+    /**
+     * Reads a CRAM container from a Seekable input stream.
+     * Returns an EOF container when there is no more data or the EOF marker found.
+     *
+     * @param version CRAM version to expect
+     * @param seekableInputStream the {@link SeekableStream} stream to read from
+     * @return a new container object read from the stream
+     */
+    public static Container readContainer(final Version version, final SeekableStream seekableInputStream) {
+        try {
+            final long containerByteOffset = seekableInputStream.position();
+            return readContainer(version, seekableInputStream, containerByteOffset);
+        }
+        catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /**
+     * Reads a CRAM container from a Counting input stream.
+     * Returns an EOF container when there is no more data or the EOF marker found.
+     *
+     * @param version CRAM version to expect
+     * @param countingInputStream the {@link CountingInputStream} stream to read from
+     * @return a new container object read from the stream
+     */
+    public static Container readContainer(final Version version, final CountingInputStream countingInputStream) {
+        final long containerByteOffset = countingInputStream.getCount();
+        return readContainer(version, countingInputStream, containerByteOffset);
     }
 
     /**
      * Reads next container from the stream.
      *
+     * @param major the CRAM version to assume
      * @param inputStream the stream to read from
+     * @param containerByteOffset the byte offset from the start of the stream
      * @return CRAM container or null if no more data
      */
-    private static Container readContainer(final int major, final InputStream inputStream) {
-        return readContainer(major, inputStream, 0, Integer.MAX_VALUE);
-    }
+    private static Container readContainerInternal(final int major,
+                                                   final InputStream inputStream,
+                                                   final long containerByteOffset) {
 
-    /**
-     * Reads container header only from a {@link InputStream}.
-     *
-     * @param major the CRAM version to assume
-     * @param inputStream    the input stream to read from
-     * @return a new {@link Container} object with container header values filled out but empty body (no slices and blocks).
-     */
-    public static Container readContainerHeader(final int major, final InputStream inputStream) {
-        return ContainerHeaderIO.readContainerHeader(major, inputStream);
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private static Container readContainer(final int major, final InputStream inputStream, final int fromSlice, int howManySlices) {
-
-        final Container container = readContainerHeader(major, inputStream);
+        final Container container = ContainerHeaderIO.readContainerHeader(major, inputStream, containerByteOffset);
         if (container.isEOF()) {
             return container;
         }
 
         container.compressionHeader = CompressionHeader.read(major, inputStream);
 
-        howManySlices = Math.min(container.landmarks.length, howManySlices);
-
-        try {
-            if (fromSlice > 0) //noinspection ResultOfMethodCallIgnored
-                inputStream.skip(container.landmarks[fromSlice]);
-        } catch (final IOException e) {
-            throw new RuntimeIOException(e);
-        }
-
         final ArrayList<Slice> slices = new ArrayList<>();
-        for (int sliceCount = fromSlice; sliceCount < howManySlices - fromSlice; sliceCount++) {
+        for (int sliceCounter = 0; sliceCounter < container.landmarks.length; sliceCounter++) {
             slices.add(SliceIO.read(major, inputStream));
         }
 
-        container.populateSlicesAndIndexingParameters(slices);
+        container.populateSlicesAndIndexingParameters(slices, containerByteOffset);
 
         log.debug("READ CONTAINER: " + container.toString());
 
         return container;
-    }
-
-    /**
-     * Writes a {@link Container} header information to a {@link OutputStream}.
-     *
-     * @param major     the CRAM version to assume
-     * @param container the container holding the header to write
-     * @param outputStream        the stream to write to
-     * @return the number of bytes written
-     */
-    public static int writeContainerHeader(final int major, final Container container, final OutputStream outputStream) {
-        return ContainerHeaderIO.writeContainerHeader(major, container, outputStream);
     }
 
     /**
@@ -139,8 +149,7 @@ public class ContainerIO {
         container.blockCount = 1;
 
         final List<Integer> landmarks = new ArrayList<>();
-        for (int i = 0; i < container.slices.length; i++) {
-            final Slice slice = container.slices[i];
+        for (final Slice slice : container.getSlices()) {
             landmarks.add(byteArrayOutputStream.size());
             SliceIO.write(version.major, slice, byteArrayOutputStream);
             container.blockCount++;
@@ -148,9 +157,7 @@ public class ContainerIO {
             if (slice.embeddedRefBlock != null) container.blockCount++;
             container.blockCount += slice.external.size();
         }
-        container.landmarks = new int[landmarks.size()];
-        for (int i = 0; i < container.landmarks.length; i++)
-            container.landmarks[i] = landmarks.get(i);
+        container.landmarks = landmarks.stream().mapToInt(Integer::intValue).toArray();
 
         container.containerByteSize = byteArrayOutputStream.size();
 

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
@@ -105,7 +105,7 @@ public class ContainerIO {
             slices.add(SliceIO.read(major, inputStream));
         }
 
-        container.setSlices(slices, containerByteOffset);
+        container.setSlicesAndByteOffset(slices, containerByteOffset);
         container.distributeIndexingParametersToSlices();
 
         log.debug("READ CONTAINER: " + container.toString());

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerIO.java
@@ -29,7 +29,7 @@ public class ContainerIO {
      * @param containerByteOffset the byte offset from the start of the stream
      * @return a new container object read from the stream
      */
-    public static Container readContainer(final Version version,
+    private static Container readContainer(final Version version,
                                           final InputStream inputStream,
                                           final long containerByteOffset) {
         Container container = readContainerInternal(version.major, inputStream, containerByteOffset);

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -123,11 +123,11 @@ public class Slice {
         final StringBuilder error = new StringBuilder();
 
         if (byteOffsetFromContainer == UNINITIALIZED_INDEXING_PARAMETER) {
-            error.append("Cannot index this Slice for BAI because its offset is unknown.").append(System.lineSeparator());
+            error.append("Cannot index this Slice for BAI because its byteOffsetFromContainer is unknown.").append(System.lineSeparator());
         }
 
         if (containerByteOffset == UNINITIALIZED_INDEXING_PARAMETER) {
-            error.append("Cannot index this Slice for BAI because its containerOffset is unknown.").append(System.lineSeparator());
+            error.append("Cannot index this Slice for BAI because its containerByteOffset is unknown.").append(System.lineSeparator());
         }
 
         if (index == UNINITIALIZED_INDEXING_PARAMETER) {
@@ -143,15 +143,15 @@ public class Slice {
         final StringBuilder error = new StringBuilder();
 
         if (byteOffsetFromContainer == UNINITIALIZED_INDEXING_PARAMETER) {
-            error.append("Cannot index this Slice for CRAI because its offset is unknown.").append(System.lineSeparator());
+            error.append("Cannot index this Slice for CRAI because its byteOffsetFromContainer is unknown.").append(System.lineSeparator());
         }
 
         if (containerByteOffset == UNINITIALIZED_INDEXING_PARAMETER) {
-            error.append("Cannot index this Slice for CRAI because its containerOffset is unknown.").append(System.lineSeparator());
+            error.append("Cannot index this Slice for CRAI because its containerByteOffset is unknown.").append(System.lineSeparator());
         }
 
         if (byteSize == UNINITIALIZED_INDEXING_PARAMETER) {
-            error.append("Cannot index this Slice for CRAI because its size is unknown.").append(System.lineSeparator());
+            error.append("Cannot index this Slice for CRAI because its byteSize is unknown.").append(System.lineSeparator());
         }
 
         if (error.length() > 0) {

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -119,6 +119,10 @@ public class Slice {
         return referenceContext;
     }
 
+    /**
+     * Confirm that we have initialized the 3 BAI index parameters:
+     * byteOffsetFromContainer, containerByteOffset, and index
+     */
     public void baiIndexInitializationCheck() {
         final StringBuilder error = new StringBuilder();
 
@@ -139,7 +143,13 @@ public class Slice {
         }
     }
 
-    public void craiIndexInitializationCheck() {
+    /**
+     * Confirm that we have initialized the 3 CRAI index parameters:
+     * byteOffsetFromContainer, containerByteOffset, and byteSize
+     *
+     * NOTE: this is currently unused because we always use BAI
+     */
+    void craiIndexInitializationCheck() {
         final StringBuilder error = new StringBuilder();
 
         if (byteOffsetFromContainer == UNINITIALIZED_INDEXING_PARAMETER) {

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -75,16 +75,22 @@ public class Slice {
 
     // for indexing purposes
 
+    public static final int UNINITIALIZED_INDEXING_PARAMETER = -1;
+
     // the Slice's offset in bytes from the beginning of its Container
     // equal to Container.landmarks[Slice.index] of its enclosing Container
-    public int offset = -1;
+    // BAI and CRAI
+    public int offset = UNINITIALIZED_INDEXING_PARAMETER;
     // this Slice's Container's offset in bytes from the beginning of the stream
-    // equal to Container.offset of its enclosing Container
-    public long containerOffset = -1;
+    // equal to Container.byteOffset of its enclosing Container
+    // BAI and CRAI
+    public long containerOffset = UNINITIALIZED_INDEXING_PARAMETER;
     // this Slice's size in bytes
-    public int size = -1;
-    // this Slice's index within its Container
-    public int index = -1;
+    // CRAI only
+    public int size = UNINITIALIZED_INDEXING_PARAMETER;
+    // this Slice's index number within its Container
+    // BAI only
+    public int index = UNINITIALIZED_INDEXING_PARAMETER;
 
     // to pass this to the container:
     public long bases;
@@ -111,6 +117,46 @@ public class Slice {
 
     public ReferenceContext getReferenceContext() {
         return referenceContext;
+    }
+
+    public void baiIndexInitializationCheck() {
+        final StringBuilder error = new StringBuilder();
+
+        if (offset == UNINITIALIZED_INDEXING_PARAMETER) {
+            error.append("Cannot index this Slice for BAI because its offset is unknown.").append(System.lineSeparator());
+        }
+
+        if (containerOffset == UNINITIALIZED_INDEXING_PARAMETER) {
+            error.append("Cannot index this Slice for BAI because its containerOffset is unknown.").append(System.lineSeparator());
+        }
+
+        if (index == UNINITIALIZED_INDEXING_PARAMETER) {
+            error.append("Cannot index this Slice for BAI because its index is unknown.").append(System.lineSeparator());
+        }
+
+        if (error.length() > 0) {
+            throw new CRAMException(error.toString());
+        }
+    }
+
+    public void craiIndexInitializationCheck() {
+        final StringBuilder error = new StringBuilder();
+
+        if (offset == UNINITIALIZED_INDEXING_PARAMETER) {
+            error.append("Cannot index this Slice for CRAI because its offset is unknown.").append(System.lineSeparator());
+        }
+
+        if (containerOffset == UNINITIALIZED_INDEXING_PARAMETER) {
+            error.append("Cannot index this Slice for CRAI because its containerOffset is unknown.").append(System.lineSeparator());
+        }
+
+        if (size == UNINITIALIZED_INDEXING_PARAMETER) {
+            error.append("Cannot index this Slice for CRAI because its size is unknown.").append(System.lineSeparator());
+        }
+
+        if (error.length() > 0) {
+            throw new CRAMException(error.toString());
+        }
     }
 
     private void alignmentBordersSanityCheck(final byte[] ref) {

--- a/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
@@ -74,8 +74,9 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
         final int expectedMapped = 1;
         final int expectedUnmappedPlaced = 2;
 
-        final Container container1 = FACTORY.buildContainer(CRAMStructureTestUtil.getSingleRefRecords(RECORDS_PER_SLICE, refId1));
-        final Container container2 = FACTORY.buildContainer(CRAMStructureTestUtil.getSingleRefRecords(RECORDS_PER_SLICE, refId2));
+        final long dummyByteOffset = 0;
+        final Container container1 = FACTORY.buildContainer(CRAMStructureTestUtil.getSingleRefRecords(RECORDS_PER_SLICE, refId1), dummyByteOffset);
+        final Container container2 = FACTORY.buildContainer(CRAMStructureTestUtil.getSingleRefRecords(RECORDS_PER_SLICE, refId2), dummyByteOffset);
 
         final AbstractBAMFileIndex index = getAbstractBAMFileIndex(indexMethod.index(container1, container2));
 
@@ -116,10 +117,11 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
 
         final List<CramCompressionRecord> records = CRAMStructureTestUtil.getMultiRefRecordsWithOneUnmapped(RECORDS_PER_SLICE * 2);
 
-        final Container container1 = FACTORY.buildContainer(records.subList(0, RECORDS_PER_SLICE));
+        final long dummyByteOffset = 0;
+        final Container container1 = FACTORY.buildContainer(records.subList(0, RECORDS_PER_SLICE), dummyByteOffset);
         Assert.assertTrue(container1.getReferenceContext().isMultiRef());
 
-        final Container container2 = FACTORY.buildContainer(records.subList(RECORDS_PER_SLICE, RECORDS_PER_SLICE * 2));
+        final Container container2 = FACTORY.buildContainer(records.subList(RECORDS_PER_SLICE, RECORDS_PER_SLICE * 2), dummyByteOffset);
         Assert.assertTrue(container2.getReferenceContext().isMultiRef());
 
         final AbstractBAMFileIndex index = getAbstractBAMFileIndex(indexMethod.index(container1, container2));
@@ -144,7 +146,8 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
     }
 
     public void unplacedContainers(final IndexContainers indexMethod) {
-        final Container unplacedContainer = FACTORY.buildContainer(CRAMStructureTestUtil.getUnplacedRecords(RECORDS_PER_SLICE));
+        final long dummyByteOffset = 0;
+        final Container unplacedContainer = FACTORY.buildContainer(CRAMStructureTestUtil.getUnplacedRecords(RECORDS_PER_SLICE), dummyByteOffset);
         Assert.assertTrue(unplacedContainer.getReferenceContext().isUnmappedUnplaced());
 
         // these two sets of records are "half" unplaced: they have either a valid reference index or start position,
@@ -153,12 +156,16 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
 
         // these will be considered unplaced by CRAMBAIIndexer
 
-        final Container halfUnplacedNoStartContainer = FACTORY.buildContainer(CRAMStructureTestUtil.getHalfUnplacedNoStartRecords(RECORDS_PER_SLICE, 0));
+        final Container halfUnplacedNoStartContainer = FACTORY.buildContainer(
+                CRAMStructureTestUtil.getHalfUnplacedNoStartRecords(RECORDS_PER_SLICE, 0),
+                dummyByteOffset);
         Assert.assertTrue(halfUnplacedNoStartContainer.getReferenceContext().isUnmappedUnplaced());
 
         // these will NOT be considered unplaced by CRAMBAIIndexer
 
-        final Container halfUnplacedNoRefContainer = FACTORY.buildContainer(CRAMStructureTestUtil.getHalfUnplacedNoRefRecords(RECORDS_PER_SLICE));
+        final Container halfUnplacedNoRefContainer = FACTORY.buildContainer(
+                CRAMStructureTestUtil.getHalfUnplacedNoRefRecords(RECORDS_PER_SLICE),
+                dummyByteOffset);
         Assert.assertTrue(halfUnplacedNoRefContainer.getReferenceContext().isUnmappedUnplaced());
 
         final AbstractBAMFileIndex index = getAbstractBAMFileIndex(indexMethod.index(
@@ -221,7 +228,7 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
 
             final CRAMBAIIndexer indexer = new CRAMBAIIndexer(indexBAOS, SAM_FILE_HEADER);
             for (final Container container : containers) {
-                indexer.processAsSingleReferenceSlice(container.slices[0]);
+                indexer.processAsSingleReferenceSlice(container.getSlices()[0]);
             }
             indexer.finish();
 

--- a/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
@@ -1,20 +1,21 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.cram.CRAMException;
 import htsjdk.samtools.cram.build.ContainerFactory;
+import htsjdk.samtools.cram.common.CramVersions;
 import htsjdk.samtools.cram.ref.ReferenceContext;
-import htsjdk.samtools.cram.structure.Container;
-import htsjdk.samtools.cram.structure.CramCompressionRecord;
-import htsjdk.samtools.cram.structure.CRAMStructureTestUtil;
-import htsjdk.samtools.cram.structure.Slice;
+import htsjdk.samtools.cram.structure.*;
 import htsjdk.samtools.seekablestream.SeekableMemoryStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Created by vadim on 12/01/2016.
@@ -27,14 +28,15 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
     @Test
     public void test_processSingleRefMappedSlice() {
         final int refId = 0;
-        final Slice mapped = new Slice(new ReferenceContext(refId));
-        mapped.mappedReadsCount = 5;
-        mapped.unmappedReadsCount = 10;
+        final int mappedCount = 10;
+        final int unmappedCount = 20;
+        final int unplacedCount = 30;
+        final Slice mapped = getSlice(new ReferenceContext(refId), mappedCount, unmappedCount, unplacedCount);
 
         final AbstractBAMFileIndex index = getAbstractBAMFileIndex(indexSingleRefSlice(mapped));
 
         // mapped and unmapped reads are counted
-        assertIndexMetadata(index, refId, mapped.mappedReadsCount, mapped.unmappedReadsCount);
+        assertIndexMetadata(index, refId, mappedCount, unmappedCount);
 
         // none are unplaced
         Assert.assertEquals(index.getNoCoordinateCount().longValue(), 0);
@@ -42,8 +44,10 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
 
     @Test
     public void test_processSingleRefUnmappedSlice() {
-        final Slice unmapped = new Slice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT);
-        unmapped.unplacedReadsCount = 20;
+        final int mappedCount = 10;
+        final int unmappedCount = 20;
+        final int unplacedCount = 30;
+        final Slice unmapped = getSlice(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT, mappedCount, unmappedCount, unplacedCount);
 
         final AbstractBAMFileIndex index = getAbstractBAMFileIndex(indexSingleRefSlice(unmapped));
         Assert.assertEquals(index.getNoCoordinateCount().longValue(), unmapped.unplacedReadsCount);
@@ -53,6 +57,34 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
     public void test_processMultiSlice() {
         final Slice multi = new Slice(ReferenceContext.MULTIPLE_REFERENCE_CONTEXT);
         indexSingleRefSlice(multi);
+    }
+
+    @DataProvider(name = "missingIndexParams")
+    private Object[][] missingIndexParams() {
+        final ReferenceContext refContext = new ReferenceContext(0);
+
+        final Slice noByteOffsetFromContainer = new Slice(refContext);
+        noByteOffsetFromContainer.containerByteOffset = 123;
+        noByteOffsetFromContainer.index = 456;
+
+        final Slice noContainerByteOffset = new Slice(refContext);
+        noContainerByteOffset.byteOffsetFromContainer = 789;
+        noContainerByteOffset.index = 456;
+
+        final Slice noIndex = new Slice(refContext);
+        noIndex.byteOffsetFromContainer = 789;
+        noIndex.containerByteOffset = 123;
+
+        return new Object[][] {
+                { noByteOffsetFromContainer },
+                { noContainerByteOffset },
+                { noIndex },
+        };
+    }
+
+    @Test(expectedExceptions = CRAMException.class, dataProvider = "missingIndexParams")
+    public void test_processSliceMissingIndexParameters(final Slice slice) {
+        indexSingleRefSlice(slice);
     }
 
     @Test
@@ -95,7 +127,7 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
         multiRefContainers(this::indexContainersAsSingleRefSlices);
     }
 
-    public void multiRefContainers(final IndexContainers indexMethod) {
+    private void multiRefContainers(final IndexContainers indexMethod) {
         // we alternate unmapped-placed with mapped, with the last one unplaced
 
         final int expectedMapped0 = 0;
@@ -145,7 +177,7 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
         unplacedContainers(this::indexContainersAsSingleRefSlices);
     }
 
-    public void unplacedContainers(final IndexContainers indexMethod) {
+    private void unplacedContainers(final IndexContainers indexMethod) {
         final long dummyByteOffset = 0;
         final Container unplacedContainer = FACTORY.buildContainer(CRAMStructureTestUtil.getUnplacedRecords(RECORDS_PER_SLICE), dummyByteOffset);
         Assert.assertTrue(unplacedContainer.getReferenceContext().isUnmappedUnplaced());
@@ -184,52 +216,59 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
         new CRAMBAIIndexer(new ByteArrayOutputStream(), header);
     }
 
+    private Slice getSlice(final ReferenceContext refContext,
+                           final int mappedReadsCount,
+                           final int unmappedReadsCount,
+                           final int unplacedReadsCount) {
+        final Slice mapped = new Slice(refContext);
+        mapped.mappedReadsCount = mappedReadsCount;
+        mapped.unmappedReadsCount = unmappedReadsCount;
+        mapped.unplacedReadsCount = unplacedReadsCount;
+        // arbitrary - need these for indexing
+        mapped.byteOffsetFromContainer = 789;
+        mapped.containerByteOffset = 123;
+        mapped.index = 456;
+        return mapped;
+    }
+
     private interface IndexContainers {
         byte[] index(final Container... containers);
     }
 
     private byte[] indexSingleRefSlice(final Slice slice) {
-        byte[] indexBytes;
-        try (final ByteArrayOutputStream indexBAOS = new ByteArrayOutputStream()) {
-
-            final CRAMBAIIndexer indexer = new CRAMBAIIndexer(indexBAOS, SAM_FILE_HEADER);
+        return indexAndFinish(((indexer) -> {
             indexer.processAsSingleReferenceSlice(slice);
-            indexer.finish();
-
-            indexBytes = indexBAOS.toByteArray();
-        }
-        catch (final IOException e) {
-            throw new RuntimeIOException(e);
-        }
-        return indexBytes;
+        }));
     }
 
     private byte[] indexContainers(final Container... containers) {
-        byte[] indexBytes;
-        try (final ByteArrayOutputStream indexBAOS = new ByteArrayOutputStream()) {
-
-            final CRAMBAIIndexer indexer = new CRAMBAIIndexer(indexBAOS, SAM_FILE_HEADER);
+        return indexAndFinish(((indexer) -> {
             for (final Container container : containers) {
+                // this sets up the Container's landmarks, required for indexing
+                // readContainer() also does this
+                ContainerIO.writeContainer(CramVersions.DEFAULT_CRAM_VERSION, container, new ByteArrayOutputStream());
                 indexer.processContainer(container, ValidationStringency.STRICT);
             }
-            indexer.finish();
-
-            indexBytes = indexBAOS.toByteArray();
-        }
-        catch (final IOException e) {
-            throw new RuntimeIOException(e);
-        }
-        return indexBytes;
+        }));
     }
 
     private byte[] indexContainersAsSingleRefSlices(final Container... containers) {
+        return indexAndFinish(((indexer) -> {
+            for (final Container container : containers) {
+                // this sets up the Container's landmarks, required for indexing
+                // readContainer() also does this
+                ContainerIO.writeContainer(CramVersions.DEFAULT_CRAM_VERSION, container, new ByteArrayOutputStream());
+                indexer.processAsSingleReferenceSlice(container.getSlices()[0]);
+            }
+        }));
+    }
+
+    private byte[] indexAndFinish(final Consumer<CRAMBAIIndexer> indexerConsumer) {
         byte[] indexBytes;
         try (final ByteArrayOutputStream indexBAOS = new ByteArrayOutputStream()) {
 
             final CRAMBAIIndexer indexer = new CRAMBAIIndexer(indexBAOS, SAM_FILE_HEADER);
-            for (final Container container : containers) {
-                indexer.processAsSingleReferenceSlice(container.getSlices()[0]);
-            }
+            indexerConsumer.accept(indexer);
             indexer.finish();
 
             indexBytes = indexBAOS.toByteArray();

--- a/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMBAIIndexerTest.java
@@ -236,39 +236,39 @@ public class CRAMBAIIndexerTest extends HtsjdkTest {
     }
 
     private byte[] indexSingleRefSlice(final Slice slice) {
-        return indexAndFinish(((indexer) -> {
+        return getIndexerOutput(indexer -> {
             indexer.processAsSingleReferenceSlice(slice);
-        }));
+        });
     }
 
     private byte[] indexContainers(final Container... containers) {
-        return indexAndFinish(((indexer) -> {
+        return getIndexerOutput(indexer -> {
             for (final Container container : containers) {
                 // this sets up the Container's landmarks, required for indexing
                 // readContainer() also does this
                 ContainerIO.writeContainer(CramVersions.DEFAULT_CRAM_VERSION, container, new ByteArrayOutputStream());
                 indexer.processContainer(container, ValidationStringency.STRICT);
             }
-        }));
+        });
     }
 
     private byte[] indexContainersAsSingleRefSlices(final Container... containers) {
-        return indexAndFinish(((indexer) -> {
+        return getIndexerOutput(indexer -> {
             for (final Container container : containers) {
                 // this sets up the Container's landmarks, required for indexing
                 // readContainer() also does this
                 ContainerIO.writeContainer(CramVersions.DEFAULT_CRAM_VERSION, container, new ByteArrayOutputStream());
                 indexer.processAsSingleReferenceSlice(container.getSlices()[0]);
             }
-        }));
+        });
     }
 
-    private byte[] indexAndFinish(final Consumer<CRAMBAIIndexer> indexerConsumer) {
+    private byte[] getIndexerOutput(final Consumer<CRAMBAIIndexer> indexerFunction) {
         byte[] indexBytes;
         try (final ByteArrayOutputStream indexBAOS = new ByteArrayOutputStream()) {
 
             final CRAMBAIIndexer indexer = new CRAMBAIIndexer(indexBAOS, SAM_FILE_HEADER);
-            indexerConsumer.accept(indexer);
+            indexerFunction.accept(indexer);
             indexer.finish();
 
             indexBytes = indexBAOS.toByteArray();

--- a/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
@@ -48,14 +48,14 @@ public class CramContainerHeaderIteratorTest extends HtsjdkTest {
             Assert.assertEquals(headerOnlyContainer.blockCount, fullContainer.blockCount);
             Assert.assertEquals(headerOnlyContainer.landmarks, fullContainer.landmarks);
             Assert.assertEquals(headerOnlyContainer.checksum, fullContainer.checksum);
-            Assert.assertEquals(headerOnlyContainer.getByteOffset(), fullContainer.getByteOffset());
+            Assert.assertEquals(headerOnlyContainer.byteOffset, fullContainer.byteOffset);
             // unpopulated fields
             Assert.assertNull(headerOnlyContainer.blocks);
             Assert.assertNull(headerOnlyContainer.compressionHeader);
             Assert.assertNull(headerOnlyContainer.getSlices());
             // try to read a container from the offset to check it's correct
             try (SeekableFileStream seekableFileStream = new SeekableFileStream(cramFile)) {
-                seekableFileStream.seek(headerOnlyContainer.getByteOffset());
+                seekableFileStream.seek(headerOnlyContainer.byteOffset);
                 Container container = ContainerIO.readContainer(actualHeader.getVersion(), seekableFileStream);
                 Assert.assertEquals(container.alignmentStart, fullContainer.alignmentStart);
                 Assert.assertEquals(container.alignmentSpan, fullContainer.alignmentSpan);

--- a/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
@@ -52,7 +52,7 @@ public class CramContainerHeaderIteratorTest extends HtsjdkTest {
             // unpopulated fields
             Assert.assertNull(headerOnlyContainer.blocks);
             Assert.assertNull(headerOnlyContainer.compressionHeader);
-            Assert.assertNull(headerOnlyContainer.slices);
+            Assert.assertNull(headerOnlyContainer.getSlices());
             // try to read a container from the offset to check it's correct
             try (SeekableFileStream seekableFileStream = new SeekableFileStream(cramFile)) {
                 seekableFileStream.seek(headerOnlyContainer.getByteOffset());

--- a/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
@@ -48,14 +48,14 @@ public class CramContainerHeaderIteratorTest extends HtsjdkTest {
             Assert.assertEquals(headerOnlyContainer.blockCount, fullContainer.blockCount);
             Assert.assertEquals(headerOnlyContainer.landmarks, fullContainer.landmarks);
             Assert.assertEquals(headerOnlyContainer.checksum, fullContainer.checksum);
-            Assert.assertEquals(headerOnlyContainer.offset, fullContainer.offset);
+            Assert.assertEquals(headerOnlyContainer.getByteOffset(), fullContainer.getByteOffset());
             // unpopulated fields
             Assert.assertNull(headerOnlyContainer.blocks);
             Assert.assertNull(headerOnlyContainer.compressionHeader);
             Assert.assertNull(headerOnlyContainer.slices);
             // try to read a container from the offset to check it's correct
             try (SeekableFileStream seekableFileStream = new SeekableFileStream(cramFile)) {
-                seekableFileStream.seek(headerOnlyContainer.offset);
+                seekableFileStream.seek(headerOnlyContainer.getByteOffset());
                 Container container = ContainerIO.readContainer(actualHeader.getVersion(), seekableFileStream);
                 Assert.assertEquals(container.alignmentStart, fullContainer.alignmentStart);
                 Assert.assertEquals(container.alignmentSpan, fullContainer.alignmentSpan);

--- a/src/test/java/htsjdk/samtools/cram/CRAIEntryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAIEntryTest.java
@@ -3,6 +3,7 @@ package htsjdk.samtools.cram;
 import htsjdk.samtools.cram.build.CompressionHeaderFactory;
 import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.*;
+import htsjdk.samtools.util.TestUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -13,6 +14,8 @@ import java.util.*;
  * Created by vadim on 25/08/2015.
  */
 public class CRAIEntryTest extends CramRecordTestHelper {
+    private static final Random RANDOM = new Random(TestUtil.RANDOM_SEED);
+
     private static final CompressionHeader COMPRESSION_HEADER =
             new CompressionHeaderFactory().build(Collections.EMPTY_LIST, null, true);
 
@@ -49,10 +52,12 @@ public class CRAIEntryTest extends CramRecordTestHelper {
 
     @Test
     public void singleRefTestGetCRAIEntries() {
-        final Slice slice1 = createSlice(0);
-        final Slice slice2 = createSlice(0);
+        final ReferenceContext refContext = new ReferenceContext(0);
+        final Slice slice1 = createSliceWithArbitraryValues(refContext);
+        final Slice slice2 = createSliceWithArbitraryValues(refContext);
 
-        final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2), COMPRESSION_HEADER);
+        final long containerByteOffset = 12345;
+        final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2), COMPRESSION_HEADER, containerByteOffset);
         final List<CRAIEntry> entries = container.getCRAIEntries();
 
         Assert.assertNotNull(entries);
@@ -102,14 +107,12 @@ public class CRAIEntryTest extends CramRecordTestHelper {
         slice1.index = slice1Index;
         slice1.byteSize = sliceByteSize;
         slice1.byteOffsetFromContainer = slice1ByteOffsetFromContainer;
-        slice1.containerByteOffset = containerOffset;
 
         slice2.index = slice2Index;
         slice2.byteSize = sliceByteSize;
         slice2.byteOffsetFromContainer = slice2ByteOffsetFromContainer;
-        slice2.containerByteOffset = containerOffset;
 
-        final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2), compressionHeader);
+        final Container container = Container.initializeFromSlices(Arrays.asList(slice1, slice2), compressionHeader, containerOffset);
 
         final List<CRAIEntry> entries = container.getCRAIEntries();
         Assert.assertNotNull(entries);
@@ -285,10 +288,10 @@ public class CRAIEntryTest extends CramRecordTestHelper {
         Assert.assertEquals(testEntries, expected);
     }
 
-    private static Slice createSlice(final int sequenceId) {
-        int counter = sequenceId;
+    private static Slice createSliceWithArbitraryValues(final ReferenceContext refContext) {
+        int counter = RANDOM.nextInt(100);
 
-        final Slice single = new Slice(new ReferenceContext(sequenceId));
+        final Slice single = new Slice(refContext);
         single.alignmentStart = counter++;
         single.alignmentSpan = counter++;
         single.containerByteOffset = counter++;

--- a/src/test/java/htsjdk/samtools/cram/CRAIEntryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAIEntryTest.java
@@ -19,33 +19,7 @@ public class CRAIEntryTest extends CramRecordTestHelper {
     private static final CompressionHeader COMPRESSION_HEADER =
             new CompressionHeaderFactory().build(Collections.EMPTY_LIST, null, true);
 
-    @DataProvider(name = "uninitializedSliceParameterTestCases")
-    private Object[][] uninitializedSliceParameterTestCases() {
-        final ReferenceContext refContext = new ReferenceContext(0);
-
-        final Slice noContainerOffset = new Slice(refContext);
-        noContainerOffset.containerByteOffset = Slice.UNINITIALIZED_INDEXING_PARAMETER;
-        noContainerOffset.byteOffsetFromContainer = 1;
-        noContainerOffset.byteSize = 1;
-
-        final Slice noOffsetFromContainer = new Slice(refContext);
-        noOffsetFromContainer.byteOffsetFromContainer = Slice.UNINITIALIZED_INDEXING_PARAMETER;
-        noOffsetFromContainer.containerByteOffset = 1;
-        noOffsetFromContainer.byteSize = 1;
-
-        final Slice noSize = new Slice(refContext);
-        noSize.byteSize = Slice.UNINITIALIZED_INDEXING_PARAMETER;
-        noSize.containerByteOffset = 1;
-        noSize.byteOffsetFromContainer = 1;
-
-        return new Object[][] {
-                { noContainerOffset },
-                { noOffsetFromContainer },
-                { noSize }
-        };
-    }
-
-    @Test(dataProvider = "uninitializedSliceParameterTestCases", expectedExceptions = CRAMException.class)
+    @Test(dataProvider = "uninitializedCRAIParameterTestCases", dataProviderClass = CRAMStructureTestUtil.class, expectedExceptions = CRAMException.class)
     public void uninitializedSliceParameterTest(final Slice s) {
         s.getCRAIEntries(COMPRESSION_HEADER);
     }

--- a/src/test/java/htsjdk/samtools/cram/VersionTest.java
+++ b/src/test/java/htsjdk/samtools/cram/VersionTest.java
@@ -10,6 +10,7 @@ import htsjdk.samtools.cram.common.Version;
 import htsjdk.samtools.cram.io.CramInt;
 import htsjdk.samtools.cram.io.InputStreamUtils;
 import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.cram.structure.ContainerHeaderIO;
 import htsjdk.samtools.cram.structure.block.Block;
 import htsjdk.samtools.cram.structure.Container;
 import htsjdk.samtools.cram.structure.ContainerIO;
@@ -74,7 +75,7 @@ public class VersionTest extends HtsjdkTest {
         // position stream at the start of the 1st container:
         cramSeekableStream.seek(containerStart);
         // read only container header:
-        ContainerIO.readContainerHeader(version.major, cramSeekableStream);
+        ContainerHeaderIO.readContainerHeader(version.major, cramSeekableStream, containerStart);
 
         // read the following 4 bytes of CRC32:
         int crcByteSize = 4;

--- a/src/test/java/htsjdk/samtools/cram/structure/CRAMStructureTestUtil.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CRAMStructureTestUtil.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.cram.build.ContainerFactory;
 import htsjdk.samtools.cram.ref.ReferenceContext;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -163,6 +164,62 @@ public class CRAMStructureTestUtil {
         testContainers.add(container1);
         testContainers.add(container2);
         return testContainers;
+    }
+
+    private static Slice getIndexInitializedSlice() {
+        final ReferenceContext refContext = new ReferenceContext(0);
+
+        final Slice slice = new Slice(refContext);
+        slice.byteOffsetFromContainer = 1;
+        slice.containerByteOffset = 1;
+        slice.byteSize = 1;
+        slice.index = 1;
+
+        return slice;
+    }
+
+    private static Slice getNoContainerOffsetSlice() {
+        final Slice noContainerOffset = getIndexInitializedSlice();
+        noContainerOffset.containerByteOffset = Slice.UNINITIALIZED_INDEXING_PARAMETER;
+        return noContainerOffset;
+    }
+
+    private static Slice getNoOffsetFromContainerSlice() {
+        final Slice noOffsetFromContainer = getIndexInitializedSlice();
+        noOffsetFromContainer.byteOffsetFromContainer = Slice.UNINITIALIZED_INDEXING_PARAMETER;
+        return noOffsetFromContainer;
+    }
+
+    private static Slice getNoSizeSlice() {
+        final Slice noSize = getIndexInitializedSlice();
+        noSize.byteSize = Slice.UNINITIALIZED_INDEXING_PARAMETER;
+        return noSize;
+    }
+
+    private static Slice getNoIndexSlice() {
+        final Slice noIndex = getIndexInitializedSlice();
+        noIndex.index = Slice.UNINITIALIZED_INDEXING_PARAMETER;
+        return noIndex;
+    }
+
+    @DataProvider(name = "uninitializedBAIParameterTestCases")
+    static Object[][] uninitializedBAIParameterTestCases() {
+
+        return new Object[][] {
+                { getNoContainerOffsetSlice() },
+                { getNoOffsetFromContainerSlice() },
+                { getNoIndexSlice() }
+        };
+    }
+
+    @DataProvider(name = "uninitializedCRAIParameterTestCases")
+    static Object[][] uninitializedCRAIParameterTestCases() {
+
+        return new Object[][] {
+                { getNoContainerOffsetSlice() },
+                { getNoOffsetFromContainerSlice() },
+                { getNoSizeSlice() }
+        };
     }
 
     // assert that slices and containers have values equal to what the caller expects

--- a/src/test/java/htsjdk/samtools/cram/structure/CRAMStructureTestUtil.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CRAMStructureTestUtil.java
@@ -141,7 +141,7 @@ public class CRAMStructureTestUtil {
         return retval;
     }
 
-    public static List<Container> getMultiRefContainersForStateTest() {
+    public static List<Container> getMultiRefContainersForStateTest(final long firstContainerByteOffset) {
         final ContainerFactory factory = new ContainerFactory(getSAMFileHeaderForTests(), 10);
         final List<Container> testContainers = new ArrayList<>(3);
 
@@ -149,15 +149,15 @@ public class CRAMStructureTestUtil {
 
         int index = 0;
         records.add(createMappedRecord(index, index, index + 1));
-        final Container container0 = factory.buildContainer(records);
+        final Container container0 = factory.buildContainer(records, firstContainerByteOffset);
 
         index++;
         records.add(createMappedRecord(index, index, index + 1));
-        final Container container1 = factory.buildContainer(records);
+        final Container container1 = factory.buildContainer(records, firstContainerByteOffset + 1);
 
         index++;
         records.add(createUnmappedUnplacedRecord(index));
-        final Container container2 = factory.buildContainer(records);
+        final Container container2 = factory.buildContainer(records, firstContainerByteOffset + 2);
 
         testContainers.add(container0);
         testContainers.add(container1);
@@ -194,10 +194,12 @@ public class CRAMStructureTestUtil {
     public static void assertContainerState(final Container container,
                                             final ReferenceContext expectedReferenceContext,
                                             final int expectedAlignmentStart,
-                                            final int expectedAlignmentSpan) {
+                                            final int expectedAlignmentSpan,
+                                            final long expectedByteOffset) {
         Assert.assertEquals(container.getReferenceContext(), expectedReferenceContext);
         Assert.assertEquals(container.alignmentStart, expectedAlignmentStart);
         Assert.assertEquals(container.alignmentSpan, expectedAlignmentSpan);
+        Assert.assertEquals(container.getByteOffset(), expectedByteOffset);
     }
 
     public static void assertContainerState(final Container container,
@@ -206,18 +208,19 @@ public class CRAMStructureTestUtil {
                                             final int expectedAlignmentSpan,
                                             final int expectedRecordCount,
                                             final int expectedBaseCount,
-                                            final int expectedGlobalRecordCounter) {
-        assertContainerState(container, expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan);
+                                            final int expectedGlobalRecordCounter,
+                                            final long expectedByteOffset) {
+        assertContainerState(container, expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan, expectedByteOffset);
 
         Assert.assertEquals(container.nofRecords, expectedRecordCount);
         Assert.assertEquals(container.bases, expectedBaseCount);
         Assert.assertEquals(container.globalRecordCounter, expectedGlobalRecordCounter);
 
-        Assert.assertEquals(container.slices.length, 1);
+        Assert.assertEquals(container.getSlices().length, 1);
 
         // verify the underlying slice too
 
-        assertSliceState(container.slices[0], expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan,
+        assertSliceState(container.getSlices()[0], expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan,
                 expectedRecordCount, expectedBaseCount, expectedGlobalRecordCounter);
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/structure/CRAMStructureTestUtil.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CRAMStructureTestUtil.java
@@ -199,7 +199,7 @@ public class CRAMStructureTestUtil {
         Assert.assertEquals(container.getReferenceContext(), expectedReferenceContext);
         Assert.assertEquals(container.alignmentStart, expectedAlignmentStart);
         Assert.assertEquals(container.alignmentSpan, expectedAlignmentSpan);
-        Assert.assertEquals(container.getByteOffset(), expectedByteOffset);
+        Assert.assertEquals(container.byteOffset, expectedByteOffset);
     }
 
     public static void assertContainerState(final Container container,

--- a/src/test/java/htsjdk/samtools/cram/structure/CRAMStructureTestUtil.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/CRAMStructureTestUtil.java
@@ -1,5 +1,6 @@
 package htsjdk.samtools.cram.structure;
 
+import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMSequenceDictionary;
@@ -13,7 +14,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class CRAMStructureTestUtil {
+public class CRAMStructureTestUtil extends HtsjdkTest {
     public static final int READ_LENGTH_FOR_TEST_RECORDS = 123;
 
     private static final SAMFileHeader header = initializeSAMFileHeaderForTests();

--- a/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
@@ -211,21 +211,21 @@ public class ContainerTest extends HtsjdkTest {
         final Container nullLandmarks = new Container(refContext);
         nullLandmarks.containerByteSize = 6789;
         nullLandmarks.landmarks = null;
-        nullLandmarks.setSlices(Collections.singletonList(new Slice(refContext)), 999);
+        nullLandmarks.setSlicesAndByteOffset(Collections.singletonList(new Slice(refContext)), 999);
 
         final Container tooManyLandmarks = new Container(refContext);
         tooManyLandmarks.containerByteSize = 111;
         tooManyLandmarks.landmarks = new int[]{ 1, 2, 3, 4, 5 };
-        tooManyLandmarks.setSlices(Collections.singletonList(new Slice(refContext)), 12345);
+        tooManyLandmarks.setSlicesAndByteOffset(Collections.singletonList(new Slice(refContext)), 12345);
 
         final Container tooManySlices = new Container(refContext);
         tooManySlices.containerByteSize = 675345389;
         tooManySlices.landmarks = new int[]{ 1 };
-        tooManySlices.setSlices(Arrays.asList(new Slice(refContext), new Slice(refContext)), 12345);
+        tooManySlices.setSlicesAndByteOffset(Arrays.asList(new Slice(refContext), new Slice(refContext)), 12345);
 
         final Container noByteSize = new Container(refContext);
         noByteSize.landmarks = new int[]{ 1, 2 };
-        noByteSize.setSlices(Arrays.asList(new Slice(refContext), new Slice(refContext)), 12345);
+        noByteSize.setSlicesAndByteOffset(Arrays.asList(new Slice(refContext), new Slice(refContext)), 12345);
 
         return new Object[][] {
                 { nullLandmarks },
@@ -251,7 +251,7 @@ public class ContainerTest extends HtsjdkTest {
                 containerHeaderSize,                // beginning of slice
         };
 
-        container.setSlices(Collections.singletonList(new Slice(refContext)), containerStreamByteOffset);
+        container.setSlicesAndByteOffset(Collections.singletonList(new Slice(refContext)), containerStreamByteOffset);
         container.distributeIndexingParametersToSlices();
         return container;
     }
@@ -271,7 +271,7 @@ public class ContainerTest extends HtsjdkTest {
                 containerHeaderSize + slice0size    // beginning of slice 2
         };
 
-        container.setSlices(Arrays.asList(new Slice(refContext), new Slice(refContext)), containerStreamByteOffset);
+        container.setSlicesAndByteOffset(Arrays.asList(new Slice(refContext), new Slice(refContext)), containerStreamByteOffset);
         container.distributeIndexingParametersToSlices();
         return container;
     }

--- a/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
@@ -67,8 +67,9 @@ public class ContainerTest extends HtsjdkTest {
                                          final ReferenceContext expectedReferenceContext,
                                          final int expectedAlignmentStart,
                                          final int expectedAlignmentSpan) {
-        final Container container = Container.initializeFromSlices(slices, COMPRESSION_HEADER);
-        CRAMStructureTestUtil.assertContainerState(container, expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan);
+        final long byteOffset = 536635;
+        final Container container = Container.initializeFromSlices(slices, COMPRESSION_HEADER, byteOffset);
+        CRAMStructureTestUtil.assertContainerState(container, expectedReferenceContext, expectedAlignmentStart, expectedAlignmentSpan, byteOffset);
     }
 
     @DataProvider(name = "illegalCombinationTestCases")
@@ -95,7 +96,8 @@ public class ContainerTest extends HtsjdkTest {
 
     @Test(dataProvider = "illegalCombinationTestCases", expectedExceptions = CRAMException.class)
     public static void illegalCombinationsStateTest(final Slice one, final Slice another) {
-        Container.initializeFromSlices(Arrays.asList(one, another), COMPRESSION_HEADER);
+        final long dummyByteOffset = 0;
+        Container.initializeFromSlices(Arrays.asList(one, another), COMPRESSION_HEADER, dummyByteOffset);
     }
 
     @DataProvider(name = "getSpansTestCases")
@@ -148,7 +150,8 @@ public class ContainerTest extends HtsjdkTest {
     public void getSpansTest(final List<CramCompressionRecord> records,
                              final ReferenceContext expectedReferenceContext,
                              final AlignmentSpan expectedAlignmentSpan) {
-        final Container container = FACTORY.buildContainer(records);
+        final long dummyByteOffset = 0;
+        final Container container = FACTORY.buildContainer(records, dummyByteOffset);
 
         final Map<ReferenceContext, AlignmentSpan> spanMap = container.getSpans(ValidationStringency.STRICT);
         Assert.assertEquals(spanMap.size(), 1);
@@ -177,7 +180,7 @@ public class ContainerTest extends HtsjdkTest {
 
         final Container container = createOneSliceContainer(containerStreamByteOffset, containerHeaderSize, sliceSize);
 
-        assertSliceIndexingParams(container.slices[0], 0, containerStreamByteOffset, sliceSize, containerHeaderSize);
+        assertSliceIndexingParams(container.getSlices()[0], 0, containerStreamByteOffset, sliceSize, containerHeaderSize);
     }
 
     // two slices
@@ -198,8 +201,8 @@ public class ContainerTest extends HtsjdkTest {
 
         final Container container = createTwoSliceContainer(containerStreamByteOffset, containerHeaderSize, slice0size, slice1size);
 
-        assertSliceIndexingParams(container.slices[0], 0, containerStreamByteOffset, slice0size, containerHeaderSize);
-        assertSliceIndexingParams(container.slices[1], 1, containerStreamByteOffset, slice1size, containerHeaderSize + slice0size);
+        assertSliceIndexingParams(container.getSlices()[0], 0, containerStreamByteOffset, slice0size, containerHeaderSize);
+        assertSliceIndexingParams(container.getSlices()[1], 1, containerStreamByteOffset, slice1size, containerHeaderSize + slice0size);
     }
 
     private static Container createOneSliceContainer(final int containerStreamByteOffset,
@@ -216,8 +219,7 @@ public class ContainerTest extends HtsjdkTest {
         final ArrayList<Slice> slices = new ArrayList<Slice>() {{
             add(new Slice(refContext));
         }};
-        container.populateSlicesAndIndexingParameters(slices);
-        container.setByteOffset(containerStreamByteOffset);
+        container.populateSlicesAndIndexingParameters(slices, containerStreamByteOffset);
         return container;
     }
 
@@ -240,8 +242,7 @@ public class ContainerTest extends HtsjdkTest {
             add(new Slice(refContext));
             add(new Slice(refContext));
         }};
-        container.populateSlicesAndIndexingParameters(slices);
-        container.setByteOffset(containerStreamByteOffset);
+        container.populateSlicesAndIndexingParameters(slices, containerStreamByteOffset);
         return container;
     }
 

--- a/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
@@ -10,7 +10,6 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -212,21 +211,21 @@ public class ContainerTest extends HtsjdkTest {
         final Container nullLandmarks = new Container(refContext);
         nullLandmarks.containerByteSize = 6789;
         nullLandmarks.landmarks = null;
-        nullLandmarks.setSlices(new Slice[] { new Slice(refContext) }, 999);
+        nullLandmarks.setSlices(Collections.singletonList(new Slice(refContext)), 999);
 
         final Container tooManyLandmarks = new Container(refContext);
         tooManyLandmarks.containerByteSize = 111;
         tooManyLandmarks.landmarks = new int[]{ 1, 2, 3, 4, 5 };
-        tooManyLandmarks.setSlices(new Slice[] { new Slice(refContext) }, 12345);
+        tooManyLandmarks.setSlices(Collections.singletonList(new Slice(refContext)), 12345);
 
         final Container tooManySlices = new Container(refContext);
         tooManySlices.containerByteSize = 675345389;
         tooManySlices.landmarks = new int[]{ 1 };
-        tooManySlices.setSlices(new Slice[] { new Slice(refContext), new Slice(refContext) }, 12345);
+        tooManySlices.setSlices(Arrays.asList(new Slice(refContext), new Slice(refContext)), 12345);
 
         final Container noByteSize = new Container(refContext);
         noByteSize.landmarks = new int[]{ 1, 2 };
-        noByteSize.setSlices(new Slice[] { new Slice(refContext), new Slice(refContext) }, 12345);
+        noByteSize.setSlices(Arrays.asList(new Slice(refContext), new Slice(refContext)), 12345);
 
         return new Object[][] {
                 { nullLandmarks },
@@ -252,10 +251,7 @@ public class ContainerTest extends HtsjdkTest {
                 containerHeaderSize,                // beginning of slice
         };
 
-        final ArrayList<Slice> slices = new ArrayList<Slice>() {{
-            add(new Slice(refContext));
-        }};
-        container.setSlices(slices.toArray(new Slice[0]), containerStreamByteOffset);
+        container.setSlices(Collections.singletonList(new Slice(refContext)), containerStreamByteOffset);
         container.distributeIndexingParametersToSlices();
         return container;
     }
@@ -275,11 +271,7 @@ public class ContainerTest extends HtsjdkTest {
                 containerHeaderSize + slice0size    // beginning of slice 2
         };
 
-        final ArrayList<Slice> slices = new ArrayList<Slice>() {{
-            add(new Slice(refContext));
-            add(new Slice(refContext));
-        }};
-        container.setSlices(slices.toArray(new Slice[0]), containerStreamByteOffset);
+        container.setSlices(Arrays.asList(new Slice(refContext), new Slice(refContext)), containerStreamByteOffset);
         container.distributeIndexingParametersToSlices();
         return container;
     }

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -189,6 +189,72 @@ public class SliceTests extends HtsjdkTest {
                 Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN, records.size(), expectedBaseCount);
     }
 
+    @DataProvider(name = "uninitializedBAIParameterTestCases")
+    private Object[][] uninitializedBAIParameterTestCases() {
+
+        return new Object[][] {
+                { getNoContainerOffsetSlice() },
+                { getNoOffsetFromContainerSlice() },
+                { getNoIndexSlice() }
+        };
+    }
+
+    @DataProvider(name = "uninitializedCRAIParameterTestCases")
+    private Object[][] uninitializedCRAIParameterTestCases() {
+
+        return new Object[][] {
+                { getNoContainerOffsetSlice() },
+                { getNoOffsetFromContainerSlice() },
+                { getNoSizeSlice() }
+        };
+    }
+
+    @Test(dataProvider = "uninitializedBAIParameterTestCases", expectedExceptions = CRAMException.class)
+    public void uninitializedBAIParameterTest(final Slice s) {
+        s.baiIndexInitializationCheck();
+    }
+
+    @Test(dataProvider = "uninitializedCRAIParameterTestCases", expectedExceptions = CRAMException.class)
+    public void uninitializedCRAIParameterTest(final Slice s) {
+        s.craiIndexInitializationCheck();
+    }
+
+    private Slice getIndexInitializedSlice() {
+        final ReferenceContext refContext = new ReferenceContext(0);
+
+        final Slice slice = new Slice(refContext);
+        slice.byteOffsetFromContainer = 1;
+        slice.containerByteOffset = 1;
+        slice.byteSize = 1;
+        slice.index = 1;
+
+        return slice;
+    }
+
+    private Slice getNoContainerOffsetSlice() {
+        final Slice noContainerOffset = getIndexInitializedSlice();
+        noContainerOffset.containerByteOffset = Slice.UNINITIALIZED_INDEXING_PARAMETER;
+        return noContainerOffset;
+    }
+
+    private Slice getNoOffsetFromContainerSlice() {
+        final Slice noOffsetFromContainer = getIndexInitializedSlice();
+        noOffsetFromContainer.byteOffsetFromContainer = Slice.UNINITIALIZED_INDEXING_PARAMETER;
+        return noOffsetFromContainer;
+    }
+
+    private Slice getNoSizeSlice() {
+        final Slice noSize = getIndexInitializedSlice();
+        noSize.byteSize = Slice.UNINITIALIZED_INDEXING_PARAMETER;
+        return noSize;
+    }
+
+    private Slice getNoIndexSlice() {
+        final Slice noIndex = getIndexInitializedSlice();
+        noIndex.index = Slice.UNINITIALIZED_INDEXING_PARAMETER;
+        return noIndex;
+    }
+
     private static void buildSliceAndAssert(final List<CramCompressionRecord> records,
                                             final ReferenceContext expectedReferenceContext,
                                             final int expectedAlignmentStart,

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -189,70 +189,14 @@ public class SliceTests extends HtsjdkTest {
                 Slice.NO_ALIGNMENT_START, Slice.NO_ALIGNMENT_SPAN, records.size(), expectedBaseCount);
     }
 
-    @DataProvider(name = "uninitializedBAIParameterTestCases")
-    private Object[][] uninitializedBAIParameterTestCases() {
-
-        return new Object[][] {
-                { getNoContainerOffsetSlice() },
-                { getNoOffsetFromContainerSlice() },
-                { getNoIndexSlice() }
-        };
-    }
-
-    @DataProvider(name = "uninitializedCRAIParameterTestCases")
-    private Object[][] uninitializedCRAIParameterTestCases() {
-
-        return new Object[][] {
-                { getNoContainerOffsetSlice() },
-                { getNoOffsetFromContainerSlice() },
-                { getNoSizeSlice() }
-        };
-    }
-
-    @Test(dataProvider = "uninitializedBAIParameterTestCases", expectedExceptions = CRAMException.class)
+    @Test(dataProvider = "uninitializedBAIParameterTestCases", dataProviderClass = CRAMStructureTestUtil.class, expectedExceptions = CRAMException.class)
     public void uninitializedBAIParameterTest(final Slice s) {
         s.baiIndexInitializationCheck();
     }
 
-    @Test(dataProvider = "uninitializedCRAIParameterTestCases", expectedExceptions = CRAMException.class)
+    @Test(dataProvider = "uninitializedCRAIParameterTestCases", dataProviderClass = CRAMStructureTestUtil.class, expectedExceptions = CRAMException.class)
     public void uninitializedCRAIParameterTest(final Slice s) {
         s.craiIndexInitializationCheck();
-    }
-
-    private Slice getIndexInitializedSlice() {
-        final ReferenceContext refContext = new ReferenceContext(0);
-
-        final Slice slice = new Slice(refContext);
-        slice.byteOffsetFromContainer = 1;
-        slice.containerByteOffset = 1;
-        slice.byteSize = 1;
-        slice.index = 1;
-
-        return slice;
-    }
-
-    private Slice getNoContainerOffsetSlice() {
-        final Slice noContainerOffset = getIndexInitializedSlice();
-        noContainerOffset.containerByteOffset = Slice.UNINITIALIZED_INDEXING_PARAMETER;
-        return noContainerOffset;
-    }
-
-    private Slice getNoOffsetFromContainerSlice() {
-        final Slice noOffsetFromContainer = getIndexInitializedSlice();
-        noOffsetFromContainer.byteOffsetFromContainer = Slice.UNINITIALIZED_INDEXING_PARAMETER;
-        return noOffsetFromContainer;
-    }
-
-    private Slice getNoSizeSlice() {
-        final Slice noSize = getIndexInitializedSlice();
-        noSize.byteSize = Slice.UNINITIALIZED_INDEXING_PARAMETER;
-        return noSize;
-    }
-
-    private Slice getNoIndexSlice() {
-        final Slice noIndex = getIndexInitializedSlice();
-        noIndex.index = Slice.UNINITIALIZED_INDEXING_PARAMETER;
-        return noIndex;
     }
 
     private static void buildSliceAndAssert(final List<CramCompressionRecord> records,


### PR DESCRIPTION
- Encapsulate Container.byteOffset and distribute to Slices on set
- enforce prerequisites to index entry creation

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Checklist

- [x] Code compiles correctly
- [x] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

