### PR TITLE
Handle "nan" in Float attribute regardless of case.

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1629,7 +1629,12 @@ public class VariantContext implements Feature, Serializable {
                         return b;
                     case String:    return string;
                     case Integer:   return Integer.valueOf(string);
-                    case Float:     return Double.valueOf(string);
+                    case Float:     if (string.compareToIgnoreCase("NaN") == 0) {
+                        // handle, e.g. "nan"
+                        return Double.NaN;
+                    } else {
+                        return Double.valueOf(string);
+                    }
                     default: throw new TribbleException("Unexpected type for field" + field);
                 }
             }


### PR DESCRIPTION
### Description

Parsing of floating-point NaN in VariantContext attribute fails if case is not "NaN".  

	Exception in thread "main" htsjdk.tribble.TribbleException: Could not decode field InbreedingCoeff with value nan of declared type Float
		at htsjdk.variant.variantcontext.VariantContext.decodeOne(VariantContext.java:1633)
		at htsjdk.variant.variantcontext.VariantContext.decodeValue(VariantContext.java:1598)
		at htsjdk.variant.variantcontext.VariantContext.fullyDecodeAttributes(VariantContext.java:1564)
		at htsjdk.variant.variantcontext.VariantContext.fullyDecodeInfo(VariantContext.java:1549)
		at htsjdk.variant.variantcontext.VariantContext.fullyDecode(VariantContext.java:1533)

Example input snippet:
`chr2	97151827	rs33971912	C	T	577027	PASS	AC=187;AF=0.5;AN=374;BaseQRankSum=1.07;ClippingRankSum=0.479;DB;DP=15060;ExcessHet=3.0103;FS=0;InbreedingCoeff=nan;MLEAC=192;MLEAF=0.5;MQ=42.54;MQRankSum=-1.511;POSITIVE_TRAIN_SITE;QD=26.11;ReadPosRankSum=1.51;SOR=1.254;VQSLOD=-7.437;culprit=DP	GT:AD:DP:GQ:PL`

### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

