### PR TITLE
only set wrapper version when htsjdk is root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,8 +148,10 @@ task testExternalApis(type: Test) {
     }
 }
 
-wrapper {
-    gradleVersion = '5.2.1'
+if(project == rootProject) {
+    wrapper {
+        gradleVersion = '5.2.1'
+    }
 }
 
 tasks.withType(Javadoc) {


### PR DESCRIPTION
### Description

Currently, htsjdk cannot be built as a submodule of a parent project that also uses gradle. This happens because Gradle only supports the use of the Gradle "wrapper" in a root project, and not in child projects.

See:  https://github.com/gradle/gradle/issues/5816

This change puts conditional logic around the `wrapper` task configuration in the `build.gradle` file so that
it is only invoked when htsjdk is built as a root project (this is applying the workaround suggested in the issue above).

### Things to think about before submitting:
- [X ] Make sure your changes compile and new tests pass locally.
- [ X] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ X] Extended the README / documentation, if necessary
- [ X] Check your code style.
- [ X] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
