### PR TITLE
TabixReader implements Autoclose

### DIFF
--- a/src/main/java/htsjdk/tribble/readers/TabixReader.java
+++ b/src/main/java/htsjdk/tribble/readers/TabixReader.java
@@ -29,7 +29,6 @@ import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.util.ParsingUtils;
-import htsjdk.tribble.util.TabixUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,7 +45,7 @@ import java.util.function.Function;
 /**
  * @author Heng Li <hengli@broadinstitute.org>
  */
-public class TabixReader {
+public class TabixReader implements AutoCloseable {
     private final String mFilePath;
     private final String mIndexPath;
     private final Function<SeekableByteChannel, SeekableByteChannel> mIndexWrapper;
@@ -532,7 +531,8 @@ public class TabixReader {
    }
 
     // ADDED BY JTR
-    public void close() {
+   @Override 
+   public void close() {
         if(mFp != null) {
             try {
                 mFp.close();
@@ -542,8 +542,8 @@ public class TabixReader {
         }
     }
 
-    @Override
-    public String toString() {
+   @Override
+   public String toString() {
         return "TabixReader: filename:"+getSource();
-    }
+   }
 }

--- a/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/TabixReaderTest.java
@@ -172,18 +172,18 @@ public class TabixReaderTest extends HtsjdkTest {
     public void testRemoteQuery() throws IOException {
         String tabixFile = TestUtil.BASE_URL_FOR_HTTP_TESTS +"igvdata/tabix/trioDup.vcf.gz";
 
-        TabixReader tabixReader = new TabixReader(tabixFile);
-
-        TabixIteratorLineReader lineReader = new TabixIteratorLineReader(
-                tabixReader.query(tabixReader.chr2tid("4"), 320, 330));
-
-        int nRecords = 0;
-        String nextLine;
-        while ((nextLine = lineReader.readLine()) != null) {
-            Assert.assertTrue(nextLine.startsWith("4"));
-            nRecords++;
+        try(TabixReader tabixReader = new TabixReader(tabixFile)) {
+            TabixIteratorLineReader lineReader = new TabixIteratorLineReader(
+                    tabixReader.query(tabixReader.chr2tid("4"), 320, 330));
+    
+            int nRecords = 0;
+            String nextLine;
+            while ((nextLine = lineReader.readLine()) != null) {
+                Assert.assertTrue(nextLine.startsWith("4"));
+                nRecords++;
+            }
+            Assert.assertTrue(nRecords > 0);
         }
-        Assert.assertTrue(nRecords > 0);
     }
     
     /**
@@ -193,8 +193,8 @@ public class TabixReaderTest extends HtsjdkTest {
      */
     @Test
     public void testTabixReaderReadLine() throws IOException {
-        TabixReader tabixReader = new TabixReader(tabixFile);
-        Assert.assertNotNull(tabixReader.readLine());
-        tabixReader.close();
+        try(TabixReader tabixReader = new TabixReader(tabixFile)) {
+            Assert.assertNotNull(tabixReader.readLine());
+        }
     }
 }


### PR DESCRIPTION
### Description

I added AutoCloseable to TabixReader so it can be used in a try-with-resource statement.

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
