### PR TITLE
Improve TextualBAMIndexWriter text output.

### DIFF
--- a/src/main/java/htsjdk/samtools/TextualBAMIndexWriter.java
+++ b/src/main/java/htsjdk/samtools/TextualBAMIndexWriter.java
@@ -24,6 +24,8 @@
 
 package htsjdk.samtools;
 
+import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
@@ -108,7 +110,7 @@ class TextualBAMIndexWriter implements BAMIndexWriter {
                 pw.println("  Ref " + reference + " bin " + bin.getBinNumber() + " has no chunkList");
                 continue;
             }
-            pw.print("  Ref " + reference + " bin " + bin.getBinNumber() + " has n_chunk= " + chunkList.size());
+            pw.println("  Ref " + reference + " bin " + bin.getBinNumber() + " (" + GenomicIndexUtil.getBinSummaryString(bin.getBinNumber()) + ") has n_chunk= " + chunkList.size());
             if (chunkList.isEmpty()) {
                  pw.println();
             }
@@ -134,7 +136,8 @@ class TextualBAMIndexWriter implements BAMIndexWriter {
         pw.println("Reference " + reference + " has n_intv= " + n_intv);
         for (int k = 0; k < entries.length; k++) {
             if (entries[k] != 0) {
-                pw.println("  Ref " + reference + " ioffset for " + (k + indexStart) + " is " + Long.toString(entries[k]));
+                pw.println("  Ref " + reference + " ioffset for " + (k + indexStart) + " is " +
+                        BlockCompressedFilePointerUtil.asAddressOffsetString(entries[k]));
             }
         }
         pw.flush ();  // write each reference to disk as it's being created
@@ -147,7 +150,7 @@ class TextualBAMIndexWriter implements BAMIndexWriter {
      */
     private void writeChunkMetaData(final int reference, final BAMIndexMetaData metaData) {
         final int nChunks = metaData == null ? 0 : 2;
-        pw.print("  Ref " + reference + " bin 37450 has n_chunk= " + nChunks);
+        pw.println("  Ref " + reference + " bin 37450 has n_chunk= " + nChunks);
         if (nChunks == 0) {
             pw.println();
         } else {

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedFilePointerUtil.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedFilePointerUtil.java
@@ -122,4 +122,15 @@ public class BlockCompressedFilePointerUtil {
     public static String asString(final long vfp) {
         return String.format("%d(0x%x): (block address: %d, offset: %d)", vfp, vfp, getBlockAddress(vfp), getBlockOffset(vfp));
     }
+
+    /**
+     * Return a String with the file pointer in "address:offset" form.
+     * @param vfp virtual file pointer to format
+     * @return {@code vfp} formatted as string in address:offset form
+     */
+    public static String asAddressOffsetString(final long vfp) {
+        return String.format("%d:%d",
+                BlockCompressedFilePointerUtil.getBlockAddress(vfp),
+                BlockCompressedFilePointerUtil.getBlockOffset(vfp));
+    }
 }

--- a/src/test/java/htsjdk/samtools/GenomicIndexUtilTest.java
+++ b/src/test/java/htsjdk/samtools/GenomicIndexUtilTest.java
@@ -10,6 +10,35 @@ import org.testng.annotations.Test;
  */
 public class GenomicIndexUtilTest extends HtsjdkTest {
 
+    @DataProvider(name="bin2LevelProvider")
+    private Object[][] getBin2LevelTests() {
+        return new Object[][] {
+                // level boundary tests
+                { 0, 0, "bin=0, level=0, first bin=0, bin size=536,870,912 bin range=(0-536,870,912)" },
+                { 1, 1, "bin=1, level=1, first bin=1, bin size=67,108,864 bin range=(0-67,108,864)"},
+                { 8, 1, "bin=8, level=1, first bin=1, bin size=67,108,864 bin range=(469,762,048-536,870,912)"},
+                { 9, 2, "bin=9, level=2, first bin=9, bin size=8,388,608 bin range=(0-8,388,608)" },
+                { 72, 2, "bin=72, level=2, first bin=9, bin size=8,388,608 bin range=(528,482,304-536,870,912)" },
+                { 73, 3, "bin=73, level=3, first bin=73, bin size=1,048,576 bin range=(0-1,048,576)"},
+                { 584, 3, "bin=584, level=3, first bin=73, bin size=1,048,576 bin range=(535,822,336-536,870,912)"},
+                { 585, 4, "bin=585, level=4, first bin=585, bin size=131,072 bin range=(0-131,072)"},
+                { 591, 4, "bin=591, level=4, first bin=585, bin size=131,072 bin range=(786,432-917,504)"},
+                { 4680, 4, "bin=4680, level=4, first bin=585, bin size=131,072 bin range=(536,739,840-536,870,912)"},
+                { 4681, 5, "bin=4681, level=5, first bin=4681, bin size=16,384 bin range=(0-16,384)"},
+                { 37448, 5, "bin=37448, level=5, first bin=4681, bin size=16,384 bin range=(536,854,528-536,870,912)"}
+        };
+    }
+
+    @Test(dataProvider = "bin2LevelProvider")
+    public void testBin2Level(final int bin, final int expectedLevel, final String ignored) {
+        Assert.assertEquals(GenomicIndexUtil.binTolevel(bin), expectedLevel);
+    }
+
+    @Test(dataProvider = "bin2LevelProvider")
+    public void testBin2RegionString(final int bin, final int ignored, final String expectedString) {
+        Assert.assertEquals(GenomicIndexUtil.getBinSummaryString(bin), expectedString);
+    }
+
     @Test(dataProvider = "testRegionToBinDataProvider")
     public void testRegionToBin(final int beg, final int end, final int bin) {
         Assert.assertEquals(GenomicIndexUtil.regionToBin(beg, end), bin);

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedFilePointerUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedFilePointerUtilTest.java
@@ -33,13 +33,14 @@ import java.util.List;
 
 
 public class BlockCompressedFilePointerUtilTest extends HtsjdkTest {
+    final static long BIG_BLOCK_ADDRESS = 1L << 46;
+
     @Test
     public void basicTest() 
     {
         List<Long> pointers = new ArrayList<Long>();
         pointers.add(makeFilePointer(0, 0));
         pointers.add(makeFilePointer(0, BlockCompressedFilePointerUtil.MAX_OFFSET));
-        final long BIG_BLOCK_ADDRESS = 1L << 46;
         pointers.add(makeFilePointer(BIG_BLOCK_ADDRESS-1, 0));
         pointers.add(makeFilePointer(BIG_BLOCK_ADDRESS-1, BlockCompressedFilePointerUtil.MAX_OFFSET));
         pointers.add(makeFilePointer(BIG_BLOCK_ADDRESS, 0));
@@ -89,7 +90,7 @@ public class BlockCompressedFilePointerUtilTest extends HtsjdkTest {
                 {0L, BlockCompressedFilePointerUtil.MAX_OFFSET+1}
         };
     }
-
+    
     @Test(dataProvider = "shiftInputs")
     public void shiftTest(long blockAddress, int blockOffset) {
         final long shift = 100;
@@ -108,6 +109,26 @@ public class BlockCompressedFilePointerUtilTest extends HtsjdkTest {
                 {1L << 46, BlockCompressedFilePointerUtil.MAX_OFFSET}
         };
     }
+    
+    @DataProvider(name="virtualFilePointerStrings")
+    public Object[][] getFilePointers() {
+        return new Object[][] {
+                { makeFilePointer(0, 0), "0:0" },
+                { makeFilePointer(0, BlockCompressedFilePointerUtil.MAX_OFFSET), "0:65535" },
+                { makeFilePointer(BIG_BLOCK_ADDRESS-1, 0), "70368744177663:0" },
+                { makeFilePointer(BIG_BLOCK_ADDRESS-1, BlockCompressedFilePointerUtil.MAX_OFFSET), "70368744177663:65535" },
+                { makeFilePointer(BIG_BLOCK_ADDRESS, 0), "70368744177664:0" },
+                { makeFilePointer(BIG_BLOCK_ADDRESS, BlockCompressedFilePointerUtil.MAX_OFFSET), "70368744177664:65535" },
+                { makeFilePointer(BlockCompressedFilePointerUtil.MAX_BLOCK_ADDRESS, 0), "281474976710655:0" },
+                { makeFilePointer(BlockCompressedFilePointerUtil.MAX_BLOCK_ADDRESS, BlockCompressedFilePointerUtil.MAX_OFFSET), "281474976710655:65535" }
+        };
+    }
+
+    @Test(dataProvider = "virtualFilePointerStrings")
+    public void testAsAddressOffsetString(final long vfp, final String addressOffset) {
+        Assert.assertEquals(BlockCompressedFilePointerUtil.asAddressOffsetString(vfp), addressOffset);
+    }
+
 }
 
 /******************************************************************/


### PR DESCRIPTION
This adds a couple of utility methods to GenomicIndexUtil for use with TextualBAMIndexWriter for easier index debugging. The new output includes the bin level for a given bin, and the genomic territory covered by that bin (along with a minor formatting tweak to put line breaks in the right spot).

Previous output:
```
Reference 0 has n_bin= 2
  Ref 0 bin 5291 has n_chunk= 1     Chunk: 1837:0-1837:1 start: 72d0000 end: 72d0001
  Ref 0 bin 37450 has n_chunk= 2     Chunk:  start: 68d end: 68d
     Chunk:  start: 0 end: 0

```
with this:
```
Reference 0 has n_bin= 2
  Ref 0 bin 5291 (bin=5291, level=5, first bin=4681, bin size=16,384 bin range=(9,994,240-10,010,624)) has n_chunk= 1
     Chunk: 1837:0-1837:1 start: 72d0000 end: 72d0001
  Ref 0 bin 37450 has n_chunk= 2
     Chunk:  start: 68d end: 68d
     Chunk:  start: 0 end: 0

```