### PR TITLE
Add LiftOver constructor that takes an input stream

### DIFF
--- a/src/main/java/htsjdk/samtools/liftover/Chain.java
+++ b/src/main/java/htsjdk/samtools/liftover/Chain.java
@@ -36,6 +36,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static htsjdk.samtools.util.IOUtil.openFileForReading;
+
 /**
  * Holds a single chain from a UCSC chain file.  Chain file format is described here: http://genome.ucsc.edu/goldenPath/help/chain.html
  *
@@ -306,16 +308,19 @@ class Chain {
         return result;
     }
 
+    static OverlapDetector<Chain> loadChains(final File chainFile) {
+        return loadChains(new BufferedLineReader(openFileForReading(chainFile)), chainFile.toString());
+    }
+
     /**
      * Read all the chains and load into an OverlapDetector.
-     * @param chainFile File in UCSC chain format.
+     * @param reader reader of file in UCSC chain format.
      * @return OverlapDetector will all Chains from reader loaded into it.
      */
-    static OverlapDetector<Chain> loadChains(final File chainFile) {
-        final BufferedLineReader reader = new BufferedLineReader(IOUtil.openFileForReading(chainFile));
+    static OverlapDetector<Chain> loadChains(final BufferedLineReader reader, String sourceName) {
         final OverlapDetector<Chain> ret = new OverlapDetector<Chain>(0, 0);
         Chain chain;
-        while ((chain = Chain.loadChain(reader, chainFile.toString())) != null) {
+        while ((chain = Chain.loadChain(reader, sourceName)) != null) {
             ret.addLhs(chain, chain.interval);
         }
         reader.close();
@@ -325,10 +330,10 @@ class Chain {
     /**
      * Read a single Chain from reader.
      * @param reader Text representation of chains.
-     * @param chainFile For error messages only.
+     * @param sourceName For error messages only.
      * @return New Chain with associated ContinuousBlocks.
      */
-    private static Chain loadChain(final BufferedLineReader reader, final String chainFile) {
+    private static Chain loadChain(final BufferedLineReader reader, final String sourceName) {
         String line;
         while (true) {
             line = reader.readLine();
@@ -342,10 +347,10 @@ class Chain {
         }
         final String[] chainFields = SPLITTER.split(line);
         if (chainFields.length != 13) {
-            throwChainFileParseException("chain line has wrong number of fields", chainFile, reader.getLineNumber());
+            throwChainFileParseException("chain line has wrong number of fields", sourceName, reader.getLineNumber());
         }
         if (!"chain".equals(chainFields[0])) {
-            throwChainFileParseException("chain line does not start with 'chain'", chainFile, reader.getLineNumber());
+            throwChainFileParseException("chain line does not start with 'chain'", sourceName, reader.getLineNumber());
         }
         double score = 0;
         String fromSequenceName = null;
@@ -372,7 +377,7 @@ class Chain {
             toChainEnd = Integer.parseInt(chainFields[11]);
             id = Integer.parseInt(chainFields[12]);
         } catch (NumberFormatException e) {
-            throwChainFileParseException("Invalid field", chainFile, reader.getLineNumber());
+            throwChainFileParseException("Invalid field", sourceName, reader.getLineNumber());
         }
         final Chain chain = new Chain(score, fromSequenceName, fromSequenceSize, fromChainStart, fromChainEnd, toSequenceName, toSequenceSize, toNegativeStrand, toChainStart,
                 toChainEnd, id);
@@ -383,18 +388,18 @@ class Chain {
             line = reader.readLine();
             if (line == null || line.equals("")) {
                 if (!sawLastLine) {
-                    throwChainFileParseException("Reached end of chain without seeing terminal block", chainFile, reader.getLineNumber());
+                    throwChainFileParseException("Reached end of chain without seeing terminal block", sourceName, reader.getLineNumber());
                 }
                 break;
             }
             if (sawLastLine) {
-                throwChainFileParseException("Terminal block seen before end of chain", chainFile, reader.getLineNumber());
+                throwChainFileParseException("Terminal block seen before end of chain", sourceName, reader.getLineNumber());
             }
             String[] blockFields = SPLITTER.split(line);
             if (blockFields.length == 1) {
                 sawLastLine = true;
             } else if (blockFields.length != 3) {
-                throwChainFileParseException("Block line has unexpected number of fields", chainFile, reader.getLineNumber());
+                throwChainFileParseException("Block line has unexpected number of fields", sourceName, reader.getLineNumber());
             }
             int size = Integer.parseInt(blockFields[0]);
             chain.addBlock(fromBlockStart, toBlockStart, size);
@@ -408,7 +413,7 @@ class Chain {
         return chain;
     }
 
-    private static void throwChainFileParseException(final String message, final String chainFile, final int lineNumber) {
-        throw new SAMException(message + " in chain file " + chainFile + " at line " + lineNumber);
+    private static void throwChainFileParseException(final String message, final String sourceName, final int lineNumber) {
+        throw new SAMException(message + " in chain file " + sourceName + " at line " + lineNumber);
     }
 }

--- a/src/main/java/htsjdk/samtools/liftover/LiftOver.java
+++ b/src/main/java/htsjdk/samtools/liftover/LiftOver.java
@@ -25,12 +25,11 @@ package htsjdk.samtools.liftover;
 
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.IOUtil;
-import htsjdk.samtools.util.Interval;
-import htsjdk.samtools.util.Log;
-import htsjdk.samtools.util.OverlapDetector;
+import htsjdk.samtools.util.*;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +37,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static htsjdk.samtools.util.IOUtil.openFileForReading;
 
 /**
  * Java port of UCSC liftOver.  Only the most basic liftOver functionality is implemented.
@@ -84,9 +85,16 @@ public class LiftOver {
     /**
      * Load UCSC chain file in order to lift over Intervals.
      */
-    public LiftOver(File chainFile) {
-        IOUtil.assertFileIsReadable(chainFile);
-        chains = Chain.loadChains(chainFile);
+    public LiftOver(File chainFile){
+        this(toInputStream(chainFile), chainFile.toString());
+    }
+
+    /**
+     * Load UCSC chain file in order to lift over Intervals.
+     */
+    public LiftOver(InputStream chainFileInputStream, String sourceName) {
+        BufferedLineReader bufferedLineReader = new BufferedLineReader(chainFileInputStream);
+        chains = Chain.loadChains(bufferedLineReader, sourceName);
 
         for (final Chain chain : this.chains.getAll()) {
             final String from = chain.fromSequenceName;
@@ -101,6 +109,11 @@ public class LiftOver {
             }
             names.add(to);
         }
+    }
+
+    private static InputStream toInputStream(File chainFile) {
+        IOUtil.assertFileIsReadable(chainFile);
+        return IOUtil.openFileForReading(chainFile);
     }
 
     /**


### PR DESCRIPTION
**Desrciption**

Add LiftOver constructor that takes an input stream. This is so that it can be used in situations where the config is not on a file system. In my case it is on AWS S3. 

**Checklist**

- [x]  Code compiles correctly
- [x]  New tests covering changes and new functionality
- [x]  All tests passing
- [ ] Extended the README / documentation, if necessary
- [ ] Is not backward compatible (breaks binary or source compatibility)