### PR TITLE
Improve exception message for unset VCF output type

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -459,9 +459,6 @@ public class VariantContextWriterBuilder {
                      "Output format type is not set, or could not be inferred from the output path. "
                      + "If a path was used, does it have a valid VCF extension, such as "
                      + String.join(", ", VCF_EXTENSIONS_LIST)
-                     + "? "
-                     + "Output path attempted: "
-                     + outPath.toString()
                 );
             case VCF:
                 if ((refDict == null) && (options.contains(Options.INDEX_ON_THE_FLY)))

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -453,7 +453,7 @@ public class VariantContextWriterBuilder {
 
         switch (typeToBuild) {
             case UNSPECIFIED:
-                throw new IllegalArgumentException("Must specify file or stream output type.");
+                throw new IllegalArgumentException("Output format type is not set, or could not be inferred from the output path. If a path was used, does it have a valid VCF extension?");
             case VCF:
                 if ((refDict == null) && (options.contains(Options.INDEX_ON_THE_FLY)))
                     throw new IllegalArgumentException("A reference dictionary is required for creating Tribble indices on the fly");

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -44,6 +44,8 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.util.EnumSet;
 
+import static htsjdk.samtools.util.IOUtil.VCF_EXTENSIONS_LIST;
+
 /*
  * Created with IntelliJ IDEA.
  * User: thibault
@@ -453,7 +455,14 @@ public class VariantContextWriterBuilder {
 
         switch (typeToBuild) {
             case UNSPECIFIED:
-                throw new IllegalArgumentException("Output format type is not set, or could not be inferred from the output path. If a path was used, does it have a valid VCF extension?");
+                throw new IllegalArgumentException(
+                     "Output format type is not set, or could not be inferred from the output path. "
+                     + "If a path was used, does it have a valid VCF extension, such as "
+                     + String.join(", ", VCF_EXTENSIONS_LIST)
+                     + "? "
+                     + "Output path attempted: "
+                     + outPath.toString()
+                );
             case VCF:
                 if ((refDict == null) && (options.contains(Options.INDEX_ON_THE_FLY)))
                     throw new IllegalArgumentException("A reference dictionary is required for creating Tribble indices on the fly");

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -457,8 +457,9 @@ public class VariantContextWriterBuilder {
             case UNSPECIFIED:
                 throw new IllegalArgumentException(
                      "Output format type is not set, or could not be inferred from the output path. "
-                     + "If a path was used, does it have a valid VCF extension, such as "
+                     + "If a path was used, does it have a valid VCF extension ("
                      + String.join(", ", VCF_EXTENSIONS_LIST)
+                     + ")?"
                 );
             case VCF:
                 if ((refDict == null) && (options.contains(Options.INDEX_ON_THE_FLY)))


### PR DESCRIPTION
### Description

I, and fellow developers, hit this exception when we've accidentally used an improper VCF extension in an output file path (our most common mistake is using `.gvcf`). I think the exception message needs to be improved so it is clear that Picard is dynamically changing output file type based on the extension of a file path in most cases.

I think the exception bites new users and could be improved so the issue is easier to resolve.

What do you think? Happy to amend!

Current behavior:

```
❯ picard VcfFormatConverter I=/dev/stdin O=demo.gvcf REQUIRE_INDEX=false

[Sun Apr 14 10:14:39 PDT 2019] picard.vcf.VcfFormatConverter INPUT=/dev/stdin OUTPUT=demo.gvcf REQUIRE_INDEX=false VALIDATION_STRINGENCY=SILENT CREATE_INDEX=true    VERBOSITY=INFO QUIET=false COMPRESSION_LEVEL=5 MAX_RECORDS_IN_RAM=500000 CREATE_MD5_FILE=false GA4GH_CLIENT_SECRETS=client_secrets.json USE_JDK_DEFLATER=false USE_JDK_INFLATER=false
[Sun Apr 14 10:14:39 PDT 2019] Executing as cvalentine@cvalentine.local on Mac OS X 10.14.3 x86_64; OpenJDK 64-Bit Server VM 1.8.0_152-release-1056-b12; Deflater: Intel; Inflater: Intel; Picard version: 2.10.6-SNAPSHOT
[Sun Apr 14 10:14:39 PDT 2019] picard.vcf.VcfFormatConverter done. Elapsed time: 0.02 minutes.
Runtime.totalMemory()=514850816
To get help, see http://broadinstitute.github.io/picard/index.html#GettingHelp
Exception in thread "main" java.lang.IllegalArgumentException: Must specify file or stream output type.
        at htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder.build(VariantContextWriterBuilder.java:423)
        at picard.vcf.VcfFormatConverter.doWork(VcfFormatConverter.java:114)
        at picard.cmdline.CommandLineProgram.instanceMain(CommandLineProgram.java:228)
        at picard.cmdline.PicardCommandLine.instanceMain(PicardCommandLine.java:94)
        at picard.cmdline.PicardCommandLine.main(PicardCommandLine.java:104)
```

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)