### PR TITLE
Allow partially spanned alleles.

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -382,7 +382,7 @@ public class Allele implements Comparable<Allele>, Serializable {
 
         for (byte base :  bases ) {
             switch (base) {
-                case 'A': case 'C': case 'G': case 'T':  case 'a': case 'c': case 'g': case 't': case 'N' : case 'n' :
+                case 'A': case 'C': case 'G': case 'T': case 'a': case 'c': case 'g': case 't': case 'N': case 'n': case '*':
                     break;
                 default:
                     return false;

--- a/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/AlleleUnitTest.java
@@ -104,6 +104,12 @@ public class AlleleUnitTest extends VariantBaseTest {
     }
 
     @Test
+    public void testPartiallySpannedAllele() {
+        final Allele partial = new Allele("*ATAT", false);
+        Assert.assertEquals(partial.getDisplayString(), "*ATAT");
+    }
+
+    @Test
     public void testCreatingIndelAlleles() {
         Assert.assertEquals(ATIns.length(), 2);
         Assert.assertEquals(ATCIns.length(), 3);


### PR DESCRIPTION
### Description

@lbergelson this is likely to be a slightly contentious change despite the small PR.  The goal here is to support partially spanned alleles in the form they are used in [octopus](https://github.com/luntergroup/octopus).  See https://github.com/luntergroup/octopus/issues/75 for a description of what's going on, but the short version is that Octopus outputs alleles like `*AT` and `**GCGA` to represent cases where the first or first two (respectively) bases of the allele are spanned by an upstream event.

This isn't prohibited by the VCF spec, although it seems like it's an unintentional thing that alleles like this are spec compliant.  Still, I'd like to be able to use HTSJDK's VCF API to read octopus VCFs and it currently blows up on records with alleles like this.