### PR TITLE
Fix IndexFactory on non-default file system.

### DIFF
--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -520,7 +520,7 @@ public class IndexFactory {
                     msg += " Saw feature " + featToString(visitedChromos.get(curChr));
                     msg += " followed later by " + featToString(lastFeature);
                     msg += " and then " + featToString(currentFeature);
-                    throw new TribbleException.MalformedFeatureFile(msg, inputPath.toAbsolutePath().toString());
+                    throw new TribbleException.MalformedFeatureFile(msg, inputPath.toString());
                 }else{
                     visitedChromos.put(curChr, currentFeature);
                 }
@@ -546,7 +546,7 @@ public class IndexFactory {
         if (lastFeature != null && currentFeature.getStart() < lastFeature.getStart() && lastFeature.getContig().equals(currentFeature.getContig()))
             throw new TribbleException.MalformedFeatureFile("Input file is not sorted by start position. \n" +
                     "We saw a record with a start of " + currentFeature.getContig() + ":" + currentFeature.getStart() +
-                    " after a record with a start of " + lastFeature.getContig() + ":" + lastFeature.getStart(), inputPath.toAbsolutePath().toString());
+                    " after a record with a start of " + lastFeature.getContig() + ":" + lastFeature.getStart(), inputPath.toString());
     }
 
 
@@ -616,7 +616,7 @@ public class IndexFactory {
             } catch (final IOException e) {
                 throw new TribbleException.FeatureFileDoesntExist(
                         "Unable to open the input file, most likely the file doesn't exist.",
-                        inputPath.toAbsolutePath().toString());
+                        inputPath.toString());
             }
         }
 
@@ -625,17 +625,17 @@ public class IndexFactory {
             try {
                 if (!IOUtil.isBlockCompressed(inputPath, true)) {
                     throw new TribbleException.MalformedFeatureFile("Input file is not in valid block compressed format.",
-                            inputPath.toAbsolutePath().toString());
+                            inputPath.toString());
                 }
 
                 final ISeekableStreamFactory ssf = SeekableStreamFactory.getInstance();
-                final SeekableStream seekableStream = ssf.getStreamFor(inputPath.toAbsolutePath().toString());
+                final SeekableStream seekableStream = ssf.getStreamFor(inputPath.toUri().toString());
                 return new BlockCompressedInputStream(seekableStream);
             } catch (final FileNotFoundException e) {
                 throw new TribbleException.FeatureFileDoesntExist("Unable to open the input file, most likely the file doesn't exist.",
-                        inputPath.toAbsolutePath().toString());
+                        inputPath.toString());
             } catch (final IOException e) {
-                throw new TribbleException.MalformedFeatureFile("Error initializing stream", inputPath.toAbsolutePath().toString(), e);
+                throw new TribbleException.MalformedFeatureFile("Error initializing stream", inputPath.toString(), e);
             }
         }
 
@@ -689,7 +689,7 @@ public class IndexFactory {
                     nextFeature = codec.decodeLoc(source);
                 }
             } catch (final IOException e) {
-                throw new TribbleException.MalformedFeatureFile("Unable to read a line from the file", inputPath.toAbsolutePath().toString(), e);
+                throw new TribbleException.MalformedFeatureFile("Unable to read a line from the file", inputPath.toString(), e);
             }
         }
     }

--- a/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.*;
@@ -117,7 +116,7 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
     @Test(dataProvider = "vcfFileAndWrapperCombinations")
     public void testGetFeatureReaderWithPathAndWrappers(String file, String index,
                                                         Function<SeekableByteChannel, SeekableByteChannel> wrapper,
-                                                        Function<SeekableByteChannel, SeekableByteChannel> indexWrapper) throws IOException, URISyntaxException {
+                                                        Function<SeekableByteChannel, SeekableByteChannel> indexWrapper) throws IOException {
         try(FileSystem fs = Jimfs.newFileSystem("test", Configuration.unix());
             final AbstractFeatureReader<VariantContext, ?> featureReader = getFeatureReader(file, index, wrapper,
                                                                                             indexWrapper,
@@ -144,7 +143,7 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "failsWithoutWrappers", expectedExceptions = {TribbleException.class, FileTruncatedException.class})
-    public void testFailureIfNoWrapper(String file, String index) throws IOException, URISyntaxException {
+    public void testFailureIfNoWrapper(String file, String index) throws IOException {
         try(final FileSystem fs = Jimfs.newFileSystem("test", Configuration.unix());
             final FeatureReader<?> reader = getFeatureReader(file, index, null, null, new VCFCodec(), fs)){
             // should have exploded by now
@@ -155,7 +154,7 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
                                                                                     Function<SeekableByteChannel, SeekableByteChannel> wrapper,
                                                                                     Function<SeekableByteChannel, SeekableByteChannel> indexWrapper,
                                                                                     FeatureCodec<T, ?> codec,
-                                                                                    FileSystem fileSystem) throws IOException, URISyntaxException {
+                                                                                    FileSystem fileSystem) throws IOException {
         final Path vcfInJimfs = TestUtils.getTribbleFileInJimfs(vcf, index, fileSystem);
         return AbstractFeatureReader.getFeatureReader(
                 vcfInJimfs.toUri().toString(),

--- a/src/test/java/htsjdk/tribble/TestUtils.java
+++ b/src/test/java/htsjdk/tribble/TestUtils.java
@@ -51,7 +51,7 @@ public class TestUtils {
      * @throws URISyntaxException if the provided strings cannot be understoos as Uris.
      */
 
-    public static Path getTribbleFileInJimfs(String vcf, String index, FileSystem fileSystem) throws IOException, URISyntaxException {
+    public static Path getTribbleFileInJimfs(String vcf, String index, FileSystem fileSystem) throws IOException {
         final FileSystem fs = fileSystem;
         final Path root = fs.getPath("/");
         final Path vcfPath = Paths.get(vcf);

--- a/src/test/java/htsjdk/tribble/index/IndexFactoryTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexFactoryTest.java
@@ -24,6 +24,8 @@
 package htsjdk.tribble.index;
 
 import com.google.common.io.Files;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
@@ -48,6 +50,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
@@ -131,6 +134,17 @@ public class IndexFactoryTest extends HtsjdkTest {
                     "Tabix indexed (bgzipped) VCF does not contain sequence: " + samSequenceRecord.getSequenceName());
         }
 
+    }
+
+    @Test
+    public void testTabixOnNonDefaultFileSystem() throws IOException {
+        try (final FileSystem fs = Jimfs.newFileSystem("test", Configuration.unix())) {
+            final Path vcfInJimfs = TestUtils.getTribbleFileInJimfs(
+                    "src/test/resources/htsjdk/tribble/tabix/testTabixIndex.vcf.gz",
+                    null, fs);
+            // IndexFactory doesn't write the output, so we just want to make sure it doesn't throw
+            IndexFactory.createTabixIndex(vcfInJimfs, new VCFCodec(), TabixFormat.VCF, null);
+        }
     }
 
     @DataProvider(name = "vcfDataProvider")


### PR DESCRIPTION
Fixes the issue seen [here](https://github.com/broadinstitute/gatk/issues/6348), along with a new test that fails without the fix. The actual fix is a one line change, the rest of the changes are to fix error messages, and there is a second commit with some other redundant code removed.