### PR TITLE
SamSequenceRecord implements Locatable

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMSequenceRecord.java
@@ -24,22 +24,20 @@
 package htsjdk.samtools;
 
 
-import htsjdk.variant.variantcontext.VariantContext;
 
 import java.math.BigInteger;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import htsjdk.samtools.util.Locatable;
 
 /**
  * Header information about a reference sequence.  Corresponds to @SQ header record in SAM text header.
  */
 
-public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Cloneable
+public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Cloneable, Locatable
 {
     public static final long serialVersionUID = 1L; // AbstractSAMHeaderRecord implements Serializable
     public final static int UNAVAILABLE_SEQUENCE_INDEX = -1;
@@ -227,6 +225,27 @@ public class SAMSequenceRecord extends AbstractSAMHeaderRecord implements Clonea
     @Override
     public String getSAMString() {
         return new SAMTextHeaderCodec().getSQLine(this);
+    }
+    /** always returns <code>getSequenceName()</code> 
+     * @see #getSequenceName()
+     * */
+    @Override
+    public final String getContig() {
+        return this.getSequenceName();
+    }
+    
+    /** always returns 1 */
+    @Override
+    public final int getStart() {
+        return 1;
+    }
+    
+    /** always returns <code>getSequenceLength()</code> 
+     * @see #getSequenceLength()
+     * */
+    @Override
+    public final int getEnd() {
+        return this.getSequenceLength();
     }
 }
 

--- a/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
@@ -24,6 +24,7 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.Interval;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -44,6 +45,17 @@ public class SAMSequenceRecordTest extends HtsjdkTest {
         Assert.assertEquals("@SQ\tSN:chr5_but_without_a_prefix\tLN:271828\tSP:Psephophorus terrypratchetti\tAS:GRCt01\tM5:7a6dd3d307de916b477e7bf304ac22bc", r.getSAMString());
     }
 
+    @Test
+    public void testLocatable() {
+        final SAMSequenceRecord r = new SAMSequenceRecord("1", 100);
+        Assert.assertTrue(r.overlaps(r));
+        Assert.assertEquals(r.getStart(),1);
+        Assert.assertEquals(r.getEnd(),r.getSequenceLength());
+        Assert.assertEquals(r.getLengthOnReference(),r.getSequenceLength());
+        Assert.assertTrue(r.overlaps(new Interval(r.getContig(), 50, 150)));
+        Assert.assertFalse(r.overlaps(new Interval(r.getContig(), 101, 101)));
+    }
+    
     @DataProvider
     public Object[][] testIsSameSequenceData() {
         final SAMSequenceRecord rec1 = new SAMSequenceRecord("chr1", 100);


### PR DESCRIPTION
### Description

This PR only makes the coding easier.

I often find myself testing if a  `Locatable` overlaps a `SamSequenceRecord` . 

`interval.overlaps(new Interval(ssr.getSequenceName(),1,ssr.getSequenceLength()));`

This PR adds the interface 'Locatable' to `SamSequenceRecord` (with start=1 && end=sequenceLength()).

`interval.overlaps(ssr);`

### Things to think about before submitting:
- [X] Make sure your changes compile and new tests pass locally.
- [X] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [X] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
