### PR TITLE
Support writing a CRAI index from CRAMContainerStreamWriter

### DIFF
--- a/src/main/java/htsjdk/samtools/AbstractCRAMIndexer.java
+++ b/src/main/java/htsjdk/samtools/AbstractCRAMIndexer.java
@@ -1,0 +1,20 @@
+package htsjdk.samtools;
+
+import htsjdk.samtools.cram.structure.Container;
+
+/**
+ * Base class for indexing CRAM.
+ */
+public abstract class AbstractCRAMIndexer {
+    /**
+     * Create index entries for a single container.
+     * @param container the container to index
+     * @param validationStringency stringency for validating records, passed to {@link Container#getSpans(ValidationStringency)}
+     */
+    abstract void processContainer(final Container container, final ValidationStringency validationStringency);
+
+    /**
+     * Finish creating the index by writing the accumulated entries out.
+     */
+    public abstract void finish();
+}

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -79,7 +79,7 @@ import java.util.TreeSet;
  * but it is unused.  This would be accomplished via {@link #createIndex(SeekableStream, File, Log, ValidationStringency)}.
  *
  */
-public class CRAMBAIIndexer {
+public class CRAMBAIIndexer extends AbstractCRAMIndexer {
 
     // The number of references (chromosomes) in the BAM file
     private final int numReferences;

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -79,7 +79,7 @@ import java.util.TreeSet;
  * but it is unused.  This would be accomplished via {@link #createIndex(SeekableStream, File, Log, ValidationStringency)}.
  *
  */
-public class CRAMBAIIndexer extends AbstractCRAMIndexer {
+public class CRAMBAIIndexer implements CRAMIndexer {
 
     // The number of references (chromosomes) in the BAM file
     private final int numReferences;
@@ -130,7 +130,8 @@ public class CRAMBAIIndexer extends AbstractCRAMIndexer {
      *
      * @param container container to be indexed
      */
-    void processContainer(final Container container, final ValidationStringency validationStringency) {
+    @Override
+    public void processContainer(final Container container, final ValidationStringency validationStringency) {
         if (container == null || container.isEOF()) {
             return;
         }
@@ -226,6 +227,7 @@ public class CRAMBAIIndexer extends AbstractCRAMIndexer {
      * After all the slices have been processed, finish is called.
      * Writes any final information and closes the output file.
      */
+    @Override
     public void finish() {
         // process any remaining references
         advanceToReference(numReferences);

--- a/src/main/java/htsjdk/samtools/CRAMCRAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMCRAIIndexer.java
@@ -26,7 +26,7 @@ import java.util.zip.GZIPOutputStream;
  * <li>read an existing index from an input stream</li>
  * </ul><p>
  */
-public class CRAMCRAIIndexer {
+public class CRAMCRAIIndexer extends AbstractCRAMIndexer {
 
     final private CRAIIndex craiIndex = new CRAIIndex();
     final private GZIPOutputStream os;
@@ -70,6 +70,10 @@ public class CRAMCRAIIndexer {
      */
     public void processContainer(final Container container) {
         craiIndex.processContainer(container);
+    }
+
+    void processContainer(final Container container, final ValidationStringency validationStringency) {
+        processContainer(container);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/CRAMCRAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMCRAIIndexer.java
@@ -26,7 +26,7 @@ import java.util.zip.GZIPOutputStream;
  * <li>read an existing index from an input stream</li>
  * </ul><p>
  */
-public class CRAMCRAIIndexer extends AbstractCRAMIndexer {
+public class CRAMCRAIIndexer implements CRAMIndexer {
 
     final private CRAIIndex craiIndex = new CRAIIndex();
     final private GZIPOutputStream os;
@@ -72,13 +72,15 @@ public class CRAMCRAIIndexer extends AbstractCRAMIndexer {
         craiIndex.processContainer(container);
     }
 
-    void processContainer(final Container container, final ValidationStringency validationStringency) {
+    @Override
+    public void processContainer(final Container container, final ValidationStringency validationStringency) {
         processContainer(container);
     }
 
     /**
      * Finish creating the index by writing the accumulated entries out to the stream.
      */
+    @Override
     public void finish() {
         try {
             craiIndex.writeIndex(os);

--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -59,7 +59,7 @@ public class CRAMContainerStreamWriter {
     private Set<String> captureTags = new TreeSet<>();
     private Set<String> ignoreTags = new TreeSet<>();
 
-    private AbstractCRAMIndexer indexer;
+    private CRAMIndexer indexer;
     private long offset;
 
     /**
@@ -96,7 +96,7 @@ public class CRAMContainerStreamWriter {
             final CRAMReferenceSource source,
             final SAMFileHeader samFileHeader,
             final String cramId,
-            final AbstractCRAMIndexer indexer) {
+            final CRAMIndexer indexer) {
         this.outputStream = outputStream;
         this.source = source;
         this.samFileHeader = samFileHeader;

--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -59,7 +59,7 @@ public class CRAMContainerStreamWriter {
     private Set<String> captureTags = new TreeSet<>();
     private Set<String> ignoreTags = new TreeSet<>();
 
-    private CRAMBAIIndexer indexer;
+    private AbstractCRAMIndexer indexer;
     private long offset;
 
     /**
@@ -78,14 +78,31 @@ public class CRAMContainerStreamWriter {
             final CRAMReferenceSource source,
             final SAMFileHeader samFileHeader,
             final String cramId) {
+        this(outputStream, source, samFileHeader, cramId, indexStream == null ? null : new CRAMBAIIndexer(indexStream, samFileHeader));
+    }
+
+    /**
+     * Create a CRAMContainerStreamWriter for writing SAM records into a series of CRAM
+     * containers on output stream, with an optional index.
+     *
+     * @param outputStream where to write the CRAM stream.
+     * @param source reference source
+     * @param samFileHeader {@link SAMFileHeader} to be used. Sort order is determined by the sortOrder property of this arg.
+     * @param cramId used for display in error message display
+     * @param indexer CRAM indexer. Can be null if no index is required.
+     */
+    public CRAMContainerStreamWriter(
+            final OutputStream outputStream,
+            final CRAMReferenceSource source,
+            final SAMFileHeader samFileHeader,
+            final String cramId,
+            final AbstractCRAMIndexer indexer) {
         this.outputStream = outputStream;
+        this.source = source;
         this.samFileHeader = samFileHeader;
         this.cramID = cramId;
-        this.source = source;
+        this.indexer = indexer;
         containerFactory = new ContainerFactory(samFileHeader, recordsPerSlice);
-        if (indexStream != null) {
-            indexer = new CRAMBAIIndexer(indexStream, samFileHeader);
-        }
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/CRAMIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMIndexer.java
@@ -3,18 +3,18 @@ package htsjdk.samtools;
 import htsjdk.samtools.cram.structure.Container;
 
 /**
- * Base class for indexing CRAM.
+ * Interface for indexing CRAM.
  */
-public abstract class AbstractCRAMIndexer {
+public interface CRAMIndexer {
     /**
      * Create index entries for a single container.
      * @param container the container to index
      * @param validationStringency stringency for validating records, passed to {@link Container#getSpans(ValidationStringency)}
      */
-    abstract void processContainer(final Container container, final ValidationStringency validationStringency);
+    void processContainer(final Container container, final ValidationStringency validationStringency);
 
     /**
      * Finish creating the index by writing the accumulated entries out.
      */
-    public abstract void finish();
+    void finish();
 }


### PR DESCRIPTION
### Description

This is to make it possible to write CRAI indexes from `CRAMContainerStreamWriter`, not just BAI indexes (as is the case currently). This is needed by https://github.com/disq-bio/disq/pull/97.

This PR introduces `AbstractCRAMIndexer` that is the common base class of `CRAMBAIIndexer` and `CRAMCRAIIndexer`; and adds a constructor to `CRAMContainerStreamWriter` that takes an `AbstractCRAMIndexer`. 

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

