### PR TITLE
Change SAMTextHeaderCodec to no longer accumulate the entire text of …

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -187,16 +187,12 @@ public class BAMFileWriter extends SAMFileWriterImpl {
     }
 
     /**
-     * Writes a header to a BAM file. Might need to regenerate the String version of the header, if one already has both the
-     * samFileHeader and the String, use the version of this method which takes both.
+     * Writes a header to a BAM file.
      */
     protected static void writeHeader(final BinaryCodec outputBinaryCodec, final SAMFileHeader samFileHeader) {
-        // Do not use SAMFileHeader.getTextHeader() as it is not updated when changes to the underlying object are made
-        final String headerString;
         final Writer stringWriter = new StringWriter();
         new SAMTextHeaderCodec().encode(stringWriter, samFileHeader, true);
-        headerString = stringWriter.toString();
-
+        final String headerString = stringWriter.toString();
         writeHeader(outputBinaryCodec, samFileHeader, headerString);
     }
 

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -101,7 +101,6 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
     private final Map<String, SAMProgramRecord> mProgramRecordMap = new HashMap<>();
     private SAMSequenceDictionary mSequenceDictionary = new SAMSequenceDictionary();
     final private List<String> mComments = new ArrayList<>();
-    private String textHeader;
     private final List<SAMValidationError> mValidationErrors = new ArrayList<>();
 
     public SAMFileHeader() {
@@ -322,24 +321,11 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord
         super.setAttribute(key, tempVal);
     }
 
-    /**
-     * If this SAMHeader was read from a file, this property contains the header
-     * as it appeared in the file, otherwise it is null.  Note that this is not a toString()
-     * operation.  Changes to the SAMFileHeader object after reading from the file are not reflected in this value.
-     *
-     * In addition this value is only set if one of the following is true:
-     *   - The size of the header is < 1,048,576 characters (1MB ascii, 2MB unicode)
-     *   - There are either validation or parsing errors associated with the header
-     *
-     * Invalid header lines may appear in value but are not stored in the SAMFileHeader object.
-     */
-    public String getTextHeader() {
-        return textHeader;
-    }
+    /** @deprecated since May 1st 2019 - text version of header is no longer stored. */
+    @Deprecated public String getTextHeader() {  return null; }
 
-    public void setTextHeader(final String textHeader) {
-        this.textHeader = textHeader;
-    }
+    /** @deprecated since May 1st 2019 - text version of header is no longer stored. */
+    @Deprecated public void setTextHeader(final String textHeader) { }
 
     public List<String> getComments() {
         return Collections.unmodifiableList(mComments);


### PR DESCRIPTION
…the header into memory.

### Description

Accumulating the entire text of the header into memory is of questionable value and causes a) performance degradation in the best case and b) outright failure in the worst case.  In cases where the header text is longer than 2^31 characters the code fails outright.  

The changes made simply no longer accumulate the text.  Lines that have errors are recorded as validation errors already.  And if the full text is really needed, the user can take a look at their input file!

I've also deprecated the methods for getting and setting the entire header text on `SAMFileHeader`.
### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

