### PR TITLE
Added fasta.gz write support to FastaReferenceWriterBuilder

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriter.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriter.java
@@ -123,8 +123,10 @@ public final class FastaReferenceWriter implements AutoCloseable {
 
     /**
      * Writer for the FAI index file.
+     *
+     * NOTE: GZI index writing (if necessary) is handled to BlockCompressedOutputStream class and thus is not controlled here.
      */
-    private final Writer indexWriter;
+    private final Writer faiIndexWriter;
 
     /**
      * Output writer to the output dictionary.
@@ -209,7 +211,7 @@ public final class FastaReferenceWriter implements AutoCloseable {
 
         this.defaultBasePerLine = basesPerLine;
         this.fastaStream = new CountingOutputStream(fastaOutput);
-        this.indexWriter = indexOutput == null ? NullWriter.NULL_WRITER : new OutputStreamWriter(indexOutput, CHARSET);
+        this.faiIndexWriter = indexOutput == null ? NullWriter.NULL_WRITER : new OutputStreamWriter(indexOutput, CHARSET);
         this.dictWriter = dictOutput == null ? NullWriter.NULL_WRITER : new OutputStreamWriter(dictOutput, CHARSET);
         this.dictCodec = new SAMSequenceDictionaryCodec(dictWriter);
         this.dictCodec.encodeHeaderLine(false);
@@ -440,7 +442,7 @@ public final class FastaReferenceWriter implements AutoCloseable {
 
     private void writeIndexEntry()
             throws IOException {
-        indexWriter.append(currentSequenceName).append(INDEX_FIELD_SEPARATOR_CHR)
+        faiIndexWriter.append(currentSequenceName).append(INDEX_FIELD_SEPARATOR_CHR)
                 .append(String.valueOf(currentBasesCount)).append(INDEX_FIELD_SEPARATOR_CHR)
                 .append(String.valueOf(currentSequenceOffset)).append(INDEX_FIELD_SEPARATOR_CHR)
                 .append(String.valueOf(currentBasesPerLine)).append(INDEX_FIELD_SEPARATOR_CHR)
@@ -635,7 +637,7 @@ public final class FastaReferenceWriter implements AutoCloseable {
             } finally {
                 closed = true;
                 fastaStream.close();
-                indexWriter.close();
+                faiIndexWriter.close();
                 dictWriter.close();
             }
         }

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriter.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriter.java
@@ -122,7 +122,7 @@ public final class FastaReferenceWriter implements AutoCloseable {
     private final CountingOutputStream fastaStream;
 
     /**
-     * Writer for the index file.
+     * Writer for the FAI index file.
      */
     private final Writer indexWriter;
 

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
@@ -50,7 +50,7 @@ import java.nio.file.Path;
  */
 public class FastaReferenceWriterBuilder {
     private Path fastaFile;
-    private boolean gzippedFastaFile = false;
+    private boolean gzippedFastaFile;
     private boolean makeGziOutput = true;
     private boolean makeFaiOutput = true;
     private boolean makeDictOutput = true;
@@ -121,20 +121,19 @@ public class FastaReferenceWriterBuilder {
      * @param makeDictOutput a boolean flag
      * @return this builder
      */
-
     public FastaReferenceWriterBuilder setMakeDictOutput(final boolean makeDictOutput) {
         this.makeDictOutput = makeDictOutput;
         return this;
     }
 
     /**
-     * Sets whether to automatically generate a gzi index file from the name of the fasta-file (assuming it is given
-     * a valid bgzipped as a file). This can only happen if both the index file and output stream have not been provided.
+     * Sets whether to automatically generate a gzi index file using an index file name derived from the name of
+     * the fasta-file (assuming the fasta file is a valid bgzipped file). This can only happen if neither an index file
+     * nor an index output stream are provided.
      *
      * @param makeGziOutput a boolean flag
      * @return this builder
      */
-
     public FastaReferenceWriterBuilder setMakeGziOutput(final boolean makeGziOutput) {
         this.makeGziOutput = makeGziOutput;
         return this;
@@ -182,9 +181,10 @@ public class FastaReferenceWriterBuilder {
 
     /**
      * Set the output stream for writing the reference. Doesn't support compressed streams.
-     *
+     * <p>
      * NOTE: If you would like to output a BlockCompressed fasta file it is recommended you use {@link #setFastaFile(Path)}
      *       as that codepath will handle generation of a gzi index automatically.
+     * </p>
      *
      * @param fastaOutput a {@link OutputStream} for the output fasta file.
      * @return this builder
@@ -199,9 +199,9 @@ public class FastaReferenceWriterBuilder {
     }
 
     /**
-     * Set the output stream for writing the index. Doesn't support compressed streams.
+     * Set the output stream for writing the index.
      *
-     * @param faiIndexOutput a  {@link OutputStream} for the output index.
+     * @param faiIndexOutput a  {@link OutputStream} for the output index. Doesn't support compressed streams.
      * @return this builder
      */
     public FastaReferenceWriterBuilder setIndexOutput(final OutputStream faiIndexOutput) {
@@ -211,9 +211,9 @@ public class FastaReferenceWriterBuilder {
     }
 
     /**
-     * Set the output stream for writing the index. Doesn't support compressed streams.
+     * Set the output stream for writing the index.
      *
-     * @param gziIndexOutput a  {@link OutputStream} for the gzi output index.
+     * @param gziIndexOutput a  {@link OutputStream} for the gzi output index. Doesn't support compressed streams.
      * @return this builder
      */
     public FastaReferenceWriterBuilder setGziIndexOutput(final OutputStream gziIndexOutput) {
@@ -223,9 +223,9 @@ public class FastaReferenceWriterBuilder {
     }
 
     /**
-     * Set the output stream for writing the dictionary. Doesn't support compressed streams.
+     * Set the output stream for writing the dictionary.
      *
-     * @param dictOutput a {@link OutputStream} for the output dictionary.
+     * @param dictOutput a {@link OutputStream} for the output dictionary. Doesn't support compressed streams.
      * @return this builder
      */
     public FastaReferenceWriterBuilder setDictOutput(final OutputStream dictOutput) {

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriterBuilder.java
@@ -265,7 +265,9 @@ public class FastaReferenceWriterBuilder {
             } else if (!gzippedFastaFile && (gziIndexFile != null || gziIndexOutput != null)) {
                 throw new IllegalArgumentException("Requested a gzi index but the output format fasta file was not a block compressed gzip file");
             }
-                //TODO Except if usere requests fai && gzippedOutputStream && noGZI
+            if (faiIndexFile != null && gzippedFastaFile && gziIndexFile == null) {
+                throw new IllegalArgumentException("Requested a fai index file for a block compressed output file. This index is unusable without a gzi index file as well");
+            }
 
         }
         // checkout bases-perline first, so that files are not created if failure;

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -260,7 +260,10 @@ public class BlockCompressedOutputStream
     }
 
     /**
-     * TODO comments here coming to a commit near you
+     * Adds a GZIIndexer to the block compressed output stream to be written to the specified output stream. See
+     * {@link GZIIndex} for details on the index. Note that the stream will be written to disk entirely when close()
+     * is called.
+     * @throws RuntimeException if attempting to add an indexer when this stream has already accepted input.
      */
     public void addIndexer(final OutputStream outputStream) {
         if (mBlockAddress != 0) {
@@ -412,13 +415,7 @@ public class BlockCompressedOutputStream
         }
 
         // Clear out from uncompressedBuffer the data that was written
-//        if (bytesToCompress == numUncompressedBytes) {
-            numUncompressedBytes = 0;
-//        } else {
-//            System.arraycopy(uncompressedBuffer, bytesToCompress, uncompressedBuffer, 0,
-//                    numUncompressedBytes - bytesToCompress);
-//            numUncompressedBytes -= bytesToCompress;
-//        }
+        numUncompressedBytes = 0;
         mBlockAddress += totalBlockSize;
         return totalBlockSize;
     }

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -114,6 +114,7 @@ public class BlockCompressedOutputStream
     private final CRC32 crc32 = new CRC32();
     private Path file = null;
     private long mBlockAddress = 0;
+    private GZIIndex.GZIIndexer indexer;
 
 
     // Really a local variable, but allocate once to reduce GC burden.
@@ -259,6 +260,16 @@ public class BlockCompressedOutputStream
     }
 
     /**
+     * TODO comments here coming to a commit near you
+     */
+    public void addIndexer(final OutputStream outputStream) {
+        if (mBlockAddress != 0) {
+            throw new RuntimeException("Cannot add gzi indexer if this BlockCompressedOutput stream has already written Gzipped blocks");
+        }
+        indexer = new GZIIndex.GZIIndexer(outputStream);
+    }
+
+    /**
      * Writes b.length bytes from the specified byte array to this output stream. The general contract for write(b)
      * is that it should have exactly the same effect as the call write(b, 0, b.length).
      * @param bytes the data
@@ -322,6 +333,9 @@ public class BlockCompressedOutputStream
         // }
         codec.writeBytes(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK);
         codec.close();
+        if (indexer != null) {
+            indexer.close();
+        }
         // Can't re-open something that is not a regular file, e.g. a named pipe or an output stream
         if (this.file == null || !Files.isRegularFile(this.file)) return;
         if (BlockCompressedInputStream.checkTermination(this.file) !=
@@ -392,14 +406,19 @@ public class BlockCompressedOutputStream
         final int totalBlockSize = writeGzipBlock(compressedSize, bytesToCompress, crc32.getValue());
         assert(bytesToCompress <= numUncompressedBytes);
 
-        // Clear out from uncompressedBuffer the data that was written
-        if (bytesToCompress == numUncompressedBytes) {
-            numUncompressedBytes = 0;
-        } else {
-            System.arraycopy(uncompressedBuffer, bytesToCompress, uncompressedBuffer, 0,
-                    numUncompressedBytes - bytesToCompress);
-            numUncompressedBytes -= bytesToCompress;
+        // Call out to the indexer if it exists
+        if (indexer != null) {
+            indexer.addGzipBlock(mBlockAddress, numUncompressedBytes);
         }
+
+        // Clear out from uncompressedBuffer the data that was written
+//        if (bytesToCompress == numUncompressedBytes) {
+            numUncompressedBytes = 0;
+//        } else {
+//            System.arraycopy(uncompressedBuffer, bytesToCompress, uncompressedBuffer, 0,
+//                    numUncompressedBytes - bytesToCompress);
+//            numUncompressedBytes -= bytesToCompress;
+//        }
         mBlockAddress += totalBlockSize;
         return totalBlockSize;
     }

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -263,7 +263,7 @@ public class BlockCompressedOutputStream
      * Adds a GZIIndexer to the block compressed output stream to be written to the specified output stream. See
      * {@link GZIIndex} for details on the index. Note that the stream will be written to disk entirely when close()
      * is called.
-     * @throws RuntimeException if attempting to add an indexer when this stream has already accepted input.
+     * @throws RuntimeException this method is called after output has already been written to the stream.
      */
     public void addIndexer(final OutputStream outputStream) {
         if (mBlockAddress != 0) {

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -226,7 +226,7 @@ public final class GZIIndex {
      *
      * @throws IOException if an I/O error occurs.
      */
-    void writeIndex(final OutputStream output) throws IOException {
+    public void writeIndex(final OutputStream output) throws IOException {
         if (output == null) {
             throw new IllegalArgumentException("null output path");
         }
@@ -434,10 +434,13 @@ public final class GZIIndex {
     }
 
     /**
+     * Helper class for constructing the GZIindex.
      *
+     * In order to construct a GZI index addGzipBlock() should be called every time a new Gzip Block is written out and
+     * the entire index will be written out when close() is called.
      */
     public static final class GZIIndexer implements Closeable {
-        private int uncompressedFileOffset = 0;
+        private int uncompressedFileOffset;
         private final OutputStream output;
         private final List<IndexEntry> entries = new ArrayList<>();
 

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -24,8 +24,7 @@
 
 package htsjdk.samtools.util;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.ByteChannel;
@@ -225,27 +224,27 @@ public final class GZIIndex {
      *
      * @throws IOException if an I/O error occurs.
      */
-    public void writeIndex(final Path output) throws IOException {
+    void writeIndex(final OutputStream output) throws IOException {
         if (output == null) {
             throw new IllegalArgumentException("null output path");
         }
+        BinaryCodec codec = new BinaryCodec(output);
 
         // the first entry is never written - 0, 0
         final int numberOfBlocksToWrite = entries.size();
 
-        final ByteBuffer buffer = allocateBuffer(numberOfBlocksToWrite, true);
         // put the number of entries
-        buffer.putLong(Integer.toUnsignedLong(numberOfBlocksToWrite));
+        codec.writeLong(Integer.toUnsignedLong(numberOfBlocksToWrite));
 
         // except the first, iterate over all the entries
         for (final IndexEntry entry : entries) {
             // implementation of entry ensures that the offsets are no negative
-            buffer.putLong(entry.getCompressedOffset());
-            buffer.putLong(entry.getUncompressedOffset());
+            codec.writeLong(entry.getCompressedOffset());
+            codec.writeLong(entry.getUncompressedOffset());
         }
 
         // write into the output
-        Files.write(output, buffer.array());
+        codec.close();
     }
 
     /**
@@ -360,7 +359,7 @@ public final class GZIIndex {
     /**
      * Builds a {@link GZIIndex} on the fly from a BGZIP file.
      *
-     * <p>Note that this method does not write the index on disk. Use {@link #writeIndex(Path)} on
+     * <p>Note that this method does not write the index on disk. Use {@link #writeIndex(OutputStream)} on
      * the returned object to save the index.
      *
      * @param bgzipFile the bgzip file.
@@ -389,6 +388,7 @@ public final class GZIIndex {
                     // gets the block address (compressed offset) - requires to parse with the file pointer utils
                     final long compressed = BlockCompressedFilePointerUtil.getBlockAddress(bgzipStream.getFilePointer());
                     // add a new IndexEntry
+                    //TODO unify this with the Indexer code
                     entries.add(new IndexEntry(compressed, currentOffset));
                 }
             }
@@ -413,7 +413,7 @@ public final class GZIIndex {
         }
         // build the index, write and return
         final GZIIndex index = buildIndex(bgzipFile);
-        index.writeIndex(indexFile);
+        index.writeIndex(new BufferedOutputStream(Files.newOutputStream(indexFile)));
         return index;
     }
 
@@ -430,5 +430,35 @@ public final class GZIIndex {
         size += numberOfEntries * 2 * Long.BYTES;
         // creates a byte buffer in little-endian
         return ByteBuffer.allocate(size).order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     *
+     */
+    public static final class GZIIndexer implements Closeable {
+        private int uncompressedFileOffset = 0;
+        private final OutputStream output;
+        private final List<IndexEntry> entries = new ArrayList<>();
+
+        public GZIIndexer(final OutputStream outputStream) {
+            output = outputStream;
+        }
+
+        public GZIIndexer(final Path outputFile) throws IOException {
+            output = Files.newOutputStream(outputFile);
+        }
+
+        // Adds a new index location given the compressed file offset and a running tally based on the uncompressed block sizes
+        public void addGzipBlock(final long compressedFileileOffset, final long uncompressedBlockSize) {
+            IndexEntry indexEntry = new IndexEntry(compressedFileileOffset, uncompressedFileOffset);
+            uncompressedFileOffset += uncompressedBlockSize;
+            entries.add(indexEntry);
+        }
+
+        @Override
+        public void close() throws IOException {
+            GZIIndex index = new GZIIndex(entries);
+            index.writeIndex(output);
+        }
     }
 }

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -220,6 +220,8 @@ public final class GZIIndex {
     /**
      * Writes this index into the requested path.
      *
+     * NOTE: This method will close out the provided output stream when it finishes writing the index
+     *
      * @param output the output file.
      *
      * @throws IOException if an I/O error occurs.
@@ -243,7 +245,7 @@ public final class GZIIndex {
             codec.writeLong(entry.getUncompressedOffset());
         }
 
-        // write into the output
+        // Close the codec to ensure the output is written
         codec.close();
     }
 
@@ -388,7 +390,6 @@ public final class GZIIndex {
                     // gets the block address (compressed offset) - requires to parse with the file pointer utils
                     final long compressed = BlockCompressedFilePointerUtil.getBlockAddress(bgzipStream.getFilePointer());
                     // add a new IndexEntry
-                    //TODO unify this with the Indexer code
                     entries.add(new IndexEntry(compressed, currentOffset));
                 }
             }
@@ -449,8 +450,8 @@ public final class GZIIndex {
         }
 
         // Adds a new index location given the compressed file offset and a running tally based on the uncompressed block sizes
-        public void addGzipBlock(final long compressedFileileOffset, final long uncompressedBlockSize) {
-            IndexEntry indexEntry = new IndexEntry(compressedFileileOffset, uncompressedFileOffset);
+        public void addGzipBlock(final long compressedFileOffset, final long uncompressedBlockSize) {
+            IndexEntry indexEntry = new IndexEntry(compressedFileOffset, uncompressedFileOffset);
             uncompressedFileOffset += uncompressedBlockSize;
             entries.add(indexEntry);
         }
@@ -458,7 +459,7 @@ public final class GZIIndex {
         @Override
         public void close() throws IOException {
             GZIIndex index = new GZIIndex(entries);
-            index.writeIndex(output);
+            index.writeIndex(output); //NOTE this relies on writeIndex closing the output stream for it
         }
     }
 }

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -220,8 +220,6 @@ public final class GZIIndex {
     /**
      * Writes this index into the requested path.
      *
-     * NOTE: This method will close out the provided output stream when it finishes writing the index
-     *
      * @param output the output path.
      *
      * @throws IOException if an I/O error occurs.

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -222,6 +222,19 @@ public final class GZIIndex {
      *
      * NOTE: This method will close out the provided output stream when it finishes writing the index
      *
+     * @param output the output path.
+     *
+     * @throws IOException if an I/O error occurs.
+     */
+    public void writeIndex(final Path output) throws IOException {
+        writeIndex(Files.newOutputStream(output));
+    }
+
+    /**
+     * Writes this index into the requested path.
+     *
+     * NOTE: This method will close out the provided output stream when it finishes writing the index
+     *
      * @param output the output file.
      *
      * @throws IOException if an I/O error occurs.

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -680,7 +680,7 @@ public class IOUtil {
     /**
      * check if the file name ends with .gz, .gzip, or .bfq
      */
-    private static boolean hasGzipFileExtension(Path path) {
+    public static boolean hasGzipFileExtension(Path path) {
         final List<String> gzippedEndings = Arrays.asList(".gz", ".gzip", ".bfq");
         final String fileName = path.getFileName().toString();
         return gzippedEndings.stream().anyMatch(fileName::endsWith);

--- a/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
@@ -193,14 +193,24 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testAddingGziIndexToNonBCFFile() throws IOException {
+    public void testAddingGziIndexToNonBlockCompressedFile() throws IOException {
         final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
         final Path testOutputGZI = File.createTempFile("fwr-test", ".fasta.gzi").toPath();
+        IOUtil.deleteOnExit(testOutputGZI);
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
 
         try (FastaReferenceWriter writer = new FastaReferenceWriterBuilder().setFastaFile(testOutput).setMakeFaiOutput(false).setMakeDictOutput(false).setGziIndexFile(testOutputGZI).build()) {
-            writer.startSequence(testOutput.toString());
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testAddingFaiIndexButNoGziIndex() throws IOException {
+        final Path testOutput = File.createTempFile("fwr-test", ".fasta.gz").toPath();
+        IOUtil.deleteOnExit(testOutput);
+        Files.delete(testOutput);
+
+        try (FastaReferenceWriter writer = new FastaReferenceWriterBuilder().setFastaFile(testOutput).setMakeFaiOutput(true).setMakeDictOutput(false).setMakeGziOutput(false).build()) {
         }
     }
 

--- a/src/test/java/htsjdk/samtools/util/GZIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/util/GZIIndexTest.java
@@ -71,7 +71,7 @@ public class GZIIndexTest extends HtsjdkTest {
         final GZIIndex index = GZIIndex.loadIndex(indexFile.toPath());
         final File temp = File.createTempFile("testWriteIndex", indexFile.getName());
         temp.deleteOnExit();
-        index.writeIndex(temp.toPath());
+        index.writeIndex(Files.newOutputStream(temp.toPath()));
 
         // test equal byte representation on disk
         final byte[] expected = Files.readAllBytes(indexFile.toPath());


### PR DESCRIPTION
Added the ability for the FastaReferenceWriterBuilder to emit block compressed output streams. Hooked up some basic checks for this into the existing test code as well.