### PR TITLE
Make VCFHeader not throw exception if contig header lines lack length field

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
@@ -76,9 +76,14 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
         return contigIndex;
     }
 
+    /**
+     * Get the SAMSequenceRecord that corresponds to this VCF header line.
+     * @return The SAMSequenceRecord containing the ID, length, assembly, and index of this contig. Returns null if the
+     * contig header line does not have a length.
+     */
 	public SAMSequenceRecord getSAMSequenceRecord() {
 		final String lengthString = this.getGenericFieldValue("length");
-		if (lengthString == null) throw new TribbleException("Contig " + this.getID() + " does not have a length field.");
+		if (lengthString == null) return null;
 		final SAMSequenceRecord record = new SAMSequenceRecord(this.getID(), Integer.parseInt(lengthString));
         record.setAssembly(this.getGenericFieldValue("assembly"));
 		record.setSequenceIndex(this.contigIndex);

--- a/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
@@ -78,13 +78,21 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
 
     /**
      * Get the SAMSequenceRecord that corresponds to this VCF header line.
+     * If the VCF header line does not have a length tag, the SAMSequenceRecord returned will be set to have a length of
+     * SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH. Records with unknown length will match any record with the same name
+     * when evaluated by SAMSequenceRecord.isSameSequence.
      * @return The SAMSequenceRecord containing the ID, length, assembly, and index of this contig. Returns null if the
      * contig header line does not have a length.
      */
 	public SAMSequenceRecord getSAMSequenceRecord() {
 		final String lengthString = this.getGenericFieldValue("length");
-		if (lengthString == null) return null;
-		final SAMSequenceRecord record = new SAMSequenceRecord(this.getID(), Integer.parseInt(lengthString));
+		final int length;
+		if (lengthString == null) {
+		    length = SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH;
+        } else {
+		    length = Integer.parseInt(lengthString);
+        }
+		final SAMSequenceRecord record = new SAMSequenceRecord(this.getID(), length);
         record.setAssembly(this.getGenericFieldValue("assembly"));
 		record.setSequenceIndex(this.contigIndex);
 		return record;

--- a/src/main/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeader.java
@@ -261,7 +261,7 @@ public class VCFHeader implements Serializable {
 
     /**
      * Returns the contigs in this VCF file as a SAMSequenceDictionary. Returns null if contigs lines are
-     * not present in the header. Throws SAMException if one or more contig lines do not have length
+     * not present in the header. Returns null if one or more contig lines do not have length
      * information.
      */
     public SAMSequenceDictionary getSequenceDictionary() {
@@ -270,7 +270,9 @@ public class VCFHeader implements Serializable {
 
         final List<SAMSequenceRecord> sequenceRecords = new ArrayList<SAMSequenceRecord>(contigHeaderLines.size());
         for (final VCFContigHeaderLine contigHeaderLine : contigHeaderLines) {
-            sequenceRecords.add(contigHeaderLine.getSAMSequenceRecord());
+            final SAMSequenceRecord samSequenceRecord = contigHeaderLine.getSAMSequenceRecord();
+            if (samSequenceRecord == null) return null;
+            sequenceRecords.add(samSequenceRecord);
         }
 
         return new SAMSequenceDictionary(sequenceRecords);

--- a/src/main/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeader.java
@@ -261,8 +261,9 @@ public class VCFHeader implements Serializable {
 
     /**
      * Returns the contigs in this VCF file as a SAMSequenceDictionary. Returns null if contigs lines are
-     * not present in the header. Returns null if one or more contig lines do not have length
-     * information.
+     * not present in the header. If contig lines are missing length tags, they will be created with
+     * length set to SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH. Records with unknown length will match any record with
+     * the same name when evaluated by SAMSequenceRecord.isSameSequence.
      */
     public SAMSequenceDictionary getSequenceDictionary() {
         final List<VCFContigHeaderLine> contigHeaderLines = this.getContigLines();
@@ -271,7 +272,6 @@ public class VCFHeader implements Serializable {
         final List<SAMSequenceRecord> sequenceRecords = new ArrayList<SAMSequenceRecord>(contigHeaderLines.size());
         for (final VCFContigHeaderLine contigHeaderLine : contigHeaderLines) {
             final SAMSequenceRecord samSequenceRecord = contigHeaderLine.getSAMSequenceRecord();
-            if (samSequenceRecord == null) return null;
             sequenceRecords.add(samSequenceRecord);
         }
 

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -239,6 +239,18 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     }
 
     @Test
+    public void testVCFHeaderContigLineMissingLength() {
+        final VCFHeader header = getHiSeqVCFHeader();
+        final VCFContigHeaderLine contigLine = new VCFContigHeaderLine(
+                "<ID=chr1>", VCFHeaderVersion.VCF4_0, VCFHeader.CONTIG_KEY, 0);
+        header.addMetaDataLine(contigLine);
+        Assert.assertTrue(header.getContigLines().contains(contigLine), "Test contig line not found in contig header lines");
+        Assert.assertTrue(header.getMetaDataInInputOrder().contains(contigLine), "Test contig line not found in set of all header lines");
+
+        Assert.assertNull(header.getSequenceDictionary());
+    }
+
+        @Test
     public void testVCFHeaderHonorContigLineOrder() throws IOException {
         try (final VCFFileReader vcfReader = new VCFFileReader(new File(variantTestDataRoot + "dbsnp_135.b37.1000.vcf"), false)) {
             // start with a header with a bunch of contig lines

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -25,6 +25,8 @@
 
 package htsjdk.variant.vcf;
 
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
@@ -247,7 +249,10 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertTrue(header.getContigLines().contains(contigLine), "Test contig line not found in contig header lines");
         Assert.assertTrue(header.getMetaDataInInputOrder().contains(contigLine), "Test contig line not found in set of all header lines");
 
-        Assert.assertNull(header.getSequenceDictionary());
+        final SAMSequenceDictionary sequenceDictionary = header.getSequenceDictionary();
+        Assert.assertNotNull(sequenceDictionary);
+        Assert.assertEquals(sequenceDictionary.getSequence("chr1").getSequenceLength(), SAMSequenceRecord.UNKNOWN_SEQUENCE_LENGTH);
+
     }
 
         @Test


### PR DESCRIPTION
### Description

`VCFHeader.getSequenceDictionary` currently throws an exception if one or more of the `Contig` header lines does not have a length field, despite the fact that:

- The VCF spec (v 4.2 and 4.3) does not require a length field (although it states that they are typically present)
- If contig lines are not present in the header it simply returns null

This generally has the effect of making htsjdk tools unable to process files missing length fields without re-headering, which is not always feasible, for example in the case of large multi-sample files in cloud storage.

Fixes https://github.com/samtools/htsjdk/issues/389

### Things to think about before submitting:
- [X] Make sure your changes compile and new tests pass locally.
- [X] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
