### PR TITLE
Updated the max isize to be Integer.MAX_VALUE.

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -158,7 +158,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     /**
      * abs(insertSize) must be <= this
      */
-    public static final int MAX_INSERT_SIZE = 1<<29;
+    public static final int MAX_INSERT_SIZE = Integer.MAX_VALUE;
 
     /**
      * Tags that are known to need the reverse complement if the read is reverse complemented.


### PR DESCRIPTION
### Description

I'm processing some data with a reference sequence that has long chromosomes, over the BAI limit.  I ran into this issue where one (likely chimeric) read-pair has an insert size of over 536,870,912 (aka `1<<29`), which causes HTSJDK to throw validation errors.

I looked at the spec and can find nothing supporting a limit on insert size this low.  The SAM section defines it as between `[−2^31 + 1, 2^31 − 1]`, and the BAM section dedicates a full `int32 t` for tlen.