### PR TITLE
Reduce test output from BlockCompressedInputStreamTest test method args.

### DIFF
--- a/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
@@ -245,11 +245,25 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
                 .map(s -> new Object[]{s}).toArray(Object[][]::new);
     }
 
+    // test case wrapper to reduce spammy TestNG output during test execution
+    private static class SAMSequenceDictionaryWrapper {
+        final SAMSequenceDictionary dictionary;
+        public SAMSequenceDictionaryWrapper(final SAMSequenceDictionary dictionary) {
+            this.dictionary = dictionary;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%d/%d", dictionary.size(),dictionary.getReferenceLength());
+        }
+    }
+
     @Test(dataProvider = "testData")
-    public void testWriter(final SAMSequenceDictionary dictionary, final boolean withIndex, final boolean withDictionary,
+    public void testWriter(final SAMSequenceDictionaryWrapper dictionaryWrapper, final boolean withIndex, final boolean withDictionary,
                            final boolean withDescriptions, final int defaultBpl,
                            final int minBpl, final int maxBpl, final int seed, final boolean gzipped)
             throws IOException, GeneralSecurityException, URISyntaxException {
+        final SAMSequenceDictionary dictionary = dictionaryWrapper.dictionary;
         final Map<String, byte[]> bases = new LinkedHashMap<>(dictionary.getSequences().size());
         final Map<String, Integer> bpl = new LinkedHashMap<>(dictionary.getSequences().size());
         final Random rdn = new Random(seed);
@@ -584,8 +598,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
         }
     }
 
-    private void assertFastaDictionaryContent(final Path dictPath, final SAMSequenceDictionary dictionary)
-            throws IOException, GeneralSecurityException, URISyntaxException {
+    private void assertFastaDictionaryContent(final Path dictPath, final SAMSequenceDictionary dictionary) {
         final SAMSequenceDictionary actualDictionary = SAMSequenceDictionaryExtractor.extractDictionary(dictPath);
         dictionary.assertSameDictionary(actualDictionary);
     }
@@ -636,7 +649,8 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
                         for (final int bpl : testBpls) {
                             for (final int seed : testSeeds) {
                                 for (final boolean gzipped : testWithGzipped)
-                                result.add(new Object[]{dictionary, withIndex, withDictionary, withDescriptions, bpl, 1, (bpl < 0 ? FastaReferenceWriter.DEFAULT_BASES_PER_LINE : bpl) * 2, seed, gzipped});
+                                result.add(new Object[]{
+                                        new SAMSequenceDictionaryWrapper(dictionary), withIndex, withDictionary, withDescriptions, bpl, 1, (bpl < 0 ? FastaReferenceWriter.DEFAULT_BASES_PER_LINE : bpl) * 2, seed, gzipped});
                             }
                         }
                     }

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
@@ -158,13 +158,11 @@ public class VariantContextTestProvider extends HtsjdkTest {
             return vcs.get(0).hasGenotypes();
         }
 
+        // Minimize the toString representation to minimize output due to test method argument expansion by testNG
         public String toString() {
             StringBuilder b = new StringBuilder();
-            b.append("VariantContextTestData: [");
             final VariantContext vc = vcs.get(0);
-            final VariantContextBuilder builder = new VariantContextBuilder(vc);
-            builder.noGenotypes();
-            b.append(builder.make().toString());
+            b.append(vc.getType());
             if ( vc.getNSamples() < 5 ) {
                 for ( final Genotype g : vc.getGenotypes() )
                     b.append(g.toString());
@@ -173,7 +171,6 @@ public class VariantContextTestProvider extends HtsjdkTest {
             }
 
             if ( vcs.size() > 1 ) b.append(" ----- with another ").append(vcs.size() - 1).append(" VariantContext records");
-            b.append("]");
             return b.toString();
         }
     }


### PR DESCRIPTION
We're within about 20k of the 5MB log output limit on travis - with my cram branch we go way over. A lot of it is the expansion of test method arg values. This change suppresses about 500k of output by wrapping large list inputs in a `Supplier`.