### PR TITLE
Prevent integer overflow in Interval countBases method.

### DIFF
--- a/src/main/java/htsjdk/samtools/util/Interval.java
+++ b/src/main/java/htsjdk/samtools/util/Interval.java
@@ -171,7 +171,7 @@ public class Interval implements Comparable<Interval>, Cloneable, Feature {
      */
     public static long countBases(final Collection<Interval> intervals) {
         return intervals.stream()
-                .mapToInt(Interval::length)
+                .mapToLong(Interval::length)
                 .sum();
     }
 

--- a/src/test/java/htsjdk/samtools/util/IntervalTest.java
+++ b/src/test/java/htsjdk/samtools/util/IntervalTest.java
@@ -6,6 +6,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class IntervalTest extends HtsjdkTest {
     @DataProvider
     public Object[][] booleanProvider(){
@@ -19,4 +22,15 @@ public class IntervalTest extends HtsjdkTest {
         Assert.assertNotEquals(isNegativeStrand, interval.isPositiveStrand());
         Assert.assertEquals(isNegativeStrand, interval.getStrand() == Strand.NEGATIVE);
     }
+
+    @Test()
+    public void testCountBases(){
+        // make sure we handle cases where the sum exceeds capacity of an integer
+        final List<Interval> intervals = Arrays.asList(
+            new Interval("chr1", 1, Integer.MAX_VALUE, false, "name1"),
+            new Interval("chr2", 1, Integer.MAX_VALUE, false, "name2"));
+        final long expected = Integer.MAX_VALUE * 2L;
+        Assert.assertEquals(Interval.countBases(intervals), expected);
+    }
+
 }


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/samtools/htsjdk/pull/1356. We should get this in before we release. Caught by Picard test `IntervalListTool` testActionsWithInvert.