### PR TITLE
Adding a few more semi-colons in shell in travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,6 @@ after_success:
     echo "JAVA_HOME='$JAVA_HOME'";
     if [ "$TRAVIS_BRANCH" == "master" ]; then
         if [[ $JAVA_HOME = *java-8-openjdk* ]]; then
-            ./gradlew publish
-        fi
-    fi
+            ./gradlew publish;
+        fi;
+    fi;


### PR DESCRIPTION
I think I missed a few semi-colons, I didn't realize I needed those on multi-line shell scripts in the travis config.  Going to merge this as it only tries to publish on master, and see if that fixes things.