### PR TITLE
Remove unecessary Array copy during VCF write

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -144,7 +144,7 @@ class VCFWriter extends IndexingVariantContextWriter {
      */
     private void writeAndResetBuffer() throws IOException {
         writer.flush();
-        getOutputStream().write(lineBuffer.toByteArray());
+        lineBuffer.writeTo(getOutputStream());
         lineBuffer.reset();
     }
 


### PR DESCRIPTION
### Description
This replaces an operation which does an array copy and then writes the array to an output stream with one that directly writes the array to the output stream without copying anything.  It should help reduce memory load when writing very wide VCFs like in Evoquer.

### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
