### PR TITLE
Add VCFHeader javadoc

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeader.java
@@ -625,6 +625,10 @@ public class VCFHeader implements Serializable {
         this.writeCommandLine = writeCommandLine;
     }
 
+    /**
+     * Get the genotype sample names, sorted in ascending order. Note: this will not necessarily match the order in the VCF.
+     * @return The sorted genotype samples. May be empty if hasGenotypingData() returns false.
+     */
     public ArrayList<String> getSampleNamesInOrder() {
         return sampleNamesInOrder;
     }


### PR DESCRIPTION
I recently got burned (my own fault) using VCFHeader.getSampleNamesInOrder().  In retrospect I should have seen it, but 'InOrder' could reasonably be interpreted to mean 'VCF order' instead of 'sorted'.  This PR adds javadoc to this method to clarify.