### PR TITLE
Extend set of valid FASTA format file extensions

### DIFF
--- a/src/main/java/htsjdk/samtools/util/FileExtensions.java
+++ b/src/main/java/htsjdk/samtools/util/FileExtensions.java
@@ -38,6 +38,8 @@ public final class FileExtensions {
     public static final Set<String> FASTA = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
         ".fasta",
         ".fasta.gz",
+        ".fas",
+        ".fas.gz",
         ".fa",
         ".fa.gz",
         ".fna",


### PR DESCRIPTION
### Description

Please explain the changes you made here.

The set of recognized file extensions for the FASTA format was  extended, adding in
.fas and .fas.gz.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

.fas is a widely used extension for FASTA-formatted files. In previous htsjdk releases, the set of
file extensions used to be modifiable, so we could add additional suffices at runtime. Since this has
been changed to an unmodifiable set, this is no longer an option. .fas (and .fas.gz) are pretty 
common enough to warrant inclusion into the set of predefined extensions.

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
