### PR TITLE
Switch to Java 11, Add GA4GH Crypt4H SeekableStream [WIP]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,8 @@ dependencies {
     compile "org.apache.commons:commons-compress:1.19"
     compile 'org.tukaani:xz:1.8'
     compile "gov.nih.nlm.ncbi:ngs-java:2.9.0"
-
+    implementation files('libs/crypt4gh-2.3.0-shaded.jar')
+    
     testCompile "org.scala-lang:scala-library:2.12.8"
     testCompile "org.scalatest:scalatest_2.12:3.0.5"
     testRuntime 'org.pegdown:pegdown:1.6.0' // Necessary for generating HTML reports with ScalaTest
@@ -46,8 +47,8 @@ dependencies {
     testCompile "com.google.guava:guava:26.0-jre"
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
 
 final isRelease = Boolean.getBoolean("release")
 final gitVersion = gitVersion().replaceAll(".dirty", "")

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableCrypt4GHStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableCrypt4GHStream.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools.seekablestream;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import no.uio.ifi.crypt4gh.stream.Crypt4GHSeekableStreamInternal;
+
+/**
+ *
+ * @author asenf
+ */
+public class SeekableCrypt4GHStream extends SeekableStream {
+
+    private final Crypt4GHSeekableStreamInternal wrappedStreamInternal;
+
+    public SeekableCrypt4GHStream(SeekableStream sourceStream, PrivateKey pK) throws IOException, GeneralSecurityException {
+        this.wrappedStreamInternal = new Crypt4GHSeekableStreamInternal(sourceStream, pK);
+    }
+    
+    @Override
+    public long length() {
+        return this.wrappedStreamInternal.length();
+    }
+
+    @Override
+    public long position() throws IOException {
+        return this.wrappedStreamInternal.position();
+    }
+
+    @Override
+    public void seek(long position) throws IOException {
+        this.wrappedStreamInternal.seek(position);
+    }
+
+    @Override
+    public int read(byte[] bytes, int i, int i1) throws IOException {
+        return this.wrappedStreamInternal.read();
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.wrappedStreamInternal.close();
+    }
+
+    @Override
+    public boolean eof() throws IOException {
+        return this.wrappedStreamInternal.eof();
+    }
+
+    @Override
+    public String getSource() {
+        return this.wrappedStreamInternal.getSource();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return this.wrappedStreamInternal.read();
+    }
+    
+}


### PR DESCRIPTION
This is just for demonstration!

This is a follow-up on adding GA4GH Crypt4GH directly to HTSJDK. This is based on a new implementation of the Crypt4GH library, based on Java 11. It uses native Java functionality to support ChaCha20-Poly1305, the dependency to Google TINK is removed.

### Description

This is a discussion point, to determine the best way forward. There exists now a version of the Crypt4GH library that is no longer dependent on Google TINK, but uses native Java functionality; although the Blake2B dependency remains.

This will be dependent on the whole library switching to Java 11+. Is there any timeline for this?
