### PR TITLE
- Add a function to calculate the value of the OA tag

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -231,16 +231,17 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             rec.setReferenceIndex(contig);
             rec.setAlignmentStart(start);
         }
-        if (!recordUnmapped) {
+        rec.setReadUnmappedFlag(recordUnmapped);
+        if (recordUnmapped) {
+            rec.setMappingQuality(SAMRecord.NO_MAPPING_QUALITY);
+        } else {
             rec.setReadNegativeStrandFlag(negativeStrand);
             if (null != cigar) {
                 rec.setCigarString(cigar);
             } else if (!rec.getReadUnmappedFlag()) {
                 rec.setCigarString(readLength + "M");
             }
-            rec.setMappingQuality(255);
-        } else {
-            rec.setReadUnmappedFlag(true);
+            rec.setMappingQuality(SAMRecord.UNKNOWN_MAPPING_QUALITY);
         }
         rec.setAttribute(SAMTag.RG.name(), READ_GROUP_ID);
 
@@ -371,7 +372,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         if (useNmFlag) {
             end1.setAttribute(ReservedTagConstants.NM, 0);
         }
-        end1.setMappingQuality(255);
+        end1.setMappingQuality(SAMRecord.UNKNOWN_MAPPING_QUALITY);
         end1.setReadPairedFlag(true);
         end1.setProperPairFlag(true);
         end1.setFirstOfPairFlag(end1IsFirstOfPair);
@@ -393,7 +394,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         if (useNmFlag) {
             end2.setAttribute(ReservedTagConstants.NM, 0);
         }
-        end2.setMappingQuality(255);
+        end2.setMappingQuality(SAMRecord.UNKNOWN_MAPPING_QUALITY);
         end2.setReadPairedFlag(true);
         end2.setProperPairFlag(true);
         end2.setFirstOfPairFlag(!end1IsFirstOfPair);

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -1268,7 +1268,13 @@ public final class SAMUtils {
         return sequence.getSequenceLength() > GenomicIndexUtil.BIN_GENOMIC_SPAN;
     }
 
-    public static String calculateOATagValue(SAMRecord record){
+    /**
+     * Function to create the OA tag value from a record. The OA tag contains the mapping information
+     * of a record encoded as a comma-separated string (REF,POS,STRAND,CIGAR,MAPPING_QUALITY,NM_TAG_VALUE)
+     * @param record to use for generating the OA tag
+     * @return the OA tag string value
+     */
+    public static String calculateOATagValue(SAMRecord record) {
         if (record.getReferenceName().contains(",")) {
             throw new SAMException(String.format("Reference name for record %s contains a comma character.", record.getReadName()));
         }

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -30,6 +30,7 @@ import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.RuntimeEOFException;
 import htsjdk.samtools.util.StringUtil;
+import htsjdk.tribble.annotation.Strand;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
@@ -1264,5 +1266,27 @@ public final class SAMUtils {
      */
     public static boolean isReferenceSequenceIncompatibleWithBAI(final SAMSequenceRecord sequence) {
         return sequence.getSequenceLength() > GenomicIndexUtil.BIN_GENOMIC_SPAN;
+    }
+
+    public static String calculateOATagValue(SAMRecord record){
+        if (record.getReferenceName().contains(",")) {
+            throw new SAMException(String.format("Reference name for record %s contains a comma character.", record.getReadName()));
+        }
+        final String oaValue;
+        if (record.getReadUnmappedFlag()) {
+            oaValue = String.format("*,0,%s,*,%s,",
+                    record.getReadNegativeStrandFlag() ? Strand.NEGATIVE : Strand.POSITIVE,
+                    record.getMappingQuality());
+        } else {
+            oaValue = String.format("%s,%s,%s,%s,%s,%s",
+                    record.getReferenceName(),
+                    record.getAlignmentStart(),
+                    record.getReadNegativeStrandFlag() ? Strand.NEGATIVE : Strand.POSITIVE,
+                    record.getCigarString(),
+                    record.getMappingQuality(),
+                    Optional.ofNullable(record.getAttribute(SAMTag.NM.name())).orElse(""));
+        }
+        return oaValue;
+
     }
 }

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -25,6 +25,7 @@ package htsjdk.samtools.util;
 
 import htsjdk.samtools.*;
 import htsjdk.samtools.fastq.FastqConstants;
+import htsjdk.tribble.annotation.Strand;
 import htsjdk.utils.ValidationUtils;
 
 import java.io.File;
@@ -34,6 +35,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -35,7 +35,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION
The OA tag can be used to record the previous ("Original") alignment information in a SAM record. This PR add a method that will construct the contents of the OA tag from a record, to make the creation of the OA tag easy and uniform.