### PR TITLE
Optimize AbstractBAMFileIndex#query to avoid quadratic behavior when …

### DIFF
--- a/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
@@ -398,14 +398,23 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
         }
     }
 
-    private void skipToSequence(final int sequenceIndex) {
+    protected void skipToSequence(final int sequenceIndex) {
     	//Use sequence position cache if available
     	if(sequenceIndexes[sequenceIndex] != -1){
     		seek(sequenceIndexes[sequenceIndex]);
     		return;
     	}
+
+        // Use previous sequence position if in cache
+        final int startSequenceIndex;
+        if (sequenceIndex > 0 && sequenceIndexes[sequenceIndex - 1] != -1) {
+            seek(sequenceIndexes[sequenceIndex - 1]);
+            startSequenceIndex = sequenceIndex - 1;
+        } else {
+            startSequenceIndex = 0;
+        }
     	
-        for (int i = 0; i < sequenceIndex; i++) {
+        for (int i = startSequenceIndex; i < sequenceIndex; i++) {
             // System.out.println("# Sequence TID: " + i);
             final int nBins = readInteger();
             // System.out.println("# nBins: " + nBins);

--- a/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
@@ -405,7 +405,8 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
     		return;
     	}
 
-        // Use previous sequence position if in cache
+        // Use previous sequence position if in cache, which optimizes for common access pattern
+        // of iterating through sequences in order.
         final int startSequenceIndex;
         if (sequenceIndex > 0 && sequenceIndexes[sequenceIndex - 1] != -1) {
             seek(sequenceIndexes[sequenceIndex - 1]);

--- a/src/main/java/htsjdk/samtools/CSIIndex.java
+++ b/src/main/java/htsjdk/samtools/CSIIndex.java
@@ -470,7 +470,8 @@ public class CSIIndex extends AbstractBAMFileIndex implements BrowseableBAMIndex
         return query(referenceSequence, 1, -1);
     }
 
-    private void skipToSequence(final int sequenceIndex) {
+    @Override
+    protected void skipToSequence(final int sequenceIndex) {
         if(sequenceIndex > getNumberOfReferences()) {
             throw new SAMException("Sequence index (" + sequenceIndex + ") is greater than maximum (" + getNumberOfReferences() + ").");
         }


### PR DESCRIPTION
…reading sequences in order.

### Description

Reading index sequences in the order they are defined in the header is a very common access pattern. However, the way it is implemented in `AbstractBAMFileIndex` means that it has quadratic complexity, since when reading sequence _i_ in `skipToSequence` that is not in the cache, it will start from the beginning, even if sequence _i_ - 1 is in the cache.

The effect is particularly stark when there are many reference sequences, such as hg38 which has over 3000. See https://github.com/disq-bio/disq/pull/109 for an example.

The fix is simple - look to see if sequence _i_ - 1 is in the cache, and start from that position if it is. The change is covered by existing tests.

/cc @lbergelson 
