### PR TITLE
Gff3BaseData precompute hash and Gff3Codec decodeShallow method

### DIFF
--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -3,6 +3,7 @@ package htsjdk.tribble.gff;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Gff3BaseData {
@@ -14,7 +15,7 @@ public class Gff3BaseData {
     private final String type;
     private final int start;
     private final int end;
-    private final Double score;
+    private final double score;
     private final Strand strand;
     private final int phase;
     private final Map<String, String> attributes;
@@ -34,11 +35,11 @@ public class Gff3BaseData {
         this.score = score;
         this.phase = phase;
         this.strand = strand;
-        this.attributes = Collections.unmodifiableMap(attributes);
+        this.attributes = Collections.unmodifiableMap(new LinkedHashMap<>(attributes));
         this.id = attributes.get(ID_ATTRIBUTE_KEY);
         this.name = attributes.get(NAME_ATTRIBUTE_KEY);
         this.alias = attributes.get(ALIAS_ATTRIBUTE_KEY);
-        hashCode = computeHashCode();
+        this.hashCode = computeHashCode();
     }
 
     @Override
@@ -56,7 +57,7 @@ public class Gff3BaseData {
                 otherBaseData.getType().equals(getType()) &&
                 otherBaseData.getStart() == getStart() &&
                 otherBaseData.getEnd() == getEnd() &&
-                otherBaseData.getScore().equals(score) &&
+                ((Double)otherBaseData.getScore()).equals(score) &&
                 otherBaseData.getPhase() == getPhase() &&
                 otherBaseData.getStrand().equals(getStrand()) &&
                 otherBaseData.getAttributes().equals(getAttributes());
@@ -92,7 +93,7 @@ public class Gff3BaseData {
         hash = 31 * hash + getType().hashCode();
         hash = 31 * hash + getStart();
         hash = 31 * hash + getEnd();
-        hash = 31 * hash + getScore().hashCode();
+        hash = 31 * hash + Double.hashCode(getScore());
         hash = 31 * hash + getPhase();
         hash = 31 * hash + getStrand().hashCode();
         hash = 31 * hash + getAttributes().hashCode();
@@ -131,7 +132,9 @@ public class Gff3BaseData {
         return end;
     }
 
-    public Double getScore() {return score;}
+    public double getScore() {
+        return score;
+    }
 
     public Strand getStrand() {
         return strand;

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -1,11 +1,12 @@
 package htsjdk.tribble.gff;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collections;
 import java.util.Map;
 
-public class Gff3BaseData {
+public class Gff3BaseData implements Locatable {
     private static final String ID_ATTRIBUTE_KEY = "ID";
     private static final String NAME_ATTRIBUTE_KEY = "Name";
     private static final String ALIAS_ATTRIBUTE_KEY = "Alias";

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -1,7 +1,5 @@
 package htsjdk.tribble.gff;
 
-import htsjdk.samtools.util.Locatable;
-import htsjdk.tribble.Feature;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collections;
@@ -22,7 +20,7 @@ public class Gff3BaseData {
     private final String id;
     private final String name;
     private final String alias;
-    final int hashCode;
+    private final int hashCode;
 
     public Gff3BaseData(final String contig, final String source, final String type,
                  final int start, final int end, final Strand strand, final int phase,

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -14,6 +14,7 @@ public class Gff3BaseData {
     private final String type;
     private final int start;
     private final int end;
+    private final Double score;
     private final Strand strand;
     private final int phase;
     private final Map<String, String> attributes;
@@ -23,13 +24,14 @@ public class Gff3BaseData {
     private final int hashCode;
 
     public Gff3BaseData(final String contig, final String source, final String type,
-                 final int start, final int end, final Strand strand, final int phase,
+                 final int start, final int end, final Double score, final Strand strand, final int phase,
                  final Map<String, String> attributes) {
         this.contig = contig;
         this.source = source;
         this.type = type;
         this.start = start;
         this.end = end;
+        this.score = score;
         this.phase = phase;
         this.strand = strand;
         this.attributes = Collections.unmodifiableMap(attributes);
@@ -54,6 +56,7 @@ public class Gff3BaseData {
                 otherBaseData.getType().equals(getType()) &&
                 otherBaseData.getStart() == getStart() &&
                 otherBaseData.getEnd() == getEnd() &&
+                otherBaseData.getScore().equals(score) &&
                 otherBaseData.getPhase() == getPhase() &&
                 otherBaseData.getStrand().equals(getStrand()) &&
                 otherBaseData.getAttributes().equals(getAttributes());
@@ -89,6 +92,7 @@ public class Gff3BaseData {
         hash = 31 * hash + getType().hashCode();
         hash = 31 * hash + getStart();
         hash = 31 * hash + getEnd();
+        hash = 31 * hash + getScore().hashCode();
         hash = 31 * hash + getPhase();
         hash = 31 * hash + getStrand().hashCode();
         hash = 31 * hash + getAttributes().hashCode();
@@ -126,6 +130,8 @@ public class Gff3BaseData {
     public int getEnd() {
         return end;
     }
+
+    public Double getScore() {return score;}
 
     public Strand getStrand() {
         return strand;

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -1,12 +1,13 @@
 package htsjdk.tribble.gff;
 
 import htsjdk.samtools.util.Locatable;
+import htsjdk.tribble.Feature;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collections;
 import java.util.Map;
 
-public class Gff3BaseData implements Locatable {
+public class Gff3BaseData {
     private static final String ID_ATTRIBUTE_KEY = "ID";
     private static final String NAME_ATTRIBUTE_KEY = "Name";
     private static final String ALIAS_ATTRIBUTE_KEY = "Alias";
@@ -23,7 +24,7 @@ public class Gff3BaseData implements Locatable {
     private final String alias;
     final int hashCode;
 
-    Gff3BaseData(final String contig, final String source, final String type,
+    public Gff3BaseData(final String contig, final String source, final String type,
                  final int start, final int end, final Strand strand, final int phase,
                  final Map<String, String> attributes) {
         this.contig = contig;

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -20,6 +20,7 @@ public class Gff3BaseData {
     final String id;
     final String name;
     final String alias;
+    final int hashCode;
 
     Gff3BaseData(final String contig, final String source, final String type,
                  final int start, final int end, final Strand strand, final int phase,
@@ -35,6 +36,7 @@ public class Gff3BaseData {
         this.id = attributes.get(ID_ATTRIBUTE_KEY);
         this.name = attributes.get(NAME_ATTRIBUTE_KEY);
         this.alias = attributes.get(ALIAS_ATTRIBUTE_KEY);
+        hashCode = computeHashCode();
     }
 
     @Override
@@ -78,6 +80,10 @@ public class Gff3BaseData {
 
     @Override
     public int hashCode() {
+        return hashCode;
+    }
+
+    private int computeHashCode() {
         int hash = contig.hashCode();
         hash = 31 * hash + source.hashCode();
         hash = 31 * hash + type.hashCode();

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -9,17 +9,17 @@ public class Gff3BaseData {
     private static final String ID_ATTRIBUTE_KEY = "ID";
     private static final String NAME_ATTRIBUTE_KEY = "Name";
     private static final String ALIAS_ATTRIBUTE_KEY = "Alias";
-    final String contig;
-    final String source;
-    final String type;
-    final int start;
-    final int end;
-    final Strand strand;
-    final int phase;
-    final Map<String, String> attributes;
-    final String id;
-    final String name;
-    final String alias;
+    private final String contig;
+    private final String source;
+    private final String type;
+    private final int start;
+    private final int end;
+    private final Strand strand;
+    private final int phase;
+    private final Map<String, String> attributes;
+    private final String id;
+    private final String name;
+    private final String alias;
     final int hashCode;
 
     Gff3BaseData(final String contig, final String source, final String type,
@@ -49,30 +49,30 @@ public class Gff3BaseData {
         }
 
         final Gff3BaseData otherBaseData = (Gff3BaseData) other;
-        boolean ret = otherBaseData.contig.equals(contig) &&
-                otherBaseData.source.equals(source) &&
-                otherBaseData.type.equals(type) &&
-                otherBaseData.start == start &&
-                otherBaseData.end == end &&
-                otherBaseData.phase == phase &&
-                otherBaseData.strand.equals(strand) &&
-                otherBaseData.attributes.equals(attributes);
-        if (id == null) {
-            ret = ret && otherBaseData.id == null;
+        boolean ret = otherBaseData.getContig().equals(getContig()) &&
+                otherBaseData.getSource().equals(getSource()) &&
+                otherBaseData.getType().equals(getType()) &&
+                otherBaseData.getStart() == getStart() &&
+                otherBaseData.getEnd() == getEnd() &&
+                otherBaseData.getPhase() == getPhase() &&
+                otherBaseData.getStrand().equals(getStrand()) &&
+                otherBaseData.getAttributes().equals(getAttributes());
+        if (getId() == null) {
+            ret = ret && otherBaseData.getId() == null;
         } else {
-            ret = ret && otherBaseData.id != null && otherBaseData.id.equals(id);
+            ret = ret && otherBaseData.getId() != null && otherBaseData.getId().equals(getId());
         }
 
-        if (name == null) {
-            ret = ret && otherBaseData.name == null;
+        if (getName() == null) {
+            ret = ret && otherBaseData.getName() == null;
         } else {
-            ret = ret && otherBaseData.name != null && otherBaseData.name.equals(name);
+            ret = ret && otherBaseData.getName() != null && otherBaseData.getName().equals(getName());
         }
 
-        if (alias == null) {
-            ret = ret && otherBaseData.alias == null;
+        if (getAlias() == null) {
+            ret = ret && otherBaseData.getAlias() == null;
         } else {
-            ret = ret && otherBaseData.alias != null && otherBaseData.alias.equals(alias);
+            ret = ret && otherBaseData.getAlias() != null && otherBaseData.getAlias().equals(getAlias());
         }
 
         return ret;
@@ -84,26 +84,70 @@ public class Gff3BaseData {
     }
 
     private int computeHashCode() {
-        int hash = contig.hashCode();
-        hash = 31 * hash + source.hashCode();
-        hash = 31 * hash + type.hashCode();
-        hash = 31 * hash + start;
-        hash = 31 * hash + end;
-        hash = 31 * hash + phase;
-        hash = 31 * hash + strand.hashCode();
-        hash = 31 * hash + attributes.hashCode();
-        if (id != null) {
-            hash = 31 * hash + id.hashCode();
+        int hash = getContig().hashCode();
+        hash = 31 * hash + getSource().hashCode();
+        hash = 31 * hash + getType().hashCode();
+        hash = 31 * hash + getStart();
+        hash = 31 * hash + getEnd();
+        hash = 31 * hash + getPhase();
+        hash = 31 * hash + getStrand().hashCode();
+        hash = 31 * hash + getAttributes().hashCode();
+        if (getId() != null) {
+            hash = 31 * hash + getId().hashCode();
         }
 
-        if (name != null) {
-            hash = 31 * hash + name.hashCode();
+        if (getName() != null) {
+            hash = 31 * hash + getName().hashCode();
         }
 
-        if (alias != null) {
-            hash = 31 * hash + alias.hashCode();
+        if (getAlias() != null) {
+            hash = 31 * hash + getAlias().hashCode();
         }
 
         return hash;
+    }
+
+    public String getContig() {
+        return contig;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public Strand getStrand() {
+        return strand;
+    }
+
+    public int getPhase() {
+        return phase;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAlias() {
+        return alias;
     }
 }

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -9,8 +9,6 @@ import htsjdk.samtools.util.Log;
 import htsjdk.tribble.AbstractFeatureCodec;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodecHeader;
-import htsjdk.tribble.SimpleFeature;
-import htsjdk.tribble.Tribble;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.index.tabix.TabixFormat;
@@ -24,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -68,8 +65,6 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
     private final Map<String, Set<Gff3FeatureImpl>> activeFeaturesWithIDs = new HashMap<>();
     private final Map<String, Set<Gff3FeatureImpl>> activeParentIDs = new HashMap<>();
 
-    private int currentLineNum = 0;
-
     private final Map<String, SequenceRegion> sequenceRegionMap = new HashMap<>();
 
     private final static Log logger = Log.getInstance(Gff3Codec.class);
@@ -94,7 +89,6 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
         }
 
         final String line = lineIterator.next();
-        currentLineNum++;
 
         if (reachedFasta) {
             //previously reached fasta, flush whatever is active

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -47,6 +47,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
     private static final int FEATURE_TYPE_INDEX = 2;
     private static final int START_LOCATION_INDEX = 3;
     private static final int END_LOCATION_INDEX = 4;
+    private static final int SCORE_INDEX = 5;
     private static final int GENOMIC_STRAND_INDEX = 6;
     private static final int GENOMIC_PHASE_INDEX = 7;
     private static final int EXTRA_FIELDS_INDEX = 8;
@@ -192,10 +193,11 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
             final String type = URLDecoder.decode(splitLine.get(FEATURE_TYPE_INDEX), "UTF-8");
             final int start = Integer.parseInt(splitLine.get(START_LOCATION_INDEX));
             final int end = Integer.parseInt(splitLine.get(END_LOCATION_INDEX));
+            final Double score = splitLine.get(SCORE_INDEX).equals(".") ? -1 : Double.parseDouble(splitLine.get(SCORE_INDEX));
             final int phase = splitLine.get(GENOMIC_PHASE_INDEX).equals(".") ? -1 : Integer.parseInt(splitLine.get(GENOMIC_PHASE_INDEX));
             final Strand strand = Strand.decode(splitLine.get(GENOMIC_STRAND_INDEX));
             final Map<String, String> attributes = parseAttributes(splitLine.get(EXTRA_FIELDS_INDEX));
-            return new Gff3BaseData(contig, source, type, start, end, strand, phase, attributes);
+            return new Gff3BaseData(contig, source, type, start, end, score, strand, phase, attributes);
         } catch (final NumberFormatException ex ) {
             throw new TribbleException("Cannot read integer value for start/end position!", ex);
         } catch (final IOException ex) {

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -239,14 +239,14 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
      * @param lineIterator
      * @return
      */
-    public Gff3BaseData decodeShallow(final LineIterator lineIterator) {
+    public Gff3Feature decodeShallow(final LineIterator lineIterator) {
         final String line = lineIterator.next();
 
         if (line.startsWith(COMMENT_START)) {
             return null;
         }
 
-        return parseLine(line);
+        return new Gff3FeatureImpl(parseLine(line));
     }
 
     @Override

--- a/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
@@ -3,7 +3,6 @@ package htsjdk.tribble.gff;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.annotation.Strand;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -23,45 +22,45 @@ public interface Gff3Feature extends Feature {
 
 
     default String getSource() {
-        return getBaseData().source;
+        return getBaseData().getSource();
     }
 
     @Override
     default int getEnd() {
-        return getBaseData().end;
+        return getBaseData().getEnd();
     }
 
     default Strand getStrand() {
-        return getBaseData().strand;
+        return getBaseData().getStrand();
     }
 
     default int getPhase() {
-        return getBaseData().phase;
+        return getBaseData().getPhase();
     }
 
-    default String getType() {return getBaseData().type;}
+    default String getType() {return getBaseData().getType();}
 
     @Override
     default String getContig() {
-        return getBaseData().contig;
+        return getBaseData().getContig();
     }
 
      @Override
     default int getStart() {
-        return getBaseData().start;
+        return getBaseData().getStart();
     }
 
     default String getAttribute(final String key) {
-        return getBaseData().attributes.get(key);
+        return getBaseData().getAttributes().get(key);
     }
 
-    default Map<String, String> getAttributes() { return getBaseData().attributes;}
+    default Map<String, String> getAttributes() { return getBaseData().getAttributes();}
 
-    default String getID() { return getBaseData().id;}
+    default String getID() { return getBaseData().getId();}
 
-    default String getName() { return getBaseData().name;}
+    default String getName() { return getBaseData().getName();}
 
-    default String getAlias() { return getBaseData().alias;}
+    default String getAlias() { return getBaseData().getAlias();}
 
     /**
      * Get BaseData object which contains all the basic information of the feature

--- a/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
@@ -62,6 +62,8 @@ public interface Gff3Feature extends Feature {
 
     default String getAlias() { return getBaseData().getAlias();}
 
+    default double getScore() { return getBaseData().getScore();}
+
     /**
      * Get BaseData object which contains all the basic information of the feature
      * @return

--- a/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
@@ -80,7 +80,7 @@ public class Gff3FeatureImpl implements Gff3Feature {
     public Set<Gff3FeatureImpl> getAncestors() {
         final List<Gff3FeatureImpl> ancestors = new ArrayList<>(parents);
         for (final Gff3FeatureImpl parent : parents) {
-            ancestors.addAll(baseData.attributes.containsKey(DERIVES_FROM_ATTRIBUTE_KEY)? parent.getAncestors(baseData.attributes.get(DERIVES_FROM_ATTRIBUTE_KEY)) : parent.getAncestors());
+            ancestors.addAll(baseData.getAttributes().containsKey(DERIVES_FROM_ATTRIBUTE_KEY)? parent.getAncestors(baseData.getAttributes().get(DERIVES_FROM_ATTRIBUTE_KEY)) : parent.getAncestors());
         }
         return new LinkedHashSet<>(ancestors);
     }
@@ -103,7 +103,7 @@ public class Gff3FeatureImpl implements Gff3Feature {
     @Override
     public Set<Gff3FeatureImpl> getDescendents() {
         final List<Gff3FeatureImpl> descendants = new ArrayList<>(children);
-        final Set<String> idsInLineage = new HashSet<>(Collections.singleton(baseData.id));
+        final Set<String> idsInLineage = new HashSet<>(Collections.singleton(baseData.getId()));
         idsInLineage.addAll(children.stream().map(Gff3Feature::getID).collect(Collectors.toSet()));
         for(final Gff3FeatureImpl child : children) {
             descendants.addAll(child.getDescendents(idsInLineage));
@@ -144,8 +144,8 @@ public class Gff3FeatureImpl implements Gff3Feature {
 
     public void addParent(final Gff3FeatureImpl parent) {
         final Set<Gff3FeatureImpl> topLevelFeaturesToAdd = new HashSet<>(parent.getTopLevelFeatures());
-        if (baseData.attributes.containsKey(DERIVES_FROM_ATTRIBUTE_KEY)) {
-            topLevelFeaturesToAdd.removeIf(f -> !f.getID().equals(baseData.attributes.get(DERIVES_FROM_ATTRIBUTE_KEY)) && f.getDescendents().stream().noneMatch(f2 -> f2.getID()== null? false:f2.getID().equals(baseData.attributes.get(DERIVES_FROM_ATTRIBUTE_KEY))));
+        if (baseData.getAttributes().containsKey(DERIVES_FROM_ATTRIBUTE_KEY)) {
+            topLevelFeaturesToAdd.removeIf(f -> !f.getID().equals(baseData.getAttributes().get(DERIVES_FROM_ATTRIBUTE_KEY)) && f.getDescendents().stream().noneMatch(f2 -> f2.getID()== null? false:f2.getID().equals(baseData.getAttributes().get(DERIVES_FROM_ATTRIBUTE_KEY))));
         }
         parents.add(parent);
         parent.addChild(this);
@@ -184,7 +184,7 @@ public class Gff3FeatureImpl implements Gff3Feature {
     public void addCoFeature(final Gff3FeatureImpl coFeature) {
         if (!parents.equals(coFeature.getParents())) {
 
-            throw new TribbleException("Co-features " + baseData.id + " do not have same parents");
+            throw new TribbleException("Co-features " + baseData.getId() + " do not have same parents");
         }
         for (final Gff3FeatureImpl feature : coFeatures) {
             feature.addCoFeatureShallow(coFeature);
@@ -196,8 +196,8 @@ public class Gff3FeatureImpl implements Gff3Feature {
 
     private void addCoFeatureShallow(final Gff3FeatureImpl coFeature) {
         coFeatures.add(coFeature);
-        if (!coFeature.getID().equals(baseData.id)) {
-            throw new TribbleException("Attempting to add co-feature with id " + coFeature.getID() + " to feature with id " + baseData.id);
+        if (!coFeature.getID().equals(baseData.getId())) {
+            throw new TribbleException("Attempting to add co-feature with id " + coFeature.getID() + " to feature with id " + baseData.getId());
         }
     }
 

--- a/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
@@ -36,6 +36,10 @@ public class Gff3FeatureImpl implements Gff3Feature {
 
     }
 
+    public Gff3FeatureImpl(final Gff3BaseData baseData) {
+        this.baseData = baseData;
+    }
+
     /**
      * Get the set of top level features from which this feature is descended
      * @return set of top level feature from which this feature is descended

--- a/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
@@ -30,9 +30,9 @@ public class Gff3FeatureImpl implements Gff3Feature {
     private final Set<Gff3FeatureImpl> topLevelFeatures = new HashSet<>();
 
     public Gff3FeatureImpl(final String contig, final String source, final String type,
-                           final int start, final int end, final Strand strand, final int phase,
+                           final int start, final int end, final Double score, final Strand strand, final int phase,
                            final Map<String, String> attributes) {
-        baseData = new Gff3BaseData(contig, source, type, start, end, strand, phase, attributes);
+        baseData = new Gff3BaseData(contig, source, type, start, end, score, strand, phase, attributes);
 
     }
 

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -151,113 +151,113 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> canonicalGeneFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl canonicalGene_gene00001 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 9000, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00001", "Name", "EDEN"));
+        final Gff3FeatureImpl canonicalGene_gene00001 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00001", "Name", "EDEN"));
         canonicalGeneFeatures.add(canonicalGene_gene00001);
 
-        final Gff3FeatureImpl canonicalGene_tfbs00001 = new Gff3FeatureImpl("ctg123", ".", "TF_binding_site", 1000, 1012, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tfbs00001", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_tfbs00001 = new Gff3FeatureImpl("ctg123", ".", "TF_binding_site", 1000, 1012, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tfbs00001", "Parent", "gene00001"));
         canonicalGene_tfbs00001.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_tfbs00001);
 
-        final Gff3FeatureImpl canonicalGene_mRNA00001 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00001", "Name", "EDEN.1", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_mRNA00001 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00001", "Name", "EDEN.1", "Parent", "gene00001"));
         canonicalGene_mRNA00001.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_mRNA00001);
 
-        final Gff3FeatureImpl canonicalGene_mRNA00002 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00002", "Name", "EDEN.2", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_mRNA00002 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00002", "Name", "EDEN.2", "Parent", "gene00001"));
         canonicalGene_mRNA00002.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_mRNA00002);
 
-        final Gff3FeatureImpl canonicalGene_mRNA00003 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1300, 9000, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00003", "Name", "EDEN.3", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_mRNA00003 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1300, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00003", "Name", "EDEN.3", "Parent", "gene00001"));
         canonicalGene_mRNA00003.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_mRNA00003);
 
-        final Gff3FeatureImpl canonicalGene_exon00001 = new Gff3FeatureImpl("ctg123", ".", "exon", 1300, 1500, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00001", "Parent", "mRNA00003"));
+        final Gff3FeatureImpl canonicalGene_exon00001 = new Gff3FeatureImpl("ctg123", ".", "exon", 1300, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00001", "Parent", "mRNA00003"));
         canonicalGene_exon00001.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_exon00001);
 
-        final Gff3FeatureImpl canonicalGene_exon00002 = new Gff3FeatureImpl("ctg123", ".", "exon", 1050, 1500, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00002", "Parent", "mRNA00001,mRNA00002"));
+        final Gff3FeatureImpl canonicalGene_exon00002 = new Gff3FeatureImpl("ctg123", ".", "exon", 1050, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00002", "Parent", "mRNA00001,mRNA00002"));
         canonicalGene_exon00002.addParent(canonicalGene_mRNA00001);
         canonicalGene_exon00002.addParent(canonicalGene_mRNA00002);
         canonicalGeneFeatures.add(canonicalGene_exon00002);
 
-        final Gff3FeatureImpl canonicalGene_exon00003 = new Gff3FeatureImpl("ctg123", ".", "exon", 3000, 3902, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00003", "Parent", "mRNA00001,mRNA00003"));
+        final Gff3FeatureImpl canonicalGene_exon00003 = new Gff3FeatureImpl("ctg123", ".", "exon", 3000, 3902, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00003", "Parent", "mRNA00001,mRNA00003"));
         canonicalGene_exon00003.addParent(canonicalGene_mRNA00001);
         canonicalGene_exon00003.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_exon00003);
 
-        final Gff3FeatureImpl canonicalGene_exon00004 = new Gff3FeatureImpl("ctg123", ".", "exon", 5000, 5500, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00004", "Parent", "mRNA00001,mRNA00002,mRNA00003"));
+        final Gff3FeatureImpl canonicalGene_exon00004 = new Gff3FeatureImpl("ctg123", ".", "exon", 5000, 5500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00004", "Parent", "mRNA00001,mRNA00002,mRNA00003"));
         canonicalGene_exon00004.addParent(canonicalGene_mRNA00001);
         canonicalGene_exon00004.addParent(canonicalGene_mRNA00002);
         canonicalGene_exon00004.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_exon00004);
 
-        final Gff3FeatureImpl canonicalGene_exon00005 = new Gff3FeatureImpl("ctg123", ".", "exon", 7000, 9000, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00005", "Parent", "mRNA00001,mRNA00002,mRNA00003"));
+        final Gff3FeatureImpl canonicalGene_exon00005 = new Gff3FeatureImpl("ctg123", ".", "exon", 7000, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00005", "Parent", "mRNA00001,mRNA00002,mRNA00003"));
         canonicalGene_exon00005.addParent(canonicalGene_mRNA00001);
         canonicalGene_exon00005.addParent(canonicalGene_mRNA00002);
         canonicalGene_exon00005.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_exon00005);
 
-        final Gff3FeatureImpl canonicalGene_cds00001_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 1201, 1500, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
+        final Gff3FeatureImpl canonicalGene_cds00001_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 1201, 1500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
         canonicalGene_cds00001_1.addParent(canonicalGene_mRNA00001);
         canonicalGeneFeatures.add(canonicalGene_cds00001_1);
 
-        final Gff3FeatureImpl canonicalGene_cds00001_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3000, 3902, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
+        final Gff3FeatureImpl canonicalGene_cds00001_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3000, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
         canonicalGene_cds00001_2.addParent(canonicalGene_mRNA00001);
         canonicalGene_cds00001_2.addCoFeature(canonicalGene_cds00001_1);
         canonicalGeneFeatures.add(canonicalGene_cds00001_2);
 
-        final Gff3FeatureImpl canonicalGene_cds00001_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
+        final Gff3FeatureImpl canonicalGene_cds00001_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
         canonicalGene_cds00001_3.addParent(canonicalGene_mRNA00001);
         canonicalGene_cds00001_3.addCoFeature(canonicalGene_cds00001_1);
         canonicalGene_cds00001_3.addCoFeature(canonicalGene_cds00001_2);
         canonicalGeneFeatures.add(canonicalGene_cds00001_3);
 
-        final Gff3FeatureImpl canonicalGene_cds00001_4 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
+        final Gff3FeatureImpl canonicalGene_cds00001_4 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
         canonicalGene_cds00001_4.addParent(canonicalGene_mRNA00001);
         canonicalGene_cds00001_4.addCoFeature(canonicalGene_cds00001_1);
         canonicalGene_cds00001_4.addCoFeature(canonicalGene_cds00001_2);
         canonicalGene_cds00001_4.addCoFeature(canonicalGene_cds00001_3);
         canonicalGeneFeatures.add(canonicalGene_cds00001_4);
 
-        final Gff3FeatureImpl canonicalGene_cds00002_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 1201, 1500, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
+        final Gff3FeatureImpl canonicalGene_cds00002_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 1201, 1500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
         canonicalGene_cds00002_1.addParent(canonicalGene_mRNA00002);
         canonicalGeneFeatures.add(canonicalGene_cds00002_1);
 
-        final Gff3FeatureImpl canonicalGene_cds00002_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
+        final Gff3FeatureImpl canonicalGene_cds00002_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
         canonicalGene_cds00002_2.addParent(canonicalGene_mRNA00002);
         canonicalGene_cds00002_2.addCoFeature(canonicalGene_cds00002_1);
         canonicalGeneFeatures.add(canonicalGene_cds00002_2);
 
-        final Gff3FeatureImpl canonicalGene_cds00002_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
+        final Gff3FeatureImpl canonicalGene_cds00002_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
         canonicalGene_cds00002_3.addParent(canonicalGene_mRNA00002);
         canonicalGene_cds00002_3.addCoFeature(canonicalGene_cds00002_1);
         canonicalGene_cds00002_3.addCoFeature(canonicalGene_cds00002_2);
         canonicalGeneFeatures.add(canonicalGene_cds00002_3);
 
-        final Gff3FeatureImpl canonicalGene_cds00003_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3301, 3902, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
+        final Gff3FeatureImpl canonicalGene_cds00003_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3301, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
         canonicalGene_cds00003_1.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_cds00003_1);
 
-        final Gff3FeatureImpl canonicalGene_cds00003_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
+        final Gff3FeatureImpl canonicalGene_cds00003_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
         canonicalGene_cds00003_2.addParent(canonicalGene_mRNA00003);
         canonicalGene_cds00003_2.addCoFeature(canonicalGene_cds00003_1);
         canonicalGeneFeatures.add(canonicalGene_cds00003_2);
 
-        final Gff3FeatureImpl canonicalGene_cds00003_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
+        final Gff3FeatureImpl canonicalGene_cds00003_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
         canonicalGene_cds00003_3.addParent(canonicalGene_mRNA00003);
         canonicalGene_cds00003_3.addCoFeature(canonicalGene_cds00003_1);
         canonicalGene_cds00003_3.addCoFeature(canonicalGene_cds00003_2);
         canonicalGeneFeatures.add(canonicalGene_cds00003_3);
 
-        final Gff3FeatureImpl canonicalGene_cds00004_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3391, 3902, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
+        final Gff3FeatureImpl canonicalGene_cds00004_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3391, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
         canonicalGene_cds00004_1.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_cds00004_1);
         
-        final Gff3FeatureImpl canonicalGene_cds00004_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
+        final Gff3FeatureImpl canonicalGene_cds00004_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
         canonicalGene_cds00004_2.addParent(canonicalGene_mRNA00003);
         canonicalGene_cds00004_2.addCoFeature(canonicalGene_cds00004_1);
         canonicalGeneFeatures.add(canonicalGene_cds00004_2);
 
-        final Gff3FeatureImpl canonicalGene_cds00004_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
+        final Gff3FeatureImpl canonicalGene_cds00004_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
         canonicalGene_cds00004_3.addParent(canonicalGene_mRNA00003);
         canonicalGene_cds00004_3.addCoFeature(canonicalGene_cds00004_1);
         canonicalGene_cds00004_3.addCoFeature(canonicalGene_cds00004_2);
@@ -271,40 +271,40 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> polycisctronicTranscriptFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl polycistronicTranscript_gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 100, 200, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "name", "resA"));
-        final Gff3FeatureImpl polycistronicTranscript_gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 250, 350, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene02", "name", "resB"));
-        final Gff3FeatureImpl polycistronicTranscript_gene03 = new Gff3FeatureImpl("chrX", ".", "gene", 400, 500, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene03", "name", "resX"));
-        final Gff3FeatureImpl polycistronicTranscript_gene04 = new Gff3FeatureImpl("chrX", ".", "gene", 550, 650, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene04", "name", "resZ"));
+        final Gff3FeatureImpl polycistronicTranscript_gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "name", "resA"));
+        final Gff3FeatureImpl polycistronicTranscript_gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 250, 350, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene02", "name", "resB"));
+        final Gff3FeatureImpl polycistronicTranscript_gene03 = new Gff3FeatureImpl("chrX", ".", "gene", 400, 500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene03", "name", "resX"));
+        final Gff3FeatureImpl polycistronicTranscript_gene04 = new Gff3FeatureImpl("chrX", ".", "gene", 550, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene04", "name", "resZ"));
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_gene01);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_gene02);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_gene03);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_gene04);
 
-        final Gff3FeatureImpl polycistronicTranscript_mRNA = new Gff3FeatureImpl("chrX", ".", "mRNA", 100, 650, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tran01", "Parent", "gene01,gene02,gene03,gene04"));
+        final Gff3FeatureImpl polycistronicTranscript_mRNA = new Gff3FeatureImpl("chrX", ".", "mRNA", 100, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tran01", "Parent", "gene01,gene02,gene03,gene04"));
         polycistronicTranscript_mRNA.addParent(polycistronicTranscript_gene01);
         polycistronicTranscript_mRNA.addParent(polycistronicTranscript_gene02);
         polycistronicTranscript_mRNA.addParent(polycistronicTranscript_gene03);
         polycistronicTranscript_mRNA.addParent(polycistronicTranscript_gene04);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_mRNA);
 
-        final Gff3FeatureImpl polycistronicTranscript_exon = new Gff3FeatureImpl("chrX", ".", "exon", 100, 650, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "tran01"));
+        final Gff3FeatureImpl polycistronicTranscript_exon = new Gff3FeatureImpl("chrX", ".", "exon", 100, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "tran01"));
         polycistronicTranscript_exon.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_exon);
 
 
-        final Gff3FeatureImpl polycistronicTranscript_CDS1 = new Gff3FeatureImpl("chrX", ".", "CDS", 100, 200, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene01"));
+        final Gff3FeatureImpl polycistronicTranscript_CDS1 = new Gff3FeatureImpl("chrX", ".", "CDS", 100, 200, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene01"));
         polycistronicTranscript_CDS1.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_CDS1);
 
-        final Gff3FeatureImpl polycistronicTranscript_CDS2 = new Gff3FeatureImpl("chrX", ".", "CDS", 250, 350, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene02"));
+        final Gff3FeatureImpl polycistronicTranscript_CDS2 = new Gff3FeatureImpl("chrX", ".", "CDS", 250, 350, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene02"));
         polycistronicTranscript_CDS2.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_CDS2);
 
-        final Gff3FeatureImpl polycistronicTranscript_CDS3 = new Gff3FeatureImpl("chrX", ".", "CDS", 400, 500, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene03"));
+        final Gff3FeatureImpl polycistronicTranscript_CDS3 = new Gff3FeatureImpl("chrX", ".", "CDS", 400, 500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene03"));
         polycistronicTranscript_CDS3.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_CDS3);
 
-        final Gff3FeatureImpl polycistronicTranscript_CDS4 = new Gff3FeatureImpl("chrX", ".", "CDS", 550, 650, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene04"));
+        final Gff3FeatureImpl polycistronicTranscript_CDS4 = new Gff3FeatureImpl("chrX", ".", "CDS", 550, 650, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene04"));
         polycistronicTranscript_CDS4.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_CDS4);
 
@@ -316,23 +316,23 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> programmedFrameshiftFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl programmedFrameshift_gene = new Gff3FeatureImpl("chrX", ".", "gene", 100, 200, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "name", "my_gene"));
+        final Gff3FeatureImpl programmedFrameshift_gene = new Gff3FeatureImpl("chrX", ".", "gene", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "name", "my_gene"));
         programmedFrameshiftFeatures.add(programmedFrameshift_gene);
 
-        final Gff3FeatureImpl programmedFrameshift_mRNA = new Gff3FeatureImpl("chrX", ".", "mRNA", 100, 200, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tran01", "Parent", "gene01", "Ontology_term", "SO:1000069"));
+        final Gff3FeatureImpl programmedFrameshift_mRNA = new Gff3FeatureImpl("chrX", ".", "mRNA", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tran01", "Parent", "gene01", "Ontology_term", "SO:1000069"));
         programmedFrameshift_mRNA.addParent(programmedFrameshift_gene);
         programmedFrameshiftFeatures.add(programmedFrameshift_mRNA);
 
-        final Gff3FeatureImpl programmedFrameshift_exon = new Gff3FeatureImpl("chrX", ".", "exon", 100, 200, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon01", "Parent", "tran01"));
+        final Gff3FeatureImpl programmedFrameshift_exon = new Gff3FeatureImpl("chrX", ".", "exon", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon01", "Parent", "tran01"));
         programmedFrameshift_exon.addParent(programmedFrameshift_mRNA);
         programmedFrameshiftFeatures.add(programmedFrameshift_exon);
 
 
-        final Gff3FeatureImpl programmedFrameshift_CDS1_1 = new Gff3FeatureImpl("chrX", ".", "CDS", 100, 150, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "tran01"));
+        final Gff3FeatureImpl programmedFrameshift_CDS1_1 = new Gff3FeatureImpl("chrX", ".", "CDS", 100, 150, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "tran01"));
         programmedFrameshift_CDS1_1.addParent(programmedFrameshift_mRNA);
         programmedFrameshiftFeatures.add(programmedFrameshift_CDS1_1);
 
-        final Gff3FeatureImpl programmedFrameshift_CDS1_2 = new Gff3FeatureImpl("chrX", ".", "CDS", 149, 200, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "tran01"));
+        final Gff3FeatureImpl programmedFrameshift_CDS1_2 = new Gff3FeatureImpl("chrX", ".", "CDS", 149, 200, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "tran01"));
         programmedFrameshift_CDS1_2.addParent(programmedFrameshift_mRNA);
         programmedFrameshift_CDS1_2.addCoFeature(programmedFrameshift_CDS1_1);
         programmedFrameshiftFeatures.add(programmedFrameshift_CDS1_2);
@@ -345,17 +345,17 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> multipleGenesFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl multipleGenes_gene1 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 1500, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00001"));
+        final Gff3FeatureImpl multipleGenes_gene1 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00001"));
         multipleGenesFeatures.add(multipleGenes_gene1);
 
-        final Gff3FeatureImpl multipleGenes_mRNA1 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 1400, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "gene00001"));
+        final Gff3FeatureImpl multipleGenes_mRNA1 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 1400, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "gene00001"));
         multipleGenes_mRNA1.addParent(multipleGenes_gene1);
         multipleGenesFeatures.add(multipleGenes_mRNA1);
 
-        final Gff3FeatureImpl multipleGenes_gene2 = new Gff3FeatureImpl("ctg123", ".", "gene", 2000, 2500, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00002"));
+        final Gff3FeatureImpl multipleGenes_gene2 = new Gff3FeatureImpl("ctg123", ".", "gene", 2000, 2500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00002"));
         multipleGenesFeatures.add(multipleGenes_gene2);
 
-        final Gff3FeatureImpl multipleGenes_mRNA2 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 2050, 2400, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "gene00002"));
+        final Gff3FeatureImpl multipleGenes_mRNA2 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 2050, 2400, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "gene00002"));
         multipleGenes_mRNA2.addParent(multipleGenes_gene2);
         multipleGenesFeatures.add(multipleGenes_mRNA2);
 

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -197,14 +197,14 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> canonicalGeneFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl canonicalGene_gene00001 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00001", "Name", "EDEN"));
+        final Gff3FeatureImpl canonicalGene_gene00001 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 9000, 1030d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00001", "Name", "EDEN"));
         canonicalGeneFeatures.add(canonicalGene_gene00001);
 
-        final Gff3FeatureImpl canonicalGene_tfbs00001 = new Gff3FeatureImpl("ctg123", ".", "TF_binding_site", 1000, 1012, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tfbs00001", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_tfbs00001 = new Gff3FeatureImpl("ctg123", ".", "TF_binding_site", 1000, 1012, 0.999d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tfbs00001", "Parent", "gene00001"));
         canonicalGene_tfbs00001.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_tfbs00001);
 
-        final Gff3FeatureImpl canonicalGene_mRNA00001 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00001", "Name", "EDEN.1", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_mRNA00001 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, 1.37d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00001", "Name", "EDEN.1", "Parent", "gene00001"));
         canonicalGene_mRNA00001.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_mRNA00001);
 
@@ -414,7 +414,6 @@ public class Gff3CodecTest extends HtsjdkTest {
     @Test(dataProvider = "examplesDataProvider")
     public void examplesTest(final String inputGff, final Set<Gff3Feature> expectedFeatures) throws IOException {
         final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(inputGff, null, new Gff3Codec(), false);
-        int observedTopLevelFeatures = 0;
         int observedFeatures = 0;
         for (final Gff3Feature feature : reader.iterator()) {
 

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -67,6 +67,24 @@ public class Gff3CodecTest extends HtsjdkTest {
         Assert.assertEquals(countTotalFeatures, expectedTotalFeatures);
     }
 
+    @Test(dataProvider = "basicDecodeDataProvider")
+    public void basicShallowDecodeTest(final Path inputGff3, final int expectedTotalFeatures) throws IOException {
+        Assert.assertTrue((new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW)).canDecode(inputGff3.toAbsolutePath().toString()));
+        final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(inputGff3.toAbsolutePath().toString(), null, new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW), false);
+        int countTotalFeatures = 0;
+        for (final Gff3Feature feature : reader.iterator()) {
+            countTotalFeatures++;
+            //shouldn't have any children, parents, or cofeatures
+            Assert.assertEquals(feature.getAncestors().size(), 0);
+            Assert.assertEquals(feature.getDescendents().size(), 0);
+            Assert.assertEquals(feature.getCoFeatures().size(), 0);
+        }
+
+        Assert.assertEquals(countTotalFeatures, expectedTotalFeatures);
+
+
+    }
+
     @DataProvider(name = "testGZippedDataProvider")
     Object[][] testGZippedDataProvider(){
         return new Object[][] {
@@ -99,6 +117,34 @@ public class Gff3CodecTest extends HtsjdkTest {
         }
 
         Assert.assertEquals(topLevelFeatures, topLevelFeaturesGZipped);
+    }
+
+    @Test(dataProvider = "testGZippedDataProvider")
+    public void testGZippedShallow(final Path inputGff3, final Path inputGff3GZipped) throws IOException {
+        Assert.assertTrue((new Gff3Codec()).canDecode(inputGff3.toAbsolutePath().toString()));
+        Assert.assertTrue((new Gff3Codec()).canDecode(inputGff3GZipped.toAbsolutePath().toString()));
+
+        final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(inputGff3.toAbsolutePath().toString(), null, new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW), false);
+        final AbstractFeatureReader<Gff3Feature, LineIterator> readerGZipped = AbstractFeatureReader.getFeatureReader(inputGff3GZipped.toAbsolutePath().toString(), null, new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW), false);
+
+        final Set<Gff3Feature> features = new HashSet<>();
+        final Set<Gff3Feature> featuresGZipped = new HashSet<>();
+
+        for (final Gff3Feature feature : reader.iterator()) {
+            features.add(feature);
+            Assert.assertEquals(feature.getAncestors().size(), 0);
+            Assert.assertEquals(feature.getDescendents().size(), 0);
+            Assert.assertEquals(feature.getCoFeatures().size(), 0);
+        }
+
+        for (final Gff3Feature feature : readerGZipped.iterator()) {
+            featuresGZipped.add(feature);
+            Assert.assertEquals(feature.getAncestors().size(), 0);
+            Assert.assertEquals(feature.getDescendents().size(), 0);
+            Assert.assertEquals(feature.getCoFeatures().size(), 0);
+        }
+
+        Assert.assertEquals(features, featuresGZipped);
     }
 
     @DataProvider(name = "sequenceRegionValidationDataProvider")

--- a/src/test/java/htsjdk/tribble/gff/Gff3FeatureTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3FeatureTest.java
@@ -23,42 +23,42 @@ public class Gff3FeatureTest extends HtsjdkTest {
     @DataProvider(name = "equalityTestDataProvider")
     public Object[][] equalityTestDatProvider() {
         final ArrayList<Object[]> examples = new ArrayList<>();
-        examples.add(new Object[] {new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01")),
-                new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01")), true});
-        examples.add(new Object[] {new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01")),
-                new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01")), true});
+        examples.add(new Object[] {new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01")),
+                new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01")), true});
+        examples.add(new Object[] {new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01")),
+                new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01")), true});
 
         //two features with same baseData, one with child (or parent) feature, one without
-        final Gff3FeatureImpl feature1_1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2_1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature3_1 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1_1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature2_1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature3_1 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature3_1.addParent(feature1_1);
-        final Gff3FeatureImpl feature4_1 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature4_1 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
 
         examples.add(new Object[] {feature1_1, feature2_1, false});
         examples.add(new Object[] {feature3_1, feature4_1, false});
 
         //give both genes child feature
-        final Gff3FeatureImpl feature1_2 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2_2 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature3_2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, -0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1_2 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature2_2 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature3_2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, -0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature3_2.addParent(feature1_2);
-        final Gff3FeatureImpl feature4_2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature4_2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature4_2.addParent(feature2_2);
 
         examples.add(new Object[] {feature1_2, feature2_2, true});
         examples.add(new Object[] {feature3_2, feature4_2, true});
 
         //give one cds a co-feature
-        final Gff3FeatureImpl feature1_3 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2_3 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature3_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1_3 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature2_3 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature3_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature3_3.addParent(feature1_3);
-        final Gff3FeatureImpl feature4_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature4_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature4_3.addParent(feature2_3);
-        final Gff3FeatureImpl feature5_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature5_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature5_3.addParent(feature1_3);
-        final Gff3FeatureImpl feature6_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature6_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
 
         feature3_3.addCoFeature(feature5_3);
 
@@ -67,15 +67,15 @@ public class Gff3FeatureTest extends HtsjdkTest {
         examples.add(new Object[] {feature5_3, feature6_3, false});
 
         //give both cds co-features
-        final Gff3FeatureImpl feature1_4 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2_4 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature3_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1_4 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature2_4 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature3_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature3_4.addParent(feature1_4);
-        final Gff3FeatureImpl feature4_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature4_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature4_4.addParent(feature2_4);
-        final Gff3FeatureImpl feature5_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature5_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature5_4.addParent(feature1_4);
-        final Gff3FeatureImpl feature6_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature6_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature6_4.addParent(feature2_4);
 
         feature3_4.addCoFeature(feature5_4);
@@ -99,8 +99,8 @@ public class Gff3FeatureTest extends HtsjdkTest {
     @Test
     public void testChildren() {
         //test that when a feature has a parent it is added as it's parent's child
-        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature2.addParent(feature1);
 
         Assert.assertTrue(feature1.getChildren().contains(feature2));
@@ -110,12 +110,12 @@ public class Gff3FeatureTest extends HtsjdkTest {
     @Test
     public void testCofeatures() {
         //test that when a adding a cofeature it is reciprocated
-        final Gff3FeatureImpl region = new Gff3FeatureImpl("chr1", ".", "region", 1, 10000, Strand.NONE, -1, ImmutableMap.of("ID", "region01"));
-        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl region = new Gff3FeatureImpl("chr1", ".", "region", 1, 10000, -1d, Strand.NONE, -1, ImmutableMap.of("ID", "region01"));
+        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
         feature1.addParent(region);
-        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "gene", 1300, 1600, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "gene", 1300, 1600, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
         feature2.addParent(region);
-        final Gff3FeatureImpl feature3 = new Gff3FeatureImpl("chr1", ".", "gene", 1700, 1900, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl feature3 = new Gff3FeatureImpl("chr1", ".", "gene", 1700, 1900, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
         feature3.addParent(region);
 
         feature1.addCoFeature(feature2);
@@ -128,11 +128,11 @@ public class Gff3FeatureTest extends HtsjdkTest {
 
     @Test(expectedExceptions = TribbleException.class)
     public void testCofeautresDifferentParents() {
-        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "gene", 1300, 1600, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene02"));
-        final Gff3FeatureImpl feature3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
+        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "gene", 1300, 1600, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene02"));
+        final Gff3FeatureImpl feature3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
         feature3.addParent(feature1);
-        final Gff3FeatureImpl feature4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1310, 1350, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene02"));
+        final Gff3FeatureImpl feature4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1310, 1350, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene02"));
         feature4.addParent(feature2);
 
         //should throw exception because feature3 and feature4 have different parents so should not be co-features
@@ -144,7 +144,7 @@ public class Gff3FeatureTest extends HtsjdkTest {
 
         final int nGenerations = 10;
 
-        final Gff3FeatureImpl topLevelFeature = new Gff3FeatureImpl("chrX", ".", "type0", 1, 100, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature0"));
+        final Gff3FeatureImpl topLevelFeature = new Gff3FeatureImpl("chrX", ".", "type0", 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature0"));
         Gff3FeatureImpl prevFeature = topLevelFeature;
 
         final Map<Gff3FeatureImpl, Set<Gff3FeatureImpl>> ancestorsMap = new HashMap<>();
@@ -156,7 +156,7 @@ public class Gff3FeatureTest extends HtsjdkTest {
         final List<Gff3FeatureImpl> features = new ArrayList<>(Arrays.asList(topLevelFeature));
 
         for (int i=1; i<nGenerations; i++) {
-            final Gff3FeatureImpl newFeature = new Gff3FeatureImpl("chrX", ".", "type" + i, 1, 100, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature" + i, "Parent", prevFeature.getID()));
+            final Gff3FeatureImpl newFeature = new Gff3FeatureImpl("chrX", ".", "type" + i, 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature" + i, "Parent", prevFeature.getID()));
             newFeature.addParent(prevFeature);
             ancestorsMap.put(newFeature, new HashSet<>(ancestorsMap.get(prevFeature)));
             ancestorsMap.get(newFeature).add(prevFeature);
@@ -179,13 +179,13 @@ public class Gff3FeatureTest extends HtsjdkTest {
     public void testFlatten() {
         final int nGenerations = 10;
 
-        final Gff3FeatureImpl topLevelFeature = new Gff3FeatureImpl("chrX", ".", "type0", 1, 100, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature0"));
+        final Gff3FeatureImpl topLevelFeature = new Gff3FeatureImpl("chrX", ".", "type0", 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature0"));
         Gff3FeatureImpl prevFeature = topLevelFeature;
 
         final Map<Gff3FeatureImpl, Set<Gff3FeatureImpl>> flattenMap = new HashMap<>(Collections.singletonMap(topLevelFeature, new HashSet<>(Collections.singleton(topLevelFeature))));
 
         for (int i=1; i<nGenerations; i++) {
-            final Gff3FeatureImpl newFeature = new Gff3FeatureImpl("chrX", ".", "type" + i, 1, 100, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature" + i, "Parent", prevFeature.getID()));
+            final Gff3FeatureImpl newFeature = new Gff3FeatureImpl("chrX", ".", "type" + i, 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature" + i, "Parent", prevFeature.getID()));
             newFeature.addParent(prevFeature);
             flattenMap.forEach((k, v) -> v.add(newFeature));
             flattenMap.put(newFeature, new HashSet<>(Collections.singleton(newFeature)));
@@ -197,22 +197,22 @@ public class Gff3FeatureTest extends HtsjdkTest {
 
     @Test
     public void testDerivesFrom() {
-        final Gff3FeatureImpl region01 = new Gff3FeatureImpl("chrX", ".", "gene", 65, 1000, Strand.POSITIVE, -1, ImmutableMap.of("ID", "region01"));
+        final Gff3FeatureImpl region01 = new Gff3FeatureImpl("chrX", ".", "gene", 65, 1000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "region01"));
 
-        final Gff3FeatureImpl gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
         gene01.addParent(region01);
-        final Gff3FeatureImpl gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 70, 100, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene02"));
+        final Gff3FeatureImpl gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 70, 100, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene02"));
 
-        final Gff3FeatureImpl mRNA01 = new Gff3FeatureImpl("chrX", ".", "mRNA", 1, 100, Strand.POSITIVE, -1 , ImmutableMap.of("ID", "mRNA01", "Parent", "gene01, gene02"));
+        final Gff3FeatureImpl mRNA01 = new Gff3FeatureImpl("chrX", ".", "mRNA", 1, 100, -1d, Strand.POSITIVE, -1 , ImmutableMap.of("ID", "mRNA01", "Parent", "gene01, gene02"));
         mRNA01.addParent(gene01);
         mRNA01.addParent(gene02);
 
-        final Gff3FeatureImpl cds01 = new Gff3FeatureImpl("chrX", ".", "CDS", 1, 35, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "mRNA01", "Derives_from", "gene01"));
+        final Gff3FeatureImpl cds01 = new Gff3FeatureImpl("chrX", ".", "CDS", 1, 35, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "mRNA01", "Derives_from", "gene01"));
         cds01.addParent(mRNA01);
-        final Gff3FeatureImpl cds02 = new Gff3FeatureImpl("chrX", ".", "CDS", 70, 100, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds02", "Parent", "mRNA01", "Derives_from", "gene02"));
+        final Gff3FeatureImpl cds02 = new Gff3FeatureImpl("chrX", ".", "CDS", 70, 100, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds02", "Parent", "mRNA01", "Derives_from", "gene02"));
         cds02.addParent(mRNA01);
 
-        final Gff3FeatureImpl codon01 = new Gff3FeatureImpl("chrX", ".", "codon", 1, 3, Strand.POSITIVE, 0, ImmutableMap.of("ID", "codon01", "Parent", "cds01"));
+        final Gff3FeatureImpl codon01 = new Gff3FeatureImpl("chrX", ".", "codon", 1, 3, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "codon01", "Parent", "cds01"));
         codon01.addParent(cds01);
 
         Assert.assertEquals(cds01.getAncestors(), ImmutableSet.of(mRNA01, gene01, region01));
@@ -232,12 +232,12 @@ public class Gff3FeatureTest extends HtsjdkTest {
 
     @Test
     public void testFeatureWithUnLoadedParent() {
-        final Gff3FeatureImpl gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
-        final Gff3FeatureImpl gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
 
         Assert.assertEquals(gene01, gene02);
 
-        final Gff3FeatureImpl mRNA01 = new Gff3FeatureImpl("chrX", ".", "mRNA", 1, 100, Strand.POSITIVE, -1 , ImmutableMap.of("ID", "mRNA01", "Parent", "gene01, gene02"));
+        final Gff3FeatureImpl mRNA01 = new Gff3FeatureImpl("chrX", ".", "mRNA", 1, 100, -1d, Strand.POSITIVE, -1 , ImmutableMap.of("ID", "mRNA01", "Parent", "gene01, gene02"));
         mRNA01.addParent(gene01);
 
         Assert.assertNotEquals(gene01, gene02);

--- a/src/test/resources/htsjdk/tribble/gff/canonical_gene.gff3
+++ b/src/test/resources/htsjdk/tribble/gff/canonical_gene.gff3
@@ -1,8 +1,8 @@
 ##gff-version 3.2.1
 ##sequence-region ctg123 1 1497228
-ctg123	.	gene	1000	9000	.	+	.	ID=gene00001;Name=EDEN
-ctg123	.	TF_binding_site	1000	1012	.	+	.	ID=tfbs00001;Parent=gene00001
-ctg123	.	mRNA	1050	9000	.	+	.	ID=mRNA00001;Parent=gene00001;Name=EDEN.1
+ctg123	.	gene	1000	9000	1.03e03	+	.	ID=gene00001;Name=EDEN
+ctg123	.	TF_binding_site	1000	1012	0.999	+	.	ID=tfbs00001;Parent=gene00001
+ctg123	.	mRNA	1050	9000	1.37	+	.	ID=mRNA00001;Parent=gene00001;Name=EDEN.1
 ctg123	.	mRNA	1050	9000	.	+	.	ID=mRNA00002;Parent=gene00001;Name=EDEN.2
 ctg123	.	mRNA	1300	9000	.	+	.	ID=mRNA00003;Parent=gene00001;Name=EDEN.3
 ctg123	.	exon	1300	1500	.	+	.	ID=exon00001;Parent=mRNA00003


### PR DESCRIPTION
Four basic changes:
1) Since Gff3BaseData hash is based only on final fields, compute hash once when object is initialized.  This speeds up any code which uses Gff3Feature or Gff3BaseData as a key in a HashMap.

2) Make Gff3BaseData constructor public, (previously package-private) fields private, and add public getter methods to access those fields.

3) Add `decodeShallow` method, which returns only a flat Gff3Feature, which is NOT linked to parent/child/cofeatures.  While this method should not be used for general analysis, it is necessary to preprocess (specifically to add flush directives to) large gff3 files which do not already have flush directives.  Otherwise, the standard decode method will lead to the entire file being held in memory, and GC overhead problems.  

4) Adds score field to Gff3Feature.  This column is included in the spec, was somehow left out of the original Gff3 commit.