### PR TITLE
Fix issue 1414- add proper behavior of clear() to DiskBackedQueue

### DIFF
--- a/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
+++ b/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
@@ -339,9 +339,14 @@ public class DiskBackedQueue<E> implements Queue<E> {
     private void closeIOResources() {
         CloserUtil.close(this.outputStream);
         CloserUtil.close(this.inputStream);
-        if (this.diskRecords != null) IOUtil.deletePaths(this.diskRecords);
+        if (this.diskRecords != null){
+            try {
+                Files.delete(this.diskRecords);
+            } catch (IOException e) {
+                System.err.println("Could not delete file " + this.diskRecords);
+            }
+        }
     }
-
     /**
      * Not supported. Cannot access particular elements, as some elements may have been written to disk
      *


### PR DESCRIPTION
### Description

Fix bug in DiskBackedQueue.

DiskBackedQueue.closeIOResources() was using IOUtil.deletePaths() to clean up its temp file, but IOUtil.deletePaths() splits a given path into an array of filenames, and there is no function in IOUtil that would properly remove this one path (without needlessly wrapping the temp file in an iterator).

I copied the try/catch that does the file deletion in IOUtil.deletePaths() to the correct place within closeIOResources, and it now works as expected.
