### PR TITLE
add documention for VariantContext.getStart() regarding telomeric events

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1663,20 +1663,34 @@ public class VariantContext implements Feature, Serializable {
     }
 
     /**
-     * @return 1-based inclusive start position of the Variant
-     * INDEL events usually start on the first unaltered reference base before the INDEL.
+     * Returns 1-based inclusive start position of the variant, 0 or greater.
+     * See below for explanation on "0".
      *
-     * Note also that for the VCF spec allows 0 and N + 1 for POS field, where N is the length of the chromosome,
-     * for telomeric event.
+     * <p>
+     *     <strong>Warning:</strong>
+     *     be aware that the start position of the VariantContext is defined
+     *     in terms of the start position specified in the underlying vcf file,
+     *     VariantContexts representing the same biological event may have different
+     *     start positions depending on the specifics of the vcf file they are derived from.
+     * </p>
+     *
+     * <p>
+     *     INDEL events usually start on the first unaltered reference base before the INDEL.
+     * </p>
+     *
+     * <p>
+     *     Note also that the VCF spec allows 0 and N + 1 for POS field for telomeric event,
+     *     where N is the length of the chromosome.
+     *     The "0" value returned should be interpreted as telomere, and does not violate the above "1-based" comment.
+     *     It's the responsibility of code generating such variants to make sure {@code start} is populated correctly.
+     *     And code consuming the returned {@code start} should be prepared for such out-of-the-ordinary values.
+     * </p>
+     *
      * The given example is in section 5.4.5 (see example event illustrated in Figure 6 and VCF records below the figure).
      * Another possible scenario is when a telomere on the p-arm of a chromosome is deleted.
-     * In these cases, the "0" value returned should be interpreted as telomere, and does not violate the above "1-based" comment.
-     * It's the responsibility of code generating such variants to make sure {@code start} is populated correctly.
-     * And code consuming the returned {@code start} should be prepared for such out-of-the-ordinary values.
-     * 
-     * <strong>Warning:</strong> be aware that the start position of the VariantContext is defined in terms of the start position specified in the
-     * underlying vcf file, VariantContexts representing the same biological event may have different start positions depending on the
-     * specifics of the vcf file they are derived from
+     * In these cases, .
+     *
+     * @return 1-based inclusive start position of the Variant
      */
     @Override
     public int getStart() {

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1686,10 +1686,6 @@ public class VariantContext implements Feature, Serializable {
      *     And code consuming the returned {@code start} should be prepared for such out-of-the-ordinary values.
      * </p>
      *
-     * The given example is in section 5.4.5 (see example event illustrated in Figure 6 and VCF records below the figure).
-     * Another possible scenario is when a telomere on the p-arm of a chromosome is deleted.
-     * In these cases, .
-     *
      * @return 1-based inclusive start position of the Variant
      */
     @Override

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1664,7 +1664,15 @@ public class VariantContext implements Feature, Serializable {
 
     /**
      * @return 1-based inclusive start position of the Variant
-     * INDEL events usually start on the first unaltered reference base before the INDEL
+     * INDEL events usually start on the first unaltered reference base before the INDEL.
+     *
+     * Note also that for the VCF spec allows 0 and N + 1 for POS field, where N is the length of the chromosome,
+     * for telomeric event.
+     * The given example is in section 5.4.5 (see example event illustrated in Figure 6 and VCF records below the figure).
+     * Another possible scenario is when a telomere on the p-arm of a chromosome is deleted.
+     * In these cases, the "0" value returned should be interpreted as telomere, and does not violate the above "1-based" comment.
+     * It's the responsibility of code generating such variants to make sure {@code start} is populated correctly.
+     * And code consuming the returned {@code start} should be prepared for such out-of-the-ordinary values.
      * 
      * <strong>Warning:</strong> be aware that the start position of the VariantContext is defined in terms of the start position specified in the
      * underlying vcf file, VariantContexts representing the same biological event may have different start positions depending on the

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1663,8 +1663,11 @@ public class VariantContext implements Feature, Serializable {
     }
 
     /**
-     * Returns 1-based inclusive start position of the variant, 0 or greater.
-     * See below for explanation on "0".
+     * Returns 1-based inclusive start position of the variant.
+     *
+     * <p>
+     *     INDEL events usually start on the first unaltered reference base before the INDEL.
+     * </p>
      *
      * <p>
      *     <strong>Warning:</strong>
@@ -1675,18 +1678,14 @@ public class VariantContext implements Feature, Serializable {
      * </p>
      *
      * <p>
-     *     INDEL events usually start on the first unaltered reference base before the INDEL.
-     * </p>
-     *
-     * <p>
+     *     <strong>Warning:</strong>
      *     Note also that the VCF spec allows 0 and N + 1 for POS field for telomeric event,
      *     where N is the length of the chromosome.
      *     The "0" value returned should be interpreted as telomere, and does not violate the above "1-based" comment.
-     *     It's the responsibility of code generating such variants to make sure {@code start} is populated correctly.
-     *     And code consuming the returned {@code start} should be prepared for such out-of-the-ordinary values.
+     *     Code consuming the returned {@code start} should be prepared for such out-of-the-ordinary values.
      * </p>
      *
-     * @return 1-based inclusive start position of the Variant
+     * @return 0 or greater.
      */
     @Override
     public int getStart() {


### PR DESCRIPTION
### Description

The VCF spec allows `POS` column to take value 0 (or chromosome length + 1), when the event is at a telomere.

Currently the documentation for `public int VariantContext.getStart()` claims it returns a 1-based value, where it seems that 0 is an invalid value.

This PR intends to clarify that, by adding documentation.

### Checklist

(Documentation change, most of the following does not apply)

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

