### PR TITLE
- Make get/set attributes methods take a SAMTag input

### DIFF
--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -57,6 +57,16 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
     }
 
     /**
+     * Set the given value for the SAMTag 'tag'.  Replaces an existing value, if any.
+     * If value is null, the attribute is removed.
+     * @param tag attribute name
+     * @param value attribute value
+     */
+    public void setAttribute(final SAMTag tag, final String value) {
+        setAttribute(tag.name(), value);
+    }
+
+    /**
      * Set the given value for the attribute named 'key'.  Replaces an existing value, if any.
      * If value is null, the attribute is removed.
      * @param key attribute name

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -1144,14 +1144,14 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return {@code true} if the SAM record has the requested attribute set, {@code false} otherwise.
      */
     public boolean hasAttribute(final String tag) {
-        return getAttribute(tag)!=null;
+        return getAttribute(tag) != null;
     }
 
     /**
      * @return {@code true} if the SAM record has the requested attribute set, {@code false} otherwise.
      */
     public boolean hasAttribute(final SAMTag tag) {
-        return getAttribute(tag.name())!=null;
+        return getAttribute(tag) != null;
     }
 
 
@@ -1174,7 +1174,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * place, because some SAMRecord implementations keep track of when attributes have been changed.  If you
      * want to change an attribute value, call setAttribute() to replace the value.
      *
-     * @param tag Two-character tag name.
+     * @param tag the SAM tag.
      * @return Appropriately typed tag value, or null if the requested tag is not present.
      */
     public Object getAttribute(final SAMTag tag) {
@@ -1188,7 +1188,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws RuntimeException If the value is not an integer type, or will not fit in a signed Integer.
      */
     public Integer getIntegerAttribute(final SAMTag tag) {
-        return getIntegerAttribute(tag.name());
+        return getIntegerAttribute(tag);
     }
 
      /**
@@ -1331,6 +1331,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     public String getStringAttribute(final SAMTag tag) {
         return getStringAttribute(tag.name());
     }
+
     public String getStringAttribute(final String tag) {
         final Object val = getAttribute(tag);
         if (val == null) return null;

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -23,17 +23,23 @@
  */
 package htsjdk.samtools;
 
-
+import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
-import htsjdk.samtools.util.BinaryCodec;
 
 import java.io.Serializable;
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -861,7 +867,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws ClassCastException if RG tag does not have a String value.
      */
     public SAMReadGroupRecord getReadGroup() {
-        final String rgId = (String)getAttribute(SAMTag.RG.getBinaryTag());
+        final String rgId = (String)getAttribute(SAMTag.RG);
         if (rgId == null || getHeader() == null) {
             return null;
         } else {
@@ -1142,6 +1148,14 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
+     * @return {@code true} if the SAM record has the requested attribute set, {@code false} otherwise.
+     */
+    public boolean hasAttribute(final SAMTag tag) {
+        return getAttribute(tag.name())!=null;
+    }
+
+
+    /**
      * Get the value for a SAM tag.
      * WARNING: Some value types (e.g. byte[]) are mutable.  It is dangerous to change one of these values in
      * place, because some SAMRecord implementations keep track of when attributes have been changed.  If you
@@ -1155,6 +1169,29 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
+     * Get the value for a SAM tag.
+     * WARNING: Some value types (e.g. byte[]) are mutable.  It is dangerous to change one of these values in
+     * place, because some SAMRecord implementations keep track of when attributes have been changed.  If you
+     * want to change an attribute value, call setAttribute() to replace the value.
+     *
+     * @param tag Two-character tag name.
+     * @return Appropriately typed tag value, or null if the requested tag is not present.
+     */
+    public Object getAttribute(final SAMTag tag) {
+        return getAttribute(tag.getBinaryTag());
+    }
+
+    /**
+     * Get the tag value and attempt to coerce it into the requested type.
+     * @param tag The requested tag.
+     * @return The value of a tag, converted into a signed Integer if possible.
+     * @throws RuntimeException If the value is not an integer type, or will not fit in a signed Integer.
+     */
+    public Integer getIntegerAttribute(final SAMTag tag) {
+        return getIntegerAttribute(tag.name());
+    }
+
+     /**
      * Get the tag value and attempt to coerce it into the requested type.
      * @param tag The requested tag.
      * @return The value of a tag, converted into a signed Integer if possible.
@@ -1182,7 +1219,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      *
      * @param tag Two-character tag name.
      * @return valid unsigned integer associated with the tag, as a Long
-     * @throws {@link htsjdk.samtools.SAMException} if the value is out of range for a 32-bit unsigned value, or not a Number
+     * @throws htsjdk.samtools.SAMException if the value is out of range for a 32-bit unsigned value, or not a Number
      */
     public Long getUnsignedIntegerAttribute(final String tag) throws SAMException {
         return getUnsignedIntegerAttribute(SAMTag.makeBinaryTag(tag));
@@ -1192,9 +1229,21 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * A convenience method that will return a valid unsigned integer as a Long,
      * or fail with an exception if the tag value is invalid.
      *
+     * @param tag Two-character tag name.
+     * @return valid unsigned integer associated with the tag, as a Long
+     * @throws htsjdk.samtools.SAMException if the value is out of range for a 32-bit unsigned value, or not a Number
+     */
+    public Long getUnsignedIntegerAttribute(final SAMTag tag) throws SAMException {
+        return getUnsignedIntegerAttribute(tag.getBinaryTag());
+    }
+
+    /**
+     * A convenience method that will return a valid unsigned integer as a Long,
+     * or fail with an exception if the tag value is invalid.
+     *
      * @param tag Binary representation of a 2-char String tag as created by SAMTagUtil.
      * @return valid unsigned integer associated with the tag, as a Long
-     * @throws {@link htsjdk.samtools.SAMException} if the value is out of range for a 32-bit unsigned value, or not a Number
+     * @throws htsjdk.samtools.SAMException if the value is out of range for a 32-bit unsigned value, or not a Number
      */
     public Long getUnsignedIntegerAttribute(final short tag) throws SAMException {
         final Object value = getAttribute(tag);
@@ -1216,6 +1265,15 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         }
     }
 
+    /**
+     * Get the tag value and attempt to coerce it into the requested type.
+     * @param tag The requested tag.
+     * @return The value of a tag, converted into a Short if possible.
+     * @throws RuntimeException If the value is not an integer type, or will not fit in a Short.
+     */
+    public Short getShortAttribute(final SAMTag tag) {
+        return getShortAttribute(tag.name());
+    }
     /**
      * Get the tag value and attempt to coerce it into the requested type.
      * @param tag The requested tag.
@@ -1244,6 +1302,16 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @return The value of a tag, converted into a Byte if possible.
      * @throws RuntimeException If the value is not an integer type, or will not fit in a Byte.
      */
+    public Byte getByteAttribute(final SAMTag tag) {
+        return getByteAttribute(tag.name());
+
+    }
+     /**
+     * Get the tag value and attempt to coerce it into the requested type.
+     * @param tag The requested tag.
+     * @return The value of a tag, converted into a Byte if possible.
+     * @throws RuntimeException If the value is not an integer type, or will not fit in a Byte.
+     */
     public Byte getByteAttribute(final String tag) {
         final Object val = getAttribute(tag);
         if (val == null) return null;
@@ -1260,6 +1328,9 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         return (byte)longVal;
     }
 
+    public String getStringAttribute(final SAMTag tag) {
+        return getStringAttribute(tag.name());
+    }
     public String getStringAttribute(final String tag) {
         final Object val = getAttribute(tag);
         if (val == null) return null;
@@ -1269,6 +1340,10 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         throw new SAMException("Value for tag " + tag + " is not a String: " + val.getClass());
     }
 
+    public Character getCharacterAttribute(final SAMTag tag) {
+        return getCharacterAttribute(tag.name());
+    }
+
     public Character getCharacterAttribute(final String tag) {
         final Object val = getAttribute(tag);
         if (val == null) return null;
@@ -1276,6 +1351,11 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             return (Character)val;
         }
         throw new SAMException("Value for tag " + tag + " is not a Character: " + val.getClass());
+    }
+
+
+    public Float getFloatAttribute(final SAMTag tag) {
+        return getFloatAttribute(tag.name());
     }
 
     public Float getFloatAttribute(final String tag) {
@@ -1288,6 +1368,11 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /** Will work for signed byte array, unsigned byte array, or old-style hex array */
+    public byte[] getByteArrayAttribute(final SAMTag tag) {
+        return getByteArrayAttribute(tag.name());
+    }
+
+    /** Will work for signed byte array, unsigned byte array, or old-style hex array */
     public byte[] getByteArrayAttribute(final String tag) {
         final Object val = getAttribute(tag);
         if (val == null) return null;
@@ -1297,19 +1382,35 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         throw new SAMException("Value for tag " + tag + " is not a byte[]: " + val.getClass());
     }
 
+    public byte[] getUnsignedByteArrayAttribute(final SAMTag tag) {
+        return getUnsignedByteArrayAttribute(tag.name());
+    }
+
     public byte[] getUnsignedByteArrayAttribute(final String tag) {
         final byte[] ret = getByteArrayAttribute(tag);
         if (ret != null) requireUnsigned(tag);
         return ret;
     }
 
-    /** Will work for signed byte array or old-style hex array */
+    /**
+     * Will work for signed byte array or old-style hex array
+     */
+    public byte[] getSignedByteArrayAttribute(final SAMTag tag) {
+        return getSignedByteArrayAttribute(tag.name());
+    }
+
+    /**
+     * Will work for signed byte array or old-style hex array
+     */
     public byte[] getSignedByteArrayAttribute(final String tag) {
         final byte[] ret = getByteArrayAttribute(tag);
         if (ret != null) requireSigned(tag);
         return ret;
     }
 
+    public short[] getUnsignedShortArrayAttribute(final SAMTag tag) {
+        return getUnsignedShortArrayAttribute(tag.name());
+    }
     public short[] getUnsignedShortArrayAttribute(final String tag) {
         final Object val = getAttribute(tag);
         if (val == null) return null;
@@ -1318,6 +1419,10 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             return (short[]) val;
         }
         throw new SAMException("Value for tag " + tag + " is not a short[]: " + val.getClass());
+    }
+
+    public short[] getSignedShortArrayAttribute(final SAMTag tag) {
+        return getSignedShortArrayAttribute(tag.name());
     }
 
     public short[] getSignedShortArrayAttribute(final String tag) {
@@ -1330,6 +1435,10 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         throw new SAMException("Value for tag " + tag + " is not a short[]: " + val.getClass());
     }
 
+    public int[] getUnsignedIntArrayAttribute(final SAMTag tag) {
+        return  getUnsignedIntArrayAttribute(tag.name());
+    }
+
     public int[] getUnsignedIntArrayAttribute(final String tag) {
         final Object val = getAttribute(tag);
         if (val == null) return null;
@@ -1340,6 +1449,10 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         throw new SAMException("Value for tag " + tag + " is not a int[]: " + val.getClass());
     }
 
+    public int[] getSignedIntArrayAttribute(final SAMTag tag) {
+        return getSignedIntArrayAttribute(tag.name());
+    }
+
     public int[] getSignedIntArrayAttribute(final String tag) {
         final Object val = getAttribute(tag);
         if (val == null) return null;
@@ -1348,6 +1461,10 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
             return (int[]) val;
         }
         throw new SAMException("Value for tag " + tag + " is not a int[]: " + val.getClass());
+    }
+
+    public float[] getFloatArrayAttribute(final SAMTag tag) {
+        return getFloatArrayAttribute(tag.name());
     }
 
     public float[] getFloatArrayAttribute(final String tag) {
@@ -1436,6 +1553,14 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     }
 
     /**
+     * @see htsjdk.samtools.SAMRecord#setAttribute(java.lang.String, java.lang.Object)
+     * @param tag Binary representation of a 2-char String tag as created by SAMTagUtil.
+     */
+    public void setAttribute(final SAMTag tag, final Object value){
+        setAttribute(tag, value, false);
+    }
+
+    /**
      * Checks if the value is allowed as an attribute value.
      *
      * @param value the value to be checked
@@ -1448,6 +1573,10 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
     @Deprecated
     protected static boolean isAllowedAttributeValue(final Object value) {
         return SAMBinaryTagAndValue.isAllowedAttributeValue(value);
+    }
+
+    protected void setAttribute(final SAMTag tag, final Object value, final boolean isUnsignedArray) {
+        setAttribute(tag.getBinaryTag(), value, isUnsignedArray);
     }
 
     protected void setAttribute(final short tag, final Object value, final boolean isUnsignedArray) {
@@ -2030,7 +2159,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
 */
         }
         // Validate the RG ID is found in header
-        final String rgId = (String)getAttribute(SAMTag.RG.getBinaryTag());
+        final String rgId = (String)getAttribute(SAMTag.RG);
         if (rgId != null && getHeader() != null && getHeader().getReadGroup(rgId) == null) {
                 if (ret == null) ret = new ArrayList<>();
                 ret.add(new SAMValidationError(SAMValidationError.Type.READ_GROUP_NOT_FOUND,

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -1188,7 +1188,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
      * @throws RuntimeException If the value is not an integer type, or will not fit in a signed Integer.
      */
     public Integer getIntegerAttribute(final SAMTag tag) {
-        return getIntegerAttribute(tag);
+        return getIntegerAttribute(tag.name());
     }
 
      /**

--- a/src/main/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
@@ -57,8 +57,8 @@ public class SAMRecordQueryNameComparator implements SAMRecordComparator, Serial
         if (samRecord1.getSupplementaryAlignmentFlag() != samRecord2.getSupplementaryAlignmentFlag()) {
             return samRecord2.getSupplementaryAlignmentFlag() ? -1 : 1;
         }
-        final Integer hitIndex1 = samRecord1.getIntegerAttribute(SAMTag.HI.name());
-        final Integer hitIndex2 = samRecord2.getIntegerAttribute(SAMTag.HI.name());
+        final Integer hitIndex1 = samRecord1.getIntegerAttribute(SAMTag.HI);
+        final Integer hitIndex2 = samRecord2.getIntegerAttribute(SAMTag.HI);
         if (hitIndex1 != null) {
             if (hitIndex2 == null) return 1;
             else {

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -243,18 +243,18 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             }
             rec.setMappingQuality(SAMRecord.UNKNOWN_MAPPING_QUALITY);
         }
-        rec.setAttribute(SAMTag.RG.name(), READ_GROUP_ID);
+        rec.setAttribute(SAMTag.RG, READ_GROUP_ID);
 
         if (useNmFlag) {
-            rec.setAttribute(SAMTag.NM.name(), SequenceUtil.calculateSamNmTagFromCigar(rec));
+            rec.setAttribute(SAMTag.NM, SequenceUtil.calculateSamNmTagFromCigar(rec));
         }
 
         if (programRecord != null) {
-            rec.setAttribute(SAMTag.PG.name(), programRecord.getProgramGroupId());
+            rec.setAttribute(SAMTag.PG, programRecord.getProgramGroupId());
         }
 
         if (readGroup != null) {
-            rec.setAttribute(SAMTag.RG.name(), readGroup.getReadGroupId());
+            rec.setAttribute(SAMTag.RG, readGroup.getReadGroupId());
         }
 
         if (!recordUnmapped || this.unmappedHasBasesAndQualities) {
@@ -377,12 +377,12 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         end1.setProperPairFlag(true);
         end1.setFirstOfPairFlag(end1IsFirstOfPair);
         end1.setSecondOfPairFlag(!end1IsFirstOfPair);
-        end1.setAttribute(SAMTag.RG.name(), READ_GROUP_ID);
+        end1.setAttribute(SAMTag.RG, READ_GROUP_ID);
         if (programRecord != null) {
-            end1.setAttribute(SAMTag.PG.name(), programRecord.getProgramGroupId());
+            end1.setAttribute(SAMTag.PG, programRecord.getProgramGroupId());
         }
         if (readGroup != null) {
-            end1.setAttribute(SAMTag.RG.name(), readGroup.getReadGroupId());
+            end1.setAttribute(SAMTag.RG, readGroup.getReadGroupId());
         }
         fillInBasesAndQualities(end1);
 
@@ -399,12 +399,12 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         end2.setProperPairFlag(true);
         end2.setFirstOfPairFlag(!end1IsFirstOfPair);
         end2.setSecondOfPairFlag(end1IsFirstOfPair);
-        end2.setAttribute(SAMTag.RG.name(), READ_GROUP_ID);
+        end2.setAttribute(SAMTag.RG, READ_GROUP_ID);
         if (programRecord != null) {
-            end2.setAttribute(SAMTag.PG.name(), programRecord.getProgramGroupId());
+            end2.setAttribute(SAMTag.PG, programRecord.getProgramGroupId());
         }
         if (readGroup != null) {
-            end2.setAttribute(SAMTag.RG.name(), readGroup.getReadGroupId());
+            end2.setAttribute(SAMTag.RG, readGroup.getReadGroupId());
         }
         fillInBasesAndQualities(end2);
 
@@ -497,14 +497,14 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         end1.setReadName(name);
         end1.setReadPairedFlag(true);
         end1.setReadUnmappedFlag(true);
-        end1.setAttribute(SAMTag.MC.name(), null);
+        end1.setAttribute(SAMTag.MC, null);
         end1.setProperPairFlag(false);
         end1.setFirstOfPairFlag(end1IsFirstOfPair);
         end1.setSecondOfPairFlag(!end1IsFirstOfPair);
         end1.setMateUnmappedFlag(true);
-        end1.setAttribute(SAMTag.RG.name(), READ_GROUP_ID);
+        end1.setAttribute(SAMTag.RG, READ_GROUP_ID);
         if (programRecord != null) {
-            end1.setAttribute(SAMTag.PG.name(), programRecord.getProgramGroupId());
+            end1.setAttribute(SAMTag.PG, programRecord.getProgramGroupId());
         }
         if (this.unmappedHasBasesAndQualities) {
             fillInBasesAndQualities(end1);
@@ -513,14 +513,14 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
         end2.setReadName(name);
         end2.setReadPairedFlag(true);
         end2.setReadUnmappedFlag(true);
-        end2.setAttribute(SAMTag.MC.name(), null);
+        end2.setAttribute(SAMTag.MC, null);
         end2.setProperPairFlag(false);
         end2.setFirstOfPairFlag(!end1IsFirstOfPair);
         end2.setSecondOfPairFlag(end1IsFirstOfPair);
         end2.setMateUnmappedFlag(true);
-        end2.setAttribute(SAMTag.RG.name(), READ_GROUP_ID);
+        end2.setAttribute(SAMTag.RG, READ_GROUP_ID);
         if (programRecord != null) {
-            end2.setAttribute(SAMTag.PG.name(), programRecord.getProgramGroupId());
+            end2.setAttribute(SAMTag.PG, programRecord.getProgramGroupId());
         }
         if (this.unmappedHasBasesAndQualities) {
             fillInBasesAndQualities(end2);

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -594,10 +594,10 @@ public final class SAMUtils {
      */
     public static void makeReadUnmappedWithOriginalTags(final SAMRecord rec) {
         if (!hasOriginalMappingInformation(rec)) {
-            rec.setAttribute(SAMTag.OP.name(), rec.getAlignmentStart());
-            rec.setAttribute(SAMTag.OC.name(), rec.getCigarString());
-            rec.setAttribute(SAMTag.OF.name(), rec.getFlags());
-            rec.setAttribute(SAMTag.OR.name(), rec.getReferenceName());
+            rec.setAttribute(SAMTag.OP, rec.getAlignmentStart());
+            rec.setAttribute(SAMTag.OC, rec.getCigarString());
+            rec.setAttribute(SAMTag.OF, rec.getFlags());
+            rec.setAttribute(SAMTag.OR, rec.getReferenceName());
         }
         makeReadUnmapped(rec);
     }
@@ -606,10 +606,10 @@ public final class SAMUtils {
      * See if any tags pertaining to original mapping information have been set.
      */
     public static boolean hasOriginalMappingInformation(final SAMRecord rec) {
-        return rec.getAttribute(SAMTag.OP.name()) != null
-                || rec.getAttribute(SAMTag.OC.name()) != null
-                || rec.getAttribute(SAMTag.OF.name()) != null
-                || rec.getAttribute(SAMTag.OR.name()) != null;
+        return rec.getAttribute(SAMTag.OP) != null
+                || rec.getAttribute(SAMTag.OC) != null
+                || rec.getAttribute(SAMTag.OF) != null
+                || rec.getAttribute(SAMTag.OR) != null;
     }
 
     /**
@@ -808,7 +808,7 @@ public final class SAMUtils {
      * @return Mate Cigar String, or null if there is none.
      */
     public static String getMateCigarString(final SAMRecord rec) {
-        return rec.getStringAttribute(SAMTag.MC.name());
+        return rec.getStringAttribute(SAMTag.MC);
     }
 
     /**
@@ -1142,7 +1142,7 @@ public final class SAMUtils {
         if (record == null) throw new IllegalArgumentException("record is null");
         if (record.getHeader() == null) throw new IllegalArgumentException("record.getHeader() is null");
         /* extract value of SA tag */
-        final Object saValue = record.getAttribute(SAMTag.SA.getBinaryTag());
+        final Object saValue = record.getAttribute(SAMTag.SA);
         if (saValue == null) return Collections.emptyList();
         if (!(saValue instanceof String)) throw new SAMException(
                 "Expected a String for attribute 'SA' but got " + saValue.getClass() + ". Record: " + record);
@@ -1235,7 +1235,7 @@ public final class SAMUtils {
             /* fill NM */
             try {
                 if (!commaStrs[5].equals("*")) {
-                    otherRec.setAttribute(SAMTag.NM.getBinaryTag(), Integer.parseInt(commaStrs[5]));
+                    otherRec.setAttribute(SAMTag.NM, Integer.parseInt(commaStrs[5]));
                 }
             } catch (final NumberFormatException err) {
                 throw new SAMException("bad NM in " + semiColonStr + ". Record: " + record, err);
@@ -1290,7 +1290,7 @@ public final class SAMUtils {
                     record.getReadNegativeStrandFlag() ? Strand.NEGATIVE : Strand.POSITIVE,
                     record.getCigarString(),
                     record.getMappingQuality(),
-                    Optional.ofNullable(record.getAttribute(SAMTag.NM.name())).orElse(""));
+                    Optional.ofNullable(record.getAttribute(SAMTag.NM)).orElse(""));
         }
         return oaValue;
 

--- a/src/main/java/htsjdk/samtools/SAMValidationError.java
+++ b/src/main/java/htsjdk/samtools/SAMValidationError.java
@@ -31,7 +31,8 @@ import java.io.Serializable;
  *
  * @author Doug Voet
  */
-public class SAMValidationError implements Serializable {
+public class
+SAMValidationError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public enum Severity {

--- a/src/main/java/htsjdk/samtools/SAMValidationError.java
+++ b/src/main/java/htsjdk/samtools/SAMValidationError.java
@@ -31,8 +31,7 @@ import java.io.Serializable;
  *
  * @author Doug Voet
  */
-public class
-SAMValidationError implements Serializable {
+public class SAMValidationError implements Serializable {
     public static final long serialVersionUID = 1L;
 
     public enum Severity {

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -410,12 +410,12 @@ public class SamFileValidator {
             addError(new SAMValidationError(Type.CG_TAG_FOUND_IN_ATTRIBUTES,
                     "The CG Tag should only be used in BAM format to hold a large cigar. " +
                             "It was found containing the value: " +
-                            record.getAttribute(SAMTag.CG.getBinaryTag()), record.getReadName(), recordNumber));
+                            record.getAttribute(SAMTag.CG), record.getReadName(), recordNumber));
         }
     }
 
     private void validateSecondaryBaseCalls(final SAMRecord record, final long recordNumber) {
-        final String e2 = (String) record.getAttribute(SAMTag.E2.name());
+        final String e2 = (String) record.getAttribute(SAMTag.E2);
         if (e2 != null) {
             if (e2.length() != record.getReadLength()) {
                 addError(new SAMValidationError(Type.MISMATCH_READ_LENGTH_AND_E2_LENGTH,
@@ -437,7 +437,7 @@ public class SamFileValidator {
                 }
             }
         }
-        final String u2 = (String) record.getAttribute(SAMTag.U2.name());
+        final String u2 = (String) record.getAttribute(SAMTag.U2);
         if (u2 != null && u2.length() != record.getReadLength()) {
             addError(new SAMValidationError(Type.MISMATCH_READ_LENGTH_AND_U2_LENGTH,
                     String.format("U2 tag length (%d) != read length (%d)", u2.length(), record.getReadLength()),
@@ -741,7 +741,7 @@ public class SamFileValidator {
             this.mateNegStrandFlag = record.getMateNegativeStrandFlag();
             this.mateReferenceIndex = record.getMateReferenceIndex();
             this.mateUnmappedFlag = record.getMateUnmappedFlag();
-            final Object mcs = record.getAttribute(SAMTag.MC.name());
+            final Object mcs = record.getAttribute(SAMTag.MC);
             this.mateCigarString = (mcs != null) ? (String) mcs : null;
 
             this.firstOfPairFlag = record.getFirstOfPairFlag();

--- a/src/main/java/htsjdk/samtools/SamPairUtil.java
+++ b/src/main/java/htsjdk/samtools/SamPairUtil.java
@@ -203,21 +203,21 @@ public class SamPairUtil {
             rec1.setMateAlignmentStart(rec2.getAlignmentStart());
             rec1.setMateNegativeStrandFlag(rec2.getReadNegativeStrandFlag());
             rec1.setMateUnmappedFlag(false);
-            rec1.setAttribute(SAMTag.MQ.name(), rec2.getMappingQuality());
+            rec1.setAttribute(SAMTag.MQ, rec2.getMappingQuality());
 
             rec2.setMateReferenceIndex(rec1.getReferenceIndex());
             rec2.setMateAlignmentStart(rec1.getAlignmentStart());
             rec2.setMateNegativeStrandFlag(rec1.getReadNegativeStrandFlag());
             rec2.setMateUnmappedFlag(false);
-            rec2.setAttribute(SAMTag.MQ.name(), rec1.getMappingQuality());
+            rec2.setAttribute(SAMTag.MQ, rec1.getMappingQuality());
 
             if (setMateCigar) {
-                rec1.setAttribute(SAMTag.MC.name(), rec2.getCigarString());
-                rec2.setAttribute(SAMTag.MC.name(), rec1.getCigarString());
+                rec1.setAttribute(SAMTag.MC, rec2.getCigarString());
+                rec2.setAttribute(SAMTag.MC, rec1.getCigarString());
             }
             else {
-                rec1.setAttribute(SAMTag.MC.name(), null);
-                rec2.setAttribute(SAMTag.MC.name(), null);
+                rec1.setAttribute(SAMTag.MC, null);
+                rec2.setAttribute(SAMTag.MC, null);
             }
         }
         // Else if they're both unmapped set that straight
@@ -228,8 +228,8 @@ public class SamPairUtil {
             rec1.setMateAlignmentStart(SAMRecord.NO_ALIGNMENT_START);
             rec1.setMateNegativeStrandFlag(rec2.getReadNegativeStrandFlag());
             rec1.setMateUnmappedFlag(true);
-            rec1.setAttribute(SAMTag.MQ.name(), null);
-            rec1.setAttribute(SAMTag.MC.name(), null);
+            rec1.setAttribute(SAMTag.MQ, null);
+            rec1.setAttribute(SAMTag.MC, null);
             rec1.setInferredInsertSize(0);
 
             rec2.setReferenceIndex(SAMRecord.NO_ALIGNMENT_REFERENCE_INDEX);
@@ -238,8 +238,8 @@ public class SamPairUtil {
             rec2.setMateAlignmentStart(SAMRecord.NO_ALIGNMENT_START);
             rec2.setMateNegativeStrandFlag(rec1.getReadNegativeStrandFlag());
             rec2.setMateUnmappedFlag(true);
-            rec2.setAttribute(SAMTag.MQ.name(), null);
-            rec2.setAttribute(SAMTag.MC.name(), null);
+            rec2.setAttribute(SAMTag.MQ, null);
+            rec2.setAttribute(SAMTag.MC, null);
             rec2.setInferredInsertSize(0);
         }
         // And if only one is mapped copy it's coordinate information to the mate
@@ -253,18 +253,18 @@ public class SamPairUtil {
             mapped.setMateAlignmentStart(unmapped.getAlignmentStart());
             mapped.setMateNegativeStrandFlag(unmapped.getReadNegativeStrandFlag());
             mapped.setMateUnmappedFlag(true);
-            mapped.setAttribute(SAMTag.MQ.name(), null);
-            mapped.setAttribute(SAMTag.MC.name(), null);
+            mapped.setAttribute(SAMTag.MQ, null);
+            mapped.setAttribute(SAMTag.MC, null);
             mapped.setInferredInsertSize(0);
 
             unmapped.setMateReferenceIndex(mapped.getReferenceIndex());
             unmapped.setMateAlignmentStart(mapped.getAlignmentStart());
             unmapped.setMateNegativeStrandFlag(mapped.getReadNegativeStrandFlag());
             unmapped.setMateUnmappedFlag(false);
-            unmapped.setAttribute(SAMTag.MQ.name(), mapped.getMappingQuality());
+            unmapped.setAttribute(SAMTag.MQ, mapped.getMappingQuality());
             // For the unmapped read, set mateCigar to the mate's Cigar, since the mate must be mapped
-            if (setMateCigar) unmapped.setAttribute(SAMTag.MC.name(), mapped.getCigarString());
-            else unmapped.setAttribute(SAMTag.MC.name(), null);
+            if (setMateCigar) unmapped.setAttribute(SAMTag.MC, mapped.getCigarString());
+            else unmapped.setAttribute(SAMTag.MC, null);
             unmapped.setInferredInsertSize(0);
         }
 
@@ -314,10 +314,10 @@ public class SamPairUtil {
         supplemental.setMateUnmappedFlag(matePrimary.getReadUnmappedFlag());
         supplemental.setInferredInsertSize(-matePrimary.getInferredInsertSize());
         if (setMateCigar && !matePrimary.getReadUnmappedFlag()) {
-            supplemental.setAttribute(SAMTag.MC.name(), matePrimary.getCigarString());
+            supplemental.setAttribute(SAMTag.MC, matePrimary.getCigarString());
         }
         else {
-            supplemental.setAttribute(SAMTag.MC.name(), null);
+            supplemental.setAttribute(SAMTag.MC, null);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/fastq/FastqEncoder.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqEncoder.java
@@ -95,7 +95,7 @@ public final class FastqEncoder {
         if(record.getReadPairedFlag() && (record.getFirstOfPairFlag() || record.getSecondOfPairFlag())) {
             readName += (record.getFirstOfPairFlag()) ? FastqConstants.FIRST_OF_PAIR : FastqConstants.SECOND_OF_PAIR;
         }
-        return new FastqRecord(readName, record.getReadString(), record.getStringAttribute(SAMTag.CO.name()), record.getBaseQualityString());
+        return new FastqRecord(readName, record.getReadString(), record.getStringAttribute(SAMTag.CO), record.getBaseQualityString());
     }
 
     /**
@@ -135,7 +135,7 @@ public final class FastqEncoder {
      * <p>Note that all tabs present in the quality header are replaced by spaces.
      */
     public static final BiConsumer<FastqRecord, SAMRecord> QUALITY_HEADER_TO_COMMENT_TAG = (record, samRecord) ->
-        samRecord.setAttribute(SAMTag.CO.name(), record.getBaseQualityHeader().replaceAll("\t", " "));
+        samRecord.setAttribute(SAMTag.CO, record.getBaseQualityHeader().replaceAll("\t", " "));
 
 
     public static final BiConsumer<FastqRecord, SAMRecord> QUALITY_HEADER_PARSE_SAM_TAGS = (record, samRecord) -> {

--- a/src/main/java/htsjdk/samtools/util/CigarUtil.java
+++ b/src/main/java/htsjdk/samtools/util/CigarUtil.java
@@ -216,9 +216,9 @@ public class CigarUtil {
 
         if (newCigar.getReferenceLength() != originalReferenceLength) {
             //invalidate NM, UQ, MD tags if we have changed the length of the read.
-            rec.setAttribute(SAMTag.NM.name(), null);
-            rec.setAttribute(SAMTag.MD.name(), null);
-            rec.setAttribute(SAMTag.UQ.name(), null);
+            rec.setAttribute(SAMTag.NM, null);
+            rec.setAttribute(SAMTag.MD, null);
+            rec.setAttribute(SAMTag.UQ, null);
         }
 
         if (!hasMappedBases) {

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -751,7 +751,7 @@ public class SequenceUtil {
      * includeReferenceBasesForDeletions==true, reference will have Ns for the skipped region.
      */
     public static byte[] makeReferenceFromAlignment(final SAMRecord rec, final boolean includeReferenceBasesForDeletions) {
-        final String md = rec.getStringAttribute(SAMTag.MD.name());
+        final String md = rec.getStringAttribute(SAMTag.MD);
         if (md == null) {
             throw new SAMException("Cannot create reference from SAMRecord with no MD tag, read: " + rec.getReadName());
         }
@@ -1016,8 +1016,8 @@ public class SequenceUtil {
         }
         mdString.append(matchCount);
 
-        if (calcMD) record.setAttribute(SAMTag.MD.name(), mdString.toString());
-        if (calcNM) record.setAttribute(SAMTag.NM.name(), nmCount);
+        if (calcMD) record.setAttribute(SAMTag.MD, mdString.toString());
+        if (calcNM) record.setAttribute(SAMTag.NM, nmCount);
     }
 
     public static byte upperCase(final byte base) {

--- a/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
@@ -436,11 +436,11 @@ public class BAMFileWriterTest extends HtsjdkTest {
         builder.addPair("pair1", 0, 1, 100_000, false, false, sentinelCigarString, sentinelCigarString, true, false, 30);
 
         final SAMRecord frag = builder.addFrag("frag1", 0, 1, false, false, sentinelCigarString, null, 30);
-        frag.setAttribute(SAMTag.CG.name(), cigarEncoding);
+        frag.setAttribute(SAMTag.CG, cigarEncoding);
 
         final List<SAMRecord> pairOfReads = builder.addPair("pair1", 0, 1, 100_000, false, false, cigar.toString(), cigar.toString(), true, false, 30);
         for (final SAMRecord rec : pairOfReads) {
-            rec.setAttribute(SAMTag.CG.name(), cigarEncoding);
+            rec.setAttribute(SAMTag.CG, cigarEncoding);
         }
 
         final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
@@ -474,7 +474,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
         }
 
         try (final SamReader reader = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT).open(bamFile)) {
-            reader.iterator().forEachRemaining(rec -> Assert.assertFalse(rec.hasAttribute(SAMTag.CG.name())));
+            reader.iterator().forEachRemaining(rec -> Assert.assertFalse(rec.hasAttribute(SAMTag.CG)));
         }
     }
 
@@ -487,11 +487,11 @@ public class BAMFileWriterTest extends HtsjdkTest {
         final Cigar cigar = Cigar.fromCigarOperators(operators);
 
         final SAMRecord record = builder.addFrag("frag1", 0, 1, false, false, cigar.toString(), null, 30);
-        record.setAttribute(SAMTag.CG.name(), "Ceci n'est pas une pipe!");
+        record.setAttribute(SAMTag.CG, "Ceci n'est pas une pipe!");
 
         final List<SAMRecord> pairOfReads = builder.addPair("pair1", 0, 1, 100_000, false, false, cigar.toString(), cigar.toString(), true, false, 30);
         for (final SAMRecord rec : pairOfReads) {
-            rec.setAttribute(SAMTag.CG.name(), "Ceci n'est pas une pipe!");
+            rec.setAttribute(SAMTag.CG, "Ceci n'est pas une pipe!");
         }
 
         testHelper(builder, SAMFileHeader.SortOrder.coordinate, true);

--- a/src/test/java/htsjdk/samtools/MergingSamRecordIteratorGroupCollisionTest.java
+++ b/src/test/java/htsjdk/samtools/MergingSamRecordIteratorGroupCollisionTest.java
@@ -254,11 +254,11 @@ public class MergingSamRecordIteratorGroupCollisionTest extends HtsjdkTest {
 
         final MergingSamRecordIterator iterator = new MergingSamRecordIterator(headerMerger, readers, false);
         SAMRecord samRecord = iterator.next();
-        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG.name()), "0");
+        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG), "0");
         samRecord = iterator.next();
-        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG.name()), "0.1");
+        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG), "0.1");
         samRecord = iterator.next();
-        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG.name()), null);
+        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG), null);
         Assert.assertFalse(iterator.hasNext());
         CloserUtil.close(readers);
     }
@@ -325,11 +325,11 @@ public class MergingSamRecordIteratorGroupCollisionTest extends HtsjdkTest {
 
         final MergingSamRecordIterator iterator = new MergingSamRecordIterator(headerMerger, readers, false);
         SAMRecord samRecord = iterator.next();
-        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG.name()), "0");
+        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG), "0");
         samRecord = iterator.next();
-        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG.name()), "0");
+        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG), "0");
         samRecord = iterator.next();
-        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG.name()), "0.1");
+        Assert.assertEquals(samRecord.getAttribute(SAMTag.PG), "0.1");
         Assert.assertFalse(iterator.hasNext());
         CloserUtil.close(readers);
     }
@@ -386,7 +386,7 @@ public class MergingSamRecordIteratorGroupCollisionTest extends HtsjdkTest {
 
     private SAMReadGroupRecord createSAMReadGroupRecord(String id) {
         SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord(id);
-        readGroupRecord.setAttribute(SAMTag.SM.name(), Double.toString(Math.random()));
+        readGroupRecord.setAttribute(SAMTag.SM, Double.toString(Math.random()));
         return readGroupRecord;
     }
 
@@ -528,7 +528,7 @@ public class MergingSamRecordIteratorGroupCollisionTest extends HtsjdkTest {
         @Override
         AbstractSAMHeaderRecord newGroup(String id) {
             SAMReadGroupRecord group = new SAMReadGroupRecord(id);
-            group.setAttribute(SAMTag.SM.name(), id);
+            group.setAttribute(SAMTag.SM, id);
             return group;
         }
 

--- a/src/test/java/htsjdk/samtools/SAMRecordQueryNameComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordQueryNameComparatorTest.java
@@ -101,15 +101,15 @@ public class SAMRecordQueryNameComparatorTest extends HtsjdkTest {
                 {copyAndSet(record, r -> r.setSupplementaryAlignmentFlag(true)), record, 1},
 
                 // the one with HI tag is first if the other is null
-                {record, copyAndSet(record, r -> r.setAttribute(SAMTag.HI.name(), 1)), -1},
-                {copyAndSet(record, r -> r.setAttribute(SAMTag.HI.name(), 1)), record, 1},
+                {record, copyAndSet(record, r -> r.setAttribute(SAMTag.HI, 1)), -1},
+                {copyAndSet(record, r -> r.setAttribute(SAMTag.HI, 1)), record, 1},
                 // if both have HI tag, order by it
-                {copyAndSet(record, r -> r.setAttribute(SAMTag.HI.name(), 1)),
-                        copyAndSet(record, r -> r.setAttribute(SAMTag.HI.name(), 1)), 0},
-                {copyAndSet(record, r -> r.setAttribute(SAMTag.HI.name(), 1)),
-                        copyAndSet(record, r -> r.setAttribute(SAMTag.HI.name(), 2)), -1},
-                {copyAndSet(record, r -> r.setAttribute(SAMTag.HI.name(), 16)),
-                        copyAndSet(record, r -> r.setAttribute(SAMTag.HI.name(), 5)), 1}
+                {copyAndSet(record, r -> r.setAttribute(SAMTag.HI, 1)),
+                        copyAndSet(record, r -> r.setAttribute(SAMTag.HI, 1)), 0},
+                {copyAndSet(record, r -> r.setAttribute(SAMTag.HI, 1)),
+                        copyAndSet(record, r -> r.setAttribute(SAMTag.HI, 2)), -1},
+                {copyAndSet(record, r -> r.setAttribute(SAMTag.HI, 16)),
+                        copyAndSet(record, r -> r.setAttribute(SAMTag.HI, 5)), 1}
         };
     }
 

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -429,12 +429,12 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     public void test_setAttribute_empty_string() {
         final SAMFileHeader header = new SAMFileHeader();
         final SAMRecord record = new SAMRecord(header);
-        Assert.assertNull(record.getStringAttribute(SAMTag.MD.name()));
-        record.setAttribute(SAMTag.MD.name(), "");
-        Assert.assertNotNull(record.getStringAttribute(SAMTag.MD.name()));
-        Assert.assertEquals(record.getStringAttribute(SAMTag.MD.name()),"");
-        record.setAttribute(SAMTag.MD.name(), null);
-        Assert.assertNull(record.getStringAttribute(SAMTag.MD.name()));
+        Assert.assertNull(record.getStringAttribute(SAMTag.MD));
+        record.setAttribute(SAMTag.MD, "");
+        Assert.assertNotNull(record.getStringAttribute(SAMTag.MD));
+        Assert.assertEquals(record.getStringAttribute(SAMTag.MD),"");
+        record.setAttribute(SAMTag.MD, null);
+        Assert.assertNull(record.getStringAttribute(SAMTag.MD));
     }
 
 

--- a/src/test/java/htsjdk/samtools/SAMTextReaderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMTextReaderTest.java
@@ -125,7 +125,7 @@ public class SAMTextReaderTest extends HtsjdkTest {
         samBuilder.addUnmappedFragment("Hi,Mom!");
         final SAMRecord rec = samBuilder.iterator().next();
         final String valueWithColons = "A:B::C:::";
-        rec.setAttribute(SAMTag.CQ.name(), valueWithColons);
+        rec.setAttribute(SAMTag.CQ, valueWithColons);
         // Write the record as SAM Text
         final ByteArrayOutputStream os = new ByteArrayOutputStream();
         final SAMFileWriter textWriter = new SAMFileWriterFactory().makeSAMWriter(samBuilder.getHeader(),
@@ -135,7 +135,7 @@ public class SAMTextReaderTest extends HtsjdkTest {
 
         final SamReader reader = SamReaderFactory.makeDefault().open(SamInputResource.of(new ByteArrayInputStream(os.toByteArray())));
         final SAMRecord recFromText = reader.iterator().next();
-        Assert.assertEquals(recFromText.getAttribute(SAMTag.CQ.name()), valueWithColons);
+        Assert.assertEquals(recFromText.getAttribute(SAMTag.CQ), valueWithColons);
         CloserUtil.close(reader);
     }
 

--- a/src/test/java/htsjdk/samtools/SAMUtilsTest.java
+++ b/src/test/java/htsjdk/samtools/SAMUtilsTest.java
@@ -206,7 +206,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(SAMUtils.getOtherCanonicalAlignments(record).size(),0);
 
 
-        record.setAttribute(SAMTag.SA.getBinaryTag(),
+        record.setAttribute(SAMTag.SA,
                 "2,500,+,3S2=1X2=2S,60,1;" +
                 "1,191,-,8M2S,60,*;");
 
@@ -235,7 +235,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(other.getAlignmentStart(),500);
         Assert.assertFalse(other.getReadNegativeStrandFlag());
         Assert.assertEquals(other.getMappingQuality(), 60);
-        Assert.assertEquals(other.getAttribute(SAMTag.NM.getBinaryTag()),1);
+        Assert.assertEquals(other.getAttribute(SAMTag.NM),1);
         Assert.assertEquals(other.getCigarString(),"3S2=1X2=2S");
         Assert.assertEquals(other.getInferredInsertSize(),0);
 
@@ -246,7 +246,7 @@ public class SAMUtilsTest extends HtsjdkTest {
         Assert.assertEquals(other.getAlignmentStart(),191);
         Assert.assertTrue(other.getReadNegativeStrandFlag());
         Assert.assertEquals(other.getMappingQuality(), 60);
-        Assert.assertEquals(other.getAttribute(SAMTag.NM.getBinaryTag()),null);
+        Assert.assertEquals(other.getAttribute(SAMTag.NM),null);
         Assert.assertEquals(other.getCigarString(),"8M2S");
         Assert.assertEquals(other.getInferredInsertSize(),-91);//100(mate) - 191(other)
     }
@@ -307,13 +307,13 @@ public class SAMUtilsTest extends HtsjdkTest {
         }
         {
             final SAMRecord record = builder.addFrag("test3", 2, 15, false, false, "36M", null, 45);
-            record.setAttribute(SAMTag.NM.name(),33);
+            record.setAttribute(SAMTag.NM,33);
 
             tests.add(new Object[]{record, "chr3,15,+,36M,255,33"});
         }
         {
             final SAMRecord record = builder.addFrag("test4", 1, 115, true, false, "12S12M12I", null, 45);
-            record.setAttribute(SAMTag.NM.name(),0);
+            record.setAttribute(SAMTag.NM,0);
             record.setMappingQuality(60);
 
             tests.add(new Object[]{record, "chr2,115,-,12S12M12I,60,0"});

--- a/src/test/java/htsjdk/samtools/fastq/FastqEncoderTest.java
+++ b/src/test/java/htsjdk/samtools/fastq/FastqEncoderTest.java
@@ -47,7 +47,7 @@ public class FastqEncoderTest extends HtsjdkTest {
         testRecord(record.getReadName() + FastqConstants.SECOND_OF_PAIR, FastqEncoder.asFastqRecord(record), record);
         record.setSecondOfPairFlag(false);
         testRecord(record.getReadName(), FastqEncoder.asFastqRecord(record), record);
-        record.setAttribute(SAMTag.CO.name(), "Comment in SAM tag");
+        record.setAttribute(SAMTag.CO, "Comment in SAM tag");
         testRecord(record.getReadName(), FastqEncoder.asFastqRecord(record), record);
     }
 
@@ -55,7 +55,7 @@ public class FastqEncoderTest extends HtsjdkTest {
         Assert.assertEquals(fastqRecord.getReadName(), expectedReadName);
         Assert.assertEquals(fastqRecord.getBaseQualities(), samRecord.getBaseQualities());
         Assert.assertEquals(fastqRecord.getReadBases(), samRecord.getReadBases());
-        Assert.assertEquals(fastqRecord.getBaseQualityHeader(), samRecord.getStringAttribute(SAMTag.CO.name()));
+        Assert.assertEquals(fastqRecord.getBaseQualityHeader(), samRecord.getStringAttribute(SAMTag.CO));
     }
 
     @Test
@@ -72,7 +72,7 @@ public class FastqEncoderTest extends HtsjdkTest {
         // default method does not include the comment header
         testConvertedSAMRecord(FastqEncoder.asSAMRecord(fastqRecord, samRecord.getHeader()), samRecord);
         // test with qualityHeaderToComment=true populates the CO tag
-        samRecord.setAttribute(SAMTag.CO.name(), fastqRecord.getBaseQualityHeader());
+        samRecord.setAttribute(SAMTag.CO, fastqRecord.getBaseQualityHeader());
         testConvertedSAMRecord(FastqEncoder.asSAMRecord(fastqRecord, samRecord.getHeader(), FastqEncoder.QUALITY_HEADER_TO_COMMENT_TAG), samRecord);
     }
 
@@ -90,9 +90,9 @@ public class FastqEncoderTest extends HtsjdkTest {
         final FastqRecord record = new FastqRecord(samRecord.getReadName(), samRecord.getReadBases(), tags, samRecord.getBaseQualities());
         final SAMRecord converted = FastqEncoder.asSAMRecord(record, samRecord.getHeader(), FastqEncoder.QUALITY_HEADER_PARSE_SAM_TAGS);
         testConvertedSAMRecord(converted, samRecord);
-        Assert.assertEquals(converted.getAttribute(SAMTag.BC.name()), bc);
-        Assert.assertEquals(converted.getAttribute(SAMTag.RG.name()), rg);
-        Assert.assertEquals(converted.getAttribute(SAMTag.FI.name()), fi);
+        Assert.assertEquals(converted.getAttribute(SAMTag.BC), bc);
+        Assert.assertEquals(converted.getAttribute(SAMTag.RG), rg);
+        Assert.assertEquals(converted.getAttribute(SAMTag.FI), fi);
         Assert.assertEquals(converted.getAttribute(customTag), ct);
     }
 
@@ -100,7 +100,7 @@ public class FastqEncoderTest extends HtsjdkTest {
         Assert.assertEquals(converted.getReadName(), original.getReadName());
         Assert.assertEquals(converted.getBaseQualities(), original.getBaseQualities());
         Assert.assertEquals(converted.getReadBases(), original.getReadBases());
-        Assert.assertEquals(converted.getStringAttribute(SAMTag.CO.name()), original.getStringAttribute(SAMTag.CO.name()));
+        Assert.assertEquals(converted.getStringAttribute(SAMTag.CO), original.getStringAttribute(SAMTag.CO));
         Assert.assertTrue(converted.getReadUnmappedFlag());
     }
 }

--- a/src/test/java/htsjdk/samtools/util/CigarUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/CigarUtilTest.java
@@ -275,20 +275,20 @@ public class CigarUtilTest extends HtsjdkTest {
     public void testTagsInvalidation(final String initialCigarString, final boolean negativeStrand, final int clipFrom, final CigarOperator clippingOperator, final boolean expectInvalidated) {
         final byte[] baseQualities1To8 = new byte[]{(byte)31, (byte)32, (byte)33, (byte)34, (byte)35, (byte)36, (byte)37, (byte)38};
         final SAMRecord rec = createTestSamRec("ACTGACTG", baseQualities1To8, initialCigarString, 100, negativeStrand);
-        rec.setAttribute(SAMTag.NM.name(), 0);
-        rec.setAttribute(SAMTag.MD.name(), 0);
-        rec.setAttribute(SAMTag.UQ.name(), 0);
+        rec.setAttribute(SAMTag.NM, 0);
+        rec.setAttribute(SAMTag.MD, 0);
+        rec.setAttribute(SAMTag.UQ, 0);
 
         CigarUtil.clip3PrimeEndOfRead(rec, clipFrom, clippingOperator);
 
         if (expectInvalidated) {
-            Assert.assertNull(rec.getAttribute(SAMTag.NM.name()));
-            Assert.assertNull(rec.getAttribute(SAMTag.MD.name()));
-            Assert.assertNull(rec.getAttribute(SAMTag.UQ.name()));
+            Assert.assertNull(rec.getAttribute(SAMTag.NM));
+            Assert.assertNull(rec.getAttribute(SAMTag.MD));
+            Assert.assertNull(rec.getAttribute(SAMTag.UQ));
         } else {
-            Assert.assertEquals(rec.getAttribute(SAMTag.NM.name()), 0);
-            Assert.assertEquals(rec.getAttribute(SAMTag.MD.name()), 0);
-            Assert.assertEquals(rec.getAttribute(SAMTag.UQ.name()), 0);
+            Assert.assertEquals(rec.getAttribute(SAMTag.NM), 0);
+            Assert.assertEquals(rec.getAttribute(SAMTag.MD), 0);
+            Assert.assertEquals(rec.getAttribute(SAMTag.UQ), 0);
         }
 
     }

--- a/src/test/java/htsjdk/samtools/util/SequenceUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/SequenceUtilTest.java
@@ -114,7 +114,7 @@ public class SequenceUtilTest extends HtsjdkTest {
         rec.setReadName("test");
         rec.setReadString(seq);
         rec.setCigarString(cigar);
-        rec.setAttribute(SAMTag.MD.name(), md);
+        rec.setAttribute(SAMTag.MD, md);
         final byte[] refBases = SequenceUtil.makeReferenceFromAlignment(rec, includeReferenceBasesForDeletions);
         Assert.assertEquals(StringUtil.bytesToString(refBases), expectedReference);
     }
@@ -497,13 +497,13 @@ public class SequenceUtilTest extends HtsjdkTest {
 
         reader.iterator().stream().forEach(r -> {
             Integer nm = SequenceUtil.calculateSamNmTag(r, ref.getSequence(r.getContig()).getBases());
-            String md = r.getStringAttribute(SAMTag.MD.name());
-            Assert.assertEquals(r.getIntegerAttribute(SAMTag.NM.name()), nm, "problem with NM in read \'" + r.getReadName() + "\':");
+            String md = r.getStringAttribute(SAMTag.MD);
+            Assert.assertEquals(r.getIntegerAttribute(SAMTag.NM), nm, "problem with NM in read \'" + r.getReadName() + "\':");
             SequenceUtil.calculateMdAndNmTags(r, ref.getSequence(r.getContig()).getBases(), true, true);
 
-            Assert.assertEquals(r.getIntegerAttribute(SAMTag.NM.name()), nm, "problem with NM in read \'" + r.getReadName() + "\':");
+            Assert.assertEquals(r.getIntegerAttribute(SAMTag.NM), nm, "problem with NM in read \'" + r.getReadName() + "\':");
             if (md != null) {
-                Assert.assertEquals(r.getStringAttribute(SAMTag.MD.name()), md, "problem with MD in read \'" + r.getReadName() + "\':");
+                Assert.assertEquals(r.getStringAttribute(SAMTag.MD), md, "problem with MD in read \'" + r.getReadName() + "\':");
             }
         });
     }


### PR DESCRIPTION
 ... so that callers do not need to adorn their code with useless .name() or .getBinaryTag() calls.

- remove superfluous .name() and .getBinaryTag() calls

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
