### PR TITLE
Updating versions of commons-compress and xz library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     compile "org.apache.commons:commons-jexl:2.1.1"
     compile "commons-logging:commons-logging:1.1.1"
     compile "org.xerial.snappy:snappy-java:1.1.4"
-    compile "org.apache.commons:commons-compress:1.4.1"
-    compile "org.tukaani:xz:1.5"
+    compile "org.apache.commons:commons-compress:1.19"
+    compile 'org.tukaani:xz:1.8'
     compile "gov.nih.nlm.ncbi:ngs-java:2.9.0"
 
     testCompile "org.scala-lang:scala-library:2.12.8"


### PR DESCRIPTION
    Updating versions of commons-compress and xz library

    * update commons-compress 1.4.1 -> 1.19
    * update xz 1.5 -> 1.8