### PR TITLE
Gff3 Writer

### DIFF
--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -1,12 +1,13 @@
 package htsjdk.tribble.gff;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class Gff3BaseData {
+public class Gff3BaseData implements Locatable {
     private static final String ID_ATTRIBUTE_KEY = "ID";
     private static final String NAME_ATTRIBUTE_KEY = "Name";
     private static final String ALIAS_ATTRIBUTE_KEY = "Alias";

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -1,9 +1,11 @@
 package htsjdk.tribble.gff;
 
+import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Gff3BaseData {
@@ -18,15 +20,15 @@ public class Gff3BaseData {
     private final double score;
     private final Strand strand;
     private final int phase;
-    private final Map<String, String> attributes;
+    private final Map<String, List<String>> attributes;
     private final String id;
     private final String name;
-    private final String alias;
+    private final List<String> aliases;
     private final int hashCode;
 
     public Gff3BaseData(final String contig, final String source, final String type,
                  final int start, final int end, final Double score, final Strand strand, final int phase,
-                 final Map<String, String> attributes) {
+                 final Map<String, List<String>> attributes) {
         this.contig = contig;
         this.source = source;
         this.type = type;
@@ -36,10 +38,9 @@ public class Gff3BaseData {
         this.phase = phase;
         this.strand = strand;
         this.attributes = Collections.unmodifiableMap(new LinkedHashMap<>(attributes));
-        this.id = attributes.get(ID_ATTRIBUTE_KEY);
-        this.name = attributes.get(NAME_ATTRIBUTE_KEY);
-        this.alias = attributes.get(ALIAS_ATTRIBUTE_KEY);
-        this.hashCode = computeHashCode();
+        this.id = Gff3Codec.extractSingleAttribute(attributes.get(ID_ATTRIBUTE_KEY));
+        this.name = Gff3Codec.extractSingleAttribute(attributes.get(NAME_ATTRIBUTE_KEY));
+        this.aliases = attributes.containsKey(ALIAS_ATTRIBUTE_KEY)? attributes.get(ALIAS_ATTRIBUTE_KEY) : Collections.emptyList();   this.hashCode = computeHashCode();
     }
 
     @Override
@@ -73,11 +74,7 @@ public class Gff3BaseData {
             ret = ret && otherBaseData.getName() != null && otherBaseData.getName().equals(getName());
         }
 
-        if (getAlias() == null) {
-            ret = ret && otherBaseData.getAlias() == null;
-        } else {
-            ret = ret && otherBaseData.getAlias() != null && otherBaseData.getAlias().equals(getAlias());
-        }
+        ret = ret && otherBaseData.getAliases().equals(getAliases());
 
         return ret;
     }
@@ -105,8 +102,8 @@ public class Gff3BaseData {
             hash = 31 * hash + getName().hashCode();
         }
 
-        if (getAlias() != null) {
-            hash = 31 * hash + getAlias().hashCode();
+        for (final String alias : aliases) {
+            hash = 31 * hash + alias.hashCode();
         }
 
         return hash;
@@ -144,8 +141,12 @@ public class Gff3BaseData {
         return phase;
     }
 
-    public Map<String, String> getAttributes() {
+    public Map<String, List<String>> getAttributes() {
         return attributes;
+    }
+
+    public List<String> getAttribute(final String key) {
+        return attributes.containsKey(key)? attributes.get(key) : Collections.emptyList();
     }
 
     public String getId() {
@@ -156,7 +157,7 @@ public class Gff3BaseData {
         return name;
     }
 
-    public String getAlias() {
-        return alias;
+    public List<String> getAliases() {
+        return aliases;
     }
 }

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -1,13 +1,14 @@
 package htsjdk.tribble.gff;
 
 import htsjdk.samtools.util.Locatable;
+import htsjdk.tribble.Feature;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class Gff3BaseData implements Locatable {
+public class Gff3BaseData {
     private static final String ID_ATTRIBUTE_KEY = "ID";
     private static final String NAME_ATTRIBUTE_KEY = "Name";
     private static final String ALIAS_ATTRIBUTE_KEY = "Alias";

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -1,7 +1,5 @@
 package htsjdk.tribble.gff;
 
-import htsjdk.samtools.util.Locatable;
-import htsjdk.tribble.Feature;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collections;

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -67,7 +67,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
     private final Map<String, Set<Gff3FeatureImpl>> activeFeaturesWithIDs = new HashMap<>();
     private final Map<String, Set<Gff3FeatureImpl>> activeParentIDs = new HashMap<>();
 
-    private final Map<String, SequenceRegion> sequenceRegionMap = new HashMap<>();
+    private final Map<String, SequenceRegion> sequenceRegionMap = new LinkedHashMap<>();
     private final List<String> comments = new ArrayList<>();
 
     private final static Log logger = Log.getInstance(Gff3Codec.class);

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -463,7 +463,13 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
      */
     enum Gff3Directive {
 
-        VERSION3_DIRECTIVE("##gff-version\\s+3(?:.\\d)*(?:\\.\\d)*$") {
+        VERSION3_DIRECTIVE("##gff-version\\s+3(?:\\.\\d*)*$") {
+            @Override
+            public Object decode(final String line) throws IOException {
+                final String[] splitLine = line.split("\\s+");
+                return splitLine[1];
+            }
+
             @Override
             public String encode(final Object object) {
                 if (!(object instanceof String)) {
@@ -471,7 +477,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
                 }
 
                 final String versionLine = "##gff-version " + (String)object;
-                if (regexPattern.matcher(versionLine).matches()) {
+                if (!regexPattern.matcher(versionLine).matches()) {
                     throw new TribbleException("Version " + (String)object + " is not a valid version");
                 }
 
@@ -506,7 +512,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
                 final SequenceRegion sequenceRegion = (SequenceRegion) object;
                 try {
                     final URI contigURI = new URI(sequenceRegion.getContig());
-                    return "##sequence-region " + contigURI.toASCIIString() + " " + sequenceRegion.getStart() + sequenceRegion.getEnd();
+                    return "##sequence-region " + contigURI.toASCIIString() + " " + sequenceRegion.getStart() + " " + sequenceRegion.getEnd();
                 } catch (final URISyntaxException ex) {
                     throw new TribbleException("Cannot encode contig " + sequenceRegion.getContig(), ex);
                 }

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -14,7 +14,7 @@ import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.*;
 import htsjdk.tribble.util.ParsingUtils;
-import javafx.util.Pair;
+
 
 
 import java.io.*;
@@ -61,7 +61,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
     private final Map<String, Set<Gff3FeatureImpl>> activeParentIDs = new HashMap<>();
 
     private final Map<String, SequenceRegion> sequenceRegionMap = new LinkedHashMap<>();
-    private final List<Pair<String, Integer>> comments = new ArrayList<>();
+    private final Map<Integer, String> commentsWithLineNumbers = new LinkedHashMap<>();
 
     private final static Log logger = Log.getInstance(Gff3Codec.class);
 
@@ -118,7 +118,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
         }
 
         if (line.startsWith(Gff3Constants.COMMENT_START) && !line.startsWith(Gff3Constants.DIRECTIVE_START)) {
-            comments.add(new Pair<>(line.substring(Gff3Constants.COMMENT_START.length()), currentLine));
+            commentsWithLineNumbers.put(currentLine, line.substring(Gff3Constants.COMMENT_START.length()));
             return featuresToFlush.poll();
         }
 
@@ -234,12 +234,19 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
     }
 
     /**
-     * Get list of comments parsed by the codec.  Each entry in the list is a pair of the text of the comment along with the line number where the
-     * comment was found.  The text of the comment EXCLUDES the leading # which indicates a comment line.
-     * @return list of comments/line number pairs
+     * Gets map from line number to comment found on that line.  The text of the comment EXCLUDES the leading # which indicates a comment line.
+     * @return Map from line number to comment found on line
      */
-    public List<Pair<String, Integer>> getComments() {
-        return Collections.unmodifiableList(new ArrayList<>(comments));
+    public Map<Integer, String> getCommentsWithLineNumbers() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(commentsWithLineNumbers));
+    }
+
+    /**
+     * Gets list of comments parsed by the codec.  Excludes leading # which indicates a comment line.
+     * @return
+     */
+    public List<String> getCommentTexts() {
+        return Collections.unmodifiableList(new ArrayList<>(commentsWithLineNumbers.values()));
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -9,7 +9,6 @@ import htsjdk.samtools.util.Log;
 import htsjdk.tribble.AbstractFeatureCodec;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureCodecHeader;
-import htsjdk.tribble.Tribble;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.index.tabix.TabixFormat;
@@ -18,10 +17,7 @@ import htsjdk.tribble.util.ParsingUtils;
 
 
 import java.io.*;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -344,7 +344,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
     }
 
     static String extractSingleAttribute(final List<String> values) {
-        if (values.isEmpty()) {
+        if (values == null || values.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -21,6 +21,7 @@ import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -333,7 +334,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
         return ParsingUtils.split(attributeValue, VALUE_DELIMITER).stream().
                 map(a -> {
                             try {
-                                return URLDecoder.decode(a, "UTF-8");
+                                return URLDecoder.decode(a.trim(), "UTF-8");
                             } catch (final UnsupportedEncodingException ex) {
                                 throw new TribbleException("Error decoding attribute", ex);
                             }
@@ -459,7 +460,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
     /**
      * Enum for parsing directive lines.  If information in directive line needs to be parsed beyond specifying directive type, decode method should be overriden
      */
-    enum Gff3Directive {
+    public enum Gff3Directive {
 
         VERSION3_DIRECTIVE("##gff-version\\s+3(?:\\.\\d*)*$") {
             @Override
@@ -508,12 +509,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
                 }
 
                 final SequenceRegion sequenceRegion = (SequenceRegion) object;
-                try {
-                    final URI contigURI = new URI(sequenceRegion.getContig());
-                    return "##sequence-region " + contigURI.toASCIIString() + " " + sequenceRegion.getStart() + " " + sequenceRegion.getEnd();
-                } catch (final URISyntaxException ex) {
-                    throw new TribbleException("Cannot encode contig " + sequenceRegion.getContig(), ex);
-                }
+                return "##sequence-region " + Gff3Writer.encodeString(sequenceRegion.getContig()) + " " + sequenceRegion.getStart() + " " + sequenceRegion.getEnd();
             }
 
             @Override

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -1,6 +1,5 @@
 package htsjdk.tribble.gff;
 
-import com.sun.tools.javac.util.Pair;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
@@ -15,6 +14,7 @@ import htsjdk.tribble.annotation.Strand;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.*;
 import htsjdk.tribble.util.ParsingUtils;
+import javafx.util.Pair;
 
 
 import java.io.*;
@@ -118,7 +118,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
         }
 
         if (line.startsWith(Gff3Constants.COMMENT_START) && !line.startsWith(Gff3Constants.DIRECTIVE_START)) {
-            comments.add(Pair.of(line.substring(Gff3Constants.COMMENT_START.length()), currentLine));
+            comments.add(new Pair<>(line.substring(Gff3Constants.COMMENT_START.length()), currentLine));
             return featuresToFlush.poll();
         }
 

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -143,9 +143,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
         activeFeatures.add(thisFeature);
         if (depth == DecodeDepth.DEEP) {
             //link to parents/children/co-features
-            final String parentIDAttribute = thisFeature.getAttribute(PARENT_ATTRIBUTE_KEY);
-            final List<String> parentIDs = parentIDAttribute != null? ParsingUtils.split(parentIDAttribute, VALUE_DELIMITER) : new ArrayList<>();
-
+            final List<String> parentIDs = thisFeature.getAttribute(PARENT_ATTRIBUTE_KEY);
             final String id = thisFeature.getID();
 
             for (final String parentID : parentIDs) {

--- a/src/main/java/htsjdk/tribble/gff/Gff3Constants.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Constants.java
@@ -1,0 +1,13 @@
+package htsjdk.tribble.gff;
+
+public class Gff3Constants {
+     public static final char FIELD_DELIMITER = '\t';
+     public static final char ATTRIBUTE_DELIMITER = ';';
+     public static final char KEY_VALUE_SEPARATOR = '=';
+     public static final char VALUE_DELIMITER = ',';
+     public static final String COMMENT_START = "#";
+     public static final String DIRECTIVE_START = "##";
+     public static final String UNDEFINED_FIELD_VALUE = ".";
+     public static final String PARENT_ATTRIBUTE_KEY = "Parent";
+     public final static char END_OF_LINE_CHARACTER = '\n';
+}

--- a/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
@@ -3,6 +3,7 @@ package htsjdk.tribble.gff;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.annotation.Strand;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,17 +51,18 @@ public interface Gff3Feature extends Feature {
         return getBaseData().getStart();
     }
 
-    default String getAttribute(final String key) {
-        return getBaseData().getAttributes().get(key);
+
+    default List<String> getAttribute(final String key) {
+        return getBaseData().getAttribute(key);
     }
 
-    default Map<String, String> getAttributes() { return getBaseData().getAttributes();}
+    default Map<String, List<String>> getAttributes() { return getBaseData().getAttributes();}
 
     default String getID() { return getBaseData().getId();}
 
     default String getName() { return getBaseData().getName();}
 
-    default String getAlias() { return getBaseData().getAlias();}
+    default List<String> getAliases() { return getBaseData().getAliases();}
 
     default double getScore() { return getBaseData().getScore();}
 

--- a/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
@@ -117,7 +117,7 @@ public class Gff3FeatureImpl implements Gff3Feature {
 
     private Set<Gff3FeatureImpl> getDescendents(final Set<String> idsInLineage) {
         final List<Gff3FeatureImpl> childrenToAdd = children.stream().filter(c -> c.getAttribute(DERIVES_FROM_ATTRIBUTE_KEY).isEmpty() ||
-                !Collections.disjoint(idsInLineage, new HashSet<>(c.getAttribute(DERIVES_FROM_ATTRIBUTE_KEY)))).
+                !Collections.disjoint(idsInLineage, c.getAttribute(DERIVES_FROM_ATTRIBUTE_KEY))).
                 collect(Collectors.toList());
         final List<Gff3FeatureImpl> descendants = new ArrayList<>(childrenToAdd);
 

--- a/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3FeatureImpl.java
@@ -31,7 +31,7 @@ public class Gff3FeatureImpl implements Gff3Feature {
 
     public Gff3FeatureImpl(final String contig, final String source, final String type,
                            final int start, final int end, final Double score, final Strand strand, final int phase,
-                           final Map<String, String> attributes) {
+                           final Map<String, List<String>> attributes) {
         baseData = new Gff3BaseData(contig, source, type, start, end, score, strand, phase, attributes);
 
     }

--- a/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
@@ -1,103 +1,175 @@
 package htsjdk.tribble.gff;
 
+import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.TribbleException;
 
+import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.zip.GZIPOutputStream;
+import java.util.function.Consumer;
 
 
+/**
+ * A class to write out gff3 files.  Features are added using {@link #addFeature(Gff3Feature)}, directives using {@link #addDirective(Gff3Codec.Gff3Directive)},
+ * and comments using {@link #addComment(String)}.  Note that the version 3 directive is automatically added at creation, so should not be added separately.
+ */
 public class Gff3Writer implements Closeable {
 
-    private final PrintStream out;
+    private final BufferedOutputStream out;
     private final static String version = "3.1.25";
 
     public Gff3Writer(final Path path) throws IOException {
-        if (!FileExtensions.GFF3.stream().anyMatch(e -> path.toString().endsWith(e))) {
+        if (FileExtensions.GFF3.stream().noneMatch(e -> path.toString().endsWith(e))) {
             throw new TribbleException("File " + path + " does not have extension consistent with gff3");
         }
 
-        final OutputStream outputStream = IOUtil.hasGzipFileExtension(path)? new GZIPOutputStream(Files.newOutputStream(path)) : Files.newOutputStream(path);
-        out = new PrintStream(outputStream);
+        final OutputStream outputStream = IOUtil.hasGzipFileExtension(path)? new BlockCompressedOutputStream(path.toFile()) : Files.newOutputStream(path);
+        out = new BufferedOutputStream(outputStream);
         //start with version directive
         initialize();
     }
 
-    public Gff3Writer(final PrintStream stream) {
-        out = stream;
+    public Gff3Writer(final OutputStream stream) {
+        out = new BufferedOutputStream(stream);
         initialize();
     }
 
     private void initialize() {
-        out.println(Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE.encode(version));
+        try {
+            writeWithNewLine(Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE.encode(version));
+        } catch (final IOException ex) {
+            throw new TribbleException("Error writing version directive", ex);
+        }
     }
 
-    public void addFeature(final Gff3Feature feature) {
-        final String lineNoAttributes = String.join("\t",
+    private void writeWithNewLine(final String txt) throws IOException {
+        out.write(txt.getBytes());
+        out.write(Gff3Constants.END_OF_LINE_CHARACTER);
+    }
+
+    private void tryToWrite(final String string) {
+        try {
+            out.write(string.getBytes());
+        } catch (final IOException ex) {
+            throw new TribbleException("Error writing out string " + string, ex);
+        }
+    }
+
+    private void writeFirstEightFields(final Gff3Feature feature) throws IOException {
+        writeJoinedByDelimiter(Gff3Constants.FIELD_DELIMITER, this::tryToWrite, Arrays.asList(
                 encodeString(feature.getContig()),
                 encodeString(feature.getSource()),
                 encodeString(feature.getType()),
                 Integer.toString(feature.getStart()),
                 Integer.toString(feature.getEnd()),
-                feature.getScore() < 0 ? "." : Double.toString(feature.getScore()),
+                feature.getScore() < 0 ? Gff3Constants.UNDEFINED_FIELD_VALUE : Double.toString(feature.getScore()),
                 feature.getStrand().toString(),
-                feature.getPhase() < 0 ? "." : Integer.toString(feature.getPhase())
+                feature.getPhase() < 0 ? Gff3Constants.UNDEFINED_FIELD_VALUE : Integer.toString(feature.getPhase())
+                )
         );
-        final List<String> attributesStrings = new ArrayList<>();
+    }
 
-        for (final Map.Entry<String, List<String>> entry : feature.getAttributes().entrySet()) {
-            final String attributeString = String.join("=", new String[]{encodeString(entry.getKey()), encodeForNinthColumn(entry.getValue())});
-            attributesStrings.add(attributeString);
+    void writeAttributes(final Map<String, List<String>> attributes) throws IOException {
+        if (attributes.isEmpty()) {
+            out.write(Gff3Constants.UNDEFINED_FIELD_VALUE.getBytes());
         }
-        final String attributesString = attributesStrings.isEmpty() ? "." : String.join(";", attributesStrings);
 
-        final String lineString = lineNoAttributes + "\t" + attributesString;
-        out.println(lineString);
+        writeJoinedByDelimiter(Gff3Constants.ATTRIBUTE_DELIMITER, e ->  writeKeyValuePair(e.getKey(), e.getValue()), attributes.entrySet());
     }
 
-
-    static String encodeForNinthColumn(final List<String> values) {
-        final List<String> encodedValues = values.stream().map(Gff3Writer::encodeString).collect(Collectors.toList());
-
-        return String.join(",", encodedValues);
+    void writeKeyValuePair(final String key, final List<String> values) {
+        try {
+            tryToWrite(key);
+            out.write(Gff3Constants.KEY_VALUE_SEPARATOR);
+            writeJoinedByDelimiter(Gff3Constants.VALUE_DELIMITER, v -> tryToWrite(encodeString(v)), values);
+        } catch (final IOException ex) {
+            throw new TribbleException("error writing out key value pair " + key + " " + values);
+        }
     }
 
+    private <T> void writeJoinedByDelimiter(final char delimiter, final Consumer<T> consumer, final Collection<T> fields) throws IOException {
+        boolean isNotFirstField = false;
+        for (final T field : fields) {
+            if (isNotFirstField) {
+                out.write(delimiter);
+            } else {
+                isNotFirstField = true;
+            }
+
+            consumer.accept(field);
+        }
+    }
+
+    /***
+     * add a feature
+     * @param feature the feature to be added
+     * @throws IOException
+     */
+    public void addFeature(final Gff3Feature feature) throws IOException {
+        writeFirstEightFields(feature);
+        out.write(Gff3Constants.FIELD_DELIMITER);
+        writeAttributes(feature.getAttributes());
+        out.write(Gff3Constants.END_OF_LINE_CHARACTER);
+    }
 
     static String encodeString(final String s) {
         try {
+            //URLEncoder.encode is hardcoded to change all spaces to +, but we want spaces left unchanged so have to do this
+            //+ is escaped to %2B, so no loss of information
             return URLEncoder.encode(s, "UTF-8").replace("+", " ");
         } catch (final UnsupportedEncodingException ex) {
             throw new TribbleException("Encoding failure", ex);
         }
     }
 
-    public void addDirective(final Gff3Codec.Gff3Directive directive, final Object object) {
-        out.println(directive.encode(object));
+    /**
+     * Add a directive with an object
+     * @param directive the directive to be added
+     * @param object the object to be encoded with the directive
+     * @throws IOException
+     */
+    public void addDirective(final Gff3Codec.Gff3Directive directive, final Object object) throws IOException {
+        if (directive == Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE) {
+            throw new TribbleException("VERSION3_DIRECTIVE is automatically added and should not be added manually.");
+        }
+        writeWithNewLine(directive.encode(object));
     }
 
-    public void addDirective(final Gff3Codec.Gff3Directive directive) {
+    /**
+     * Add a directive
+     * @param directive the directive to be added
+     * @throws IOException
+     */
+    public void addDirective(final Gff3Codec.Gff3Directive directive) throws IOException {
+        if (directive == Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE) {
+            throw new TribbleException("VERSION3_DIRECTIVE is automatically added and should not be added manually.");
+        }
         addDirective(directive, null);
     }
 
-
-    public void addComment(final String comment) {
-        out.println("#" + comment);
+    /**
+     * Add comment line
+     * @param comment the comment line (not including leading #)
+     * @throws IOException
+     */
+    public void addComment(final String comment) throws IOException {
+        out.write(Gff3Constants.COMMENT_START.getBytes());
+        writeWithNewLine(comment);
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
         out.close();
     }
 }

--- a/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
  */
 public class Gff3Writer implements Closeable {
 
-    private final BufferedOutputStream out;
+    private final OutputStream out;
     private final static String version = "3.1.25";
 
     public Gff3Writer(final Path path) throws IOException {
@@ -41,7 +41,7 @@ public class Gff3Writer implements Closeable {
     }
 
     public Gff3Writer(final OutputStream stream) {
-        out = new BufferedOutputStream(stream);
+        out = stream;
         initialize();
     }
 

--- a/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
@@ -3,15 +3,12 @@ package htsjdk.tribble.gff;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.TribbleException;
-import htsjdk.tribble.util.ParsingUtils;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,8 +21,8 @@ public class Gff3Writer implements Closeable {
     final private PrintStream out;
     final static String version = "3.1.25";
 
-    Gff3Writer(final Path path) throws IOException {
-        if (!FileExtensions.GFF3.stream().anyMatch(path::endsWith)) {
+    public Gff3Writer(final Path path) throws IOException {
+        if (!FileExtensions.GFF3.stream().anyMatch(e -> path.toString().endsWith(e))) {
             throw new TribbleException("File " + path + " does not have extension consistent with gff3");
         }
 
@@ -35,7 +32,7 @@ public class Gff3Writer implements Closeable {
         initialize();
     }
 
-    Gff3Writer(final PrintStream stream) {
+    public Gff3Writer(final PrintStream stream) {
         out = stream;
         initialize();
     }
@@ -70,12 +67,12 @@ public class Gff3Writer implements Closeable {
     private String encodeForNinthColumn(final List<String> values) {
         final List<String> encodedValues = values.stream().map(v -> {
                     try {
-                        return new URI(v);
-                    } catch (final URISyntaxException ex) {
+                        return URLEncoder.encode(v, "UTF-8");
+                    } catch (final UnsupportedEncodingException ex) {
                         throw new TribbleException("Error encoding ninth column value " + v, ex);
                     }
                 }
-        ).map(URI::toASCIIString).collect(Collectors.toList());
+        ).collect(Collectors.toList());
 
         return String.join(",", encodedValues);
     }

--- a/src/main/java/htsjdk/tribble/gff/SequenceRegion.java
+++ b/src/main/java/htsjdk/tribble/gff/SequenceRegion.java
@@ -67,6 +67,4 @@ public class SequenceRegion implements Locatable {
 
     @Override
     public int hashCode() { return hashCode;}
-
-
 }

--- a/src/main/java/htsjdk/tribble/gff/SequenceRegion.java
+++ b/src/main/java/htsjdk/tribble/gff/SequenceRegion.java
@@ -26,6 +26,7 @@ public class SequenceRegion implements Locatable {
 
     void setCircular(final boolean isCircular) {
         this.isCircular = isCircular;
+        hashCode = computeHashCode();
     }
 
     void setCircular() {

--- a/src/main/java/htsjdk/tribble/gff/SequenceRegion.java
+++ b/src/main/java/htsjdk/tribble/gff/SequenceRegion.java
@@ -9,7 +9,8 @@ public class SequenceRegion implements Locatable {
     private final int start;
     private final int end;
     private final String contig;
-    private boolean isCircular;
+    private Boolean isCircular;
+    private int hashCode;
 
     SequenceRegion(final String contig, final int start, final int end) {
         this(contig, start, end, false);
@@ -20,6 +21,7 @@ public class SequenceRegion implements Locatable {
         this.start = start;
         this.end = end;
         this.isCircular = isCircular;
+        hashCode = computeHashCode();
     }
 
     void setCircular(final boolean isCircular) {
@@ -41,9 +43,30 @@ public class SequenceRegion implements Locatable {
 
     public boolean isCircular(){return  isCircular;}
 
-    public boolean equals(final SequenceRegion other) {
-        return other.start == start && other.end==end && other.contig.equals(contig) && other.isCircular == isCircular;
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof SequenceRegion)) {
+            return false;
+        }
+
+        final SequenceRegion otherSequenceRegion = (SequenceRegion) other;
+        return otherSequenceRegion.start == start && otherSequenceRegion.end==end && otherSequenceRegion.contig.equals(contig) && otherSequenceRegion.isCircular == isCircular;
     }
+
+    private int computeHashCode() {
+        int hash = contig.hashCode();
+        hash = 31 * hash + start;
+        hash = 31 * hash + end;
+        hash = 31 * hash + isCircular.hashCode();
+        return hash;
+    }
+
+    @Override
+    public int hashCode() { return hashCode;}
 
 
 }

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -178,8 +178,7 @@ public class Gff3CodecTest extends HtsjdkTest {
         Assert.assertEquals(feature.getSource(), "a source & also a str*)%nge source");
         Assert.assertEquals(feature.getType(), "a region");
         Assert.assertEquals(feature.getID(), "this is the ID of this wacky feature^&%##$%*&>,. ,.");
-        Assert.assertEquals(feature.getAttribute("Another key"), "Another%3Dvalue,And%20a%20second%2C%20value");
-        Assert.assertEquals(Gff3Codec.decodeAttributeValue(feature.getAttribute("Another key")), Arrays.asList("Another=value", "And a second, value"));
+        Assert.assertEquals(feature.getAttribute("Another key"), Arrays.asList("Another=value", "And a second, value"));
     }
 
 
@@ -198,113 +197,113 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> canonicalGeneFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl canonicalGene_gene00001 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 9000, 1030d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00001", "Name", "EDEN"));
+        final Gff3FeatureImpl canonicalGene_gene00001 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene00001"), "Name", Collections.singletonList("EDEN")));
         canonicalGeneFeatures.add(canonicalGene_gene00001);
 
-        final Gff3FeatureImpl canonicalGene_tfbs00001 = new Gff3FeatureImpl("ctg123", ".", "TF_binding_site", 1000, 1012, 0.999d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tfbs00001", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_tfbs00001 = new Gff3FeatureImpl("ctg123", ".", "TF_binding_site", 1000, 1012, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("tfbs00001"), "Parent", Collections.singletonList("gene00001")));
         canonicalGene_tfbs00001.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_tfbs00001);
 
-        final Gff3FeatureImpl canonicalGene_mRNA00001 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, 1.37d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00001", "Name", "EDEN.1", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_mRNA00001 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("mRNA00001"), "Name", Collections.singletonList("EDEN.1"), "Parent", Collections.singletonList("gene00001")));
         canonicalGene_mRNA00001.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_mRNA00001);
 
-        final Gff3FeatureImpl canonicalGene_mRNA00002 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00002", "Name", "EDEN.2", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_mRNA00002 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("mRNA00002"), "Name", Collections.singletonList("EDEN.2"), "Parent", Collections.singletonList("gene00001")));
         canonicalGene_mRNA00002.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_mRNA00002);
 
-        final Gff3FeatureImpl canonicalGene_mRNA00003 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1300, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "mRNA00003", "Name", "EDEN.3", "Parent", "gene00001"));
+        final Gff3FeatureImpl canonicalGene_mRNA00003 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1300, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("mRNA00003"), "Name", Collections.singletonList("EDEN.3"), "Parent", Collections.singletonList("gene00001")));
         canonicalGene_mRNA00003.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_mRNA00003);
 
-        final Gff3FeatureImpl canonicalGene_exon00001 = new Gff3FeatureImpl("ctg123", ".", "exon", 1300, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00001", "Parent", "mRNA00003"));
+        final Gff3FeatureImpl canonicalGene_exon00001 = new Gff3FeatureImpl("ctg123", ".", "exon", 1300, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("exon00001"), "Parent", Collections.singletonList("mRNA00003")));
         canonicalGene_exon00001.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_exon00001);
 
-        final Gff3FeatureImpl canonicalGene_exon00002 = new Gff3FeatureImpl("ctg123", ".", "exon", 1050, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00002", "Parent", "mRNA00001,mRNA00002"));
+        final Gff3FeatureImpl canonicalGene_exon00002 = new Gff3FeatureImpl("ctg123", ".", "exon", 1050, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("exon00002"), "Parent", Arrays.asList("mRNA00001", "mRNA00002")));
         canonicalGene_exon00002.addParent(canonicalGene_mRNA00001);
         canonicalGene_exon00002.addParent(canonicalGene_mRNA00002);
         canonicalGeneFeatures.add(canonicalGene_exon00002);
 
-        final Gff3FeatureImpl canonicalGene_exon00003 = new Gff3FeatureImpl("ctg123", ".", "exon", 3000, 3902, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00003", "Parent", "mRNA00001,mRNA00003"));
+        final Gff3FeatureImpl canonicalGene_exon00003 = new Gff3FeatureImpl("ctg123", ".", "exon", 3000, 3902, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("exon00003"), "Parent", Arrays.asList("mRNA00001", "mRNA00003")));
         canonicalGene_exon00003.addParent(canonicalGene_mRNA00001);
         canonicalGene_exon00003.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_exon00003);
 
-        final Gff3FeatureImpl canonicalGene_exon00004 = new Gff3FeatureImpl("ctg123", ".", "exon", 5000, 5500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00004", "Parent", "mRNA00001,mRNA00002,mRNA00003"));
+        final Gff3FeatureImpl canonicalGene_exon00004 = new Gff3FeatureImpl("ctg123", ".", "exon", 5000, 5500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("exon00004"), "Parent", Arrays.asList("mRNA00001", "mRNA00002", "mRNA00003")));
         canonicalGene_exon00004.addParent(canonicalGene_mRNA00001);
         canonicalGene_exon00004.addParent(canonicalGene_mRNA00002);
         canonicalGene_exon00004.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_exon00004);
 
-        final Gff3FeatureImpl canonicalGene_exon00005 = new Gff3FeatureImpl("ctg123", ".", "exon", 7000, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon00005", "Parent", "mRNA00001,mRNA00002,mRNA00003"));
+        final Gff3FeatureImpl canonicalGene_exon00005 = new Gff3FeatureImpl("ctg123", ".", "exon", 7000, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("exon00005"), "Parent", Arrays.asList("mRNA00001", "mRNA00002", "mRNA00003")));
         canonicalGene_exon00005.addParent(canonicalGene_mRNA00001);
         canonicalGene_exon00005.addParent(canonicalGene_mRNA00002);
         canonicalGene_exon00005.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_exon00005);
 
-        final Gff3FeatureImpl canonicalGene_cds00001_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 1201, 1500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
+        final Gff3FeatureImpl canonicalGene_cds00001_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 1201, 1500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00001"), "Parent", Collections.singletonList("mRNA00001"), "Name", Collections.singletonList("edenprotein.1")));
         canonicalGene_cds00001_1.addParent(canonicalGene_mRNA00001);
         canonicalGeneFeatures.add(canonicalGene_cds00001_1);
 
-        final Gff3FeatureImpl canonicalGene_cds00001_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3000, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
+        final Gff3FeatureImpl canonicalGene_cds00001_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3000, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00001"), "Parent", Collections.singletonList("mRNA00001"), "Name", Collections.singletonList("edenprotein.1")));
         canonicalGene_cds00001_2.addParent(canonicalGene_mRNA00001);
         canonicalGene_cds00001_2.addCoFeature(canonicalGene_cds00001_1);
         canonicalGeneFeatures.add(canonicalGene_cds00001_2);
 
-        final Gff3FeatureImpl canonicalGene_cds00001_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
+        final Gff3FeatureImpl canonicalGene_cds00001_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00001"), "Parent", Collections.singletonList("mRNA00001"), "Name", Collections.singletonList("edenprotein.1")));
         canonicalGene_cds00001_3.addParent(canonicalGene_mRNA00001);
         canonicalGene_cds00001_3.addCoFeature(canonicalGene_cds00001_1);
         canonicalGene_cds00001_3.addCoFeature(canonicalGene_cds00001_2);
         canonicalGeneFeatures.add(canonicalGene_cds00001_3);
 
-        final Gff3FeatureImpl canonicalGene_cds00001_4 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00001", "Parent", "mRNA00001", "Name", "edenprotein.1"));
+        final Gff3FeatureImpl canonicalGene_cds00001_4 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00001"), "Parent", Collections.singletonList("mRNA00001"), "Name", Collections.singletonList("edenprotein.1")));
         canonicalGene_cds00001_4.addParent(canonicalGene_mRNA00001);
         canonicalGene_cds00001_4.addCoFeature(canonicalGene_cds00001_1);
         canonicalGene_cds00001_4.addCoFeature(canonicalGene_cds00001_2);
         canonicalGene_cds00001_4.addCoFeature(canonicalGene_cds00001_3);
         canonicalGeneFeatures.add(canonicalGene_cds00001_4);
 
-        final Gff3FeatureImpl canonicalGene_cds00002_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 1201, 1500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
+        final Gff3FeatureImpl canonicalGene_cds00002_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 1201, 1500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00002"), "Parent", Collections.singletonList("mRNA00002"), "Name", Collections.singletonList("edenprotein.2")));
         canonicalGene_cds00002_1.addParent(canonicalGene_mRNA00002);
         canonicalGeneFeatures.add(canonicalGene_cds00002_1);
 
-        final Gff3FeatureImpl canonicalGene_cds00002_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
+        final Gff3FeatureImpl canonicalGene_cds00002_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00002"), "Parent", Collections.singletonList("mRNA00002"), "Name", Collections.singletonList("edenprotein.2")));
         canonicalGene_cds00002_2.addParent(canonicalGene_mRNA00002);
         canonicalGene_cds00002_2.addCoFeature(canonicalGene_cds00002_1);
         canonicalGeneFeatures.add(canonicalGene_cds00002_2);
 
-        final Gff3FeatureImpl canonicalGene_cds00002_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00002", "Parent", "mRNA00002", "Name", "edenprotein.2"));
+        final Gff3FeatureImpl canonicalGene_cds00002_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00002"), "Parent", Collections.singletonList("mRNA00002"), "Name", Collections.singletonList("edenprotein.2")));
         canonicalGene_cds00002_3.addParent(canonicalGene_mRNA00002);
         canonicalGene_cds00002_3.addCoFeature(canonicalGene_cds00002_1);
         canonicalGene_cds00002_3.addCoFeature(canonicalGene_cds00002_2);
         canonicalGeneFeatures.add(canonicalGene_cds00002_3);
 
-        final Gff3FeatureImpl canonicalGene_cds00003_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3301, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
+        final Gff3FeatureImpl canonicalGene_cds00003_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3301, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00003"), "Parent", Collections.singletonList("mRNA00003"), "Name", Collections.singletonList("edenprotein.3")));
         canonicalGene_cds00003_1.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_cds00003_1);
 
-        final Gff3FeatureImpl canonicalGene_cds00003_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
+        final Gff3FeatureImpl canonicalGene_cds00003_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", Collections.singletonList("cds00003"), "Parent", Collections.singletonList("mRNA00003"), "Name", Collections.singletonList("edenprotein.3")));
         canonicalGene_cds00003_2.addParent(canonicalGene_mRNA00003);
         canonicalGene_cds00003_2.addCoFeature(canonicalGene_cds00003_1);
         canonicalGeneFeatures.add(canonicalGene_cds00003_2);
 
-        final Gff3FeatureImpl canonicalGene_cds00003_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00003", "Parent", "mRNA00003", "Name", "edenprotein.3"));
+        final Gff3FeatureImpl canonicalGene_cds00003_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", Collections.singletonList("cds00003"), "Parent", Collections.singletonList("mRNA00003"), "Name", Collections.singletonList("edenprotein.3")));
         canonicalGene_cds00003_3.addParent(canonicalGene_mRNA00003);
         canonicalGene_cds00003_3.addCoFeature(canonicalGene_cds00003_1);
         canonicalGene_cds00003_3.addCoFeature(canonicalGene_cds00003_2);
         canonicalGeneFeatures.add(canonicalGene_cds00003_3);
 
-        final Gff3FeatureImpl canonicalGene_cds00004_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3391, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
+        final Gff3FeatureImpl canonicalGene_cds00004_1 = new Gff3FeatureImpl("ctg123", ".", "CDS", 3391, 3902, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds00004"), "Parent", Collections.singletonList("mRNA00003"), "Name", Collections.singletonList("edenprotein.4")));
         canonicalGene_cds00004_1.addParent(canonicalGene_mRNA00003);
         canonicalGeneFeatures.add(canonicalGene_cds00004_1);
         
-        final Gff3FeatureImpl canonicalGene_cds00004_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
+        final Gff3FeatureImpl canonicalGene_cds00004_2 = new Gff3FeatureImpl("ctg123", ".", "CDS", 5000, 5500, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", Collections.singletonList("cds00004"), "Parent", Collections.singletonList("mRNA00003"), "Name", Collections.singletonList("edenprotein.4")));
         canonicalGene_cds00004_2.addParent(canonicalGene_mRNA00003);
         canonicalGene_cds00004_2.addCoFeature(canonicalGene_cds00004_1);
         canonicalGeneFeatures.add(canonicalGene_cds00004_2);
 
-        final Gff3FeatureImpl canonicalGene_cds00004_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", "cds00004", "Parent", "mRNA00003", "Name", "edenprotein.4"));
+        final Gff3FeatureImpl canonicalGene_cds00004_3 = new Gff3FeatureImpl("ctg123", ".", "CDS", 7000, 7600, -1d, Strand.POSITIVE, 1, ImmutableMap.of("ID", Collections.singletonList("cds00004"), "Parent", Collections.singletonList("mRNA00003"), "Name", Collections.singletonList("edenprotein.4")));
         canonicalGene_cds00004_3.addParent(canonicalGene_mRNA00003);
         canonicalGene_cds00004_3.addCoFeature(canonicalGene_cds00004_1);
         canonicalGene_cds00004_3.addCoFeature(canonicalGene_cds00004_2);
@@ -318,40 +317,40 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> polycisctronicTranscriptFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl polycistronicTranscript_gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "name", "resA"));
-        final Gff3FeatureImpl polycistronicTranscript_gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 250, 350, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene02", "name", "resB"));
-        final Gff3FeatureImpl polycistronicTranscript_gene03 = new Gff3FeatureImpl("chrX", ".", "gene", 400, 500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene03", "name", "resX"));
-        final Gff3FeatureImpl polycistronicTranscript_gene04 = new Gff3FeatureImpl("chrX", ".", "gene", 550, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene04", "name", "resZ"));
+        final Gff3FeatureImpl polycistronicTranscript_gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"), "name", Collections.singletonList("resA")));
+        final Gff3FeatureImpl polycistronicTranscript_gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 250, 350, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene02"), "name", Collections.singletonList("resB")));
+        final Gff3FeatureImpl polycistronicTranscript_gene03 = new Gff3FeatureImpl("chrX", ".", "gene", 400, 500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene03"), "name", Collections.singletonList("resX")));
+        final Gff3FeatureImpl polycistronicTranscript_gene04 = new Gff3FeatureImpl("chrX", ".", "gene", 550, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene04"), "name", Collections.singletonList("resZ")));
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_gene01);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_gene02);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_gene03);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_gene04);
 
-        final Gff3FeatureImpl polycistronicTranscript_mRNA = new Gff3FeatureImpl("chrX", ".", "mRNA", 100, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tran01", "Parent", "gene01,gene02,gene03,gene04"));
+        final Gff3FeatureImpl polycistronicTranscript_mRNA = new Gff3FeatureImpl("chrX", ".", "mRNA", 100, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("tran01"), "Parent", Arrays.asList("gene01", "gene02", "gene03", "gene04")));
         polycistronicTranscript_mRNA.addParent(polycistronicTranscript_gene01);
         polycistronicTranscript_mRNA.addParent(polycistronicTranscript_gene02);
         polycistronicTranscript_mRNA.addParent(polycistronicTranscript_gene03);
         polycistronicTranscript_mRNA.addParent(polycistronicTranscript_gene04);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_mRNA);
 
-        final Gff3FeatureImpl polycistronicTranscript_exon = new Gff3FeatureImpl("chrX", ".", "exon", 100, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "tran01"));
+        final Gff3FeatureImpl polycistronicTranscript_exon = new Gff3FeatureImpl("chrX", ".", "exon", 100, 650, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", Collections.singletonList("tran01")));
         polycistronicTranscript_exon.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_exon);
 
 
-        final Gff3FeatureImpl polycistronicTranscript_CDS1 = new Gff3FeatureImpl("chrX", ".", "CDS", 100, 200, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene01"));
+        final Gff3FeatureImpl polycistronicTranscript_CDS1 = new Gff3FeatureImpl("chrX", ".", "CDS", 100, 200, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", Collections.singletonList("tran01"), "Derives_from", Collections.singletonList("gene01")));
         polycistronicTranscript_CDS1.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_CDS1);
 
-        final Gff3FeatureImpl polycistronicTranscript_CDS2 = new Gff3FeatureImpl("chrX", ".", "CDS", 250, 350, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene02"));
+        final Gff3FeatureImpl polycistronicTranscript_CDS2 = new Gff3FeatureImpl("chrX", ".", "CDS", 250, 350, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", Collections.singletonList("tran01"), "Derives_from", Collections.singletonList("gene02")));
         polycistronicTranscript_CDS2.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_CDS2);
 
-        final Gff3FeatureImpl polycistronicTranscript_CDS3 = new Gff3FeatureImpl("chrX", ".", "CDS", 400, 500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene03"));
+        final Gff3FeatureImpl polycistronicTranscript_CDS3 = new Gff3FeatureImpl("chrX", ".", "CDS", 400, 500, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", Collections.singletonList("tran01"), "Derives_from", Collections.singletonList("gene03")));
         polycistronicTranscript_CDS3.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_CDS3);
 
-        final Gff3FeatureImpl polycistronicTranscript_CDS4 = new Gff3FeatureImpl("chrX", ".", "CDS", 550, 650, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", "tran01", "Derives_from", "gene04"));
+        final Gff3FeatureImpl polycistronicTranscript_CDS4 = new Gff3FeatureImpl("chrX", ".", "CDS", 550, 650, -1d, Strand.POSITIVE, 0, ImmutableMap.of("Parent", Collections.singletonList("tran01"), "Derives_from", Collections.singletonList("gene04")));
         polycistronicTranscript_CDS4.addParent(polycistronicTranscript_mRNA);
         polycisctronicTranscriptFeatures.add(polycistronicTranscript_CDS4);
 
@@ -363,23 +362,23 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> programmedFrameshiftFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl programmedFrameshift_gene = new Gff3FeatureImpl("chrX", ".", "gene", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "name", "my_gene"));
+        final Gff3FeatureImpl programmedFrameshift_gene = new Gff3FeatureImpl("chrX", ".", "gene", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"), "name", Collections.singletonList("my_gene")));
         programmedFrameshiftFeatures.add(programmedFrameshift_gene);
 
-        final Gff3FeatureImpl programmedFrameshift_mRNA = new Gff3FeatureImpl("chrX", ".", "mRNA", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "tran01", "Parent", "gene01", "Ontology_term", "SO:1000069"));
+        final Gff3FeatureImpl programmedFrameshift_mRNA = new Gff3FeatureImpl("chrX", ".", "mRNA", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("tran01"), "Parent", Collections.singletonList("gene01"), "Ontology_term", Collections.singletonList("SO:1000069")));
         programmedFrameshift_mRNA.addParent(programmedFrameshift_gene);
         programmedFrameshiftFeatures.add(programmedFrameshift_mRNA);
 
-        final Gff3FeatureImpl programmedFrameshift_exon = new Gff3FeatureImpl("chrX", ".", "exon", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "exon01", "Parent", "tran01"));
+        final Gff3FeatureImpl programmedFrameshift_exon = new Gff3FeatureImpl("chrX", ".", "exon", 100, 200, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("exon01"), "Parent", Collections.singletonList("tran01")));
         programmedFrameshift_exon.addParent(programmedFrameshift_mRNA);
         programmedFrameshiftFeatures.add(programmedFrameshift_exon);
 
 
-        final Gff3FeatureImpl programmedFrameshift_CDS1_1 = new Gff3FeatureImpl("chrX", ".", "CDS", 100, 150, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "tran01"));
+        final Gff3FeatureImpl programmedFrameshift_CDS1_1 = new Gff3FeatureImpl("chrX", ".", "CDS", 100, 150, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"), "Parent",Collections.singletonList( "tran01")));
         programmedFrameshift_CDS1_1.addParent(programmedFrameshift_mRNA);
         programmedFrameshiftFeatures.add(programmedFrameshift_CDS1_1);
 
-        final Gff3FeatureImpl programmedFrameshift_CDS1_2 = new Gff3FeatureImpl("chrX", ".", "CDS", 149, 200, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "tran01"));
+        final Gff3FeatureImpl programmedFrameshift_CDS1_2 = new Gff3FeatureImpl("chrX", ".", "CDS", 149, 200, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"), "Parent", Collections.singletonList("tran01")));
         programmedFrameshift_CDS1_2.addParent(programmedFrameshift_mRNA);
         programmedFrameshift_CDS1_2.addCoFeature(programmedFrameshift_CDS1_1);
         programmedFrameshiftFeatures.add(programmedFrameshift_CDS1_2);
@@ -392,17 +391,17 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> multipleGenesFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl multipleGenes_gene1 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00001"));
+        final Gff3FeatureImpl multipleGenes_gene1 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 1500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene00001")));
         multipleGenesFeatures.add(multipleGenes_gene1);
 
-        final Gff3FeatureImpl multipleGenes_mRNA1 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 1400, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "gene00001"));
+        final Gff3FeatureImpl multipleGenes_mRNA1 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 1400, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", Collections.singletonList("gene00001")));
         multipleGenes_mRNA1.addParent(multipleGenes_gene1);
         multipleGenesFeatures.add(multipleGenes_mRNA1);
 
-        final Gff3FeatureImpl multipleGenes_gene2 = new Gff3FeatureImpl("ctg123", ".", "gene", 2000, 2500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene00002"));
+        final Gff3FeatureImpl multipleGenes_gene2 = new Gff3FeatureImpl("ctg123", ".", "gene", 2000, 2500, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene00002")));
         multipleGenesFeatures.add(multipleGenes_gene2);
 
-        final Gff3FeatureImpl multipleGenes_mRNA2 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 2050, 2400, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", "gene00002"));
+        final Gff3FeatureImpl multipleGenes_mRNA2 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 2050, 2400, -1d, Strand.POSITIVE, -1, ImmutableMap.of("Parent", Collections.singletonList("gene00002")));
         multipleGenes_mRNA2.addParent(multipleGenes_gene2);
         multipleGenesFeatures.add(multipleGenes_mRNA2);
 

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -197,14 +197,14 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         final Set<Gff3Feature> canonicalGeneFeatures = new HashSet<>();
 
-        final Gff3FeatureImpl canonicalGene_gene00001 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene00001"), "Name", Collections.singletonList("EDEN")));
+        final Gff3FeatureImpl canonicalGene_gene00001 = new Gff3FeatureImpl("ctg123", ".", "gene", 1000, 9000, 1030d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene00001"), "Name", Collections.singletonList("EDEN")));
         canonicalGeneFeatures.add(canonicalGene_gene00001);
 
-        final Gff3FeatureImpl canonicalGene_tfbs00001 = new Gff3FeatureImpl("ctg123", ".", "TF_binding_site", 1000, 1012, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("tfbs00001"), "Parent", Collections.singletonList("gene00001")));
+        final Gff3FeatureImpl canonicalGene_tfbs00001 = new Gff3FeatureImpl("ctg123", ".", "TF_binding_site", 1000, 1012, 0.999d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("tfbs00001"), "Parent", Collections.singletonList("gene00001")));
         canonicalGene_tfbs00001.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_tfbs00001);
 
-        final Gff3FeatureImpl canonicalGene_mRNA00001 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("mRNA00001"), "Name", Collections.singletonList("EDEN.1"), "Parent", Collections.singletonList("gene00001")));
+        final Gff3FeatureImpl canonicalGene_mRNA00001 = new Gff3FeatureImpl("ctg123", ".", "mRNA", 1050, 9000, 1.37d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("mRNA00001"), "Name", Collections.singletonList("EDEN.1"), "Parent", Collections.singletonList("gene00001")));
         canonicalGene_mRNA00001.addParent(canonicalGene_gene00001);
         canonicalGeneFeatures.add(canonicalGene_mRNA00001);
 

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -423,4 +423,31 @@ public class Gff3CodecTest extends HtsjdkTest {
 
         Assert.assertEquals(observedFeatures, expectedFeatures.size());
     }
+
+    @DataProvider(name = "directiveDataProvider")
+    public Object[][] directiveDataProvider() {
+        return new Object[][] {
+                {"##gff-version 3.1.25", Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE, "3.1.25"},
+                {"##gff-version 3.7", Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE, "3.7"},
+                {"##gff-version 3", Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE, "3"},
+                {"##gff-version 3.112.25.4.2", Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE, "3.112.25.4.2"},
+                {"##gff-version 2.7", null, null},
+                {"##sequence-region chr10 250 277", Gff3Codec.Gff3Directive.SEQUENCE_REGION_DIRECTIVE, new SequenceRegion("chr10", 250, 277)},
+                {"###", Gff3Codec.Gff3Directive.FLUSH_DIRECTIVE, null},
+                {"####", null, null},
+                {"##FASTA", Gff3Codec.Gff3Directive.FASTA_DIRECTIVE, null}
+        };
+    }
+
+    @Test(dataProvider = "directiveDataProvider")
+    public void directiveTest(final String line, final Gff3Codec.Gff3Directive expectedDirectiveType, final Object expectedDecodedDirective) throws IOException {
+        final Gff3Codec.Gff3Directive directive = Gff3Codec.Gff3Directive.toDirective(line);
+        Assert.assertEquals(directive, expectedDirectiveType);
+        if (directive != null) {
+            Assert.assertEquals(directive.decode(line), expectedDecodedDirective);
+            if (expectedDecodedDirective != null) {
+                Assert.assertEquals(directive.encode(expectedDecodedDirective), line);
+            }
+        }
+    }
 }

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -104,7 +105,6 @@ public class Gff3CodecTest extends HtsjdkTest {
         final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(inputGff3.toAbsolutePath().toString(), null, new Gff3Codec(), false);
         final AbstractFeatureReader<Gff3Feature, LineIterator> readerGZipped = AbstractFeatureReader.getFeatureReader(inputGff3GZipped.toAbsolutePath().toString(), null, new Gff3Codec(), false);
 
-
         final Set<Gff3Feature> topLevelFeatures = new HashSet<>();
         final Set<Gff3Feature> topLevelFeaturesGZipped = new HashSet<>();
 
@@ -178,7 +178,8 @@ public class Gff3CodecTest extends HtsjdkTest {
         Assert.assertEquals(feature.getSource(), "a source & also a str*)%nge source");
         Assert.assertEquals(feature.getType(), "a region");
         Assert.assertEquals(feature.getID(), "this is the ID of this wacky feature^&%##$%*&>,. ,.");
-        Assert.assertEquals(feature.getAttribute("Another key"), "Another=value");
+        Assert.assertEquals(feature.getAttribute("Another key"), "Another%3Dvalue,And%20a%20second%2C%20value");
+        Assert.assertEquals(Gff3Codec.decodeAttributeValue(feature.getAttribute("Another key")), Arrays.asList("Another=value", "And a second, value"));
     }
 
 

--- a/src/test/java/htsjdk/tribble/gff/Gff3FeatureTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3FeatureTest.java
@@ -23,42 +23,42 @@ public class Gff3FeatureTest extends HtsjdkTest {
     @DataProvider(name = "equalityTestDataProvider")
     public Object[][] equalityTestDatProvider() {
         final ArrayList<Object[]> examples = new ArrayList<>();
-        examples.add(new Object[] {new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01")),
-                new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01")), true});
-        examples.add(new Object[] {new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01")),
-                new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01")), true});
+        examples.add(new Object[] {new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"))),
+                new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"))), true});
+        examples.add(new Object[] {new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01"))),
+                new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01"))), true});
 
         //two features with same baseData, one with child (or parent) feature, one without
-        final Gff3FeatureImpl feature1_1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2_1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature3_1 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1_1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature2_1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature3_1 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature3_1.addParent(feature1_1);
-        final Gff3FeatureImpl feature4_1 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature4_1 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
 
         examples.add(new Object[] {feature1_1, feature2_1, false});
         examples.add(new Object[] {feature3_1, feature4_1, false});
 
         //give both genes child feature
-        final Gff3FeatureImpl feature1_2 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2_2 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature3_2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, -0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1_2 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature2_2 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature3_2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, -0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature3_2.addParent(feature1_2);
-        final Gff3FeatureImpl feature4_2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature4_2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature4_2.addParent(feature2_2);
 
         examples.add(new Object[] {feature1_2, feature2_2, true});
         examples.add(new Object[] {feature3_2, feature4_2, true});
 
         //give one cds a co-feature
-        final Gff3FeatureImpl feature1_3 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2_3 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature3_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1_3 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature2_3 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature3_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature3_3.addParent(feature1_3);
-        final Gff3FeatureImpl feature4_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature4_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature4_3.addParent(feature2_3);
-        final Gff3FeatureImpl feature5_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature5_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature5_3.addParent(feature1_3);
-        final Gff3FeatureImpl feature6_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature6_3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
 
         feature3_3.addCoFeature(feature5_3);
 
@@ -67,15 +67,15 @@ public class Gff3FeatureTest extends HtsjdkTest {
         examples.add(new Object[] {feature5_3, feature6_3, false});
 
         //give both cds co-features
-        final Gff3FeatureImpl feature1_4 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2_4 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature3_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1_4 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature2_4 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature3_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature3_4.addParent(feature1_4);
-        final Gff3FeatureImpl feature4_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature4_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature4_4.addParent(feature2_4);
-        final Gff3FeatureImpl feature5_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature5_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature5_4.addParent(feature1_4);
-        final Gff3FeatureImpl feature6_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature6_4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1080, 1150, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature6_4.addParent(feature2_4);
 
         feature3_4.addCoFeature(feature5_4);
@@ -99,8 +99,8 @@ public class Gff3FeatureTest extends HtsjdkTest {
     @Test
     public void testChildren() {
         //test that when a feature has a parent it is added as it's parent's child
-        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature2.addParent(feature1);
 
         Assert.assertTrue(feature1.getChildren().contains(feature2));
@@ -110,12 +110,12 @@ public class Gff3FeatureTest extends HtsjdkTest {
     @Test
     public void testCofeatures() {
         //test that when a adding a cofeature it is reciprocated
-        final Gff3FeatureImpl region = new Gff3FeatureImpl("chr1", ".", "region", 1, 10000, -1d, Strand.NONE, -1, ImmutableMap.of("ID", "region01"));
-        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl region = new Gff3FeatureImpl("chr1", ".", "region", 1, 10000, -1d, Strand.NONE, -1, ImmutableMap.of("ID", Collections.singletonList("region01")));
+        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"), "Parent", Collections.singletonList("region01")));
         feature1.addParent(region);
-        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "gene", 1300, 1600, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "gene", 1300, 1600, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"), "Parent", Collections.singletonList("region01")));
         feature2.addParent(region);
-        final Gff3FeatureImpl feature3 = new Gff3FeatureImpl("chr1", ".", "gene", 1700, 1900, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl feature3 = new Gff3FeatureImpl("chr1", ".", "gene", 1700, 1900, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"), "Parent", Collections.singletonList("region01")));
         feature3.addParent(region);
 
         feature1.addCoFeature(feature2);
@@ -128,11 +128,11 @@ public class Gff3FeatureTest extends HtsjdkTest {
 
     @Test(expectedExceptions = TribbleException.class)
     public void testCofeautresDifferentParents() {
-        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene01"));
-        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "gene", 1300, 1600, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", "gene02"));
-        final Gff3FeatureImpl feature3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene01"));
+        final Gff3FeatureImpl feature1 = new Gff3FeatureImpl("chr1", ".", "gene", 1000, 1200, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01")));
+        final Gff3FeatureImpl feature2 = new Gff3FeatureImpl("chr1", ".", "gene", 1300, 1600, -1d, Strand.NEGATIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene02")));
+        final Gff3FeatureImpl feature3 = new Gff3FeatureImpl("chr1", ".", "CDS", 1010, 1050, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene01")));
         feature3.addParent(feature1);
-        final Gff3FeatureImpl feature4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1310, 1350, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "cds01","Parent", "gene02"));
+        final Gff3FeatureImpl feature4 = new Gff3FeatureImpl("chr1", ".", "CDS", 1310, 1350, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"),"Parent", Collections.singletonList("gene02")));
         feature4.addParent(feature2);
 
         //should throw exception because feature3 and feature4 have different parents so should not be co-features
@@ -144,7 +144,7 @@ public class Gff3FeatureTest extends HtsjdkTest {
 
         final int nGenerations = 10;
 
-        final Gff3FeatureImpl topLevelFeature = new Gff3FeatureImpl("chrX", ".", "type0", 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature0"));
+        final Gff3FeatureImpl topLevelFeature = new Gff3FeatureImpl("chrX", ".", "type0", 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("feature0")));
         Gff3FeatureImpl prevFeature = topLevelFeature;
 
         final Map<Gff3FeatureImpl, Set<Gff3FeatureImpl>> ancestorsMap = new HashMap<>();
@@ -156,7 +156,7 @@ public class Gff3FeatureTest extends HtsjdkTest {
         final List<Gff3FeatureImpl> features = new ArrayList<>(Arrays.asList(topLevelFeature));
 
         for (int i=1; i<nGenerations; i++) {
-            final Gff3FeatureImpl newFeature = new Gff3FeatureImpl("chrX", ".", "type" + i, 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature" + i, "Parent", prevFeature.getID()));
+            final Gff3FeatureImpl newFeature = new Gff3FeatureImpl("chrX", ".", "type" + i, 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("feature" + i), "Parent", Collections.singletonList(prevFeature.getID())));
             newFeature.addParent(prevFeature);
             ancestorsMap.put(newFeature, new HashSet<>(ancestorsMap.get(prevFeature)));
             ancestorsMap.get(newFeature).add(prevFeature);
@@ -179,13 +179,13 @@ public class Gff3FeatureTest extends HtsjdkTest {
     public void testFlatten() {
         final int nGenerations = 10;
 
-        final Gff3FeatureImpl topLevelFeature = new Gff3FeatureImpl("chrX", ".", "type0", 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature0"));
+        final Gff3FeatureImpl topLevelFeature = new Gff3FeatureImpl("chrX", ".", "type0", 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("feature0")));
         Gff3FeatureImpl prevFeature = topLevelFeature;
 
         final Map<Gff3FeatureImpl, Set<Gff3FeatureImpl>> flattenMap = new HashMap<>(Collections.singletonMap(topLevelFeature, new HashSet<>(Collections.singleton(topLevelFeature))));
 
         for (int i=1; i<nGenerations; i++) {
-            final Gff3FeatureImpl newFeature = new Gff3FeatureImpl("chrX", ".", "type" + i, 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", "feature" + i, "Parent", prevFeature.getID()));
+            final Gff3FeatureImpl newFeature = new Gff3FeatureImpl("chrX", ".", "type" + i, 1, 100, -1d, Strand.NEGATIVE, 0, ImmutableMap.of("ID", Collections.singletonList("feature" + i), "Parent", Collections.singletonList(prevFeature.getID())));
             newFeature.addParent(prevFeature);
             flattenMap.forEach((k, v) -> v.add(newFeature));
             flattenMap.put(newFeature, new HashSet<>(Collections.singleton(newFeature)));
@@ -197,22 +197,22 @@ public class Gff3FeatureTest extends HtsjdkTest {
 
     @Test
     public void testDerivesFrom() {
-        final Gff3FeatureImpl region01 = new Gff3FeatureImpl("chrX", ".", "gene", 65, 1000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "region01"));
+        final Gff3FeatureImpl region01 = new Gff3FeatureImpl("chrX", ".", "gene", 65, 1000, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("region01")));
 
-        final Gff3FeatureImpl gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"), "Parent", Collections.singletonList("region01")));
         gene01.addParent(region01);
-        final Gff3FeatureImpl gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 70, 100, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene02"));
+        final Gff3FeatureImpl gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 70, 100, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene02")));
 
-        final Gff3FeatureImpl mRNA01 = new Gff3FeatureImpl("chrX", ".", "mRNA", 1, 100, -1d, Strand.POSITIVE, -1 , ImmutableMap.of("ID", "mRNA01", "Parent", "gene01, gene02"));
+        final Gff3FeatureImpl mRNA01 = new Gff3FeatureImpl("chrX", ".", "mRNA", 1, 100, -1d, Strand.POSITIVE, -1 , ImmutableMap.of("ID", Collections.singletonList("mRNA01"), "Parent", Arrays.asList("gene01", "gene02")));
         mRNA01.addParent(gene01);
         mRNA01.addParent(gene02);
 
-        final Gff3FeatureImpl cds01 = new Gff3FeatureImpl("chrX", ".", "CDS", 1, 35, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds01", "Parent", "mRNA01", "Derives_from", "gene01"));
+        final Gff3FeatureImpl cds01 = new Gff3FeatureImpl("chrX", ".", "CDS", 1, 35, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds01"), "Parent", Collections.singletonList("mRNA01"), "Derives_from", Collections.singletonList("gene01")));
         cds01.addParent(mRNA01);
-        final Gff3FeatureImpl cds02 = new Gff3FeatureImpl("chrX", ".", "CDS", 70, 100, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "cds02", "Parent", "mRNA01", "Derives_from", "gene02"));
+        final Gff3FeatureImpl cds02 = new Gff3FeatureImpl("chrX", ".", "CDS", 70, 100, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("cds02"), "Parent", Collections.singletonList("mRNA01"), "Derives_from", Collections.singletonList("gene02")));
         cds02.addParent(mRNA01);
 
-        final Gff3FeatureImpl codon01 = new Gff3FeatureImpl("chrX", ".", "codon", 1, 3, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", "codon01", "Parent", "cds01"));
+        final Gff3FeatureImpl codon01 = new Gff3FeatureImpl("chrX", ".", "codon", 1, 3, -1d, Strand.POSITIVE, 0, ImmutableMap.of("ID", Collections.singletonList("codon01"), "Parent", Collections.singletonList("cds01")));
         codon01.addParent(cds01);
 
         Assert.assertEquals(cds01.getAncestors(), ImmutableSet.of(mRNA01, gene01, region01));
@@ -232,12 +232,12 @@ public class Gff3FeatureTest extends HtsjdkTest {
 
     @Test
     public void testFeatureWithUnLoadedParent() {
-        final Gff3FeatureImpl gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
-        final Gff3FeatureImpl gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", "gene01", "Parent", "region01"));
+        final Gff3FeatureImpl gene01 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"), "Parent", Collections.singletonList("region01")));
+        final Gff3FeatureImpl gene02 = new Gff3FeatureImpl("chrX", ".", "gene", 1, 35, -1d, Strand.POSITIVE, -1, ImmutableMap.of("ID", Collections.singletonList("gene01"), "Parent", Collections.singletonList("region01")));
 
         Assert.assertEquals(gene01, gene02);
 
-        final Gff3FeatureImpl mRNA01 = new Gff3FeatureImpl("chrX", ".", "mRNA", 1, 100, -1d, Strand.POSITIVE, -1 , ImmutableMap.of("ID", "mRNA01", "Parent", "gene01, gene02"));
+        final Gff3FeatureImpl mRNA01 = new Gff3FeatureImpl("chrX", ".", "mRNA", 1, 100, -1d, Strand.POSITIVE, -1 , ImmutableMap.of("ID", Collections.singletonList("mRNA01"), "Parent", Arrays.asList("gene01", "gene02")));
         mRNA01.addParent(gene01);
 
         Assert.assertNotEquals(gene01, gene02);

--- a/src/test/java/htsjdk/tribble/gff/Gff3Writer.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3Writer.java
@@ -15,7 +15,6 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
@@ -33,6 +32,15 @@ public class Gff3Writer implements Closeable {
         final OutputStream outputStream = IOUtil.hasGzipFileExtension(path)? new GZIPOutputStream(Files.newOutputStream(path)) : Files.newOutputStream(path);
         out = new PrintStream(outputStream);
         //start with version directive
+        initialize();
+    }
+
+    Gff3Writer(final PrintStream stream) {
+        out = stream;
+        initialize();
+    }
+
+    private void initialize() {
         out.println(Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE.encode(version));
     }
 

--- a/src/test/java/htsjdk/tribble/gff/Gff3Writer.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3Writer.java
@@ -1,0 +1,97 @@
+package htsjdk.tribble.gff;
+
+import htsjdk.samtools.util.FileExtensions;
+import htsjdk.samtools.util.IOUtil;
+import htsjdk.tribble.TribbleException;
+import htsjdk.tribble.util.ParsingUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPOutputStream;
+
+public class Gff3Writer implements Closeable {
+
+    final private PrintStream out;
+    final static String version = "3.1.25";
+
+    Gff3Writer(final Path path) throws IOException {
+        if (!FileExtensions.GFF3.stream().anyMatch(path::endsWith)) {
+            throw new TribbleException("File " + path + " does not have extension consistent with gff3");
+        }
+
+        final OutputStream outputStream = IOUtil.hasGzipFileExtension(path)? new GZIPOutputStream(Files.newOutputStream(path)) : Files.newOutputStream(path);
+        out = new PrintStream(outputStream);
+        //start with version directive
+        out.println(Gff3Codec.Gff3Directive.VERSION3_DIRECTIVE.encode(version));
+    }
+
+    public void addFeature(final Gff3Feature feature) {
+        try {
+            final String lineNoAttributes = String.join("\t",
+                    URLEncoder.encode(feature.getContig(), "UTF-8"),
+                    URLEncoder.encode(feature.getSource(), "UTF-8"),
+                    URLEncoder.encode(feature.getType(), "UTF-8"),
+                    Integer.toString(feature.getStart()),
+                    Integer.toString(feature.getEnd()),
+                    feature.getScore() < 0 ? "." : Double.toString(feature.getScore()),
+                    feature.getStrand().toString(),
+                    feature.getPhase() < 0 ? "." : Integer.toString(feature.getPhase())
+            );
+            final List<String> attributesStrings = feature.getAttributes().entrySet().stream().map(e -> {
+                        try {
+                            return String.join("=", new String[]{encodeForNinthColumn(e.getKey()), encodeForNinthColumn(e.getValue())});
+                        } catch (final URISyntaxException ex) {
+                            throw new TribbleException("Exception writing out gff",ex);
+                        }
+                    }
+            ).collect(Collectors.toList());
+            final String attributesString = attributesStrings.isEmpty() ? "." : String.join(";", attributesStrings);
+
+            final String lineString = lineNoAttributes + "\t" + attributesString;
+            out.println(lineString);
+        } catch(final UnsupportedEncodingException ex) {
+            throw new TribbleException("Exception writing out gff",ex);
+        }
+    }
+
+    private String encodeForNinthColumn(final String decodedString) throws URISyntaxException {
+        //in the ninth column of Gff certain characters have special meaning
+        final List<String> splitString = ParsingUtils.split(decodedString, ',');
+        final List<String> encodedSplitString = new ArrayList<>();
+        for (final String string : splitString) {
+            final URI uri = new URI(string);
+            encodedSplitString.add(uri.toASCIIString());
+        }
+
+        return String.join(",", encodedSplitString);
+    }
+
+    public void addFlushDirective() {
+        out.println(Gff3Codec.Gff3Directive.FLUSH_DIRECTIVE.encode());
+    }
+
+    public void addSequenceRegionDirective(final SequenceRegion sequenceRegion) {
+        out.println(Gff3Codec.Gff3Directive.SEQUENCE_REGION_DIRECTIVE.encode(sequenceRegion));
+    }
+
+
+    public void addComment(final String comment) {
+        out.println("#" + comment);
+    }
+
+    @Override
+    public void close() {
+        out.close();
+    }
+}

--- a/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
@@ -1,29 +1,36 @@
 package htsjdk.tribble.gff;
 
+import com.google.common.collect.ImmutableMap;
+import com.sun.tools.javac.util.Pair;
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.TestUtils;
-import htsjdk.tribble.Tribble;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.LineIterator;
 import org.testng.Assert;
+import org.testng.TestException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
-import java.nio.file.Files;
+import java.io.RandomAccessFile;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 public class Gff3WriterTest extends HtsjdkTest {
-    final static String DATA_DIR = TestUtils.DATA_DIR + "/gff/";
+    private final static String DATA_DIR = TestUtils.DATA_DIR + "/gff/";
     private final Path ensembl_human_small = Paths.get(DATA_DIR + "Homo_sapiens.GRCh38.97.chromosome.1.small.gff3");
     private final Path gencode_mouse_small = Paths.get(DATA_DIR + "gencode.vM22.annotation.small.gff3");
     private final Path ncbi_woodpecker_small = Paths.get(DATA_DIR + "ref_ASM69900v1_top_level.small.gff3");
@@ -33,66 +40,52 @@ public class Gff3WriterTest extends HtsjdkTest {
     private final Path ordered_cofeature = Paths.get(DATA_DIR, "ordered_cofeatures.gff3");
     private final Path child_before_parent = Paths.get(DATA_DIR, "child_before_parent.gff3");
     private final Path url_encoding = Paths.get(DATA_DIR, "url_encoding.gff3");
+    private final static Path[] tmpDir = new Path[] {IOUtil.getDefaultTmpDirPath()};
+    private final static String version3Directive = "##gff-version 3.1.25\n";
 
     @DataProvider(name = "roundTripDataProvider")
     public Object[][] roundTripDataProvider() {
         return new Object[][] {
-                {ensembl_human_small , 5}, {gencode_mouse_small, 7}, {ncbi_woodpecker_small, 7}, {feature_extends_past_circular_region, 1}, {with_fasta, 2}, {with_fasta_artemis, 2},
-                {ordered_cofeature, 3}, {child_before_parent, 1}, {url_encoding, 1}
+                {ensembl_human_small}, {gencode_mouse_small}, {ncbi_woodpecker_small}, {feature_extends_past_circular_region}, {with_fasta}, {with_fasta_artemis},
+                {ordered_cofeature}, {child_before_parent}, {url_encoding}
         };
     }
 
     @Test(dataProvider = "roundTripDataProvider")
-    public void testRoundTrip(final Path path, final int expectedCompression) {
+    public void testRoundTrip(final Path path) {
 
-        final HashSet<String> comments1 = new HashSet<>();
+        final HashSet<Pair<String, Integer>> comments1 = new HashSet<>();
         final HashSet<SequenceRegion> regions1 = new HashSet<>();
         final LinkedHashSet<Gff3Feature> features1 = readFromFile(path, comments1, regions1);
 
             //write out to temp files (one gzipped, on not)
         try {
-            final Path tempFile = Files.createTempFile("gff3Writer", ".gff3");
-            final Path tempFileGzip = Files.createTempFile("gff3Writer", ".gff3.gz");
+            final Path tempFile = IOUtil.newTempPath("gff3Writer", ".gff3", tmpDir);
+            final Path tempFileGzip = IOUtil.newTempPath("gff3Writer", ".gff3.gz", tmpDir);
 
-            try (final Gff3Writer writer = new Gff3Writer(tempFile); final Gff3Writer writerGzip = new Gff3Writer(tempFileGzip)) {
-                for (final String comment : comments1) {
-                    writer.addComment(comment);
-                    writerGzip.addComment(comment);
-                }
-
-                for (final SequenceRegion region : regions1) {
-                    writer.addDirective(Gff3Codec.Gff3Directive.SEQUENCE_REGION_DIRECTIVE, region);
-                    writerGzip.addDirective(Gff3Codec.Gff3Directive.SEQUENCE_REGION_DIRECTIVE, region);
-                }
-
-                for (final Gff3Feature feature : features1) {
-                    writer.addFeature(feature);
-                    writerGzip.addFeature(feature);
-                }
-            } catch (final IOException ex) {
-                throw new TribbleException("Error writing gff3 files", ex);
-            }
+            writeToFile(tempFile, comments1, regions1, features1);
+            writeToFile(tempFileGzip, comments1, regions1, features1);
 
             //read temp files back in
 
-
-            final long unzippedSize = tempFile.toFile().length();
-            final long zippedSize = tempFileGzip.toFile().length();
-
-            Assert.assertTrue(unzippedSize > zippedSize * expectedCompression);
-            final HashSet<String> comments2 = new HashSet<>();
+            Assert.assertTrue(isGZipped(tempFileGzip.toFile()));
+            final HashSet<Pair<String, Integer>> comments2 = new HashSet<>();
             final HashSet<SequenceRegion> regions2 = new HashSet<>();
             final LinkedHashSet<Gff3Feature> features2 = readFromFile(tempFile, comments2, regions2);
 
 
-            final HashSet<String> comments3 = new HashSet<>();
+            final HashSet<Pair<String, Integer>> comments3 = new HashSet<>();
             final HashSet<SequenceRegion> regions3 = new HashSet<>();
             final LinkedHashSet<Gff3Feature> features3 = readFromFile(path, comments3, regions3);
 
             Assert.assertEquals(features1, features2);
             Assert.assertEquals(features1, features3);
-            Assert.assertEquals(comments1, comments2);
-            Assert.assertEquals(comments1, comments3);
+
+            final Set<String> comments1Strings = comments1.stream().map(p -> p.fst).collect(Collectors.toSet());
+            final Set<String> comments2Strings = comments2.stream().map(p -> p.fst).collect(Collectors.toSet());
+            final Set<String> comments3Strings = comments3.stream().map(p -> p.fst).collect(Collectors.toSet());
+            Assert.assertEquals(comments1Strings, comments2Strings);
+            Assert.assertEquals(comments1Strings, comments3Strings);
             Assert.assertEquals(regions1, regions2);
             Assert.assertEquals(regions1, regions3);
         } catch (final IOException ex) {
@@ -100,7 +93,25 @@ public class Gff3WriterTest extends HtsjdkTest {
         }
     }
 
-    private LinkedHashSet<Gff3Feature> readFromFile(final Path path, Set<String> commentsStore, Set<SequenceRegion> regionsStore) {
+    private void writeToFile(final Path path, final Set<Pair<String, Integer>> comments, final Set<SequenceRegion> regions, final Set<Gff3Feature> features) {
+        try (final Gff3Writer writer = new Gff3Writer(path)) {
+            for (final Pair<String, Integer> comment : comments) {
+                writer.addComment(comment.fst);
+            }
+
+            for (final SequenceRegion region : regions) {
+                writer.addDirective(Gff3Codec.Gff3Directive.SEQUENCE_REGION_DIRECTIVE, region);
+            }
+
+            for (final Gff3Feature feature : features) {
+                writer.addFeature(feature);
+            }
+        } catch (final IOException ex) {
+            throw new TribbleException("Error writing to file " + path, ex);
+        }
+    }
+
+    private LinkedHashSet<Gff3Feature> readFromFile(final Path path, Set<Pair<String, Integer>> commentsStore, Set<SequenceRegion> regionsStore) {
         final Gff3Codec codec = new Gff3Codec();
         final LinkedHashSet<Gff3Feature> features = new LinkedHashSet<>();
         try (final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(path.toAbsolutePath().toString(), null, codec, false)) {
@@ -117,19 +128,51 @@ public class Gff3WriterTest extends HtsjdkTest {
         return features;
     }
 
-    @DataProvider(name = "encodeForNinthColumnDataProvider")
-    public Object[][] encodeForNinthColumnDataProvider() {
+    @DataProvider(name = "writeKeyValuePairDataProvider")
+    public Object[][] writeKeyValuePairDataProvider() {
         return new Object[][] {
-                {Arrays.asList("value1", "value2", "value3"), "value1,value2,value3"},
-                {Arrays.asList("value1", "value ; with = special & encoded , characters", "value3"), "value1,value %3B with %3D special %26 encoded %2C characters,value3"}
+                {"key",Arrays.asList("value1", "value2", "value3"), "key=value1,value2,value3"},
+                {"key",Arrays.asList("value1", "value ; with = special & encoded , characters", "value3"), "key=value1,value %3B with %3D special %26 encoded %2C characters,value3"}
         };
     }
 
-    @Test(dataProvider = "encodeForNinthColumnDataProvider")
-    public void testEncodeForNinthColumn(final List<String> decoded, final String expectedEncoded) {
-        final String encoded = Gff3Writer.encodeForNinthColumn(decoded);
+    @Test(dataProvider = "writeKeyValuePairDataProvider")
+    public void testWriteKeyValuePair(final String key, final List<String> values, final String expectedOutput) {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try(final Gff3Writer writer = new Gff3Writer(outputStream)) {
+            writer.writeKeyValuePair(key, values);
+        } catch (final IOException ex) {
+            throw new TestException("Error writing key value pair", ex);
+        }
 
-        Assert.assertEquals(encoded, expectedEncoded);
+        final byte[] expectedBytes = (version3Directive + expectedOutput).getBytes();
+
+        Assert.assertEquals(outputStream.toByteArray(), expectedBytes);
+    }
+
+    @DataProvider(name = "writeAttributesDataProvider")
+    public Object[][] writeAttributesDataProvider() {
+        return new Object[][] {
+                {ImmutableMap.of("key1", Arrays.asList("value1", "value2"), "key2", Collections.singletonList("another value"), "key3", Arrays.asList("thisValue")),
+                "key1=value1,value2;key2=another value;key3=thisValue"},
+                {ImmutableMap.of("singleKey", Arrays.asList("multipleValue1", "multipleValue2")), "singleKey=multipleValue1,multipleValue2"},
+                {ImmutableMap.of("singleKey", Collections.singletonList("singleValue")), "singleKey=singleValue"},
+                {Collections.emptyMap(), "."}
+        };
+    }
+
+    @Test(dataProvider = "writeAttributesDataProvider")
+    public void testWriteAttributes(final Map<String, List<String>> attributes, final String expectedOutput) {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try(final Gff3Writer writer = new Gff3Writer(outputStream)) {
+            writer.writeAttributes(attributes);
+        } catch (final IOException ex) {
+            throw new TestException("Error writing key value pair", ex);
+        }
+
+        final byte[] expectedBytes = (version3Directive + expectedOutput).getBytes();
+
+        Assert.assertEquals(outputStream.toByteArray(), expectedBytes);
     }
 
     @DataProvider(name = "encodeStringDataProvider")
@@ -141,7 +184,7 @@ public class Gff3WriterTest extends HtsjdkTest {
                 {"&", "%26"},
                 {",", "%2C"},
                 {" ", " "},
-                {"qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM", "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM"} //these should remain unchanged
+                {"qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM ", "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM "} //these should remain unchanged
         };
     }
 
@@ -152,4 +195,15 @@ public class Gff3WriterTest extends HtsjdkTest {
         Assert.assertEquals(encoded, expectedEncoded);
     }
 
+    private static boolean isGZipped(final File f) {
+        int magic = 0;
+        try {
+            RandomAccessFile raf = new RandomAccessFile(f, "r");
+            magic = raf.read() & 0xff | ((raf.read() << 8) & 0xff00);
+            raf.close();
+        } catch (Throwable e) {
+            e.printStackTrace(System.err);
+        }
+        return magic == GZIPInputStream.GZIP_MAGIC;
+    }
 }

--- a/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
@@ -16,8 +16,10 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 public class Gff3WriterTest extends HtsjdkTest {
@@ -45,7 +47,7 @@ public class Gff3WriterTest extends HtsjdkTest {
         final HashSet<String> comments1 = new HashSet<>();
         final HashSet<SequenceRegion> regions1 = new HashSet<>();
         final LinkedHashSet<Gff3Feature> features1 = readFromFile(path, comments1, regions1);
-        
+
             //write out to temp files (one gzipped, on not)
         try {
             final Path tempFile = Files.createTempFile("gff3Writer", ".gff3");
@@ -58,8 +60,8 @@ public class Gff3WriterTest extends HtsjdkTest {
                 }
 
                 for (final SequenceRegion region : regions1) {
-                    writer.addSequenceRegionDirective(region);
-                    writerGzip.addSequenceRegionDirective(region);
+                    writer.addDirective(Gff3Codec.Gff3Directive.SEQUENCE_REGION_DIRECTIVE, region);
+                    writerGzip.addDirective(Gff3Codec.Gff3Directive.SEQUENCE_REGION_DIRECTIVE, region);
                 }
 
                 for (final Gff3Feature feature : features1) {
@@ -112,6 +114,21 @@ public class Gff3WriterTest extends HtsjdkTest {
         }
 
         return features;
+    }
+
+    @DataProvider(name = "encodeForNinthColumnDataProvider")
+    public Object[][] encodeForNinthColumnDataProvider() {
+        return new Object[][] {
+                {Arrays.asList("value1", "value2", "value3"), "value1,value2,value3"},
+                {Arrays.asList("value1", "value ; with = special & encoded , characters", "value3"), "value1,value %3B with %3D special %26 encoded %2C characters,value3"}
+        };
+    }
+
+    @Test(dataProvider = "encodeForNinthColumnDataProvider")
+    public void testEncodeForNinthColumn(final List<String> decoded, final String expectedEncoded) {
+        final String encoded = Gff3Writer.encodeForNinthColumn(decoded);
+
+        Assert.assertEquals(encoded, expectedEncoded);
     }
 
 }

--- a/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
@@ -1,0 +1,118 @@
+package htsjdk.tribble.gff;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.tribble.AbstractFeatureReader;
+import htsjdk.tribble.TestUtils;
+import htsjdk.tribble.Tribble;
+import htsjdk.tribble.TribbleException;
+import htsjdk.tribble.readers.LineIterator;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class Gff3WriterTest extends HtsjdkTest {
+    final static String DATA_DIR = TestUtils.DATA_DIR + "/gff/";
+    private final Path ensembl_human_small = Paths.get(DATA_DIR + "Homo_sapiens.GRCh38.97.chromosome.1.small.gff3");
+    private final Path gencode_mouse_small = Paths.get(DATA_DIR + "gencode.vM22.annotation.small.gff3");
+    private final Path ncbi_woodpecker_small = Paths.get(DATA_DIR + "ref_ASM69900v1_top_level.small.gff3");
+    private final Path feature_extends_past_circular_region = Paths.get(DATA_DIR + "feature_extends_past_circular_region.gff3");
+    private final Path with_fasta = Paths.get(DATA_DIR + "fasta_test.gff3");
+    private final Path with_fasta_artemis = Paths.get(DATA_DIR + "fasta_test_artemis.gff3");
+    private final Path ordered_cofeature = Paths.get(DATA_DIR, "ordered_cofeatures.gff3");
+    private final Path child_before_parent = Paths.get(DATA_DIR, "child_before_parent.gff3");
+
+    @DataProvider(name = "roundTripDataProvider")
+    public Object[][] roundTripDataProvider() {
+        return new Object[][] {
+                {ensembl_human_small , 5}, {gencode_mouse_small, 7}, {ncbi_woodpecker_small, 7}, {feature_extends_past_circular_region, 1}, {with_fasta, 2}, {with_fasta_artemis, 2},
+                {ordered_cofeature, 3}, {child_before_parent, 1}
+        };
+    }
+
+    @Test(dataProvider = "roundTripDataProvider")
+    public void testRoundTrip(final Path path, final int expectedCompression) {
+
+        final HashSet<String> comments1 = new HashSet<>();
+        final HashSet<SequenceRegion> regions1 = new HashSet<>();
+        final LinkedHashSet<Gff3Feature> features1 = readFromFile(path, comments1, regions1);
+
+
+            //write out to temp files (one gzipped, on not)
+        try {
+            final Path tempFile = Files.createTempFile("gff3Writer", ".gff3");
+            final Path tempFileGzip = Files.createTempFile("gff3Writer", ".gff3.gz");
+
+            try (final Gff3Writer writer = new Gff3Writer(tempFile); final Gff3Writer writerGzip = new Gff3Writer(tempFileGzip)) {
+                for (final String comment : comments1) {
+                    writer.addComment(comment);
+                    writerGzip.addComment(comment);
+                }
+
+                for (final SequenceRegion region : regions1) {
+                    writer.addSequenceRegionDirective(region);
+                    writerGzip.addSequenceRegionDirective(region);
+                }
+
+                for (final Gff3Feature feature : features1) {
+                    writer.addFeature(feature);
+                    writerGzip.addFeature(feature);
+                }
+            } catch (final IOException ex) {
+                throw new TribbleException("Error writing gff3 files", ex);
+            }
+
+            //read temp files back in
+
+
+            final long unzippedSize = tempFile.toFile().length();
+            final long zippedSize = tempFileGzip.toFile().length();
+
+            Assert.assertTrue(unzippedSize > zippedSize * expectedCompression);
+            final HashSet<String> comments2 = new HashSet<>();
+            final HashSet<SequenceRegion> regions2 = new HashSet<>();
+            final LinkedHashSet<Gff3Feature> features2 = readFromFile(tempFile, comments2, regions2);
+
+
+            final HashSet<String> comments3 = new HashSet<>();
+            final HashSet<SequenceRegion> regions3 = new HashSet<>();
+            final LinkedHashSet<Gff3Feature> features3 = readFromFile(path, comments3, regions3);
+
+            Assert.assertEquals(features1, features2);
+            Assert.assertEquals(features1, features3);
+            Assert.assertEquals(comments1, comments2);
+            Assert.assertEquals(comments1, comments3);
+            Assert.assertEquals(regions1, regions2);
+            Assert.assertEquals(regions1, regions3);
+        } catch (final IOException ex) {
+            throw new TribbleException("Error creating temp files", ex);
+        }
+    }
+
+    private LinkedHashSet<Gff3Feature> readFromFile(final Path path, Set<String> commentsStore, Set<SequenceRegion> regionsStore) {
+        final Gff3Codec codec = new Gff3Codec();
+        final LinkedHashSet<Gff3Feature> features = new LinkedHashSet<>();
+        try (final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(path.toAbsolutePath().toString(), null, codec, false)) {
+            for (final Gff3Feature feature : reader.iterator()) {
+                features.add(feature);
+            }
+
+            commentsStore.addAll(codec.getComments());
+            regionsStore.addAll(codec.getSequenceRegions());
+        } catch (final IOException ex) {
+            throw new TribbleException("Error reading gff3 file " + path);
+        }
+
+        return features;
+    }
+
+}

--- a/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
@@ -32,12 +32,13 @@ public class Gff3WriterTest extends HtsjdkTest {
     private final Path with_fasta_artemis = Paths.get(DATA_DIR + "fasta_test_artemis.gff3");
     private final Path ordered_cofeature = Paths.get(DATA_DIR, "ordered_cofeatures.gff3");
     private final Path child_before_parent = Paths.get(DATA_DIR, "child_before_parent.gff3");
+    private final Path url_encoding = Paths.get(DATA_DIR, "url_encoding.gff3");
 
     @DataProvider(name = "roundTripDataProvider")
     public Object[][] roundTripDataProvider() {
         return new Object[][] {
                 {ensembl_human_small , 5}, {gencode_mouse_small, 7}, {ncbi_woodpecker_small, 7}, {feature_extends_past_circular_region, 1}, {with_fasta, 2}, {with_fasta_artemis, 2},
-                {ordered_cofeature, 3}, {child_before_parent, 1}
+                {ordered_cofeature, 3}, {child_before_parent, 1}, {url_encoding, 1}
         };
     }
 
@@ -127,6 +128,26 @@ public class Gff3WriterTest extends HtsjdkTest {
     @Test(dataProvider = "encodeForNinthColumnDataProvider")
     public void testEncodeForNinthColumn(final List<String> decoded, final String expectedEncoded) {
         final String encoded = Gff3Writer.encodeForNinthColumn(decoded);
+
+        Assert.assertEquals(encoded, expectedEncoded);
+    }
+
+    @DataProvider(name = "encodeStringDataProvider")
+    public Object[][] encodeStringDataProvider() {
+        return new Object[][] {
+                {"%", "%25"},
+                {";", "%3B"},
+                {"=", "%3D"},
+                {"&", "%26"},
+                {",", "%2C"},
+                {" ", " "},
+                {"qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM", "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM"} //these should remain unchanged
+        };
+    }
+
+    @Test(dataProvider = "encodeStringDataProvider")
+    public void testEncodeString(final String decoded, final String expectedEncoded) {
+        final String encoded = Gff3Writer.encodeString(decoded);
 
         Assert.assertEquals(encoded, expectedEncoded);
     }

--- a/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
@@ -45,8 +45,7 @@ public class Gff3WriterTest extends HtsjdkTest {
         final HashSet<String> comments1 = new HashSet<>();
         final HashSet<SequenceRegion> regions1 = new HashSet<>();
         final LinkedHashSet<Gff3Feature> features1 = readFromFile(path, comments1, regions1);
-
-
+        
             //write out to temp files (one gzipped, on not)
         try {
             final Path tempFile = Files.createTempFile("gff3Writer", ".gff3");

--- a/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
@@ -1,13 +1,13 @@
 package htsjdk.tribble.gff;
 
 import com.google.common.collect.ImmutableMap;
-import com.sun.tools.javac.util.Pair;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.TestUtils;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.LineIterator;
+import javafx.util.Pair;
 import org.testng.Assert;
 import org.testng.TestException;
 import org.testng.annotations.DataProvider;
@@ -81,9 +81,9 @@ public class Gff3WriterTest extends HtsjdkTest {
             Assert.assertEquals(features1, features2);
             Assert.assertEquals(features1, features3);
 
-            final Set<String> comments1Strings = comments1.stream().map(p -> p.fst).collect(Collectors.toSet());
-            final Set<String> comments2Strings = comments2.stream().map(p -> p.fst).collect(Collectors.toSet());
-            final Set<String> comments3Strings = comments3.stream().map(p -> p.fst).collect(Collectors.toSet());
+            final Set<String> comments1Strings = comments1.stream().map(p -> p.getKey()).collect(Collectors.toSet());
+            final Set<String> comments2Strings = comments2.stream().map(p -> p.getKey()).collect(Collectors.toSet());
+            final Set<String> comments3Strings = comments3.stream().map(p -> p.getKey()).collect(Collectors.toSet());
             Assert.assertEquals(comments1Strings, comments2Strings);
             Assert.assertEquals(comments1Strings, comments3Strings);
             Assert.assertEquals(regions1, regions2);
@@ -96,7 +96,7 @@ public class Gff3WriterTest extends HtsjdkTest {
     private void writeToFile(final Path path, final Set<Pair<String, Integer>> comments, final Set<SequenceRegion> regions, final Set<Gff3Feature> features) {
         try (final Gff3Writer writer = new Gff3Writer(path)) {
             for (final Pair<String, Integer> comment : comments) {
-                writer.addComment(comment.fst);
+                writer.addComment(comment.getKey());
             }
 
             for (final SequenceRegion region : regions) {

--- a/src/test/resources/htsjdk/tribble/gff/feature_extends_past_circular_region.gff3
+++ b/src/test/resources/htsjdk/tribble/gff/feature_extends_past_circular_region.gff3
@@ -1,4 +1,4 @@
 ##gff-version 3
 ##sequence-region   1 1 10
 1	.	region	1	10	.	.	.	ID=chromosome:1; Is_circular=true
-1	.	biological_region	7	11	.	.	.	
+1	.	biological_region	7	11	.	.	.	.

--- a/src/test/resources/htsjdk/tribble/gff/url_encoding.gff3
+++ b/src/test/resources/htsjdk/tribble/gff/url_encoding.gff3
@@ -1,3 +1,3 @@
 ##gff-version 3
 ##sequence-region   1 1 10
-the%20contig	a%20source%20%26%20also%20a%20str*)%25nge%20source	a%20region	1	10	.	.	.	ID=this%20is%20the%20ID%20of%20this%20wacky%20feature%5E%26%25%23%23%24%25*%26%3E%2C.%20%2C.; Another%20key=Another%3Dvalue,And%20a%20second%2C%20value
+the contig	a source %26 also a str*)%25nge source	a region	1	10	.	.	.	ID=this is the ID of this wacky feature%5E%26%25%23%23%24%25*%26%3E%2C. %2C.; Another key=Another%3Dvalue,And a second%2C value

--- a/src/test/resources/htsjdk/tribble/gff/url_encoding.gff3
+++ b/src/test/resources/htsjdk/tribble/gff/url_encoding.gff3
@@ -1,3 +1,3 @@
 ##gff-version 3
 ##sequence-region   1 1 10
-the%20contig	a%20source%20%26%20also%20a%20str*)%25nge%20source	a%20region	1	10	.	.	.	ID=this%20is%20the%20ID%20of%20this%20wacky%20feature%5E%26%25%23%23%24%25*%26%3E%2C.%20%2C.; Another%20key=Another%3Dvalue
+the%20contig	a%20source%20%26%20also%20a%20str*)%25nge%20source	a%20region	1	10	.	.	.	ID=this%20is%20the%20ID%20of%20this%20wacky%20feature%5E%26%25%23%23%24%25*%26%3E%2C.%20%2C.; Another%20key=Another%3Dvalue,And%20a%20second%2C%20value


### PR DESCRIPTION
Adds a Gff3 Writer to write out Gff3 files.  Also adjusts the attributes field to account for the fact that attributes map a key to a list of strings, which are separated by commas.  As previously written, the comma separated list was left as a single string, which could later be processed into a list by the user.  This was vulnerable to situations where one of the entries in the list contained an encoded comma (ie %2C), so that after decoding the decoded comma could not be differentiated from the list separating commas.
