### PR TITLE
Fix to ensure we only publish snapshots compiled with openjdk-8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,7 @@ after_success:
   - echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'";
     echo "JAVA_HOME='$JAVA_HOME'";
     if [ "$TRAVIS_BRANCH" == "master" ]; then
-       ./gradlew publish;
+        if [[ $JAVA_HOME = *java-8-openjdk* ]]; then
+            ./gradlew publish
+        fi
     fi


### PR DESCRIPTION
### Description

With the travis builds now running on multiple Java versions, whichever one finishes last wins at publishing the snapshot build.  This is problematic as there are situations where compiling on Java10 (targeting Java 1.8) still causes issues.  Specifically there are changes to `ByteBuffer` to make some methods return `ByteBuffer` where in Java 8 they returned `Buffer`, and at runtime this causes link/no-such-method problems running on Java 8!

The solution is only to publish if the Java Home is set to openjdk-8.

### Checklist

- [x] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

