### PR TITLE
Spotbugs fix tests

### DIFF
--- a/src/test/java/htsjdk/TestDataProviders.java
+++ b/src/test/java/htsjdk/TestDataProviders.java
@@ -76,6 +76,15 @@ public class TestDataProviders extends HtsjdkTest {
                     throw new IllegalStateException(String.format("@BeforeSuite threw an exception (%s::%s). Dependent tests will be skipped. Please fix.", clazz.getName(), method.getName()), e);
                 }
             }
+
+            if (otherMethod.isAnnotationPresent(BeforeTest.class)) {
+                try {
+                    otherMethod.setAccessible(true);
+                    otherMethod.invoke(instance);
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                    throw new IllegalStateException(String.format("@BeforeTest threw an exception (%s::%s). Dependent tests will be skipped. Please fix.", clazz.getName(), method.getName()), e);
+                }
+            }
         }
 
         try {

--- a/src/test/java/htsjdk/samtools/CSIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CSIIndexTest.java
@@ -2,7 +2,7 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -16,22 +16,22 @@ import java.util.List;
 public class CSIIndexTest extends HtsjdkTest {
 
     public static final String TEST_DATA_DIR = "src/test/resources/htsjdk/samtools/BAMFileIndexTest/";
-    private static DiskBasedBAMFileIndex bai;
-    private static CSIIndex csi;
-    private static CSIIndex mcsi;
-    private static CSIIndex ucsi;
-    private static DiskBasedBAMFileIndex ubai;
+    private DiskBasedBAMFileIndex bai;
+    private CSIIndex csi;
+    private CSIIndex mcsi;
+    private CSIIndex ucsi;
+    private DiskBasedBAMFileIndex ubai;
 
-    private static Bin bin1 = new Bin(0, 0);
-    private static Bin bin2 = new Bin(0, 1);
-    private static Bin bin3 = new Bin(1, 0);
-    private static Bin bin4 = new Bin(1, 1);
-    private static Bin bin5 = new Bin(1, 9);
-    private static Bin bin6 = new Bin(1, 586);
-    private static Bin bin7 = new Bin(1, 80);
-    private static Bin bin8 = new Bin(1, 4689);
-    private static Bin bin9 = new Bin(1, 135853);
-    private static Bin bin10 = new Bin(1, 163);
+    private Bin bin1 = new Bin(0, 0);
+    private Bin bin2 = new Bin(0, 1);
+    private Bin bin3 = new Bin(1, 0);
+    private Bin bin4 = new Bin(1, 1);
+    private Bin bin5 = new Bin(1, 9);
+    private Bin bin6 = new Bin(1, 586);
+    private Bin bin7 = new Bin(1, 80);
+    private Bin bin8 = new Bin(1, 4689);
+    private Bin bin9 = new Bin(1, 135853);
+    private Bin bin10 = new Bin(1, 163);
 
     // The CSI index is a generalization of the bai index which introduces these as parameters instead of hard coding them.
     // These are equivalent parameter values for CSI that are baked into the bai calculations.
@@ -39,7 +39,7 @@ public class CSIIndexTest extends HtsjdkTest {
     public static final int BAI_EQUIVALENT_MIN_SHIFT = 14;
     public static final int BAI_EQUIVALENT_BIN_DEPTH = 6;
 
-    @BeforeClass
+    @BeforeTest
     public void init() {
         bai = new DiskBasedBAMFileIndex(new File(TEST_DATA_DIR, "index_test.bam.bai"), null);
         csi = new CSIIndex(new File(TEST_DATA_DIR, "index_test.bam.csi"), false, null);
@@ -54,25 +54,25 @@ public class CSIIndexTest extends HtsjdkTest {
 
 
     @Test
-    public static void testGetNumIndexLevels() {
+    public void testGetNumIndexLevels() {
         Assert.assertEquals(csi.getBinDepth(), 6);
         Assert.assertEquals(ucsi.getBinDepth(), 7);
     }
 
     @Test
-    public static void testGetMinShift() {
+    public void testGetMinShift() {
         Assert.assertEquals(csi.getMinShift(), 14);
         Assert.assertEquals(ucsi.getMinShift(), 12);
     }
 
     @Test
-    public static void testGetMaxBins() {
+    public void testGetMaxBins() {
         Assert.assertEquals(csi.getMaxBins(), 37449);
         Assert.assertEquals(ucsi.getMaxBins(), 299593);
     }
 
     @Test
-    public static void testGetMaxSpan() {
+    public void testGetMaxSpan() {
         Assert.assertEquals(csi.getMaxSpan(), 512 * 1024 * 1024);
         Assert.assertEquals(ucsi.getMaxSpan(), 1024 * 1024 * 1024);
     }
@@ -98,17 +98,17 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getTestFirstBinInLevelData")
-    public static void testGetFirstBinInLevelOK(CSIIndex index, int levelNumber, int expected) {
+    public void testGetFirstBinInLevelOK(CSIIndex index, int levelNumber, int expected) {
         Assert.assertEquals(index.getFirstBinInLevelForCSI(levelNumber), expected);
     }
 
     @Test(expectedExceptions = SAMException.class)
-    public static void testGetFirstBinInLevelFail1() {
+    public void testGetFirstBinInLevelFail1() {
         csi.getFirstBinInLevelForCSI(6);
     }
 
     @Test(expectedExceptions = SAMException.class)
-    public static void testGetFirstBinInLevelFail2() {
+    public void testGetFirstBinInLevelFail2() {
         ucsi.getFirstBinInLevelForCSI(7);
     }
 
@@ -133,27 +133,27 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getTestLevelSizeData")
-    public static void testGetLevelSizeOK(CSIIndex index, int level, int expected) {
+    public void testGetLevelSizeOK(CSIIndex index, int level, int expected) {
         Assert.assertEquals(index.getLevelSize(level), expected);
     }
 
     @Test(expectedExceptions = SAMException.class)
-    public static void testGetLevelSizeFail1() {
+    public void testGetLevelSizeFail1() {
         csi.getLevelSize(6);
     }
 
     @Test(expectedExceptions = SAMException.class)
-    public static void testGetLevelSizeFail12() {
+    public void testGetLevelSizeFail12() {
         csi.getLevelSize(7);
     }
 
     @Test
-    public static void testGetAuxData() {
+    public void testGetAuxData() {
         Assert.assertEquals(csi.getAuxData().length, 0);
     }
 
     @Test
-    public static void testGetNReferences() {
+    public void testGetNReferences() {
         Assert.assertEquals(csi.getNumberOfReferences(), 45);
     }
 
@@ -171,12 +171,12 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getTestParentBinData")
-    public static void testGetParentBinOK(int bin, int expected) {
+    public void testGetParentBinOK(int bin, int expected) {
         Assert.assertEquals(csi.getParentBinNumber(bin), expected);
     }
 
     @Test(expectedExceptions = SAMException.class)
-    public static void testGetParentBinFail() {
+    public void testGetParentBinFail() {
         csi.getParentBinNumber(37449);
     }
 
@@ -191,14 +191,14 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getTestRegionToBinMatchesBaiData")
-    public static void testRegionToBinMatchesBai(int start, int end) {
+    public void testRegionToBinMatchesBai(int start, int end) {
         final int csiComputation = GenomicIndexUtil.regionToBin(start, end, BAI_EQUIVALENT_MIN_SHIFT, BAI_EQUIVALENT_BIN_DEPTH);
         final int baiComputation = GenomicIndexUtil.regionToBin(start, end);
         Assert.assertEquals(csiComputation, baiComputation);
     }
 
     @Test
-    public static void testGetNoCoorCount() {
+    public void testGetNoCoorCount() {
         long noCoorBai = bai.getNoCoordinateCount();
         long noCoorCsi = csi.getNoCoordinateCount();
 
@@ -231,12 +231,12 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getDataForTestGetLevelForBin")
-    public static void testGetLevelForBin(CSIIndex index, Bin bin, int expected) {
+    public void testGetLevelForBin(CSIIndex index, Bin bin, int expected) {
         Assert.assertEquals(index.getLevelForBin(bin), expected);
     }
 
     @Test
-    public static void testGetParentBinNumber() {
+    public void testGetParentBinNumber() {
         Assert.assertEquals(csi.getParentBinNumber(bin1), 0);
         Assert.assertEquals(csi.getParentBinNumber(bin2), 0);
         Assert.assertEquals(csi.getParentBinNumber(bin3), 0);
@@ -286,7 +286,7 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "testDataForGetFirstLocusInBin")
-    public static void testGetFirstLocusInBin(CSIIndex index, Bin bin, int expected) {
+    public void testGetFirstLocusInBin(CSIIndex index, Bin bin, int expected) {
         Assert.assertEquals(index.getFirstLocusInBin(bin), expected);
     }
 
@@ -316,7 +316,7 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getDataForTestGetLastLocusInBin")
-    public static void testGetLastLocusInBin(CSIIndex index, Bin bin, int expected) {
+    public void testGetLastLocusInBin(CSIIndex index, Bin bin, int expected) {
         Assert.assertEquals(index.getLastLocusInBin(bin), expected);
     }
 
@@ -342,7 +342,7 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getTestRegionToBinsMatchesBaiData")
-    public static void testRegionToBinsMatchesBai(int start, int end) {
+    public void testRegionToBinsMatchesBai(int start, int end) {
         final BitSet csiComputation = GenomicIndexUtil.regionToBins(start, end, BAI_EQUIVALENT_MIN_SHIFT, BAI_EQUIVALENT_BIN_DEPTH);
         final BitSet baiComputation = GenomicIndexUtil.regionToBins(start, end);
         Assert.assertEquals(csiComputation, baiComputation);
@@ -362,7 +362,7 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getTestRegionToBinsData")
-    public static void testRegionToBins(int start, int end, int minShift, int binDepth, List<Integer> expectedBins) {
+    public void testRegionToBins(int start, int end, int minShift, int binDepth, List<Integer> expectedBins) {
         BitSet bins = GenomicIndexUtil.regionToBins(start, end, minShift, binDepth);
         final BitSet expected = new BitSet();
         expectedBins.forEach(expected::set);
@@ -370,7 +370,7 @@ public class CSIIndexTest extends HtsjdkTest {
     }
 
     @Test
-    public static void testGetSpanOverlapping() {
+    public void testGetSpanOverlapping() {
         BAMFileSpan bfs1 = ucsi.getSpanOverlapping(1, 939520000, 939529000);
         BAMFileSpan bfs2 = ucsi.getSpanOverlapping(1, 240000000, 249228250);
         BAMFileSpan bfs3 = ubai.getSpanOverlapping(1, 240000000, 249228250);

--- a/src/test/java/htsjdk/samtools/CSIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CSIIndexTest.java
@@ -2,7 +2,7 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -39,7 +39,7 @@ public class CSIIndexTest extends HtsjdkTest {
     public static final int BAI_EQUIVALENT_MIN_SHIFT = 14;
     public static final int BAI_EQUIVALENT_BIN_DEPTH = 6;
 
-    @BeforeTest
+    @BeforeClass
     public void init() {
         bai = new DiskBasedBAMFileIndex(new File(TEST_DATA_DIR, "index_test.bam.bai"), null);
         csi = new CSIIndex(new File(TEST_DATA_DIR, "index_test.bam.csi"), false, null);

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -395,7 +395,6 @@ public class SamReaderFactoryTest extends HtsjdkTest {
         InputResource bam = new NeverFilePathInputResource(localBam.toPath());
         InputResource index = new FileInputResource(localBamIndex);
 
-        final SamInputResource resource = new SamInputResource(bam, index);
         queryInputResourcePermutation(new SamInputResource(bam, index));
     }
 

--- a/src/test/java/htsjdk/samtools/reference/SamLocusAndReferenceIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/reference/SamLocusAndReferenceIteratorTest.java
@@ -51,6 +51,6 @@ public class SamLocusAndReferenceIteratorTest extends HtsjdkTest {
 
         final SamReader samReader = SamReaderFactory.makeDefault().open(samFile);
         final SamLocusIterator samLocusIterator = new SamLocusIterator(samReader);
-        final SamLocusAndReferenceIterator shouldThrow = new SamLocusAndReferenceIterator(referenceSequenceFileWalker, samLocusIterator);
+        new SamLocusAndReferenceIterator(referenceSequenceFileWalker, samLocusIterator); // should throw
     }
 }

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
@@ -139,7 +139,6 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
     @Test public void testOverflow() throws Exception {
         final File f = File.createTempFile("BCOST.", ".gz");
         f.deleteOnExit();
-        final List<String> linesWritten = new ArrayList<>();
         System.out.println("Creating file " + f);
         final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(f);
         Random r = new Random(15555);

--- a/src/test/java/htsjdk/samtools/util/CigarElementUnitTest.java
+++ b/src/test/java/htsjdk/samtools/util/CigarElementUnitTest.java
@@ -12,7 +12,7 @@ public class CigarElementUnitTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNegativeLengthCheck(){
-        final CigarElement element = new CigarElement(-1, CigarOperator.M);
+        new CigarElement(-1, CigarOperator.M);
     }
 
 

--- a/src/test/java/htsjdk/tribble/index/interval/IntervalTreeTest.java
+++ b/src/test/java/htsjdk/tribble/index/interval/IntervalTreeTest.java
@@ -28,7 +28,7 @@ import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.io.BufferedReader;
@@ -45,10 +45,10 @@ import java.util.Set;
  */
 public class IntervalTreeTest extends HtsjdkTest {
 
-    static IntervalTree tree;
+    private IntervalTree tree;
 
-    @BeforeClass
-    public static void setupTree() {
+    @BeforeTest
+    public void setupTree() {
         tree = new IntervalTree();
         tree.insert(new Interval(0, 3, null));
         tree.insert(new Interval(5, 8, null));

--- a/src/test/java/htsjdk/variant/bcf2/BCF2EncoderDecoderUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2EncoderDecoderUnitTest.java
@@ -377,7 +377,6 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
 
     @Test(dataProvider = "BestIntTypeTests")
     public void determineBestEncoding(final List<Integer> ints, final BCF2Type expectedType) throws IOException {
-        BCF2Encoder encoder = new BCF2Encoder();
         Assert.assertEquals(BCF2Utils.determineIntegerType(ints), expectedType);
         Assert.assertEquals(BCF2Utils.determineIntegerType(toPrimitive(ints.toArray(new Integer[0]))), expectedType);
     }

--- a/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
@@ -39,7 +39,7 @@ public class VCFCompoundHeaderLineUnitTest extends VariantBaseTest {
     @Test
     public void supportsVersionFields() {
 	final String line = "<ID=FOO,Number=1,Type=Float,Description=\"foo\",Version=3>";
-	final VCFCompoundHeaderLine headerline = new VCFInfoHeaderLine(line, VCFHeaderVersion.VCF4_2);
+	new VCFInfoHeaderLine(line, VCFHeaderVersion.VCF4_2);
 	// if we don't support version fields then we should fail before we ever get here
 	Assert.assertTrue(true);
     }

--- a/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
@@ -38,9 +38,9 @@ public class VCFCompoundHeaderLineUnitTest extends VariantBaseTest {
 
     @Test
     public void supportsVersionFields() {
-	final String line = "<ID=FOO,Number=1,Type=Float,Description=\"foo\",Version=3>";
-	new VCFInfoHeaderLine(line, VCFHeaderVersion.VCF4_2);
-	// if we don't support version fields then we should fail before we ever get here
-	Assert.assertTrue(true);
+        final String line = "<ID=FOO,Number=1,Type=Float,Description=\"foo\",Version=3>";
+        new VCFInfoHeaderLine(line, VCFHeaderVersion.VCF4_2);
+        // if we don't support version fields then we should fail before we ever get here
+        Assert.assertTrue(true);
     }
 }

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -51,6 +51,7 @@ import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Created by IntelliJ IDEA.
@@ -175,10 +176,15 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertTrue(header.getMetaDataInInputOrder().contains(infoLine), "TestInfoLine not found in set of all header lines");
         Assert.assertNotNull(header.getInfoHeaderLine("TestInfoLine"), "Lookup for TestInfoLine by key failed");
 
-        Assert.assertFalse(header.getFormatHeaderLines().contains(infoLine), "TestInfoLine present in format header lines");
-        Assert.assertFalse(header.getFilterLines().contains(infoLine), "TestInfoLine present in filter header lines");
-        Assert.assertFalse(header.getContigLines().contains(infoLine), "TestInfoLine present in contig header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getFormatHeaderLines()).contains(infoLine), "TestInfoLine present in format header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getFilterLines()).contains(infoLine), "TestInfoLine present in filter header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getContigLines()).contains(infoLine), "TestInfoLine present in contig header lines");
         Assert.assertFalse(header.getOtherHeaderLines().contains(infoLine), "TestInfoLine present in other header lines");
+    }
+
+    private static <T extends VCFHeaderLine> Collection<VCFHeaderLine> asCollectionOfVCFHeaderLine(Collection<T> headers) {
+        // create a collection of VCFHeaderLine so that contains tests work correctly
+        return headers.stream().map(h -> (VCFHeaderLine) h).collect(Collectors.toList());
     }
 
     @Test
@@ -191,9 +197,9 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertTrue(header.getMetaDataInInputOrder().contains(formatLine), "TestFormatLine not found in set of all header lines");
         Assert.assertNotNull(header.getFormatHeaderLine("TestFormatLine"), "Lookup for TestFormatLine by key failed");
 
-        Assert.assertFalse(header.getInfoHeaderLines().contains(formatLine), "TestFormatLine present in info header lines");
-        Assert.assertFalse(header.getFilterLines().contains(formatLine), "TestFormatLine present in filter header lines");
-        Assert.assertFalse(header.getContigLines().contains(formatLine), "TestFormatLine present in contig header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getInfoHeaderLines()).contains(formatLine), "TestFormatLine present in info header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getFilterLines()).contains(formatLine), "TestFormatLine present in filter header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getContigLines()).contains(formatLine), "TestFormatLine present in contig header lines");
         Assert.assertFalse(header.getOtherHeaderLines().contains(formatLine), "TestFormatLine present in other header lines");
     }
 
@@ -209,9 +215,9 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertTrue(header.getMetaDataInInputOrder().contains(filterLine), "TestFilterLine not found in set of all header lines");
         Assert.assertNotNull(header.getFilterHeaderLine("TestFilterLine"), "Lookup for TestFilterLine by key failed");
 
-        Assert.assertFalse(header.getInfoHeaderLines().contains(filterLine), "TestFilterLine present in info header lines");
-        Assert.assertFalse(header.getFormatHeaderLines().contains(filterLine), "TestFilterLine present in format header lines");
-        Assert.assertFalse(header.getContigLines().contains(filterLine), "TestFilterLine present in contig header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getInfoHeaderLines()).contains(filterLine), "TestFilterLine present in info header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getFormatHeaderLines()).contains(filterLine), "TestFilterLine present in format header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getContigLines()).contains(filterLine), "TestFilterLine present in contig header lines");
         Assert.assertFalse(header.getOtherHeaderLines().contains(filterLine), "TestFilterLine present in other header lines");
     }
 
@@ -225,9 +231,9 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertTrue(header.getContigLines().contains(contigLine), "Test contig line not found in contig header lines");
         Assert.assertTrue(header.getMetaDataInInputOrder().contains(contigLine), "Test contig line not found in set of all header lines");
 
-        Assert.assertFalse(header.getInfoHeaderLines().contains(contigLine), "Test contig line present in info header lines");
-        Assert.assertFalse(header.getFormatHeaderLines().contains(contigLine), "Test contig line present in format header lines");
-        Assert.assertFalse(header.getFilterLines().contains(contigLine), "Test contig line present in filter header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getInfoHeaderLines()).contains(contigLine), "Test contig line present in info header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getFormatHeaderLines()).contains(contigLine), "Test contig line present in format header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getFilterLines()).contains(contigLine), "Test contig line present in filter header lines");
         Assert.assertFalse(header.getOtherHeaderLines().contains(contigLine), "Test contig line present in other header lines");
     }
 
@@ -281,10 +287,10 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertTrue(header.getMetaDataInInputOrder().contains(otherLine), "TestOtherLine not found in set of all header lines");
         Assert.assertNotNull(header.getOtherHeaderLine("TestOtherLine"), "Lookup for TestOtherLine by key failed");
 
-        Assert.assertFalse(header.getInfoHeaderLines().contains(otherLine), "TestOtherLine present in info header lines");
-        Assert.assertFalse(header.getFormatHeaderLines().contains(otherLine), "TestOtherLine present in format header lines");
-        Assert.assertFalse(header.getContigLines().contains(otherLine), "TestOtherLine present in contig header lines");
-        Assert.assertFalse(header.getFilterLines().contains(otherLine), "TestOtherLine present in filter header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getInfoHeaderLines()).contains(otherLine), "TestOtherLine present in info header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getFormatHeaderLines()).contains(otherLine), "TestOtherLine present in format header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getContigLines()).contains(otherLine), "TestOtherLine present in contig header lines");
+        Assert.assertFalse(asCollectionOfVCFHeaderLine(header.getFilterLines()).contains(otherLine), "TestOtherLine present in filter header lines");
     }
 
     @Test


### PR DESCRIPTION
copy of https://github.com/samtools/htsjdk/pull/1277 with a fix for the dataprovider meta test

Addresses #1267 for the tests (except for some valid violation that will be excluded in another PR).