### PR TITLE
Improve calculation of available memory when sizing buffers in SortingCollection

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -524,11 +524,16 @@ public class SortingCollection<T> implements Iterable<T> {
         // enough memory for buffering it will return zero and all reading will be unbuffered.
         private int checkMemoryAndAdjustBuffer(int numFiles) {
             int bufferSize = Defaults.BUFFER_SIZE;
+
             // garbage collect so that our calculation is accurate.
-            Runtime.getRuntime().gc();
+            final Runtime rt = Runtime.getRuntime();
+            rt.gc();
+
+            //                             free in heap       space available to expand heap
+            final long allocatableMemory = rt.freeMemory() + (rt.maxMemory() - rt.totalMemory());
 
             // There is ~20k in overhead per file.
-            final long freeMemory = Runtime.getRuntime().freeMemory() - (numFiles * 20 * 1024);
+            final long freeMemory = allocatableMemory - (numFiles * 20 * 1024);
             // use the floor value from the divide
             final int memoryPerFile = (int) (freeMemory / numFiles);
 


### PR DESCRIPTION
### Description

SortingCollection keeps insisting that it doesn't have enough memory to buffer files for reading. But this is testably false - if you keep the same number of items in memory, same number of files, and increase the heap size, it continues to insist there is not enough space to buffer.

The existing implementation uses a method that returns the amount of free memory _in the currently allocated heap_.  It does not take into account that the heap may not have been expanded to it's max size as specified by `-Xmx`.

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
