### PR TITLE
Make Validation error emit the validation type that was violated

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMValidationError.java
+++ b/src/main/java/htsjdk/samtools/SAMValidationError.java
@@ -288,8 +288,8 @@ public class SAMValidationError implements Serializable {
 
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(type.severity.toString()).append("::");
-        builder.append(type.toString()).append(":");
+        builder.append(type.severity.name()).append("::");
+        builder.append(type.name()).append(":");
         if (source != null) {
             builder.append("File ").append(source).append(", ");
         }

--- a/src/main/java/htsjdk/samtools/SAMValidationError.java
+++ b/src/main/java/htsjdk/samtools/SAMValidationError.java
@@ -276,10 +276,10 @@ public class SAMValidationError implements Serializable {
 
     /**
      * Construct a SAMValidationError with possibly-known record number.
-     * @param type
-     * @param message
-     * @param readName May be null if readName is not known.
-     * @param recordNumber Position of the record in the SAM file it has been read from.  -1 if not known.
+     * @param type The validation error type
+     * @param message The message explaining the problem
+     * @param readName The read which is the cause of the violation. May be null if readName is not known.
+     * @param recordNumber Position of the record in the SAM file it has been read from. -1 if not known.
      */
     public SAMValidationError(final Type type, final String message, final String readName, final long recordNumber) {
         this(type, message, readName);
@@ -288,9 +288,10 @@ public class SAMValidationError implements Serializable {
 
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(type.severity.toString()).append(": ");
+        builder.append(type.severity.toString()).append("::");
+        builder.append(type.toString()).append(":");
         if (source != null) {
-            builder.append("File ").append(source.toString()).append(", ");
+            builder.append("File ").append(source).append(", ");
         }
         if (recordNumber > 0) {
             builder.append("Record ").append(recordNumber).append(", ");


### PR DESCRIPTION
Validation errors are not helpful for figuring out how to ignore or fix the problem. 

By emitting the Type of the validation error, this PR helps the user know which validation error needs to be ignored, or search the code to understand the problem.
