### PR TITLE
fix resource leak in VCFFileReader.getSequenceDictionary

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -116,7 +116,9 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
      * Returns the SAMSequenceDictionary from the provided VCF file.
      */
     public static SAMSequenceDictionary getSequenceDictionary(final Path path) {
-        return new VCFFileReader(path, false).getFileHeader().getSequenceDictionary();
+        try (final VCFFileReader r = new VCFFileReader(path, false)) {
+            return r.getFileHeader().getSequenceDictionary();
+        }
     }
 
     /**


### PR DESCRIPTION
### Description

small fix: close VCFFileReader in VCFFileReader.getSequenceDictionary(File) using try-with-resource

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
- [ ] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
