### PR TITLE
Add a URLHelper factory API to ParsingUtils 

### DIFF
--- a/src/main/java/htsjdk/tribble/util/FTPHelper.java
+++ b/src/main/java/htsjdk/tribble/util/FTPHelper.java
@@ -43,7 +43,6 @@ public class FTPHelper implements URLHelper {
     }
 
     @Override
-    @Deprecated
     public InputStream openInputStreamForRange(long start, long end) throws IOException {
         throw new UnsupportedOperationException("Cannot perform range operations over FTP");
     }

--- a/src/main/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/main/java/htsjdk/tribble/util/ParsingUtils.java
@@ -46,12 +46,10 @@ public class ParsingUtils {
 
     public static final Map<Object, Color> colorCache = new WeakHashMap<>(100);
 
-    // HTML 4.1 color table,  + orange and magenta
-    static Map<String, String> colorSymbols = new HashMap();
+    private static URLHelperFactory urlHelperFactory = new URLHelperFactory() {};
 
-    private static URLHelperFactory urlHelperFactory;
-    private static final Class defaultUrlHelperClass = RemoteURLHelper.class;
-    public static Class urlHelperClass = defaultUrlHelperClass;
+    // HTML 4.1 color table,  + orange and magenta
+    private static Map<String, String> colorSymbols = new HashMap();
 
     static {
         colorSymbols.put("white", "FFFFFF");
@@ -424,62 +422,30 @@ public class ParsingUtils {
     }
 
     /**
-     * Return the registered URLHelper, constructed with the provided URL
-     * @see #registerHelperClass(Class)
+     * Return a URLHelper from the current URLHelperFactory
+     *
      * @param url
      * @return
      */
     public static URLHelper getURLHelper(URL url) {
-
-        if(urlHelperFactory != null) {
             return urlHelperFactory.getHelper(url);
-        }
-        else {
-            try {
-                return getURLHelper(urlHelperClass, url);
-            } catch (Exception e) {
-                return getURLHelper(defaultUrlHelperClass, url);
-            }
-        }
-    }
-
-    private static URLHelper getURLHelper(Class helperClass, URL url) {
-        try {
-            Constructor constr = helperClass.getConstructor(URL.class);
-            return (URLHelper) constr.newInstance(url);
-        } catch (Exception e) {
-            String errMsg = "Error instantiating url helper for class: " + helperClass;
-            throw new IllegalStateException(errMsg, e);
-        }
     }
 
     /**
-     * Register a {@code URLHelper} class to be used for URL operations. The helper
-     * may be used for both FTP and HTTP operations, so if any FTP URLs are used
-     * the {@code URLHelper} must support it.
+     * Set the factory object for providing URLHelpers.  {@see URLHelperFactory}.
      *
-     * The default helper class is {@link RemoteURLHelper}, which delegates to FTP/HTTP
-     * helpers as appropriate.
-     *
-     * @deprecated use {@code registerHelperFactory}
-     * @see URLHelper
-     * @param helperClass Class which implements {@link URLHelper}, and have a constructor
-     *                    which takes a URL as it's only argument.
+     * @param factory
      */
-    public static void registerHelperClass(Class helperClass) {
-        if (!URLHelper.class.isAssignableFrom(helperClass)) {
-            throw new IllegalArgumentException("helperClass must implement URLHelper");
-            //TODO check that it has 1 arg constructor of proper type
-        }
-        urlHelperClass = helperClass;
-    }
-
-
-    public static void registerHelperFactory(URLHelperFactory factory) {
+    public static void setURLHelperFactory(URLHelperFactory factory) {
         urlHelperFactory = factory;
     }
 
+    public static URLHelperFactory getURLHelperFactory() {
+        return urlHelperFactory;
+    }
+
     /**
+     *
      * Add the {@code indexExtension} to the {@code filepath}, preserving
      * query string elements if present. Intended for use where {@code filepath}
      * is a URL. Will behave correctly on regular file paths (just add the extension

--- a/src/main/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/main/java/htsjdk/tribble/util/ParsingUtils.java
@@ -46,7 +46,7 @@ public class ParsingUtils {
 
     public static final Map<Object, Color> colorCache = new WeakHashMap<>(100);
 
-    private static URLHelperFactory urlHelperFactory = new URLHelperFactory() {};
+    private static URLHelperFactory urlHelperFactory = RemoteURLHelper::new;
 
     // HTML 4.1 color table,  + orange and magenta
     private static Map<String, String> colorSymbols = new HashMap();
@@ -438,6 +438,9 @@ public class ParsingUtils {
      * @param factory
      */
     public static void setURLHelperFactory(URLHelperFactory factory) {
+        if(factory == null) {
+            throw new NullPointerException("Null URLHelperFactory");
+        }
         urlHelperFactory = factory;
     }
 

--- a/src/main/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/main/java/htsjdk/tribble/util/ParsingUtils.java
@@ -49,6 +49,7 @@ public class ParsingUtils {
     // HTML 4.1 color table,  + orange and magenta
     static Map<String, String> colorSymbols = new HashMap();
 
+    private static URLHelperFactory urlHelperFactory;
     private static final Class defaultUrlHelperClass = RemoteURLHelper.class;
     public static Class urlHelperClass = defaultUrlHelperClass;
 
@@ -429,10 +430,16 @@ public class ParsingUtils {
      * @return
      */
     public static URLHelper getURLHelper(URL url) {
-        try {
-            return getURLHelper(urlHelperClass, url);
-        } catch (Exception e) {
-            return getURLHelper(defaultUrlHelperClass, url);
+
+        if(urlHelperFactory != null) {
+            return urlHelperFactory.getHelper(url);
+        }
+        else {
+            try {
+                return getURLHelper(urlHelperClass, url);
+            } catch (Exception e) {
+                return getURLHelper(defaultUrlHelperClass, url);
+            }
         }
     }
 
@@ -454,6 +461,7 @@ public class ParsingUtils {
      * The default helper class is {@link RemoteURLHelper}, which delegates to FTP/HTTP
      * helpers as appropriate.
      *
+     * @deprecated use {@code registerHelperFactory}
      * @see URLHelper
      * @param helperClass Class which implements {@link URLHelper}, and have a constructor
      *                    which takes a URL as it's only argument.
@@ -464,6 +472,11 @@ public class ParsingUtils {
             //TODO check that it has 1 arg constructor of proper type
         }
         urlHelperClass = helperClass;
+    }
+
+
+    public static void registerHelperFactory(URLHelperFactory factory) {
+        urlHelperFactory = factory;
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/main/java/htsjdk/tribble/util/ParsingUtils.java
@@ -423,6 +423,7 @@ public class ParsingUtils {
 
     /**
      * Return a URLHelper from the current URLHelperFactory
+     * @see #setURLHelperFactory(URLHelperFactory) 
      *
      * @param url
      * @return

--- a/src/main/java/htsjdk/tribble/util/RemoteURLHelper.java
+++ b/src/main/java/htsjdk/tribble/util/RemoteURLHelper.java
@@ -43,7 +43,6 @@ public class RemoteURLHelper implements URLHelper {
     }
 
     @Override
-    @Deprecated
     public InputStream openInputStreamForRange(long start, long end) throws IOException {
         return this.wrappedHelper.openInputStreamForRange(start, end);
     }

--- a/src/main/java/htsjdk/tribble/util/URLHelper.java
+++ b/src/main/java/htsjdk/tribble/util/URLHelper.java
@@ -57,8 +57,6 @@ public interface URLHelper {
      * Open an InputStream to stream a slice (range)  of the resource.
      *
      * May throw an OperationUnsupportedException
-     * @deprecated Will be removed in a future release, as is somewhat fragile
-     * and not used.
      * @param start
      * @param end
      * @return

--- a/src/main/java/htsjdk/tribble/util/URLHelper.java
+++ b/src/main/java/htsjdk/tribble/util/URLHelper.java
@@ -23,8 +23,10 @@ import java.io.InputStream;
 import java.net.URL;
 
 /**
- * Interface defining a helper class for dealing with URL resources.  Purpose of this class is to provide the
- * flexibility to use either URLConnection or Apache HTTPClient. Also want to delegate to either HTTP or FTP
+ * Interface defining a helper class for dealing with URL resources.  The purpose of this class is to provide the
+ * flexibility to use alternative http implementations, for example Apache HTTPClient, and secondly to provide
+ * a hook for clients to inject custom headers, for example oAuth tokens, into the requests.  An instance of
+ * URLHelper is created for a URL (there is a 1-1 relation between a URL and HRLHelper).
  *
  * @see HTTPHelper
  * @see FTPHelper
@@ -33,13 +35,27 @@ import java.net.URL;
  */
 public interface URLHelper {
 
+    /**
+     * @return URL of the associated resource
+     */
     URL getUrl();
 
+    /**
+     * @return content length of the resource, or -1 if not available
+     * @throws IOException
+     */
     long getContentLength() throws IOException;
 
+    /**
+     * Open an InputStream to stream the contents of the resource
+     * @return
+     * @throws IOException
+     */
     InputStream openInputStream() throws IOException;
 
     /**
+     * Open an InputStream to stream a slice (range)  of the resource.
+     *
      * May throw an OperationUnsupportedException
      * @deprecated Will be removed in a future release, as is somewhat fragile
      * and not used.
@@ -48,7 +64,7 @@ public interface URLHelper {
      * @return
      * @throws IOException
      */
-    @Deprecated
+
     InputStream openInputStreamForRange(long start, long end) throws IOException;
 
     public boolean exists() throws IOException;

--- a/src/main/java/htsjdk/tribble/util/URLHelperFactory.java
+++ b/src/main/java/htsjdk/tribble/util/URLHelperFactory.java
@@ -2,8 +2,17 @@ package htsjdk.tribble.util;
 
 import java.net.URL;
 
+/**
+ * A factory for creating {@link  URLHelper} instances.
+ */
 public interface URLHelperFactory {
 
-    URLHelper getHelper(URL url);
+    /**
+     * @param url
+     * @return a {@link URLHelper} object for the given URL
+     */
+    default URLHelper getHelper(URL url) {
+        return new RemoteURLHelper(url);
+    }
 
 }

--- a/src/main/java/htsjdk/tribble/util/URLHelperFactory.java
+++ b/src/main/java/htsjdk/tribble/util/URLHelperFactory.java
@@ -1,0 +1,9 @@
+package htsjdk.tribble.util;
+
+import java.net.URL;
+
+public interface URLHelperFactory {
+
+    URLHelper getHelper(URL url);
+
+}

--- a/src/main/java/htsjdk/tribble/util/URLHelperFactory.java
+++ b/src/main/java/htsjdk/tribble/util/URLHelperFactory.java
@@ -11,10 +11,7 @@ public interface URLHelperFactory {
     /**
      * @param url
      * @return a {@link URLHelper} object for the given URL
-     * @throws
      */
-    default URLHelper getHelper(URL url)   {
-        return new RemoteURLHelper(url);
-    }
+    URLHelper getHelper(URL url);
 
 }

--- a/src/main/java/htsjdk/tribble/util/URLHelperFactory.java
+++ b/src/main/java/htsjdk/tribble/util/URLHelperFactory.java
@@ -3,15 +3,17 @@ package htsjdk.tribble.util;
 import java.net.URL;
 
 /**
- * A factory for creating {@link  URLHelper} instances.
+ * A factory for creating {@link  URLHelper} instances.  The factory contains a single function
+ * @see #getHelper(URL) which should return a <code>URLHelper</code> instance for the given URL.
  */
 public interface URLHelperFactory {
 
     /**
      * @param url
      * @return a {@link URLHelper} object for the given URL
+     * @throws
      */
-    default URLHelper getHelper(URL url) {
+    default URLHelper getHelper(URL url)   {
         return new RemoteURLHelper(url);
     }
 


### PR DESCRIPTION
This PR adds a URLHelper factory interface and function on ParsingUtils to set the factory.   It is a replacement or alternative to the previous implementation which used reflection to accomplish the same thing.  Reflection won't work for Java 11 clients,  its illegal across module boundaries for the most part, and bad practice as well.   The reflection API was left in place in case anyone is using it with Java 8.
