### PR TITLE
Output missing vcf fields as a single .

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
@@ -338,23 +338,6 @@ public class VCFEncoder {
                             }
                         } else {
                             Object val = g.hasExtendedAttribute(field) ? g.getExtendedAttribute(field) : VCFConstants.MISSING_VALUE_v4;
-
-                            final VCFFormatHeaderLine metaData = this.header.getFormatHeaderLine(field);
-                            if (metaData != null) {
-                                final int numInFormatField = metaData.getCount(vc);
-                                if (numInFormatField > 1 && val.equals(VCFConstants.MISSING_VALUE_v4)) {
-                                    // If we have a missing field but multiple values are expected, we need to construct a new string with all fields.
-                                    // For example, if Number=2, the string has to be ".,."
-                                    final StringBuilder sb = new StringBuilder(VCFConstants.MISSING_VALUE_v4);
-                                    for (int i = 1; i < numInFormatField; i++) {
-                                        sb.append(',');
-                                        sb.append(VCFConstants.MISSING_VALUE_v4);
-                                    }
-                                    val = sb.toString();
-                                }
-                            }
-
-                            // assume that if key is absent, then the given string encoding suffices
                             outputValue = formatVCFField(val);
                         }
                     }

--- a/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
@@ -23,7 +23,7 @@ public class VCFEncoderTest extends HtsjdkTest {
 
 	@DataProvider(name = "VCFWriterDoubleFormatTestData")
 	public Object[][] makeVCFWriterDoubleFormatTestData() {
-		final List<Object[]> tests = new ArrayList<Object[]>();
+		final List<Object[]> tests = new ArrayList<>();
 		tests.add(new Object[]{1.0, "1.00"});
 		tests.add(new Object[]{10.1, "10.10"});
 		tests.add(new Object[]{10.01, "10.01"});
@@ -56,19 +56,19 @@ public class VCFEncoderTest extends HtsjdkTest {
 
     @DataProvider(name = "MissingFormatTestData")
     public Object[][] makeMissingFormatTestData() {
-        final VCFHeader header = createSyntheticHeader(Arrays.asList("Sample1"));
+        final VCFHeader header = createSyntheticHeader(Collections.singletonList("Sample1"));
 
         final VCFEncoder dropMissing = new VCFEncoder(header, false, false);
         final VCFEncoder keepMissing = new VCFEncoder(header, false, true);
         final VariantContextBuilder baseVC = new VariantContextBuilder().chr("1").start(1).stop(1).noID().passFilters().log10PError(1).alleles("A", "C");
         final GenotypeBuilder baseGT = new GenotypeBuilder("Sample1").alleles(Arrays.asList(Allele.NO_CALL, Allele.NO_CALL));
-        final Map<Allele, String> alleleMap = new HashMap<Allele, String>(3);
+        final Map<Allele, String> alleleMap = new HashMap<>(3);
         final List<String> formatKeys = Arrays.asList("GT", "AA", "BB");
         alleleMap.put(Allele.NO_CALL, VCFConstants.EMPTY_ALLELE);
         alleleMap.put(Allele.create("A", true), "0");
         alleleMap.put(Allele.create("C", false), "1");
 
-        final List<Object[]> tests = new ArrayList<Object[]>();
+        final List<Object[]> tests = new ArrayList<>();
 
         VariantContext vc = baseVC.genotypes(baseGT.attribute("AA", "a").make()).make();
         tests.add(new Object[]{dropMissing, vc, "./.:a", alleleMap, formatKeys});
@@ -90,6 +90,11 @@ public class VCFEncoderTest extends HtsjdkTest {
         tests.add(new Object[]{keepMissing, vc, "./.:.:2", alleleMap, formatKeys});
         baseGT.noAttributes();
 
+        //check that we only produce a single . when writing attributes with multiple values instead of .,.
+        vc = baseVC.genotypes(baseGT.attribute("CC", VCFConstants.MISSING_VALUE_v4).make()).make();
+        tests.add(new Object[]{keepMissing, vc, "./.:.", alleleMap, Arrays.asList("GT", "CC")});
+        baseGT.noAttributes();
+
         return tests.toArray(new Object[][]{});
     }
 
@@ -103,22 +108,19 @@ public class VCFEncoderTest extends HtsjdkTest {
         Assert.assertEquals(columns[nCol-1], expectedLastColumn, "Format fields don't handle missing data in the expected way");
     }
 
-    private Set<VCFHeaderLine> createSyntheticMetadata() {
-        final Set<VCFHeaderLine> metaData = new TreeSet<VCFHeaderLine>();
+    private static Set<VCFHeaderLine> createSyntheticMetadata() {
+        final Set<VCFHeaderLine> metaData = new TreeSet<>();
 
         metaData.add(new VCFContigHeaderLine(Collections.singletonMap("ID", "1"), 0));
 
         metaData.add(new VCFFormatHeaderLine("GT", 1, VCFHeaderLineType.String, "x"));
         metaData.add(new VCFFormatHeaderLine("AA", 1, VCFHeaderLineType.String, "aa"));
         metaData.add(new VCFFormatHeaderLine("BB", 1, VCFHeaderLineType.Integer, "bb"));
+        metaData.add(new VCFFormatHeaderLine("CC", 3, VCFHeaderLineType.Integer, "CC"));
         return metaData;
     }
 
-    private VCFHeader createSyntheticHeader() {
-        return new VCFHeader(createSyntheticMetadata());
-    }
-
-    private VCFHeader createSyntheticHeader(final List<String> samples) {
+    private static VCFHeader createSyntheticHeader(final List<String> samples) {
         return new VCFHeader(createSyntheticMetadata(), samples);
     }
 

--- a/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
@@ -90,7 +90,7 @@ public class VCFEncoderTest extends HtsjdkTest {
         tests.add(new Object[]{keepMissing, vc, "./.:.:2", alleleMap, formatKeys});
         baseGT.noAttributes();
 
-        //check that we only produce a single . when writing attributes with multiple values instead of .,.
+        // check that we only produce a single . when writing attributes with multiple values instead of .,.
         vc = baseVC.genotypes(baseGT.attribute("CC", VCFConstants.MISSING_VALUE_v4).make()).make();
         tests.add(new Object[]{keepMissing, vc, "./.:.", alleleMap, Arrays.asList("GT", "CC")});
         baseGT.noAttributes();


### PR DESCRIPTION

### Description
* Previously vcf genotype fields with a specific number of elements were output as a comma separated list of dots
* This is valid, but uneccessarily long and doesn't provide any additional information.
* Now only a single dot will be emitted.
* ex:  .,.,. -> .


This is a follow up to #1371 
### Checklist

- [ ] Code compiles correctly
- [ ] New tests covering changes and new functionality
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)

