### PR TITLE
Added alignment type to RecordAndOffset class

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AbstractRecordAndOffset.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractRecordAndOffset.java
@@ -38,6 +38,16 @@ import htsjdk.samtools.SAMRecord;
 public class AbstractRecordAndOffset {
 
     /**
+     * Classifies whether the given event is a match, insertion, or deletion. This is deliberately not expressed
+     * as CIGAR operators, since there is no knowledge of the CIGAR string at the time that this is determined.
+     */
+    public enum AlignmentType {
+        Match,
+        Insertion,
+        Deletion,
+    }
+
+    /**
      * A SAMRecord aligned to reference position
      */
     protected final SAMRecord record;
@@ -47,12 +57,31 @@ public class AbstractRecordAndOffset {
     protected final int offset;
 
     /**
+     * The {@link AlignmentType} of this object, which classifies whether the given event is a match, insertion, or
+     * deletion when queried from a {@link SamLocusIterator}.
+     */
+    protected final AlignmentType alignmentType;
+
+    /**
      * @param record inner SAMRecord
      * @param offset from the start of the read
      */
     public AbstractRecordAndOffset(final SAMRecord record, final int offset) {
         this.offset = offset;
         this.record = record;
+        this.alignmentType = AlignmentType.Match;
+    }
+
+    /**
+     * @param record inner SAMRecord
+     * @param offset from the start of the read
+     * @param alignmentType The {@link AlignmentType} of this object, which is used when queried in
+     *                      a {@link SamLocusIterator}.
+     */
+    public AbstractRecordAndOffset(final SAMRecord record, final int offset, final AlignmentType alignmentType) {
+        this.offset = offset;
+        this.record = record;
+        this.alignmentType = alignmentType;
     }
 
     /**
@@ -67,6 +96,14 @@ public class AbstractRecordAndOffset {
      */
     public SAMRecord getRecord() {
         return record;
+    }
+
+    /**
+     * The {@link AlignmentType} of this object, which classifies whether the given event is a match, insertion, or
+     * deletion when queried from a {@link SamLocusIterator}.
+     */
+    public AlignmentType getAlignmentType() {
+        return alignmentType;
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
@@ -206,6 +206,16 @@ public class SamLocusIterator extends AbstractLocusIterator<SamLocusIterator.Rec
         public RecordAndOffset(final SAMRecord record, final int offset) {
             super(record, offset);
         }
+
+        /**
+         * @param record inner <code>SAMRecord</code>
+         * @param offset 0-based offset from the start of <code>SAMRecord</code>
+         * @param alignmentType The {@link AlignmentType} of this object, which is used when queried in
+         *                      a {@link SamLocusIterator}.
+         */
+        public RecordAndOffset(final SAMRecord record, final int offset, final AlignmentType alignmentType) {
+            super(record, offset, alignmentType);
+        }
     }
 
     /**
@@ -234,7 +244,7 @@ public class SamLocusIterator extends AbstractLocusIterator<SamLocusIterator.Rec
             if (deletedInRecord == null) {
                 deletedInRecord = new ArrayList<>();
             }
-            deletedInRecord.add(new RecordAndOffset(read, previousPosition));
+            deletedInRecord.add(new RecordAndOffset(read, previousPosition, AbstractRecordAndOffset.AlignmentType.Deletion));
         }
 
         /**
@@ -247,7 +257,7 @@ public class SamLocusIterator extends AbstractLocusIterator<SamLocusIterator.Rec
             if (insertedInRecord == null) {
                 insertedInRecord = new ArrayList<>();
             }
-            insertedInRecord.add(new RecordAndOffset(read, firstPosition));
+            insertedInRecord.add(new RecordAndOffset(read, firstPosition, AbstractRecordAndOffset.AlignmentType.Insertion));
         }
 
         public List<RecordAndOffset> getDeletedInRecord() {

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -62,6 +62,10 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
             for (final SamLocusIterator.LocusInfo li : sli) {
                 Assert.assertEquals(li.getPosition(), pos++);
                 Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
                 Assert.assertEquals(li.size(), coverage);
                 // make sure that we are not accumulating indels
                 Assert.assertEquals(li.getDeletedInRecord().size(), 0);
@@ -87,6 +91,10 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
         for (final SamLocusIterator.LocusInfo li : sli) {
             Assert.assertEquals(li.getPosition(), pos++);
             Assert.assertEquals(li.getRecordAndOffsets().size(), 2);
+            // Check the correct assignment of the alignment type
+            for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+            }
             Assert.assertEquals(li.size(), 2);
         }
     }
@@ -124,6 +132,10 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                     expectedReads = 0;
                 }
                 Assert.assertEquals(li.getRecordAndOffsets().size(), expectedReads);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
                 Assert.assertEquals(li.size(), expectedReads);
                 // make sure that we are not accumulating indels
                 Assert.assertEquals(li.getDeletedInRecord().size(), 0);
@@ -162,6 +174,10 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
             int pos = startPosition;
             for (final SamLocusIterator.LocusInfo li : sli) {
                 Assert.assertEquals(li.getRecordAndOffsets().size(), (pos % 2 == 0) ? coverage / 2 : coverage);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
                 Assert.assertEquals(li.size(), (pos % 2 == 0) ? coverage / 2 : coverage);
                 Assert.assertEquals(li.getPosition(), pos++);
                 // make sure that we are not accumulating indels
@@ -205,10 +221,18 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
 
                     // make sure that we are accumulating indels
                     Assert.assertEquals(li.getDeletedInRecord().size(), coverage);
+                    // Check the correct assignment of the alignment type
+                    for (final SamLocusIterator.RecordAndOffset rao : li.getDeletedInRecord()) {
+                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Deletion);
+                    }
                     Assert.assertEquals(li.getInsertedInRecord().size(), 0);
                 } else {
                     // make sure we are accumulating normal coverage
                     Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
+                    // Check the correct assignment of the alignment type
+                    for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                    }
                     Assert.assertEquals(li.size(), coverage);
 
                     // make sure that we are not accumulating indels
@@ -242,12 +266,20 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 Assert.assertEquals(li.getPosition(), pos++);
                 // make sure we are accumulating normal coverage
                 Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
                 Assert.assertEquals(li.size(), coverage);
 
                 // make sure that we are not accumulating deletions
                 Assert.assertEquals(li.getDeletedInRecord().size(), 0);
                 if (incIndels && li.getPosition() == insStart) {
                     Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
+                    // Check the correct assignment of the alignment type
+                    for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+                    }
                 } else {
                     Assert.assertEquals(li.getInsertedInRecord().size(), 0);
                 }
@@ -281,12 +313,20 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 Assert.assertEquals(li.getPosition(), pos);
                 // accumulation of coverage
                 Assert.assertEquals(li.getRecordAndOffsets().size(), (indelPosition) ? 0 : coverage + 1);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
                 Assert.assertEquals(li.size(), (indelPosition) ? 0 : coverage + 1);
 
                 // no accumulation of deletions
                 Assert.assertEquals(li.getDeletedInRecord().size(), 0);
                 // accumulation of insertion
                 Assert.assertEquals(li.getInsertedInRecord().size(), (indelPosition) ? coverage : 0);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+                }
                 // check offsets of the insertion
                 if (indelPosition) {
                     Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 0);
@@ -322,11 +362,19 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 Assert.assertEquals(li.getPosition(), pos);
                 // accumulation of coverage
                 Assert.assertEquals(li.getRecordAndOffsets().size(), (indelPosition) ? 0 : coverage);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
                 Assert.assertEquals(li.size(), (indelPosition) ? 0 : coverage);
                 // no accumulation of deletions
                 Assert.assertEquals(li.getDeletedInRecord().size(), 0);
                 // accumulation of insertion
                 Assert.assertEquals(li.getInsertedInRecord().size(), (indelPosition) ? coverage : 0);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+                }
                 // check offsets of the insertion
                 if (indelPosition) {
                     Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 1);
@@ -367,11 +415,19 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 Assert.assertEquals(li.getPosition(), pos);
                 // accumulation of coverage
                 Assert.assertEquals(li.getRecordAndOffsets().size(), (pos == endN) ? 0 : coverage);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
                 Assert.assertEquals(li.size(), (pos == endN) ? 0 : coverage);
                 // no accumulation of deletions
                 Assert.assertEquals(li.getDeletedInRecord().size(), 0);
                 // accumulation of insertion
                 Assert.assertEquals(li.getInsertedInRecord().size(), (pos == endN) ? coverage : 0);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+                }
                 // check offsets of the insertion
                 if (pos == endN) {
                     Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), 2);
@@ -419,9 +475,17 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 Assert.assertEquals(li.getPosition(), pos);
                 // accumulation of coverage
                 Assert.assertEquals(li.getRecordAndOffsets().size(), (insideDeletion) ? 0 : coverage);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
                 Assert.assertEquals(li.size(), coverage); // either will be all deletions, or all non-deletions, but always of size `coverage`.
                 // accumulation of deletions
                 Assert.assertEquals(li.getDeletedInRecord().size(), (insideDeletion) ? coverage : 0);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getDeletedInRecord()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Deletion);
+                }
                 // no accumulation of insertion
                 Assert.assertEquals(li.getInsertedInRecord().size(), 0);
                 // check offsets of the insertion
@@ -498,6 +562,10 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 if (incIndels && li.getPosition() == expectedInsertionPosition) {
                     // check the accumulated coverage
                     Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
+                    // Check the correct assignment of the alignment type
+                    for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+                    }
                     // check the record offset
                     Assert.assertEquals(li.getInsertedInRecord().get(0).getOffset(), expectedInsertionOffset);
                     Assert.assertEquals(li.getInsertedInRecord().get(1).getOffset(), expectedInsertionOffset);
@@ -508,6 +576,10 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 if (inDelRange) {
                     // check the coverage for insertion and normal records
                     Assert.assertEquals(li.getDeletedInRecord().size(), coverage);
+                    // Check the correct assignment of the alignment type
+                    for (final SamLocusIterator.RecordAndOffset rao : li.getDeletedInRecord()) {
+                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Deletion);
+                    }
                     Assert.assertEquals(li.getRecordAndOffsets().size(), 0);
                     Assert.assertEquals(li.size(), coverage); // includes deletions
                     // check the offset for the deletion
@@ -516,6 +588,10 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 } else {
                     // if it is not a deletion, perform the same test as before
                     Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
+                    // Check the correct assignment of the alignment type
+                    for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                    }
                     Assert.assertEquals(li.size(), coverage);
                     // Assert.assertEquals(li.getDeletedInRecord().size(), 0);
                     Assert.assertEquals(li.getRecordAndOffsets().get(0).getOffset(), expectedReadOffsets[i]);
@@ -582,6 +658,10 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
             Assert.assertEquals(li.size(), expectedDepths[i]);
             Assert.assertEquals(li.getPosition(), expectedReferencePositions[i]);
             Assert.assertEquals(li.getRecordAndOffsets().size(), expectedReadOffsets[i].length);
+            // Check the correct assignment of the alignment type
+            for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+            }
             for (int j = 0; j < expectedReadOffsets[i].length; ++j) {
                 Assert.assertEquals(li.getRecordAndOffsets().get(j).getOffset(), expectedReadOffsets[i][j]);
             }
@@ -658,11 +738,19 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
             Assert.assertEquals(li.size(), expectedDepths[i] + expectedDelDepths[i]); // include deletions
             Assert.assertEquals(li.getPosition(), expectedReferencePositions[i]);
             Assert.assertEquals(li.getRecordAndOffsets().size(), expectedReadOffsets[i].length);
+            // Check the correct assignment of the alignment type
+            for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+            }
             for (int j = 0; j < expectedReadOffsets[i].length; ++j) {
                 Assert.assertEquals(li.getRecordAndOffsets().get(j).getOffset(), expectedReadOffsets[i][j]);
             }
             // check the deletions
             Assert.assertEquals(li.getDeletedInRecord().size(), expectedDelDepths[i]);
+            // Check the correct assignment of the alignment type
+            for (final SamLocusIterator.RecordAndOffset rao : li.getDeletedInRecord()) {
+                Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Deletion);
+            }
             if (expectedDelDepths[i] != 0) {
                 Assert.assertEquals(li.getDeletedInRecord().get(0).getOffset(), expectedDelOffset);
             }


### PR DESCRIPTION
- as requested per Picard pull request https://github.com/broadinstitute/picard/pull/1370
- necessary to determine whether a RecordAndOffset object is an
(alignment) match, insertion, or deletion when queried by a
SamLocusIterator
- default behavior is preserved by overloading the default constructor

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
