### PR TITLE
Moved loading of sequence dictionary into a separate, overriddeable me…

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -78,17 +78,14 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     /** Attempts to find and load the sequence dictionary if present. */
     protected SAMSequenceDictionary findAndLoadSequenceDictionary(final Path fasta) {
         final Path dictPath = findSequenceDictionary(path);
-        if (dictPath == null) {
-            return null;
+        if (dictPath == null) return null;
+
+        IOUtil.assertFileIsReadable(dictPath);
+        try (InputStream dictionaryIn = IOUtil.openFileForReading(dictPath)) {
+            return ReferenceSequenceFileFactory.loadDictionary(dictionaryIn);
         }
-        else {
-            IOUtil.assertFileIsReadable(dictPath);
-            try (InputStream dictionaryIn = IOUtil.openFileForReading(dictPath)) {
-                return ReferenceSequenceFileFactory.loadDictionary(dictionaryIn);
-            }
-            catch (Exception e) {
-                throw new SAMException("Could not open sequence dictionary file: " + dictPath, e);
-            }
+        catch (Exception e) {
+            throw new SAMException("Could not open sequence dictionary file: " + dictPath, e);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -90,6 +90,12 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
         }
     }
 
+    /** @deprecated use findSequenceDictionary(Path) instead. */
+    @Deprecated protected static File findSequenceDictionary(final File file) {
+        final Path dict = findSequenceDictionary(file.toPath());
+        return dict == null ? null : dict.toFile();
+    }
+
     /** Attempts to locate the sequence dictionary file adjacent to the reference fasta file. */
     protected static Path findSequenceDictionary(final Path fastaPath) {
         if (fastaPath == null) {

--- a/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -30,6 +30,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMTextHeaderCodec;
 import htsjdk.samtools.util.BufferedLineReader;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Lazy;
 
 import java.io.File;
 import java.io.InputStream;
@@ -43,7 +44,7 @@ import java.nio.file.Path;
 abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     private final Path path;
     private final String source;
-    protected SAMSequenceDictionary sequenceDictionary;
+    private final Lazy<SAMSequenceDictionary> dictionary;
 
     /**
      * Finds and loads the sequence file dictionary.
@@ -60,7 +61,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     AbstractFastaSequenceFile(final Path path) {
         this.path = path;
         this.source = path == null ? "unknown" : path.toAbsolutePath().toString();
-        this.sequenceDictionary = findAndLoadSequenceDictionary(path);
+        this.dictionary = new Lazy<>(() -> findAndLoadSequenceDictionary(path));
     }
 
     /**
@@ -72,7 +73,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     AbstractFastaSequenceFile(final Path path, final String source, final SAMSequenceDictionary sequenceDictionary) {
         this.path = path;
         this.source = source;
-        this.sequenceDictionary = sequenceDictionary;
+        this.dictionary = new Lazy<>(() -> sequenceDictionary);
     }
 
     /** Attempts to find and load the sequence dictionary if present. */
@@ -125,7 +126,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
      */
     @Override
     public SAMSequenceDictionary getSequenceDictionary() {
-        return this.sequenceDictionary;
+        return this.dictionary.get();
     }
 
     /** Returns the full path to the reference file. */

--- a/src/main/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFile.java
@@ -64,8 +64,8 @@ abstract class AbstractIndexedFastaSequenceFile extends AbstractFastaSequenceFil
         this.index = index;
         IOUtil.assertFileIsReadable(path);
         reset();
-        if(getSequenceDictionary() != null) {
-            sanityCheckDictionaryAgainstIndex(path.toAbsolutePath().toString(),sequenceDictionary,index);
+        if (getSequenceDictionary() != null) {
+            sanityCheckDictionaryAgainstIndex(path.toAbsolutePath().toString(), getSequenceDictionary(), index);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceFile.java
@@ -95,9 +95,8 @@ public class FastaSequenceFile extends AbstractFastaSequenceFile {
         }
 
         // Read the sequence
-        final int knownLength = (this.sequenceDictionary == null) ? -1 : this.sequenceDictionary.getSequence(this.sequenceIndex).getSequenceLength();
+        final int knownLength = (getSequenceDictionary() == null) ? -1 : getSequenceDictionary().getSequence(this.sequenceIndex).getSequenceLength();
         final byte[] bases = readSequence(knownLength);
-
         return new ReferenceSequence(name, this.sequenceIndex, bases);
     }
 


### PR DESCRIPTION
…thod.

### Description

In rare cases it may be desirable to either not load the sequence dictionary for a reference, or to customize how it's loaded.  The change here simply moves some code out of the constructor into a protected method that can be easily overridden to customize the behaviour.
### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

