### PR TITLE
SAMFileWriter does not do proper cleanup on IOException

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -204,17 +204,24 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
     @Override
     public final void close()
     {
-        if (!isClosed) {
-            if (alignmentSorter != null) {
-                for (final SAMRecord alignment : alignmentSorter) {
-                    writeAlignment(alignment);
-                    if (progressLogger != null) progressLogger.record(alignment);
+        try {
+            if (!isClosed) {
+                if (alignmentSorter != null) {
+                    try {
+                        for (final SAMRecord alignment : alignmentSorter) {
+                            writeAlignment(alignment);
+                            if (progressLogger != null)
+                                progressLogger.record(alignment);
+                        }
+                    } finally {
+                        alignmentSorter.cleanup();
+                    }
                 }
-                alignmentSorter.cleanup();
+                finish();
             }
-            finish();
+        } finally {
+            isClosed = true;
         }
-        isClosed = true;
     }
 
     /**


### PR DESCRIPTION
### Description

In case an IOException is encountered during closing of the SAMFileWriter the contained alignment sorter is not properly closed and as a result temporary sorting files potentially end up being left behind. This is fixed by putting the cleanup of the alignment sorter within a finally block.
