### PR TITLE
new interface VCFReader (+ VCFFIleReader implements VCFReader)

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -24,13 +24,11 @@
 
 package htsjdk.variant.vcf;
 
-import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
-import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.FeatureCodec;
 import htsjdk.tribble.FeatureReader;
@@ -38,7 +36,6 @@ import htsjdk.tribble.TribbleException;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -48,7 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Simplified interface for reading from VCF/BCF files.
  */
-public class VCFFileReader implements Closeable, Iterable<VariantContext> {
+public class VCFFileReader implements VCFReader {
 
     private final FeatureReader<VariantContext> reader;
 
@@ -311,8 +308,16 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
     /**
      * Returns the VCFHeader associated with this VCF/BCF file.
      */
-    public VCFHeader getFileHeader() {
+    @Override
+    public VCFHeader getHeader() {
         return (VCFHeader) reader.getHeader();
+    }
+ 
+    /**
+     * Synonym of {@link #getHeader()}
+     */
+    public final VCFHeader getFileHeader() {
+        return getHeader();
     }
 
     /**
@@ -344,16 +349,6 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
         }
     }
 
-    /**
-     * Queries for records overlapping the {@link Locatable} specified.
-     * Note that this method requires VCF files with an associated index.  If no index exists a TribbleException will be thrown.
-     *
-     * @return non-null iterator over VariantContexts
-     */
-    public CloseableIterator<VariantContext> query(final Locatable locatable) {
-        return query(locatable.getContig(), locatable.getStart(), locatable.getEnd());
-    }
-
     @Override
     public void close() {
         try {
@@ -369,6 +364,7 @@ public class VCFFileReader implements Closeable, Iterable<VariantContext> {
      *
      * @return true if the reader can be queried, i.e. if the underlying Tribble reader is queryable.
      */
+    @Override
     public boolean isQueryable() {
         return reader.isQueryable();
     }

--- a/src/main/java/htsjdk/variant/vcf/VCFReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFReader.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package htsjdk.variant.vcf;
+
+import java.io.Closeable;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.Locatable;
+import htsjdk.variant.variantcontext.VariantContext;
+
+/**
+ * Interface for reading VCF/BCF files.
+ */
+public interface VCFReader extends Closeable, Iterable<VariantContext> {
+
+    /**
+     * Returns the VCFHeader associated with this VCFReader.
+     */
+    public VCFHeader getHeader();
+    
+    /**
+     * Queries for records overlapping the region specified.
+     * Note that this method requires VCF files with an associated index.  If no index exists a TribbleException will be thrown.
+     *
+     * @param chrom the chomosome to query
+     * @param start query interval start
+     * @param end   query interval end
+     * @return non-null iterator over VariantContexts
+     */
+    public CloseableIterator<VariantContext> query(final String chrom, final int start, final int end);
+    
+    /**
+     * Queries for records overlapping the {@link Locatable} specified.
+     * Note that this method requires VCF files with an associated index.  If no index exists a TribbleException will be thrown.
+     *
+     * @return non-null iterator over VariantContexts
+     */
+    public default CloseableIterator<VariantContext> query(final Locatable locatable) {
+        return query(locatable.getContig(), locatable.getStart(), locatable.getEnd());
+    }
+
+    /**
+     * A method to check if the reader is query-able, i.e. if a call to {@link VCFFileReader#query(String, int, int)}
+     * can be successful
+     *
+     * @return true if the reader can be queried, i.e. if the underlying Tribble reader is queryable.
+     */
+    public boolean isQueryable();
+
+    @Override
+    public CloseableIterator<VariantContext> iterator();
+
+}


### PR DESCRIPTION
### Description

I created a  new ` interface VCFReader  extends Closeable, Iterable<VariantContext>` and I changed VCFFileReader to `class VCFFileReader extends VCFReader` 

The idea is to  use an interface instead of a File-based class to read+query the VCF files

``` 
public interface VCFReader extends Closeable, Iterable<VariantContext> {
    public VCFHeader getHeader();
    public CloseableIterator<VariantContext> query(final String chrom, final int start, final int end); 
    public default CloseableIterator<VariantContext> query(final Locatable locatable) {...}
    public boolean isQueryable();
    public CloseableIterator<VariantContext> iterator();
}
```


I would like to be able to use some different sources of VCF (one could imagine a **SQL** database, plink ... ) with the same interface. 

My current need is to use a System-call to `bcftools view` to parse the lastest version of the bcf format.

I use `getHeader` instead of `getFileHeader` because it's not always file-based.

I also wondered i I should create a even more generic interface like

``` 
public interface QuerySource<HEADER,ITEM> extends Closeable, Iterable<ITEM> {
    public HEADER getHeader();
    public CloseableIterator<ITEM> query(final String chrom, final int start, final int end); 
    public default CloseableIterator<ITEM> query(final Locatable locatable) {...}
    public boolean isQueryable();
    public CloseableIterator<ITEM> iterator();
}
``` 
... but everything in its time ?

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [x] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
