### PR TITLE
SortingCollection logging should only be if DEBUG

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -505,7 +505,7 @@ public class SortingCollection<T> implements Iterable<T> {
         MergingIterator() {
             this.queue = new TreeSet<>(new PeekFileRecordIteratorComparator());
             int n = 0;
-            log.info(String.format("Creating merging iterator from %d files", files.size()));
+            log.debug(String.format("Creating merging iterator from %d files", files.size()));
             int suggestedBufferSize = checkMemoryAndAdjustBuffer(files.size());
             for (final Path f : files) {
                 final FileRecordIterator it = new FileRecordIterator(f, suggestedBufferSize);


### PR DESCRIPTION
### Description

A utility like SortingCollection should not fill log output with unnecessary output by default.  Caller can enable debug output if they want to see these messages.  We sometimes create a lot of SortingCollections, and these messages become annoying.

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

