### PR TITLE
There should be a constants class for file extensions

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/BAMFileReader.java
@@ -433,9 +433,9 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      */
     public SamIndexes getIndexType() {
         if (mIndexFile != null) {
-            if (mIndexFile.getName().toLowerCase().endsWith(BAMIndex.BAI_INDEX_SUFFIX)) {
+            if (mIndexFile.getName().toLowerCase().endsWith(FileExtensions.BAM_INDEX)) {
                 return SamIndexes.BAI;
-            } else if (mIndexFile.getName().toLowerCase().endsWith(BAMIndex.CSI_INDEX_SUFFIX)) {
+            } else if (mIndexFile.getName().toLowerCase().endsWith(FileExtensions.CSI)) {
                 return SamIndexes.CSI;
             }
 

--- a/src/main/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/BAMFileReader.java
@@ -433,7 +433,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      */
     public SamIndexes getIndexType() {
         if (mIndexFile != null) {
-            if (mIndexFile.getName().toLowerCase().endsWith(FileExtensions.BAM_INDEX)) {
+            if (mIndexFile.getName().toLowerCase().endsWith(FileExtensions.BAI_INDEX)) {
                 return SamIndexes.BAI;
             } else if (mIndexFile.getName().toLowerCase().endsWith(FileExtensions.CSI)) {
                 return SamIndexes.CSI;

--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.zip.DeflaterFactory;
@@ -109,9 +110,9 @@ public class BAMFileWriter extends SAMFileWriterImpl {
 
     private BAMIndexer createBamIndex(final String pathURI) {
         try {
-            final String indexFileBase = pathURI.endsWith(BamFileIoUtils.BAM_FILE_EXTENSION) ?
+            final String indexFileBase = pathURI.endsWith(FileExtensions.BAM) ?
                     pathURI.substring(0, pathURI.lastIndexOf('.')) : pathURI;
-            final Path indexPath = IOUtil.getPath(indexFileBase + BAMIndex.BAI_INDEX_SUFFIX);
+            final Path indexPath = IOUtil.getPath(indexFileBase + FileExtensions.BAM_INDEX);
             if (Files.exists(indexPath)) {
                 if (!Files.isWritable(indexPath)) {
                     throw new SAMException("Not creating BAM index since unable to write index file " + indexPath.toUri());

--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -112,7 +112,7 @@ public class BAMFileWriter extends SAMFileWriterImpl {
         try {
             final String indexFileBase = pathURI.endsWith(FileExtensions.BAM) ?
                     pathURI.substring(0, pathURI.lastIndexOf('.')) : pathURI;
-            final Path indexPath = IOUtil.getPath(indexFileBase + FileExtensions.BAM_INDEX);
+            final Path indexPath = IOUtil.getPath(indexFileBase + FileExtensions.BAI_INDEX);
             if (Files.exists(indexPath)) {
                 if (!Files.isWritable(indexPath)) {
                     throw new SAMException("Not creating BAM index since unable to write index file " + indexPath.toUri());

--- a/src/main/java/htsjdk/samtools/BAMIndex.java
+++ b/src/main/java/htsjdk/samtools/BAMIndex.java
@@ -25,6 +25,8 @@ package htsjdk.samtools;
 
 import java.io.Closeable;
 
+import htsjdk.samtools.util.FileExtensions;
+
 /**
  * A basic interface for querying BAM indices.
  *
@@ -34,12 +36,20 @@ import java.io.Closeable;
 public interface BAMIndex extends Closeable {
 
     /**
-     * @deprecated prefer {@link BAMIndex#BAI_INDEX_SUFFIX} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#BAM_INDEX} instead.
      */
     @Deprecated
-    String BAMIndexSuffix = ".bai";
-    String BAI_INDEX_SUFFIX = ".bai";
-    String CSI_INDEX_SUFFIX = ".csi";
+    String BAMIndexSuffix = FileExtensions.BAM_INDEX;
+    /**
+     * @deprecated since June 2019 Use {@link FileExtensions#BAM_INDEX} instead.
+     */
+    @Deprecated
+    String BAI_INDEX_SUFFIX = FileExtensions.BAM_INDEX;
+    /**
+     * @deprecated since June 2019 Use {@link FileExtensions#CSI} instead.
+     */
+    @Deprecated
+    String CSI_INDEX_SUFFIX = FileExtensions.CSI;
 
     /**
      * Gets the compressed chunks which should be searched for the contents of records contained by the span

--- a/src/main/java/htsjdk/samtools/BAMIndex.java
+++ b/src/main/java/htsjdk/samtools/BAMIndex.java
@@ -36,15 +36,15 @@ import htsjdk.samtools.util.FileExtensions;
 public interface BAMIndex extends Closeable {
 
     /**
-     * @deprecated since June 2019 Use {@link FileExtensions#BAM_INDEX} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#BAI_INDEX} instead.
      */
     @Deprecated
-    String BAMIndexSuffix = FileExtensions.BAM_INDEX;
+    String BAMIndexSuffix = FileExtensions.BAI_INDEX;
     /**
-     * @deprecated since June 2019 Use {@link FileExtensions#BAM_INDEX} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#BAI_INDEX} instead.
      */
     @Deprecated
-    String BAI_INDEX_SUFFIX = FileExtensions.BAM_INDEX;
+    String BAI_INDEX_SUFFIX = FileExtensions.BAI_INDEX;
     /**
      * @deprecated since June 2019 Use {@link FileExtensions#CSI} instead.
      */

--- a/src/main/java/htsjdk/samtools/BAMSBIIndexer.java
+++ b/src/main/java/htsjdk/samtools/BAMSBIIndexer.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.cram.io.InputStreamUtils;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeEOFException;
 
@@ -50,7 +51,7 @@ public final class BAMSBIIndexer {
      * @throws IOException as per java IO contract
      */
     public static void createIndex(final Path bamFile, final long granularity) throws IOException {
-        final Path splittingBaiFile = IOUtil.addExtension(bamFile, SBIIndex.FILE_EXTENSION);
+        final Path splittingBaiFile = IOUtil.addExtension(bamFile, FileExtensions.SBI);
         try (SeekableStream in = new SeekablePathStream(bamFile); OutputStream out = Files.newOutputStream(splittingBaiFile)) {
             createIndex(in, out, granularity);
         }

--- a/src/main/java/htsjdk/samtools/BamFileIoUtils.java
+++ b/src/main/java/htsjdk/samtools/BamFileIoUtils.java
@@ -5,7 +5,7 @@ import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.BlockCompressedStreamConstants;
 import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.IOExtensions;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.Md5CalculatingOutputStream;
@@ -23,10 +23,10 @@ public class BamFileIoUtils {
     private static final Log LOG = Log.getInstance(BamFileIoUtils.class);
 
     /**
-     * @deprecated Use {@link IOExtensions#BAM_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#BAM} instead.
      */
     @Deprecated
-    public static final String BAM_FILE_EXTENSION = IOExtensions.BAM_FILE_EXTENSION;
+    public static final String BAM_FILE_EXTENSION = FileExtensions.BAM;
 
     public static boolean isBamFile(final File file) {
         return ((file != null) && SamReader.Type.BAM_TYPE.hasValidFileExtension(file.getName()));
@@ -132,7 +132,7 @@ public class BamFileIoUtils {
             if (createMd5) out = new Md5CalculatingOutputStream(out, new File(output.getAbsolutePath() + ".md5"));
             File indexFile = null;
             if (createIndex) {
-                indexFile = new File(output.getParentFile(), IOUtil.basename(output) + BAMIndex.BAI_INDEX_SUFFIX);
+                indexFile = new File(output.getParentFile(), IOUtil.basename(output) + FileExtensions.BAM_INDEX);
                 out = new StreamInflatingIndexingOutputStream(out, indexFile);
             }
 
@@ -167,7 +167,7 @@ public class BamFileIoUtils {
             outputStream = new Md5CalculatingOutputStream(outputStream, new File(outputFile.getAbsolutePath() + ".md5"));
         }
         if (createIndex) {
-            outputStream = new StreamInflatingIndexingOutputStream(outputStream, new File(outputFile.getParentFile(), IOUtil.basename(outputFile) + BAMIndex.BAI_INDEX_SUFFIX));
+            outputStream = new StreamInflatingIndexingOutputStream(outputStream, new File(outputFile.getParentFile(), IOUtil.basename(outputFile) + FileExtensions.BAM_INDEX));
         }
         return outputStream;
     }

--- a/src/main/java/htsjdk/samtools/BamFileIoUtils.java
+++ b/src/main/java/htsjdk/samtools/BamFileIoUtils.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.BlockCompressedStreamConstants;
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.IOExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.Md5CalculatingOutputStream;
@@ -21,7 +22,11 @@ import java.util.List;
 public class BamFileIoUtils {
     private static final Log LOG = Log.getInstance(BamFileIoUtils.class);
 
-    public static final String BAM_FILE_EXTENSION = "." + SamReader.Type.BAM_TYPE.fileExtension();
+    /**
+     * @deprecated Use {@link IOExtensions#BAM_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String BAM_FILE_EXTENSION = IOExtensions.BAM_FILE_EXTENSION;
 
     public static boolean isBamFile(final File file) {
         return ((file != null) && SamReader.Type.BAM_TYPE.hasValidFileExtension(file.getName()));

--- a/src/main/java/htsjdk/samtools/BamFileIoUtils.java
+++ b/src/main/java/htsjdk/samtools/BamFileIoUtils.java
@@ -132,7 +132,7 @@ public class BamFileIoUtils {
             if (createMd5) out = new Md5CalculatingOutputStream(out, new File(output.getAbsolutePath() + ".md5"));
             File indexFile = null;
             if (createIndex) {
-                indexFile = new File(output.getParentFile(), IOUtil.basename(output) + FileExtensions.BAM_INDEX);
+                indexFile = new File(output.getParentFile(), IOUtil.basename(output) + FileExtensions.BAI_INDEX);
                 out = new StreamInflatingIndexingOutputStream(out, indexFile);
             }
 
@@ -167,7 +167,7 @@ public class BamFileIoUtils {
             outputStream = new Md5CalculatingOutputStream(outputStream, new File(outputFile.getAbsolutePath() + ".md5"));
         }
         if (createIndex) {
-            outputStream = new StreamInflatingIndexingOutputStream(outputStream, new File(outputFile.getParentFile(), IOUtil.basename(outputFile) + FileExtensions.BAM_INDEX));
+            outputStream = new StreamInflatingIndexingOutputStream(outputStream, new File(outputFile.getParentFile(), IOUtil.basename(outputFile) + FileExtensions.BAI_INDEX));
         }
         return outputStream;
     }

--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -17,7 +17,6 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.SAMFileHeader.SortOrder;
 import htsjdk.samtools.SamReader.Type;
-import htsjdk.samtools.cram.CRAIIndex;
 import htsjdk.samtools.cram.ref.CRAMReferenceSource;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.cram.structure.Container;
@@ -26,6 +25,7 @@ import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeEOFException;
 
@@ -277,7 +277,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
         if (mIndex == null) {
             final SAMSequenceDictionary dictionary = getFileHeader()
                     .getSequenceDictionary();
-            if (mIndexFile.getName().endsWith(BAMIndex.BAI_INDEX_SUFFIX)) {
+            if (mIndexFile.getName().endsWith(FileExtensions.BAM_INDEX)) {
                 mIndex = mEnableIndexCaching ? new CachingBAMFileIndex(mIndexFile,
                         dictionary, mEnableIndexMemoryMapping)
                         : new DiskBasedBAMFileIndex(mIndexFile, dictionary,
@@ -285,7 +285,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
                 return mIndex;
             }
 
-            if (!mIndexFile.getName().endsWith(CRAIIndex.CRAI_INDEX_SUFFIX)) return null;
+            if (!mIndexFile.getName().endsWith(FileExtensions.CRAM_INDEX)) return null;
             // convert CRAI into BAI:
             final SeekableStream baiStream;
             try {

--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -277,7 +277,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
         if (mIndex == null) {
             final SAMSequenceDictionary dictionary = getFileHeader()
                     .getSequenceDictionary();
-            if (mIndexFile.getName().endsWith(FileExtensions.BAM_INDEX)) {
+            if (mIndexFile.getName().endsWith(FileExtensions.BAI_INDEX)) {
                 mIndex = mEnableIndexCaching ? new CachingBAMFileIndex(mIndexFile,
                         dictionary, mEnableIndexMemoryMapping)
                         : new DiskBasedBAMFileIndex(mIndexFile, dictionary,

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -26,6 +26,7 @@ package htsjdk.samtools;
 import htsjdk.samtools.cram.ref.CRAMReferenceSource;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.Md5CalculatingOutputStream;
@@ -651,7 +652,7 @@ public class SAMFileWriterFactory implements Cloneable {
             if (!IOUtil.isRegularPath(outputFile)) {
                 log.warn("Cannot create index for CRAM because output file is not a regular file: " + outputFile.toUri());
             } else {
-                final Path indexPath = IOUtil.addExtension(outputFile, BAMIndex.BAI_INDEX_SUFFIX);
+                final Path indexPath = IOUtil.addExtension(outputFile, FileExtensions.BAM_INDEX);
                 try {
 
                     indexOS = Files.newOutputStream(indexPath) ;

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -652,7 +652,7 @@ public class SAMFileWriterFactory implements Cloneable {
             if (!IOUtil.isRegularPath(outputFile)) {
                 log.warn("Cannot create index for CRAM because output file is not a regular file: " + outputFile.toUri());
             } else {
-                final Path indexPath = IOUtil.addExtension(outputFile, FileExtensions.BAM_INDEX);
+                final Path indexPath = IOUtil.addExtension(outputFile, FileExtensions.BAI_INDEX);
                 try {
 
                     indexOS = Files.newOutputStream(indexPath) ;

--- a/src/main/java/htsjdk/samtools/SBIIndex.java
+++ b/src/main/java/htsjdk/samtools/SBIIndex.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
+import htsjdk.samtools.util.IOExtensions;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -113,7 +114,11 @@ public final class SBIIndex implements Serializable {
         }
     }
 
-    public static final String FILE_EXTENSION = ".sbi";
+    /**
+     * @deprecated Use {@link IOExtensions#SBI_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String FILE_EXTENSION = IOExtensions.SBI_FILE_EXTENSION;
 
     /**
      * SBI magic number.

--- a/src/main/java/htsjdk/samtools/SBIIndex.java
+++ b/src/main/java/htsjdk/samtools/SBIIndex.java
@@ -25,7 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
-import htsjdk.samtools.util.IOExtensions;
+import htsjdk.samtools.util.FileExtensions;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -115,10 +115,10 @@ public final class SBIIndex implements Serializable {
     }
 
     /**
-     * @deprecated Use {@link IOExtensions#SBI_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#SBI} instead.
      */
     @Deprecated
-    public static final String FILE_EXTENSION = IOExtensions.SBI_FILE_EXTENSION;
+    public static final String FILE_EXTENSION = FileExtensions.SBI;
 
     /**
      * SBI magic number.

--- a/src/main/java/htsjdk/samtools/SamFiles.java
+++ b/src/main/java/htsjdk/samtools/SamFiles.java
@@ -1,8 +1,7 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.cram.CRAIIndex;
-import htsjdk.samtools.cram.build.CramIO;
-
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import java.io.File;
@@ -67,9 +66,9 @@ public class SamFiles {
     private static Path lookForIndex(final Path samPath) {// If input is foo.bam, look for foo.bai or foo.csi
         Path indexPath;
         final String fileName = samPath.getFileName().toString(); // works for all path types (e.g. HDFS)
-        if (fileName.endsWith(BamFileIoUtils.BAM_FILE_EXTENSION)) {
-            final String bai = fileName.substring(0, fileName.length() - BamFileIoUtils.BAM_FILE_EXTENSION.length()) + BAMIndex.BAI_INDEX_SUFFIX;
-            final String csi = fileName.substring(0, fileName.length() - BamFileIoUtils.BAM_FILE_EXTENSION.length()) + BAMIndex.CSI_INDEX_SUFFIX;
+        if (fileName.endsWith(FileExtensions.BAM)) {
+            final String bai = fileName.substring(0, fileName.length() - FileExtensions.BAM.length()) + FileExtensions.BAM_INDEX;
+            final String csi = fileName.substring(0, fileName.length() - FileExtensions.BAM.length()) + FileExtensions.CSI;
             indexPath = samPath.resolveSibling(bai);
             if (Files.isRegularFile(indexPath)) { // works for all path types (e.g. HDFS)
                 return indexPath;
@@ -81,25 +80,25 @@ public class SamFiles {
             }
 
 
-        } else if (fileName.endsWith(CramIO.CRAM_FILE_EXTENSION)) {
-            final String crai = fileName.substring(0, fileName.length() - CramIO.CRAM_FILE_EXTENSION.length()) + CRAIIndex.CRAI_INDEX_SUFFIX;
+        } else if (fileName.endsWith(FileExtensions.CRAM)) {
+            final String crai = fileName.substring(0, fileName.length() - FileExtensions.CRAM.length()) + FileExtensions.CRAM_INDEX;
             indexPath = samPath.resolveSibling(crai);
             if (Files.isRegularFile(indexPath)) {
                 return indexPath;
             }
 
-            indexPath = samPath.resolveSibling(fileName + CRAIIndex.CRAI_INDEX_SUFFIX);
+            indexPath = samPath.resolveSibling(fileName + FileExtensions.CRAM_INDEX);
             if (Files.isRegularFile(indexPath)) {
                 return indexPath;
             }
         }
 
         // If foo.bai doesn't exist look for foo.bam.bai or foo.cram.bai
-        indexPath = samPath.resolveSibling(fileName + BAMIndex.BAI_INDEX_SUFFIX);
+        indexPath = samPath.resolveSibling(fileName + FileExtensions.BAM_INDEX);
         if (Files.isRegularFile(indexPath)) {
             return indexPath;
         } else {
-            indexPath = samPath.resolveSibling(fileName + BAMIndex.CSI_INDEX_SUFFIX);
+            indexPath = samPath.resolveSibling(fileName + FileExtensions.CSI);
             if (Files.isRegularFile(indexPath)) {
                 return indexPath;
             }

--- a/src/main/java/htsjdk/samtools/SamFiles.java
+++ b/src/main/java/htsjdk/samtools/SamFiles.java
@@ -67,7 +67,7 @@ public class SamFiles {
         Path indexPath;
         final String fileName = samPath.getFileName().toString(); // works for all path types (e.g. HDFS)
         if (fileName.endsWith(FileExtensions.BAM)) {
-            final String bai = fileName.substring(0, fileName.length() - FileExtensions.BAM.length()) + FileExtensions.BAM_INDEX;
+            final String bai = fileName.substring(0, fileName.length() - FileExtensions.BAM.length()) + FileExtensions.BAI_INDEX;
             final String csi = fileName.substring(0, fileName.length() - FileExtensions.BAM.length()) + FileExtensions.CSI;
             indexPath = samPath.resolveSibling(bai);
             if (Files.isRegularFile(indexPath)) { // works for all path types (e.g. HDFS)
@@ -94,7 +94,7 @@ public class SamFiles {
         }
 
         // If foo.bai doesn't exist look for foo.bam.bai or foo.cram.bai
-        indexPath = samPath.resolveSibling(fileName + FileExtensions.BAM_INDEX);
+        indexPath = samPath.resolveSibling(fileName + FileExtensions.BAI_INDEX);
         if (Files.isRegularFile(indexPath)) {
             return indexPath;
         } else {

--- a/src/main/java/htsjdk/samtools/SamIndexes.java
+++ b/src/main/java/htsjdk/samtools/SamIndexes.java
@@ -3,6 +3,7 @@ package htsjdk.samtools;
 import htsjdk.samtools.cram.CRAIIndex;
 import htsjdk.samtools.seekablestream.SeekableBufferedStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.FileExtensions;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -16,10 +17,10 @@ import java.net.URL;
  * Created by vadim on 14/08/2015.
  */
 public enum SamIndexes {
-    BAI(BAMIndex.BAI_INDEX_SUFFIX, "BAI\1".getBytes()),
+    BAI(FileExtensions.BAM_INDEX, "BAI\1".getBytes()),
     // CRAI is gzipped text, so it's magic is same as {@link java.util.zip.GZIPInputStream.GZIP_MAGIC}
-    CRAI(CRAIIndex.CRAI_INDEX_SUFFIX, new byte[]{(byte) 0x1f, (byte) 0x8b}),
-    CSI(BAMIndex.CSI_INDEX_SUFFIX, "CSI\1".getBytes());
+    CRAI(FileExtensions.CRAM_INDEX, new byte[]{(byte) 0x1f, (byte) 0x8b}),
+    CSI(FileExtensions.CSI, "CSI\1".getBytes());
 
     public final String fileNameSuffix;
     public final byte[] magic;

--- a/src/main/java/htsjdk/samtools/SamIndexes.java
+++ b/src/main/java/htsjdk/samtools/SamIndexes.java
@@ -17,7 +17,7 @@ import java.net.URL;
  * Created by vadim on 14/08/2015.
  */
 public enum SamIndexes {
-    BAI(FileExtensions.BAM_INDEX, "BAI\1".getBytes()),
+    BAI(FileExtensions.BAI_INDEX, "BAI\1".getBytes()),
     // CRAI is gzipped text, so it's magic is same as {@link java.util.zip.GZIPInputStream.GZIP_MAGIC}
     CRAI(FileExtensions.CRAM_INDEX, new byte[]{(byte) 0x1f, (byte) 0x8b}),
     CSI(FileExtensions.CSI, "CSI\1".getBytes());

--- a/src/main/java/htsjdk/samtools/cram/CRAIIndex.java
+++ b/src/main/java/htsjdk/samtools/cram/CRAIIndex.java
@@ -9,6 +9,7 @@ import htsjdk.samtools.cram.structure.*;
 import htsjdk.samtools.cram.structure.Slice;
 import htsjdk.samtools.seekablestream.SeekableMemoryStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.RuntimeIOException;
 
 import java.io.*;
@@ -19,7 +20,11 @@ import java.util.stream.Collectors;
  * CRAI index used for CRAM files.
  */
 public class CRAIIndex {
-    public static final String CRAI_INDEX_SUFFIX = ".crai";
+    /**
+     * @deprecated since June 2019 Use {@link FileExtensions#CRAM_INDEX} instead.
+     */
+    @Deprecated
+    public static final String CRAI_INDEX_SUFFIX = FileExtensions.CRAM_INDEX;
     final private List<CRAIEntry> entries = new ArrayList<>();
 
     /**

--- a/src/main/java/htsjdk/samtools/cram/build/CramIO.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramIO.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.cram.structure.block.Block;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BufferedLineReader;
+import htsjdk.samtools.util.IOExtensions;
 import htsjdk.samtools.util.LineReader;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
@@ -51,7 +52,12 @@ import java.util.Arrays;
  * A collection of methods to open and close CRAM files.
  */
 public class CramIO {
-    public static final String CRAM_FILE_EXTENSION = ".cram";
+
+    /**
+     * @deprecated Use {@link IOExtensions#CRAM_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String CRAM_FILE_EXTENSION = IOExtensions.CRAM_FILE_EXTENSION;
     /**
      * The 'zero-B' EOF marker as per CRAM specs v2.1. This is basically a serialized empty CRAM container with sequence id set to some
      * number to spell out 'EOF' in hex.

--- a/src/main/java/htsjdk/samtools/cram/build/CramIO.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CramIO.java
@@ -29,7 +29,7 @@ import htsjdk.samtools.cram.structure.block.Block;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BufferedLineReader;
-import htsjdk.samtools.util.IOExtensions;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.LineReader;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.RuntimeIOException;
@@ -54,10 +54,10 @@ import java.util.Arrays;
 public class CramIO {
 
     /**
-     * @deprecated Use {@link IOExtensions#CRAM_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#CRAM} instead.
      */
     @Deprecated
-    public static final String CRAM_FILE_EXTENSION = IOExtensions.CRAM_FILE_EXTENSION;
+    public static final String CRAM_FILE_EXTENSION = FileExtensions.CRAM;
     /**
      * The 'zero-B' EOF marker as per CRAM specs v2.1. This is basically a serialized empty CRAM container with sequence id set to some
      * number to spell out 'EOF' in hex.

--- a/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMTextHeaderCodec;
 import htsjdk.samtools.util.BufferedLineReader;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Lazy;
 
@@ -107,7 +108,7 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
             return dictionary;
         }
         // try without removing the file extension
-        final Path dictionaryExt = fastaPath.resolveSibling(fastaPath.getFileName().toString() + IOUtil.DICT_FILE_EXTENSION);
+        final Path dictionaryExt = fastaPath.resolveSibling(fastaPath.getFileName().toString() + FileExtensions.DICT);
         if (Files.exists(dictionaryExt)) {
             return dictionaryExt;
         }

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
@@ -32,6 +32,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMTextHeaderCodec;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BufferedLineReader;
+import htsjdk.samtools.util.IOExtensions;
 import htsjdk.samtools.util.IOUtil;
 
 import java.io.BufferedInputStream;
@@ -52,18 +53,18 @@ import java.util.Set;
  * @author Tim Fennell
  */
 public class ReferenceSequenceFileFactory {
-    public static final Set<String> FASTA_EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>() {{
-        add(".fasta");
-        add(".fasta.gz");
-        add(".fa");
-        add(".fa.gz");
-        add(".fna");
-        add(".fna.gz");
-        add(".txt");
-        add(".txt.gz");
-    }});
 
-    public static final String FASTA_INDEX_EXTENSION = ".fai";
+    /**
+     * @deprecated Use {@link IOExtensions#FASTA_EXTENSIONS} instead.
+     */
+    @Deprecated
+    public static final Set<String> FASTA_EXTENSIONS = IOExtensions.FASTA_EXTENSIONS;
+
+    /**
+     * @deprecated Use {@link IOExtensions#FASTA_INDEX_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String FASTA_INDEX_EXTENSION = IOExtensions.FASTA_INDEX_EXTENSION;
 
     /**
      * Attempts to determine the type of the reference file and return an instance

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
@@ -32,7 +32,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMTextHeaderCodec;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BufferedLineReader;
-import htsjdk.samtools.util.IOExtensions;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 
 import java.io.BufferedInputStream;
@@ -55,16 +55,16 @@ import java.util.Set;
 public class ReferenceSequenceFileFactory {
 
     /**
-     * @deprecated Use {@link IOExtensions#FASTA_EXTENSIONS} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#FASTA} instead.
      */
     @Deprecated
-    public static final Set<String> FASTA_EXTENSIONS = IOExtensions.FASTA_EXTENSIONS;
+    public static final Set<String> FASTA_EXTENSIONS = FileExtensions.FASTA;
 
     /**
-     * @deprecated Use {@link IOExtensions#FASTA_INDEX_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#FASTA_INDEX} instead.
      */
     @Deprecated
-    public static final String FASTA_INDEX_EXTENSION = IOExtensions.FASTA_INDEX_EXTENSION;
+    public static final String FASTA_INDEX_EXTENSION = FileExtensions.FASTA_INDEX;
 
     /**
      * Attempts to determine the type of the reference file and return an instance
@@ -221,7 +221,7 @@ public class ReferenceSequenceFileFactory {
     public static Path getDefaultDictionaryForReferenceSequence(final Path path) {
         final String name = path.getFileName().toString();
         final int extensionIndex = name.length() - getFastaExtension(path).length();
-        return path.resolveSibling(name.substring(0, extensionIndex) + IOUtil.DICT_FILE_EXTENSION);
+        return path.resolveSibling(name.substring(0, extensionIndex) + FileExtensions.DICT);
     }
 
     /**
@@ -249,7 +249,7 @@ public class ReferenceSequenceFileFactory {
      */
     public static String getFastaExtension(final Path path) {
         final String name = path.getFileName().toString();
-        return FASTA_EXTENSIONS.stream().filter(name::endsWith).findFirst()
+        return FileExtensions.FASTA.stream().filter(name::endsWith).findFirst()
                 .orElseGet(() -> {throw new IllegalArgumentException("File is not a supported reference file type: " + path.toAbsolutePath());});
     }
 
@@ -259,6 +259,6 @@ public class ReferenceSequenceFileFactory {
      * @param fastaFile the reference sequence file path.
      */
     public static Path getFastaIndexFileName(Path fastaFile) {
-        return fastaFile.resolveSibling(fastaFile.getFileName() + FASTA_INDEX_EXTENSION);
+        return fastaFile.resolveSibling(fastaFile.getFileName() + FileExtensions.FASTA_INDEX);
     }
 }

--- a/src/main/java/htsjdk/samtools/util/FileExtensions.java
+++ b/src/main/java/htsjdk/samtools/util/FileExtensions.java
@@ -66,7 +66,6 @@ public final class FileExtensions {
     public static final String COMPRESSED_VCF = ".vcf.gz";
     public static final String COMPRESSED_VCF_INDEX = ".tbi";
     public static final List<String> VCF_LIST = Collections.unmodifiableList(Arrays.asList(VCF, COMPRESSED_VCF, BCF));
-    public static final String[] VCF_ARRAY = VCF_LIST.toArray(new String[0]);
 
     public static final String INTERVAL_LIST = ".interval_list";
     public static final String DICT = ".dict";

--- a/src/main/java/htsjdk/samtools/util/FileExtensions.java
+++ b/src/main/java/htsjdk/samtools/util/FileExtensions.java
@@ -32,10 +32,10 @@ import java.util.Set;
 /**
  * Contains file extension constants for read, alignment, and variant files
  */
-public final class IOExtensions {
+public final class FileExtensions {
 
     /** extensions for read files and related formats. */
-    public static final Set<String> FASTA_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    public static final Set<String> FASTA = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
         ".fasta",
         ".fasta.gz",
         ".fa",
@@ -46,29 +46,33 @@ public final class IOExtensions {
         ".txt.gz"
     )));
         
-    public static final String FASTA_INDEX_EXTENSION = ".fai";
+    public static final String FASTA_INDEX = ".fai";
 
     /** extensions for alignment files SAM, BAM, CRAM. */
-    public static final String SAM_FILE_EXTENSION = ".sam";
-    public static final String BAM_FILE_EXTENSION = ".bam";
-    public static final String CRAM_FILE_EXTENSION = ".cram";
+    public static final String SAM = ".sam";
+    public static final String BAM = ".bam";
+    public static final String BAM_INDEX = ".bai";
+    public static final String CRAM = ".cram";
+    public static final String CRAM_INDEX = ".crai";
     
-    public static final String BED_EXTENSION = ".bed";
-    public static final String TABIX_STANDARD_INDEX_EXTENSION = ".tbi";
-    public static final String TRIBBLE_STANDARD_INDEX_EXTENSION = ".idx";
+    public static final String BED = ".bed";
+    public static final String TABIX_INDEX = ".tbi";
+    public static final String TRIBBLE_INDEX = ".idx";
 
     /** extensions for VCF files and related formats. */
-    public static final String VCF_FILE_EXTENSION = ".vcf";
-    public static final String VCF_INDEX_EXTENSION = TRIBBLE_STANDARD_INDEX_EXTENSION;
-    public static final String BCF_FILE_EXTENSION = ".bcf";
-    public static final String COMPRESSED_VCF_FILE_EXTENSION = ".vcf.gz";
-    public static final String COMPRESSED_VCF_INDEX_EXTENSION = ".tbi";
-    public static final List<String> VCF_EXTENSIONS_LIST = Collections.unmodifiableList(Arrays.asList(VCF_FILE_EXTENSION, COMPRESSED_VCF_FILE_EXTENSION, BCF_FILE_EXTENSION));
+    public static final String VCF = ".vcf";
+    public static final String VCF_INDEX = TRIBBLE_INDEX;
+    public static final String BCF = ".bcf";
+    public static final String COMPRESSED_VCF = ".vcf.gz";
+    public static final String COMPRESSED_VCF_INDEX = ".tbi";
+    public static final List<String> VCF_LIST = Collections.unmodifiableList(Arrays.asList(VCF, COMPRESSED_VCF, BCF));
+    public static final String[] VCF_ARRAY = VCF_LIST.toArray(new String[0]);
 
-    public static final String INTERVAL_LIST_FILE_EXTENSION = ".interval_list";
-    public static final String DICT_FILE_EXTENSION = ".dict";
-    public static final String GZI_DEFAULT_EXTENSION = ".gzi";
-    public static final String SBI_FILE_EXTENSION = ".sbi";
+    public static final String INTERVAL_LIST = ".interval_list";
+    public static final String DICT = ".dict";
+    public static final String GZI = ".gzi";
+    public static final String SBI = ".sbi";
+    public static final String CSI = ".csi";
 
-    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
+    public static final Set<String> BLOCK_COMPRESSED = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
 }

--- a/src/main/java/htsjdk/samtools/util/FileExtensions.java
+++ b/src/main/java/htsjdk/samtools/util/FileExtensions.java
@@ -51,7 +51,7 @@ public final class FileExtensions {
     /** extensions for alignment files SAM, BAM, CRAM. */
     public static final String SAM = ".sam";
     public static final String BAM = ".bam";
-    public static final String BAM_INDEX = ".bai";
+    public static final String BAI_INDEX = ".bai";
     public static final String CRAM = ".cram";
     public static final String CRAM_INDEX = ".crai";
     

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -54,7 +54,11 @@ import java.util.List;
 public final class GZIIndex {
 
     /** Default extension for the files storing a {@link GZIIndex}. */
-    public static final String DEFAULT_EXTENSION = ".gzi";
+    /**
+     * @deprecated Use {@link IOExtensions#GZI_DEFAULT_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String DEFAULT_EXTENSION = IOExtensions.GZI_DEFAULT_EXTENSION;
 
     /**
      * Index entry mapping the block-offset (compressed offset) to the uncompressed offset where the

--- a/src/main/java/htsjdk/samtools/util/GZIIndex.java
+++ b/src/main/java/htsjdk/samtools/util/GZIIndex.java
@@ -55,10 +55,10 @@ public final class GZIIndex {
 
     /** Default extension for the files storing a {@link GZIIndex}. */
     /**
-     * @deprecated Use {@link IOExtensions#GZI_DEFAULT_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#GZI} instead.
      */
     @Deprecated
-    public static final String DEFAULT_EXTENSION = IOExtensions.GZI_DEFAULT_EXTENSION;
+    public static final String DEFAULT_EXTENSION = FileExtensions.GZI;
 
     /**
      * Index entry mapping the block-offset (compressed offset) to the uncompressed offset where the
@@ -435,7 +435,7 @@ public final class GZIIndex {
 
     /** Gets the default index path for the bgzip file. */
     public static Path resolveIndexNameForBgzipFile(final Path bgzipFile) {
-        return bgzipFile.resolveSibling(bgzipFile.getFileName().toString() + DEFAULT_EXTENSION);
+        return bgzipFile.resolveSibling(bgzipFile.getFileName().toString() + FileExtensions.GZI);
     }
 
     // helper method for allocate a buffer for read/write

--- a/src/main/java/htsjdk/samtools/util/IOExtensions.java
+++ b/src/main/java/htsjdk/samtools/util/IOExtensions.java
@@ -30,8 +30,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Miscellaneous stateless static IO-oriented methods.
- *  Also used for utility methods that wrap or aggregate functionality in Java IO.
+ * Contains file extension constants for read, alignment, and variant files
  */
 public class IOExtensions {
 

--- a/src/main/java/htsjdk/samtools/util/IOExtensions.java
+++ b/src/main/java/htsjdk/samtools/util/IOExtensions.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.util;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Miscellaneous stateless static IO-oriented methods.
+ *  Also used for utility methods that wrap or aggregate functionality in Java IO.
+ */
+public class IOExtensions {
+
+    /** extensions for read files and related formats. */
+    public static final Set<String> FASTA_EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>() {{
+        add(".fasta");
+        add(".fasta.gz");
+        add(".fa");
+        add(".fa.gz");
+        add(".fna");
+        add(".fna.gz");
+        add(".txt");
+        add(".txt.gz");
+    }});
+    public static final String FASTA_INDEX_EXTENSION = ".fai";
+
+    /** extensions for alignment files SAM, BAM, CRAM. */
+    public static final String SAM_FILE_EXTENSION = ".sam";
+    public static final String BAM_FILE_EXTENSION = ".bam";
+    public static final String CRAM_FILE_EXTENSION = ".cram";
+    
+    public static final String BED_EXTENSION = ".bed";
+    public static final String TABIX_STANDARD_INDEX_EXTENSION = ".tbi";
+    public final static String TRIBBLE_STANDARD_INDEX_EXTENSION = ".idx";
+
+    /** extensions for VCF files and related formats. */
+    public static final String VCF_FILE_EXTENSION = ".vcf";
+    public static final String VCF_INDEX_EXTENSION = TRIBBLE_STANDARD_INDEX_EXTENSION;
+    public static final String BCF_FILE_EXTENSION = ".bcf";
+    public static final String COMPRESSED_VCF_FILE_EXTENSION = ".vcf.gz";
+    public static final String COMPRESSED_VCF_INDEX_EXTENSION = ".tbi";
+    public static final List<String> VCF_EXTENSIONS_LIST = Collections.unmodifiableList(Arrays.asList(VCF_FILE_EXTENSION, COMPRESSED_VCF_FILE_EXTENSION, BCF_FILE_EXTENSION));
+
+    public static final String INTERVAL_LIST_FILE_EXTENSION = ".interval_list";
+    public static final String DICT_FILE_EXTENSION = ".dict";
+    public static final String GZI_DEFAULT_EXTENSION = ".gzi";
+    public static final String SBI_FILE_EXTENSION = ".sbi";
+
+    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
+}

--- a/src/main/java/htsjdk/samtools/util/IOExtensions.java
+++ b/src/main/java/htsjdk/samtools/util/IOExtensions.java
@@ -32,19 +32,20 @@ import java.util.Set;
 /**
  * Contains file extension constants for read, alignment, and variant files
  */
-public class IOExtensions {
+public final class IOExtensions {
 
     /** extensions for read files and related formats. */
-    public static final Set<String> FASTA_EXTENSIONS = Collections.unmodifiableSet(new HashSet<String>() {{
-        add(".fasta");
-        add(".fasta.gz");
-        add(".fa");
-        add(".fa.gz");
-        add(".fna");
-        add(".fna.gz");
-        add(".txt");
-        add(".txt.gz");
-    }});
+    public static final Set<String> FASTA_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+        ".fasta",
+        ".fasta.gz",
+        ".fa",
+        ".fa.gz",
+        ".fna",
+        ".fna.gz",
+        ".txt",
+        ".txt.gz"
+    )));
+        
     public static final String FASTA_INDEX_EXTENSION = ".fai";
 
     /** extensions for alignment files SAM, BAM, CRAM. */
@@ -54,7 +55,7 @@ public class IOExtensions {
     
     public static final String BED_EXTENSION = ".bed";
     public static final String TABIX_STANDARD_INDEX_EXTENSION = ".tbi";
-    public final static String TRIBBLE_STANDARD_INDEX_EXTENSION = ".idx";
+    public static final String TRIBBLE_STANDARD_INDEX_EXTENSION = ".idx";
 
     /** extensions for VCF files and related formats. */
     public static final String VCF_FILE_EXTENSION = ".vcf";

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -94,30 +94,69 @@ public class IOUtil {
     public static final long TWO_GBS = 2 * ONE_GB;
     public static final long FIVE_GBS = 5 * ONE_GB;
 
-    public static final String VCF_FILE_EXTENSION = ".vcf";
-    public static final String VCF_INDEX_EXTENSION = Tribble.STANDARD_INDEX_EXTENSION;
-
-    public static final String BCF_FILE_EXTENSION = ".bcf";
-    public static final String COMPRESSED_VCF_FILE_EXTENSION = ".vcf.gz";
-    public static final String COMPRESSED_VCF_INDEX_EXTENSION = ".tbi";
+    /**
+     * @deprecated Use {@link IOExtensions#VCF_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String VCF_FILE_EXTENSION = IOExtensions.VCF_FILE_EXTENSION;
+    /**
+     * @deprecated Use {@link IOExtensions#VCF_INDEX_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String VCF_INDEX_EXTENSION = IOExtensions.VCF_INDEX_EXTENSION;
+    /**
+     * @deprecated Use {@link IOExtensions#BCF_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String BCF_FILE_EXTENSION = IOExtensions.BCF_FILE_EXTENSION;
+    /**
+     * @deprecated Use {@link IOExtensions#COMPRESSED_VCF_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String COMPRESSED_VCF_FILE_EXTENSION = IOExtensions.COMPRESSED_VCF_FILE_EXTENSION;
+    /**
+     * @deprecated Use {@link IOExtensions#COMPRESSED_VCF_INDEX_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String COMPRESSED_VCF_INDEX_EXTENSION = IOExtensions.COMPRESSED_VCF_INDEX_EXTENSION;
 
     /** Possible extensions for VCF files and related formats. */
-    public static final List<String> VCF_EXTENSIONS_LIST = Collections.unmodifiableList(Arrays.asList(VCF_FILE_EXTENSION, COMPRESSED_VCF_FILE_EXTENSION, BCF_FILE_EXTENSION));
+    /**
+     * @deprecated Use {@link IOExtensions#VCF_EXTENSIONS_LIST} instead.
+     */
+    @Deprecated
+    public static final List<String> VCF_EXTENSIONS_LIST = IOExtensions.VCF_EXTENSIONS_LIST;
 
     /**
      * Possible extensions for VCF files and related formats.
-     * @deprecated Use {@link #VCF_EXTENSIONS_LIST} instead.
+     * @deprecated Use {@link IOExtensions#VCF_EXTENSIONS_LIST} instead.
      */
     @Deprecated
     public static final String[] VCF_EXTENSIONS = VCF_EXTENSIONS_LIST.toArray(new String[0]);
 
-    public static final String INTERVAL_LIST_FILE_EXTENSION = IntervalList.INTERVAL_LIST_FILE_EXTENSION;
+    /**
+     * @deprecated Use {@link IOExtensions#INTERVAL_LIST_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String INTERVAL_LIST_FILE_EXTENSION = IOExtensions.INTERVAL_LIST_FILE_EXTENSION;
 
-    public static final String SAM_FILE_EXTENSION = ".sam";
+    /**
+     * @deprecated Use {@link IOExtensions#SAM_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String SAM_FILE_EXTENSION = IOExtensions.SAM_FILE_EXTENSION;
 
-    public static final String DICT_FILE_EXTENSION = ".dict";
+    /**
+     * @deprecated Use {@link IOExtensions#DICT_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String DICT_FILE_EXTENSION = IOExtensions.DICT_FILE_EXTENSION;
 
-    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(".gz", ".gzip", ".bgz", ".bgzf")));
+    /**
+     * @deprecated Use {@link IOExtensions#BLOCK_COMPRESSED_EXTENSIONS} instead.
+     */
+    @Deprecated
+    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = IOExtensions.BLOCK_COMPRESSED_EXTENSIONS;
 
     /** number of bytes that will be read for the GZIP-header in the function {@link #isGZIPInputStream(InputStream)} */
     public static final int GZIP_HEADER_READ_LENGTH = 8000;

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -95,68 +95,68 @@ public class IOUtil {
     public static final long FIVE_GBS = 5 * ONE_GB;
 
     /**
-     * @deprecated Use {@link IOExtensions#VCF_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#VCF} instead.
      */
     @Deprecated
-    public static final String VCF_FILE_EXTENSION = IOExtensions.VCF_FILE_EXTENSION;
+    public static final String VCF_FILE_EXTENSION = FileExtensions.VCF;
     /**
-     * @deprecated Use {@link IOExtensions#VCF_INDEX_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#VCF_INDEX} instead.
      */
     @Deprecated
-    public static final String VCF_INDEX_EXTENSION = IOExtensions.VCF_INDEX_EXTENSION;
+    public static final String VCF_INDEX_EXTENSION = FileExtensions.VCF_INDEX;
     /**
-     * @deprecated Use {@link IOExtensions#BCF_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#BCF} instead.
      */
     @Deprecated
-    public static final String BCF_FILE_EXTENSION = IOExtensions.BCF_FILE_EXTENSION;
+    public static final String BCF_FILE_EXTENSION = FileExtensions.BCF;
     /**
-     * @deprecated Use {@link IOExtensions#COMPRESSED_VCF_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#COMPRESSED_VCF} instead.
      */
     @Deprecated
-    public static final String COMPRESSED_VCF_FILE_EXTENSION = IOExtensions.COMPRESSED_VCF_FILE_EXTENSION;
+    public static final String COMPRESSED_VCF_FILE_EXTENSION = FileExtensions.COMPRESSED_VCF;
     /**
-     * @deprecated Use {@link IOExtensions#COMPRESSED_VCF_INDEX_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#COMPRESSED_VCF_INDEX} instead.
      */
     @Deprecated
-    public static final String COMPRESSED_VCF_INDEX_EXTENSION = IOExtensions.COMPRESSED_VCF_INDEX_EXTENSION;
+    public static final String COMPRESSED_VCF_INDEX_EXTENSION = FileExtensions.COMPRESSED_VCF_INDEX;
 
     /** Possible extensions for VCF files and related formats. */
     /**
-     * @deprecated Use {@link IOExtensions#VCF_EXTENSIONS_LIST} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#VCF_LIST} instead.
      */
     @Deprecated
-    public static final List<String> VCF_EXTENSIONS_LIST = IOExtensions.VCF_EXTENSIONS_LIST;
+    public static final List<String> VCF_EXTENSIONS_LIST = FileExtensions.VCF_LIST;
 
     /**
      * Possible extensions for VCF files and related formats.
-     * @deprecated Use {@link IOExtensions#VCF_EXTENSIONS_LIST} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#VCF_ARRAY} instead.
      */
     @Deprecated
-    public static final String[] VCF_EXTENSIONS = VCF_EXTENSIONS_LIST.toArray(new String[0]);
+    public static final String[] VCF_EXTENSIONS = FileExtensions.VCF_ARRAY;
 
     /**
-     * @deprecated Use {@link IOExtensions#INTERVAL_LIST_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#INTERVAL_LIST} instead.
      */
     @Deprecated
-    public static final String INTERVAL_LIST_FILE_EXTENSION = IOExtensions.INTERVAL_LIST_FILE_EXTENSION;
+    public static final String INTERVAL_LIST_FILE_EXTENSION = FileExtensions.INTERVAL_LIST;
 
     /**
-     * @deprecated Use {@link IOExtensions#SAM_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#SAM} instead.
      */
     @Deprecated
-    public static final String SAM_FILE_EXTENSION = IOExtensions.SAM_FILE_EXTENSION;
+    public static final String SAM_FILE_EXTENSION = FileExtensions.SAM;
 
     /**
-     * @deprecated Use {@link IOExtensions#DICT_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#DICT} instead.
      */
     @Deprecated
-    public static final String DICT_FILE_EXTENSION = IOExtensions.DICT_FILE_EXTENSION;
+    public static final String DICT_FILE_EXTENSION = FileExtensions.DICT;
 
     /**
-     * @deprecated Use {@link IOExtensions#BLOCK_COMPRESSED_EXTENSIONS} instead.
+     * @deprecated Use since June 2019 {@link FileExtensions#BLOCK_COMPRESSED} instead.
      */
     @Deprecated
-    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = IOExtensions.BLOCK_COMPRESSED_EXTENSIONS;
+    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = FileExtensions.BLOCK_COMPRESSED;
 
     /** number of bytes that will be read for the GZIP-header in the function {@link #isGZIPInputStream(InputStream)} */
     public static final int GZIP_HEADER_READ_LENGTH = 8000;
@@ -1316,7 +1316,7 @@ public class IOUtil {
     /**
      * Checks if the provided path is block-compressed (including extension).
      *
-     * <p>Note that block-compressed file extensions {@link #BLOCK_COMPRESSED_EXTENSIONS} are not
+     * <p>Note that block-compressed file extensions {@link FileExtensions#BLOCK_COMPRESSED} are not
      * checked by this method.
      *
      * @param path file to check if it is block-compressed.
@@ -1328,7 +1328,7 @@ public class IOUtil {
     }
 
     /**
-     * Checks if a file ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
+     * Checks if a file ends in one of the {@link FileExtensions#BLOCK_COMPRESSED}.
      *
      * @param fileName string name for the file. May be an HTTP/S url.
      *
@@ -1336,7 +1336,7 @@ public class IOUtil {
      */
     public static boolean hasBlockCompressedExtension (final String fileName) {
         String cleanedPath = stripQueryStringIfPathIsAnHttpUrl(fileName);
-        for (final String extension : BLOCK_COMPRESSED_EXTENSIONS) {
+        for (final String extension : FileExtensions.BLOCK_COMPRESSED) {
             if (cleanedPath.toLowerCase().endsWith(extension))
                 return true;
         }
@@ -1344,7 +1344,7 @@ public class IOUtil {
     }
 
     /**
-     * Checks if a path ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
+     * Checks if a path ends in one of the {@link FileExtensions#BLOCK_COMPRESSED}.
      *
      * @param path object to extract the name from.
      *
@@ -1355,7 +1355,7 @@ public class IOUtil {
     }
 
     /**
-     * Checks if a file ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
+     * Checks if a file ends in one of the {@link FileExtensions#BLOCK_COMPRESSED}.
      *
      * @param file object to extract the name from.
      *
@@ -1366,7 +1366,7 @@ public class IOUtil {
     }
 
     /**
-     * Checks if a file ends in one of the {@link #BLOCK_COMPRESSED_EXTENSIONS}.
+     * Checks if a file ends in one of the {@link FileExtensions#BLOCK_COMPRESSED}.
      *
      * @param uri file as an URI.
      *

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -129,10 +129,10 @@ public class IOUtil {
 
     /**
      * Possible extensions for VCF files and related formats.
-     * @deprecated since June 2019 Use {@link FileExtensions#VCF_ARRAY} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#VCF_LIST} instead.
      */
     @Deprecated
-    public static final String[] VCF_EXTENSIONS = FileExtensions.VCF_ARRAY;
+    public static final String[] VCF_EXTENSIONS = FileExtensions.VCF_LIST.toArray(new String[0]);
 
     /**
      * @deprecated since June 2019 Use {@link FileExtensions#INTERVAL_LIST} instead.

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -63,7 +63,11 @@ import java.util.Optional;
  * @author Yossi Farjoun
  */
 public class IntervalList implements Iterable<Interval> {
-    public static final String INTERVAL_LIST_FILE_EXTENSION = ".interval_list";
+    /**
+     * @deprecated Use {@link IOExtensions#INTERVAL_LIST_FILE_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String INTERVAL_LIST_FILE_EXTENSION = IOExtensions.INTERVAL_LIST_FILE_EXTENSION;
 
     private final SAMFileHeader header;
     private final List<Interval> intervals = new ArrayList<>();

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -64,10 +64,10 @@ import java.util.Optional;
  */
 public class IntervalList implements Iterable<Interval> {
     /**
-     * @deprecated Use {@link IOExtensions#INTERVAL_LIST_FILE_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#INTERVAL_LIST} instead.
      */
     @Deprecated
-    public static final String INTERVAL_LIST_FILE_EXTENSION = IOExtensions.INTERVAL_LIST_FILE_EXTENSION;
+    public static final String INTERVAL_LIST_FILE_EXTENSION = FileExtensions.INTERVAL_LIST;
 
     private final SAMFileHeader header;
     private final List<Interval> intervals = new ArrayList<>();

--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -18,6 +18,7 @@
 
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.util.ParsingUtils;
@@ -61,9 +62,9 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
 
     private static ComponentMethods methods = new ComponentMethods();
 
-    /** @deprecated use {@link IOUtil#BLOCK_COMPRESSED_EXTENSIONS} instead. */
+    /** @deprecated since June 2019 use {@link FileExtensions#BLOCK_COMPRESSED} instead. */
     @Deprecated
-    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = IOUtil.BLOCK_COMPRESSED_EXTENSIONS;
+    public static final Set<String> BLOCK_COMPRESSED_EXTENSIONS = FileExtensions.BLOCK_COMPRESSED;
 
     /**
      * Calls {@link #getFeatureReader(String, FeatureCodec, boolean)} with {@code requireIndex} = true
@@ -224,7 +225,7 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
 
     public static boolean isTabix(String resourcePath, String indexPath) throws IOException {
         if(indexPath == null){
-            indexPath = ParsingUtils.appendToPath(resourcePath, TabixUtils.STANDARD_INDEX_EXTENSION);
+            indexPath = ParsingUtils.appendToPath(resourcePath, FileExtensions.TABIX_INDEX);
         }
         return IOUtil.hasBlockCompressedExtension(resourcePath) && ParsingUtils.resourceExists(indexPath);
     }

--- a/src/main/java/htsjdk/tribble/Tribble.java
+++ b/src/main/java/htsjdk/tribble/Tribble.java
@@ -23,7 +23,7 @@
  */
 package htsjdk.tribble;
 
-import htsjdk.samtools.util.IOExtensions;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.tribble.util.TabixUtils;
 
@@ -37,10 +37,10 @@ public class Tribble {
     private Tribble() { } // can't be instantiated
 
     /**
-     * @deprecated Use {@link IOExtensions#TRIBBLE_STANDARD_INDEX_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#TRIBBLE_INDEX} instead.
      */
     @Deprecated
-    public final static String STANDARD_INDEX_EXTENSION = IOExtensions.TRIBBLE_STANDARD_INDEX_EXTENSION;
+    public final static String STANDARD_INDEX_EXTENSION = FileExtensions.TRIBBLE_INDEX;
 
     /**
      * Return the name of the index file for the provided {@code filename}
@@ -49,7 +49,7 @@ public class Tribble {
      * @return non-null String representing the index filename
      */
     public static String indexFile(final String filename) {
-        return indexFile(filename, STANDARD_INDEX_EXTENSION);
+        return indexFile(filename, FileExtensions.TRIBBLE_INDEX);
     }
 
     /**
@@ -59,7 +59,7 @@ public class Tribble {
      * @return a non-null File representing the index
      */
     public static File indexFile(final File file) {
-        return indexFile(file.getAbsoluteFile(), STANDARD_INDEX_EXTENSION);
+        return indexFile(file.getAbsoluteFile(), FileExtensions.TRIBBLE_INDEX);
     }
 
     /**
@@ -79,7 +79,7 @@ public class Tribble {
      * @return non-null String representing the index filename
      */
     public static String tabixIndexFile(final String filename) {
-        return indexFile(filename, TabixUtils.STANDARD_INDEX_EXTENSION);
+        return indexFile(filename, FileExtensions.TABIX_INDEX);
     }
 
     /**
@@ -89,7 +89,7 @@ public class Tribble {
      * @return a non-null File representing the index
      */
     public static File tabixIndexFile(final File file) {
-        return indexFile(file.getAbsoluteFile(), TabixUtils.STANDARD_INDEX_EXTENSION);
+        return indexFile(file.getAbsoluteFile(), FileExtensions.TABIX_INDEX);
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/Tribble.java
+++ b/src/main/java/htsjdk/tribble/Tribble.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.tribble;
 
+import htsjdk.samtools.util.IOExtensions;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.tribble.util.TabixUtils;
 
@@ -35,7 +36,11 @@ import java.nio.file.Path;
 public class Tribble {
     private Tribble() { } // can't be instantiated
 
-    public final static String STANDARD_INDEX_EXTENSION = ".idx";
+    /**
+     * @deprecated Use {@link IOExtensions#TRIBBLE_STANDARD_INDEX_EXTENSION} instead.
+     */
+    @Deprecated
+    public final static String STANDARD_INDEX_EXTENSION = IOExtensions.TRIBBLE_STANDARD_INDEX_EXTENSION;
 
     /**
      * Return the name of the index file for the provided {@code filename}

--- a/src/main/java/htsjdk/tribble/bed/BEDCodec.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDCodec.java
@@ -23,7 +23,7 @@
  */
 package htsjdk.tribble.bed;
 
-import htsjdk.samtools.util.IOExtensions;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.AsciiFeatureCodec;
@@ -45,10 +45,10 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
 
     /** Default extension for BED files. */
     /**
-     * @deprecated Use {@link IOExtensions#BED_EXTENSION} instead.
+     * @deprecated since June 2019 Use {@link FileExtensions#BED} instead.
      */
     @Deprecated
-    public static final String BED_EXTENSION = IOExtensions.BED_EXTENSION;
+    public static final String BED_EXTENSION = FileExtensions.BED;
 
     private static final Pattern SPLIT_PATTERN = Pattern.compile("\\t|( +)");
     private final int startOffsetValue;
@@ -240,7 +240,7 @@ public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
         } else {
             toDecode = path;
         }
-        return toDecode.toLowerCase().endsWith(BED_EXTENSION);
+        return toDecode.toLowerCase().endsWith(FileExtensions.BED);
     }
 
     public int getStartOffset() {

--- a/src/main/java/htsjdk/tribble/bed/BEDCodec.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDCodec.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.tribble.bed;
 
+import htsjdk.samtools.util.IOExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.AsciiFeatureCodec;
@@ -43,7 +44,11 @@ import java.util.regex.Pattern;
 public class BEDCodec extends AsciiFeatureCodec<BEDFeature> {
 
     /** Default extension for BED files. */
-    public static final String BED_EXTENSION = ".bed";
+    /**
+     * @deprecated Use {@link IOExtensions#BED_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String BED_EXTENSION = IOExtensions.BED_EXTENSION;
 
     private static final Pattern SPLIT_PATTERN = Pattern.compile("\\t|( +)");
     private final int startOffsetValue;

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -40,7 +40,6 @@ import htsjdk.tribble.index.tabix.TabixIndexCreator;
 import htsjdk.tribble.readers.*;
 import htsjdk.tribble.util.LittleEndianInputStream;
 import htsjdk.tribble.util.ParsingUtils;
-import htsjdk.tribble.util.TabixUtils;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -210,7 +209,7 @@ public class IndexFactory {
         if (indexFile.endsWith(".gz")) {
             return new GZIPInputStream(inputStreamInitial);
         }
-        else if (indexFile.endsWith(TabixUtils.STANDARD_INDEX_EXTENSION)) {
+        else if (indexFile.endsWith(FileExtensions.TABIX_INDEX)) {
             return new BlockCompressedInputStream(inputStreamInitial);
         }
         else {

--- a/src/main/java/htsjdk/tribble/readers/TabixReader.java
+++ b/src/main/java/htsjdk/tribble/readers/TabixReader.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.seekablestream.ISeekableStreamFactory;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.tribble.util.TabixUtils;
 
@@ -158,7 +159,7 @@ public class TabixReader {
         mFp = new BlockCompressedInputStream(stream);
         mIndexWrapper = indexWrapper;
         if(indexPath == null){
-            mIndexPath = ParsingUtils.appendToPath(filePath, TabixUtils.STANDARD_INDEX_EXTENSION);
+            mIndexPath = ParsingUtils.appendToPath(filePath, FileExtensions.TABIX_INDEX);
         } else {
             mIndexPath = indexPath;
         }

--- a/src/main/java/htsjdk/tribble/util/TabixUtils.java
+++ b/src/main/java/htsjdk/tribble/util/TabixUtils.java
@@ -23,10 +23,10 @@
  */
 package htsjdk.tribble.util;
 
-
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.IOExtensions;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.TabixReader;
 
@@ -40,7 +40,11 @@ import java.util.List;
  */
 public class TabixUtils {
 
-    public static final String STANDARD_INDEX_EXTENSION = ".tbi";
+    /**
+     * @deprecated Use {@link IOExtensions#TABIX_STANDARD_INDEX_EXTENSION} instead.
+     */
+    @Deprecated
+    public static final String STANDARD_INDEX_EXTENSION = IOExtensions.TABIX_STANDARD_INDEX_EXTENSION;
 
     public static class TPair64 implements Comparable<TPair64> {
         public long u, v;

--- a/src/main/java/htsjdk/tribble/util/TabixUtils.java
+++ b/src/main/java/htsjdk/tribble/util/TabixUtils.java
@@ -26,7 +26,7 @@ package htsjdk.tribble.util;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.BlockCompressedInputStream;
-import htsjdk.samtools.util.IOExtensions;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.TabixReader;
 
@@ -41,10 +41,10 @@ import java.util.List;
 public class TabixUtils {
 
     /**
-     * @deprecated Use {@link IOExtensions#TABIX_STANDARD_INDEX_EXTENSION} instead.
+     * @deprecated Use since June 2019 {@link FileExtensions#TABIX_INDEX} instead.
      */
     @Deprecated
-    public static final String STANDARD_INDEX_EXTENSION = IOExtensions.TABIX_STANDARD_INDEX_EXTENSION;
+    public static final String STANDARD_INDEX_EXTENSION = FileExtensions.TABIX_INDEX;
 
     public static class TPair64 implements Comparable<TPair64> {
         public long u, v;

--- a/src/main/java/htsjdk/variant/bcf2/BCF2Utils.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2Utils.java
@@ -25,7 +25,7 @@
 
 package htsjdk.variant.bcf2;
 
-import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.*;
 
@@ -184,10 +184,10 @@ public final class BCF2Utils {
      */
     public static final File shadowBCF(final File vcfFile) {
         final String path = vcfFile.getAbsolutePath();
-        if ( path.contains(IOUtil.VCF_FILE_EXTENSION) )
-            return new File(path.replace(IOUtil.VCF_FILE_EXTENSION, IOUtil.BCF_FILE_EXTENSION));
+        if ( path.contains(FileExtensions.VCF) )
+            return new File(path.replace(FileExtensions.VCF, FileExtensions.BCF));
         else {
-            final File bcf = new File( path + IOUtil.BCF_FILE_EXTENSION );
+            final File bcf = new File( path + FileExtensions.BCF );
             if ( bcf.canRead() )
                 return bcf;
             else {

--- a/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
+++ b/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
@@ -96,7 +96,7 @@ public class SAMSequenceDictionaryExtractor {
                 return SamReaderFactory.makeDefault().getFileHeader(sam).getSequenceDictionary();
             }
         },
-        VCF(FileExtensions.VCF_ARRAY) {
+        VCF(FileExtensions.VCF_LIST.toArray(new String[0])) {
 
             @Override
             SAMSequenceDictionary extractDictionary(final Path vcf) {

--- a/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
+++ b/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
@@ -48,7 +48,7 @@ import java.util.Optional;
 public class SAMSequenceDictionaryExtractor {
 
     enum TYPE {
-        FASTA(ReferenceSequenceFileFactory.FASTA_EXTENSIONS) {
+        FASTA(FileExtensions.FASTA) {
 
             @Override
             SAMSequenceDictionary extractDictionary(final Path reference) {
@@ -58,7 +58,7 @@ public class SAMSequenceDictionaryExtractor {
                 return dict;
             }
         },
-        DICTIONARY(IOUtil.DICT_FILE_EXTENSION) {
+        DICTIONARY(FileExtensions.DICT) {
 
             @Override
             SAMSequenceDictionary extractDictionary(final Path dictionary) {
@@ -72,7 +72,7 @@ public class SAMSequenceDictionaryExtractor {
                 }
             }
         },
-        CRAM(CramIO.CRAM_FILE_EXTENSION) {
+        CRAM(FileExtensions.CRAM) {
             
             @Override
             SAMSequenceDictionary extractDictionary(final Path cramPath) {
@@ -89,14 +89,14 @@ public class SAMSequenceDictionaryExtractor {
                 throw new SAMException(String.format("Can't retrieve sequence dictionary from %s", cramPath));
             }
         },
-        SAM(IOUtil.SAM_FILE_EXTENSION, BamFileIoUtils.BAM_FILE_EXTENSION) {
+        SAM(FileExtensions.SAM, FileExtensions.BAM) {
 
             @Override
             SAMSequenceDictionary extractDictionary(final Path sam) {
                 return SamReaderFactory.makeDefault().getFileHeader(sam).getSequenceDictionary();
             }
         },
-        VCF(IOUtil.VCF_EXTENSIONS) {
+        VCF(FileExtensions.VCF_ARRAY) {
 
             @Override
             SAMSequenceDictionary extractDictionary(final Path vcf) {
@@ -105,7 +105,7 @@ public class SAMSequenceDictionaryExtractor {
                 }
             }
         },
-        INTERVAL_LIST(IOUtil.INTERVAL_LIST_FILE_EXTENSION) {
+        INTERVAL_LIST(FileExtensions.INTERVAL_LIST) {
 
             @Override
             SAMSequenceDictionary extractDictionary(final Path intervalList) {

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -28,6 +28,7 @@ package htsjdk.variant.variantcontext.writer;
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Md5CalculatingOutputStream;
 import htsjdk.samtools.util.Log;
@@ -44,8 +45,6 @@ import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.util.EnumSet;
-
-import static htsjdk.samtools.util.IOUtil.VCF_EXTENSIONS_LIST;
 
 /*
  * Created with IntelliJ IDEA.
@@ -460,7 +459,7 @@ public class VariantContextWriterBuilder {
                 throw new IllegalArgumentException(
                      "Output format type is not set, or could not be inferred from the output path. "
                      + "If a path was used, does it have a valid VCF extension ("
-                     + String.join(", ", VCF_EXTENSIONS_LIST)
+                     + String.join(", ", FileExtensions.VCF_LIST)
                      + ")?"
                 );
             case VCF:
@@ -560,11 +559,11 @@ public class VariantContextWriterBuilder {
     }
 
     private static boolean isVCF(final Path outPath) {
-        return outPath != null && outPath.getFileName().toString().endsWith(IOUtil.VCF_FILE_EXTENSION);
+        return outPath != null && outPath.getFileName().toString().endsWith(FileExtensions.VCF);
     }
 
     private static boolean isBCF(final Path outPath) {
-        return outPath != null && outPath.getFileName().toString().endsWith(IOUtil.BCF_FILE_EXTENSION);
+        return outPath != null && outPath.getFileName().toString().endsWith(FileExtensions.BCF);
     }
 
     private static boolean isCompressedVCF(final Path outPath) {

--- a/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -57,7 +57,7 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
      * Returns true if the given path appears to be a BCF file.
      */
     public static boolean isBCF(final Path path) {
-        return path.toUri().getRawPath().endsWith(IOUtil.BCF_FILE_EXTENSION);
+        return path.toUri().getRawPath().endsWith(FileExtensions.BCF);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/vcf/VCFUtils.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFUtils.java
@@ -27,7 +27,7 @@ package htsjdk.variant.vcf;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
-import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.variant.utils.GeneralUtils;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.Options;
@@ -209,10 +209,10 @@ public class VCFUtils {
         final File out = File.createTempFile(prefix, suffix);
         out.deleteOnExit();
         String indexFileExtension = null;
-        if (suffix.endsWith(IOUtil.COMPRESSED_VCF_FILE_EXTENSION)) {
-            indexFileExtension = IOUtil.COMPRESSED_VCF_INDEX_EXTENSION;
-        } else if (suffix.endsWith(IOUtil.VCF_FILE_EXTENSION)) {
-            indexFileExtension = IOUtil.VCF_INDEX_EXTENSION;
+        if (suffix.endsWith(FileExtensions.COMPRESSED_VCF)) {
+            indexFileExtension = FileExtensions.COMPRESSED_VCF_INDEX;
+        } else if (suffix.endsWith(FileExtensions.VCF)) {
+            indexFileExtension = FileExtensions.VCF_INDEX;
         }
         if (indexFileExtension != null) {
             final File indexOut = new File(out.getAbsolutePath() + indexFileExtension);
@@ -232,11 +232,11 @@ public class VCFUtils {
     public static File createTemporaryIndexedVcfFromInput(final File vcfFile, final String tempFilePrefix) throws IOException {
         final String extension;
 
-        if (vcfFile.getAbsolutePath().endsWith(IOUtil.VCF_FILE_EXTENSION)) extension = IOUtil.VCF_FILE_EXTENSION;
-        else if (vcfFile.getAbsolutePath().endsWith(IOUtil.COMPRESSED_VCF_FILE_EXTENSION))
-            extension = IOUtil.COMPRESSED_VCF_FILE_EXTENSION;
+        if (vcfFile.getAbsolutePath().endsWith(FileExtensions.VCF)) extension = FileExtensions.VCF;
+        else if (vcfFile.getAbsolutePath().endsWith(FileExtensions.COMPRESSED_VCF))
+            extension = FileExtensions.COMPRESSED_VCF;
         else
-            throw new IllegalArgumentException("couldn't find a " + IOUtil.VCF_FILE_EXTENSION + " or " + IOUtil.COMPRESSED_VCF_FILE_EXTENSION + " ending for input file " + vcfFile.getAbsolutePath());
+            throw new IllegalArgumentException("couldn't find a " + FileExtensions.VCF + " or " + FileExtensions.COMPRESSED_VCF + " ending for input file " + vcfFile.getAbsolutePath());
 
         File output = createTemporaryIndexedVcfFile(tempFilePrefix, extension);
 

--- a/src/test/java/htsjdk/samtools/BAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileIndexTest.java
@@ -298,7 +298,7 @@ public class BAMFileIndexTest extends HtsjdkTest {
                 "one_end_mapped\t73\tchr7\t100\t255\t101M\t*\t0\t0\tCAACAGAAGCNGGNATCTGTGTTTGTGTTTCGGATTTCCTGCTGAANNGNTTNTCGNNTCNNNNNNNNATCCCGATTTCNTTCCGCAGCTNACCTCCCAAN\t)'.*.+2,))&&'&*/)-&*-)&.-)&)&),/-&&..)./.,.).*&&,&.&&-)&&&0*&&&&&&&&/32/,01460&&/6/*0*/2/283//36868/&\tRG:Z:0\n" +
                 "one_end_mapped\t133\tchr7\t100\t0\t*\t=\t100\t0\tNCGCGGCATCNCGATTTCTTTCCGCAGCTAACCTCCCGACAGATCGGCAGCGCGTCGTGTAGGTTATTATGGTACATCTTGTCGTGCGGCNAGAGCATACA\t&/15445666651/566666553+2/14/&/555512+3/)-'/-&-'*+))*''13+3)'//++''/'))/3+&*5++)&'2+&+/*&-&&*)&-./1'1\tRG:Z:0\n";
         final ByteArrayInputStream bis = new ByteArrayInputStream(StringUtil.stringToBytes(samText));
-        final File bamFile = File.createTempFile("BAMFileIndexTest.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("BAMFileIndexTest.", FileExtensions.BAM);
         bamFile.deleteOnExit();
         final SamReader textReader = SamReaderFactory.makeDefault().open(SamInputResource.of(bis));
         SAMFileWriterFactory samFileWriterFactory = new SAMFileWriterFactory();

--- a/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.metrics.MetricsFile;
 import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.SequenceUtil;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -61,7 +62,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
      * @param presorted           If true, samText is in the order specified by sortOrder
      */
     private void testHelper(final SAMRecordSetBuilder samRecordSetBuilder, final SAMFileHeader.SortOrder sortOrder, final boolean presorted) throws Exception {
-        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
         bamFile.deleteOnExit();
 
         try (final SamReader samReader = samRecordSetBuilder.getSamReader()) {
@@ -149,7 +150,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
         }
 
         // make sure the records can actually be written out
-        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
         bamFile.deleteOnExit();
         samHeader.setSortOrder(order);
         try (final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(samHeader, presorted, bamFile)) {
@@ -174,7 +175,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
         // sequence dictionary and unresolvable references
         final SAMFileHeader fakeHeader = new SAMFileHeader();
         fakeHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
-        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
         bamFile.deleteOnExit();
 
         try (final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(fakeHeader, false, bamFile);) {
@@ -193,7 +194,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
         // sequence dictionary and unresolvable references
         final SAMFileHeader fakeHeader = new SAMFileHeader();
         fakeHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
-        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
         bamFile.deleteOnExit();
 
         try (final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(fakeHeader, false, bamFile);) {
@@ -327,7 +328,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
 
         builder.addFrag("frag1", 0, 1, false, false, cigar.toString(), null, 30);
 
-        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
         bamFile.deleteOnExit();
 
         try (final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, bamFile)) {
@@ -442,7 +443,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
             rec.setAttribute(SAMTag.CG.name(), cigarEncoding);
         }
 
-        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
         bamFile.deleteOnExit();
 
         try (final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, bamFile)) {
@@ -464,7 +465,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
         builder.addFrag("frag1", 0, 1, false, false, cigar.toString(), null, 30);
         builder.addPair("pair1", 0, 1, 100_000, false, false, cigar.toString(), cigar.toString(), true, false, 30);
 
-        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
         bamFile.deleteOnExit();
 
         try (final SAMFileWriter bamWriter = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, bamFile)) {
@@ -499,7 +500,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
     @Test
     public void testRealDataLongCigar() throws Exception {
         final File samFile = new File("src/test/resources/htsjdk/samtools/BAMCigarOverflowTest/cigar-64k.sam.gz");
-        final File bamFile = File.createTempFile("test.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
         bamFile.deleteOnExit();
 
         try (final SamReader samReader = SamReaderFactory.make().open(samFile);

--- a/src/test/java/htsjdk/samtools/CRAMComplianceTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMComplianceTest.java
@@ -3,10 +3,10 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import htsjdk.samtools.cram.build.CramIO;
 import htsjdk.samtools.cram.common.CramVersions;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.Log;
 
 import htsjdk.samtools.util.SequenceUtil;
@@ -249,7 +249,7 @@ public class CRAMComplianceTest extends HtsjdkTest {
         SAMFileHeader samHeader;
         List<SAMRecord> bamRecords;
         try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
-            final Path tempBam = jimfs.getPath("testCRAMToBAMToCRAM" + BamFileIoUtils.BAM_FILE_EXTENSION);
+            final Path tempBam = jimfs.getPath("testCRAMToBAMToCRAM" + FileExtensions.BAM);
             samHeader = getFileHeader(originalCRAMFile, referenceFile);
             writeRecordsToPath(copiedCRAMRecords, tempBam, referenceFile, samHeader);
             bamRecords = getSAMRecordsFromPath(tempBam, referenceFile);
@@ -265,7 +265,7 @@ public class CRAMComplianceTest extends HtsjdkTest {
         // write the BAM records to a CRAM and read them back in
         List<SAMRecord> roundTripCRAMRecords;
         try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
-            final Path tempCRAM = jimfs.getPath("testCRAMToBAMToCRAM" + CramIO.CRAM_FILE_EXTENSION);
+            final Path tempCRAM = jimfs.getPath("testCRAMToBAMToCRAM" + FileExtensions.CRAM);
             writeRecordsToPath(bamRecords, tempCRAM, referenceFile, samHeader);
             roundTripCRAMRecords = getSAMRecordsFromPath(tempCRAM, referenceFile);
         }
@@ -293,7 +293,7 @@ public class CRAMComplianceTest extends HtsjdkTest {
         List<SAMRecord> originalBAMRecords = getSAMRecordsFromFile(originalBAMInputFile, referenceFile);
 
         // write the BAM records to a temporary CRAM
-        final File tempCRAMFile = File.createTempFile("testBAMThroughCRAMRoundTrip", CramIO.CRAM_FILE_EXTENSION);
+        final File tempCRAMFile = File.createTempFile("testBAMThroughCRAMRoundTrip", FileExtensions.CRAM);
         tempCRAMFile.deleteOnExit();
         SAMFileHeader samHeader = getFileHeader(originalBAMInputFile, referenceFile);
         writeRecordsToFile(originalBAMRecords, tempCRAMFile, referenceFile, samHeader);
@@ -322,7 +322,7 @@ public class CRAMComplianceTest extends HtsjdkTest {
 
         // write the BAM records to a temporary CRAM
         try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
-            final Path tempCRAM = jimfs.getPath("testBAMThroughCRAMRoundTrip" + CramIO.CRAM_FILE_EXTENSION);
+            final Path tempCRAM = jimfs.getPath("testBAMThroughCRAMRoundTrip" + FileExtensions.CRAM);
             SAMFileHeader samHeader = getFileHeader(originalBAMInputFile, referenceFile);
             writeRecordsToPath(originalBAMRecords, tempCRAM, referenceFile, samHeader);
 

--- a/src/test/java/htsjdk/samtools/CachingBAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CachingBAMFileIndexTest.java
@@ -2,6 +2,7 @@ package htsjdk.samtools;
 
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -55,7 +56,7 @@ public class CachingBAMFileIndexTest extends HtsjdkTest {
             }).forEach(writer::addAlignment);
         }
 
-        final File indexFile = new File(outBam.getParent(), IOUtil.basename(outBam) + BAMIndex.BAMIndexSuffix);
+        final File indexFile = new File(outBam.getParent(), IOUtil.basename(outBam) + FileExtensions.BAM_INDEX);
         indexFile.deleteOnExit();
         outBam.deleteOnExit();
         return new CachingBAMFileIndex(indexFile, dict);

--- a/src/test/java/htsjdk/samtools/CachingBAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CachingBAMFileIndexTest.java
@@ -56,7 +56,7 @@ public class CachingBAMFileIndexTest extends HtsjdkTest {
             }).forEach(writer::addAlignment);
         }
 
-        final File indexFile = new File(outBam.getParent(), IOUtil.basename(outBam) + FileExtensions.BAM_INDEX);
+        final File indexFile = new File(outBam.getParent(), IOUtil.basename(outBam) + FileExtensions.BAI_INDEX);
         indexFile.deleteOnExit();
         outBam.deleteOnExit();
         return new CachingBAMFileIndex(indexFile, dict);

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -26,9 +26,9 @@ package htsjdk.samtools;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.cram.build.CramIO;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import org.testng.Assert;
@@ -58,7 +58,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
     @Test()
     public void ordinaryFileWriterTest() throws Exception {
-        final File outputFile = File.createTempFile("tmp.", BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File outputFile = File.createTempFile("tmp.", FileExtensions.BAM);
         outputFile.delete();
         outputFile.deleteOnExit();
         createSmallBam(outputFile);
@@ -74,7 +74,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
     @Test()
     public void ordinaryPathWriterTest() throws Exception {
         try (FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
-            final Path outputPath = jimfs.getPath("ordinaryPathWriterTest" + BamFileIoUtils.BAM_FILE_EXTENSION);
+            final Path outputPath = jimfs.getPath("ordinaryPathWriterTest" + FileExtensions.BAM);
             createSmallBam(outputPath);
             final Path indexPath = SamFiles.findIndex(outputPath);
             final Path md5File = IOUtil.addExtension(outputPath, ".md5");
@@ -383,7 +383,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
     @Test
     public void testMakeCRAMWriterWithOptions() throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + CramIO.CRAM_FILE_EXTENSION);
+        final File outputFile = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
         final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
@@ -399,7 +399,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
     // throws an exception since no reference is provided
     @Test(expectedExceptions = IllegalStateException.class)
     public void testMakeCRAMWriterWithNoReference() throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + CramIO.CRAM_FILE_EXTENSION);
+        final File outputFile = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
 
@@ -410,7 +410,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
     @Test
     public void testMakeCRAMWriterIgnoresOptions() throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + CramIO.CRAM_FILE_EXTENSION);
+        final File outputFile = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
         final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
@@ -426,7 +426,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
     @Test
     public void testMakeCRAMWriterPresortedDefault() throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + CramIO.CRAM_FILE_EXTENSION);
+        final File outputFile = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
         final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
@@ -444,7 +444,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
     public void testAsync() throws IOException {
         final SAMFileWriterFactory builder = new SAMFileWriterFactory();
 
-        final File outputFile = prepareOutputFileWithSuffix(BamFileIoUtils.BAM_FILE_EXTENSION);
+        final File outputFile = prepareOutputFileWithSuffix(FileExtensions.BAM);
         final SAMFileHeader header = new SAMFileHeader();
         final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
 

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -25,8 +25,8 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.cram.build.CramIO;
 import htsjdk.samtools.util.BinaryCodec;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.utils.TestNGUtils;
@@ -1134,7 +1134,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
 
     private static Object[][] getFileExtensions(){
         return new Object[][]{
-                {BamFileIoUtils.BAM_FILE_EXTENSION}, {IOUtil.SAM_FILE_EXTENSION}, {CramIO.CRAM_FILE_EXTENSION}
+                {FileExtensions.BAM}, {FileExtensions.SAM}, {FileExtensions.CRAM}
         };
     }
 

--- a/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
@@ -258,7 +258,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
         IOUtil.deleteOnExit(fastaFile);
         Files.delete(fastaFile);
 
-        final Path fastaIndexFile = fastaFile.resolveSibling(fastaFile.getFileName().toString() + ReferenceSequenceFileFactory.FASTA_INDEX_EXTENSION);
+        final Path fastaIndexFile = fastaFile.resolveSibling(fastaFile.getFileName().toString() + FileExtensions.FASTA_INDEX);
         final Path gzipIndexFile = GZIIndex.resolveIndexNameForBgzipFile(fastaFile);
         final Path dictFile = fastaFile.resolveSibling(fastaFile.getFileName().toString().replaceAll("\\.fa", ".dict").replaceAll("\\.gz", ""));
         IOUtil.deleteOnExit(gzipIndexFile);
@@ -648,7 +648,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @DataProvider
     Iterator<Object[]> fastaExtensions() {
-        return ReferenceSequenceFileFactory.FASTA_EXTENSIONS.stream()
+        return FileExtensions.FASTA.stream()
                 .filter(s -> !s.endsWith(".gz"))
                 .map(s -> new Object[]{s})
                 .collect(Collectors.toList())

--- a/src/test/java/htsjdk/samtools/util/IupacTest.java
+++ b/src/test/java/htsjdk/samtools/util/IupacTest.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.BamFileIoUtils;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMFileWriter;
 import htsjdk.samtools.SAMFileWriterFactory;
@@ -71,7 +70,7 @@ public class IupacTest extends HtsjdkTest {
     @DataProvider(name = "basicDataProvider")
     public Object[][] basicDataProvider() {
         return new Object[][]{
-                {BamFileIoUtils.BAM_FILE_EXTENSION},
+                {FileExtensions.BAM},
                 {".sam"}
         };
     }

--- a/src/test/java/htsjdk/tribble/TribbleTest.java
+++ b/src/test/java/htsjdk/tribble/TribbleTest.java
@@ -1,7 +1,7 @@
 package htsjdk.tribble;
 
 import htsjdk.HtsjdkTest;
-import htsjdk.tribble.util.TabixUtils;
+import htsjdk.samtools.util.FileExtensions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -14,7 +14,7 @@ public class TribbleTest extends HtsjdkTest {
     public void testStandardIndex() {
 
 	final String vcf = "foo.vcf";
-	final String expectedIndex = vcf + Tribble.STANDARD_INDEX_EXTENSION;
+	final String expectedIndex = vcf + FileExtensions.TRIBBLE_INDEX;
 
 	Assert.assertEquals(Tribble.indexFile(vcf), expectedIndex);
 	Assert.assertEquals(Tribble.indexFile(new File(vcf).getAbsolutePath()), new File(expectedIndex).getAbsolutePath());
@@ -24,7 +24,7 @@ public class TribbleTest extends HtsjdkTest {
     public void testTabixIndex() {
 
 	final String vcf = "foo.vcf.gz";
-	final String expectedIndex = vcf + TabixUtils.STANDARD_INDEX_EXTENSION;
+	final String expectedIndex = vcf + FileExtensions.TABIX_INDEX;
 
 	Assert.assertEquals(Tribble.tabixIndexFile(vcf), expectedIndex);
 	Assert.assertEquals(Tribble.tabixIndexFile(new File(vcf).getAbsolutePath()), new File(expectedIndex).getAbsolutePath());

--- a/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
@@ -27,6 +27,7 @@ package htsjdk.tribble.bed;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
 import htsjdk.samtools.util.BlockCompressedInputStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
@@ -251,7 +252,7 @@ public class BEDCodecTest extends HtsjdkTest {
     public void testCanDecode() {
         final BEDCodec codec = new BEDCodec();
         final String pattern = "filename.%s%s";
-        for(final String bcExt: IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
+        for(final String bcExt: FileExtensions.BLOCK_COMPRESSED) {
             Assert.assertTrue(codec.canDecode(String.format(pattern, "bed", bcExt)));
             Assert.assertFalse(codec.canDecode(String.format(pattern, "vcf", bcExt)));
             Assert.assertFalse(codec.canDecode(String.format(pattern, "bed.gzip", bcExt)));

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -3,6 +3,7 @@ package htsjdk.tribble.index;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.TestUtils;
@@ -85,7 +86,7 @@ public class IndexTest extends HtsjdkTest {
     @Test(dataProvider = "writeIndexData")
     public void testWriteIndex(final File inputFile, final IndexFactory.IndexType type, final  FeatureCodec codec) throws Exception {
         // temp index file for this test
-        final File tempIndex = File.createTempFile("index", (type == IndexFactory.IndexType.TABIX) ? TabixUtils.STANDARD_INDEX_EXTENSION : Tribble.STANDARD_INDEX_EXTENSION);
+        final File tempIndex = File.createTempFile("index", (type == IndexFactory.IndexType.TABIX) ? FileExtensions.TABIX_INDEX : FileExtensions.TRIBBLE_INDEX);
         tempIndex.delete();
         tempIndex.deleteOnExit();
         // create the index

--- a/src/test/java/htsjdk/tribble/index/tabix/TabixIndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/tabix/TabixIndexTest.java
@@ -26,6 +26,7 @@ package htsjdk.tribble.index.tabix;
 import htsjdk.HtsjdkTest;
 import com.google.common.io.Files;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.tribble.AbstractFeatureReader;
@@ -36,7 +37,6 @@ import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.index.IndexFactory;
 import htsjdk.tribble.util.LittleEndianOutputStream;
-import htsjdk.tribble.util.TabixUtils;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
@@ -64,7 +64,7 @@ public class TabixIndexTest extends HtsjdkTest {
     @Test(dataProvider = "readWriteTestDataProvider")
     public void readWriteTest(final File tabixFile) throws Exception {
         final TabixIndex index = new TabixIndex(tabixFile);
-        final File indexFile = File.createTempFile("TabixIndexTest.", TabixUtils.STANDARD_INDEX_EXTENSION);
+        final File indexFile = File.createTempFile("TabixIndexTest.", FileExtensions.TABIX_INDEX);
         indexFile.deleteOnExit();
         final LittleEndianOutputStream los = new LittleEndianOutputStream(new BlockCompressedOutputStream(indexFile));
         index.write(los);

--- a/src/test/java/htsjdk/variant/PrintVariantsExampleTest.java
+++ b/src/test/java/htsjdk/variant/PrintVariantsExampleTest.java
@@ -26,6 +26,7 @@
 package htsjdk.variant;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.example.PrintVariantsExample;
 import htsjdk.variant.vcf.VCFUtils;
@@ -41,7 +42,7 @@ import java.util.stream.IntStream;
 public class PrintVariantsExampleTest extends HtsjdkTest {
     @Test
     public void testExampleWriteFile() throws IOException {
-        final File tempFile = File.createTempFile("example", IOUtil.VCF_FILE_EXTENSION);
+        final File tempFile = File.createTempFile("example", FileExtensions.VCF);
         tempFile.deleteOnExit();
         File f1 = new File("src/test/resources/htsjdk/variant/ILLUMINA.wex.broad_phase2_baseline.20111114.both.exome.genotypes.1000.vcf");
         final String[] args = {

--- a/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
@@ -26,7 +26,7 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.tribble.Tribble;
 import htsjdk.tribble.readers.AsciiLineReader;
@@ -72,7 +72,7 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
     /** test, using the writer and reader, that we can output and input a VCF body without problems */
     @Test
     public void testWriteAndReadAsyncVCFHeaderless() throws IOException {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadAsyncVCFHeaderless.", IOUtil.VCF_FILE_EXTENSION);
+        final File fakeVCFFile = VariantBaseTest.createTempFile("testWriteAndReadAsyncVCFHeaderless.", FileExtensions.VCF);
         fakeVCFFile.deleteOnExit();
 
         Tribble.indexFile(fakeVCFFile).deleteOnExit();

--- a/src/test/java/htsjdk/variant/variantcontext/writer/TabixOnTheFlyIndexCreationTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/TabixOnTheFlyIndexCreationTest.java
@@ -24,12 +24,11 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.FeatureReader;
 import htsjdk.tribble.index.tabix.TabixIndex;
-import htsjdk.tribble.util.TabixUtils;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCF3Codec;
 import htsjdk.variant.vcf.VCFHeader;
@@ -45,8 +44,8 @@ public class TabixOnTheFlyIndexCreationTest extends HtsjdkTest {
         final VCF3Codec codec = new VCF3Codec();
         final FeatureReader<VariantContext> reader = AbstractFeatureReader.getFeatureReader(SMALL_VCF.getAbsolutePath(), codec, false);
         final VCFHeader headerFromFile = (VCFHeader)reader.getHeader();
-        final File vcf = File.createTempFile("TabixOnTheFlyIndexCreationTest.", IOUtil.COMPRESSED_VCF_FILE_EXTENSION);
-        final File tabix = new File(vcf.getAbsolutePath() + TabixUtils.STANDARD_INDEX_EXTENSION);
+        final File vcf = File.createTempFile("TabixOnTheFlyIndexCreationTest.", FileExtensions.COMPRESSED_VCF);
+        final File tabix = new File(vcf.getAbsolutePath() + FileExtensions.TABIX_INDEX);
         vcf.deleteOnExit();
         tabix.deleteOnExit();
         final VariantContextWriter vcfWriter = new VariantContextWriterBuilder()

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -27,7 +27,7 @@ package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.BlockCompressedInputStream;
-import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.FeatureReader;
@@ -90,8 +90,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     public void testBasicWriteAndRead(final String extension) throws IOException {
         final File fakeVCFFile = File.createTempFile("testBasicWriteAndRead.", extension, tempDir);
         fakeVCFFile.deleteOnExit();
-        if (IOUtil.COMPRESSED_VCF_FILE_EXTENSION.equals(extension)) {
-            new File(fakeVCFFile.getAbsolutePath() + IOUtil.VCF_INDEX_EXTENSION);
+        if (FileExtensions.COMPRESSED_VCF.equals(extension)) {
+            new File(fakeVCFFile.getAbsolutePath() + FileExtensions.VCF_INDEX);
         } else {
             Tribble.indexFile(fakeVCFFile).deleteOnExit();
         }
@@ -136,7 +136,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     public void testWriteAndReadVCFHeaderless(final String extension) throws IOException {
         final File fakeVCFFile = File.createTempFile("testWriteAndReadVCFHeaderless.", extension, tempDir);
         fakeVCFFile.deleteOnExit();
-        if (IOUtil.COMPRESSED_VCF_FILE_EXTENSION.equals(extension)) {
+        if (FileExtensions.COMPRESSED_VCF.equals(extension)) {
             new File(fakeVCFFile.getAbsolutePath() + ".tbi");
         } else {
             Tribble.indexFile(fakeVCFFile).deleteOnExit();
@@ -172,7 +172,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testWriteHeaderTwice() {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", IOUtil.VCF_FILE_EXTENSION);
+        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
         fakeVCFFile.deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
@@ -189,7 +189,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingHeader() {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", IOUtil.VCF_FILE_EXTENSION);
+        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
         fakeVCFFile.deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
@@ -205,7 +205,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingBody() {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", IOUtil.VCF_FILE_EXTENSION);
+        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
         fakeVCFFile.deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
@@ -300,10 +300,10 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
         final File vcf = new File(tempDir, "test" + extension);
         final String indexExtension;
-        if (extension.equals(IOUtil.COMPRESSED_VCF_FILE_EXTENSION)) {
-            indexExtension = TabixUtils.STANDARD_INDEX_EXTENSION;
+        if (extension.equals(FileExtensions.COMPRESSED_VCF)) {
+            indexExtension = FileExtensions.TABIX_INDEX;
         } else {
-            indexExtension = Tribble.STANDARD_INDEX_EXTENSION;
+            indexExtension = FileExtensions.TRIBBLE_INDEX;
         }
         final File vcfIndex = new File(vcf.getAbsolutePath() + indexExtension);
         vcfIndex.deleteOnExit();
@@ -332,8 +332,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         return new Object[][] {
                 // TODO: BCF doesn't work because header is not properly constructed.
                 // {".bcf"},
-                {IOUtil.VCF_FILE_EXTENSION},
-                {IOUtil.COMPRESSED_VCF_FILE_EXTENSION}
+                {FileExtensions.VCF},
+                {FileExtensions.COMPRESSED_VCF}
         };
     }
 
@@ -351,7 +351,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
         header.addMetaDataLine(new VCFHeaderLine("FOOBAR", "foovalue"));
 
-        final File outputVCF = createTempFile("testModifyHeader", IOUtil.VCF_FILE_EXTENSION);
+        final File outputVCF = createTempFile("testModifyHeader", FileExtensions.VCF);
         final VariantContextWriter writer = new VariantContextWriterBuilder().setOutputFile(outputVCF).setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER)).build();
         writer.writeHeader(header);
         writer.close();

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -30,9 +30,8 @@ import com.google.common.jimfs.Jimfs;
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
-import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.Tribble;
-import htsjdk.tribble.util.TabixUtils;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder.OutputType;
 import htsjdk.variant.vcf.VCFHeader;
@@ -74,13 +73,13 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
     @BeforeSuite
     public void before() throws IOException {
         dictionary = createArtificialSequenceDictionary();
-        vcf = File.createTempFile(TEST_BASENAME, IOUtil.VCF_FILE_EXTENSION);
+        vcf = File.createTempFile(TEST_BASENAME, FileExtensions.VCF);
         vcf.deleteOnExit();
         vcfIdx = Tribble.indexFile(vcf);
         vcfIdx.deleteOnExit();
         vcfMD5 = new File(vcf.getAbsolutePath() + ".md5");
         vcfMD5.deleteOnExit();
-        bcf = File.createTempFile(TEST_BASENAME, IOUtil.BCF_FILE_EXTENSION);
+        bcf = File.createTempFile(TEST_BASENAME, FileExtensions.BCF);
         bcf.deleteOnExit();
         bcfIdx = Tribble.indexFile(bcf);
         bcfIdx.deleteOnExit();
@@ -89,12 +88,12 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
 
         blockCompressedVCFs = new ArrayList<File>();
         blockCompressedIndices = new ArrayList<File>();
-        for (final String extension : IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
-            final File blockCompressed = File.createTempFile(TEST_BASENAME, IOUtil.VCF_FILE_EXTENSION + extension);
+        for (final String extension : FileExtensions.BLOCK_COMPRESSED) {
+            final File blockCompressed = File.createTempFile(TEST_BASENAME, FileExtensions.VCF + extension);
             blockCompressed.deleteOnExit();
             blockCompressedVCFs.add(blockCompressed);
 
-            final File index = new File(blockCompressed.getAbsolutePath() + TabixUtils.STANDARD_INDEX_EXTENSION);
+            final File index = new File(blockCompressed.getAbsolutePath() + FileExtensions.TABIX_INDEX);
             index.deleteOnExit();
             blockCompressedIndices.add(index);
         }
@@ -113,7 +112,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
         Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF File");
         Assert.assertFalse(((VCFWriter)writer).getOutputStream() instanceof BlockCompressedOutputStream, "testSetOutputFile VCF File was compressed");
 
-        for (final String extension : IOUtil.BLOCK_COMPRESSED_EXTENSIONS) {
+        for (final String extension : FileExtensions.BLOCK_COMPRESSED) {
             final File file = File.createTempFile(TEST_BASENAME + ".setoutput", extension);
             file.deleteOnExit();
             final String filename = file.getAbsolutePath();

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWritersUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWritersUnitTest.java
@@ -30,7 +30,7 @@ package htsjdk.variant.variantcontext.writer;
 
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -129,7 +129,7 @@ public class VariantContextWritersUnitTest extends VariantBaseTest {
     private class VCFIOTester extends VariantContextTestProvider.VariantContextIOTest<VCFCodec> {
         @Override
         public String getExtension() {
-            return IOUtil.VCF_FILE_EXTENSION;
+            return FileExtensions.VCF;
         }
 
         @Override

--- a/src/test/java/htsjdk/variant/vcf/IndexFactoryUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/IndexFactoryUnitTest.java
@@ -26,7 +26,7 @@
 package htsjdk.variant.vcf;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.Tribble;
@@ -51,7 +51,7 @@ import java.util.EnumSet;
 public class IndexFactoryUnitTest extends VariantBaseTest {
 
     File inputFile = new File(variantTestDataRoot + "HiSeq.10000.vcf");
-    File outputFile = createTempFile("onTheFlyOutputTest", IOUtil.VCF_FILE_EXTENSION);
+    File outputFile = createTempFile("onTheFlyOutputTest", FileExtensions.VCF);
     File outputFileIndex = Tribble.indexFile(outputFile);
 
     private SAMSequenceDictionary dict;

--- a/src/test/java/htsjdk/variant/vcf/VCFCodec43FeaturesTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFCodec43FeaturesTest.java
@@ -1,12 +1,12 @@
 package htsjdk.variant.vcf;
 
 import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.samtools.util.Tuple;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
-import htsjdk.tribble.util.TabixUtils;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -163,7 +163,7 @@ public class VCFCodec43FeaturesTest extends VariantBaseTest {
         Files.copy(testFile, (new File (tempDir, testFile.toFile().getName())).toPath());
         final File vcfFileCopy = new File(tempDir, testFile.toFile().getName());
         final Index index = IndexFactory.createIndex(vcfFileCopy, new VCFCodec(), IndexFactory.IndexType.TABIX);
-        final File indexFile = new File(tempDir, vcfFileCopy.getName() + TabixUtils.STANDARD_INDEX_EXTENSION);
+        final File indexFile = new File(tempDir, vcfFileCopy.getName() + FileExtensions.TABIX_INDEX);
         index.write(indexFile);
         Assert.assertTrue(indexFile.exists());
 

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.vcf;
 
 import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.tribble.TribbleException;
@@ -458,7 +459,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertEquals(originalEscapingNonQuoteOrBackslashInfoLine.getDescription(), "This other value has a \\n newline in it");
 
         // write the file out into a new copy
-        final File firstCopyVCFFile = File.createTempFile("testEscapeHeaderQuotes1.", IOUtil.VCF_FILE_EXTENSION);
+        final File firstCopyVCFFile = File.createTempFile("testEscapeHeaderQuotes1.", FileExtensions.VCF);
         firstCopyVCFFile.deleteOnExit();
 
         final VariantContextWriter firstCopyWriter = new VariantContextWriterBuilder()
@@ -502,7 +503,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
 
 
         // write one more copy to make sure things don't get double escaped
-        final File secondCopyVCFFile = File.createTempFile("testEscapeHeaderQuotes2.", IOUtil.VCF_FILE_EXTENSION);
+        final File secondCopyVCFFile = File.createTempFile("testEscapeHeaderQuotes2.", FileExtensions.VCF);
         secondCopyVCFFile.deleteOnExit();
         final VariantContextWriter secondCopyWriter = new VariantContextWriterBuilder()
                 .setOutputFile(secondCopyVCFFile)
@@ -564,7 +565,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         File expectedFile = new File("src/test/resources/htsjdk/variant/Vcf4.2WithSourceVersionInfoFields.vcf");
 
         // write the file out into a new copy
-        final File actualFile = File.createTempFile("testVcf4.2roundtrip.", IOUtil.VCF_FILE_EXTENSION);
+        final File actualFile = File.createTempFile("testVcf4.2roundtrip.", FileExtensions.VCF);
         actualFile.deleteOnExit();
 
         try (final VCFFileReader originalFileReader = new VCFFileReader(expectedFile, false);

--- a/src/test/java/htsjdk/variant/vcf/VCFIteratorTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFIteratorTest.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.CloserUtil;
+import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.variant.VariantBaseTest;
@@ -94,8 +95,8 @@ public class VCFIteratorTest extends VariantBaseTest {
          * https://github.com/samtools/htsjdk/pull/837#discussion_r139490218
          * https://github.com/samtools/htsjdk/issues/946
          */
-        if( tmp.getName().endsWith(IOUtil.VCF_FILE_EXTENSION)) {
-            tmp = File.createTempFile("tmp",IOUtil.COMPRESSED_VCF_FILE_EXTENSION);
+        if( tmp.getName().endsWith(FileExtensions.VCF)) {
+            tmp = File.createTempFile("tmp",FileExtensions.COMPRESSED_VCF);
             tmp.deleteOnExit();
             try(    FileInputStream in = new FileInputStream(filepath);
                     OutputStream out =  outputStreamProvider.apply(tmp); ) {


### PR DESCRIPTION
Solution for issue #1229 

Moved file extension constants (for FASTQ, SAM/BAM/CRAM, VCFs) to a single file: `IOExtensions` so that they can be all referenced easily. Variables instantiated in original locations now import the file extension from `IOExtensions`, and `@deprecated` tags have been added to variables declared in original locations.

All tests passing locally
