### PR TITLE
BasicFastqWriter: no longer flushing on every write

### DIFF
--- a/src/main/java/htsjdk/samtools/fastq/BasicFastqWriter.java
+++ b/src/main/java/htsjdk/samtools/fastq/BasicFastqWriter.java
@@ -62,6 +62,9 @@ public class BasicFastqWriter implements FastqWriter,Flushable {
         FastqEncoder.write(writer, rec);
         // and print a new line
         writer.println();
+    }
+
+    private void checkError() {
         if (writer.checkError()) {
             throw new SAMException("Error in writing fastq file " + path);
         }
@@ -69,11 +72,13 @@ public class BasicFastqWriter implements FastqWriter,Flushable {
 
     @Override
     public void flush() {
+        checkError();
         writer.flush();
     }
 
     @Override
     public void close() {
+        flush();
         writer.close();
     }
 

--- a/src/test/java/htsjdk/samtools/fastq/BasicFastqWriterTest.java
+++ b/src/test/java/htsjdk/samtools/fastq/BasicFastqWriterTest.java
@@ -7,7 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 
-public class BasicFastqWriterTest {
+public class BasicFastqWriterTest extends HtsjdkTest {
     public class OutputStreamWrapper extends ByteArrayOutputStream {
         public int flushCalled = 0;
         public int writeCalled = 0;

--- a/src/test/java/htsjdk/samtools/fastq/BasicFastqWriterTest.java
+++ b/src/test/java/htsjdk/samtools/fastq/BasicFastqWriterTest.java
@@ -1,0 +1,42 @@
+package htsjdk.samtools.fastq;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+public class BasicFastqWriterTest {
+    public class OutputStreamWrapper extends ByteArrayOutputStream {
+        public int flushCalled = 0;
+        public int writeCalled = 0;
+        @Override
+        public void flush() throws IOException {
+            flushCalled++;
+            super.flush();
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            writeCalled++;
+            super.write(b);
+        }
+    }
+
+    /**
+     * #1497
+     */
+    @Test
+    public void testFlushNotSpammed() {
+        OutputStreamWrapper loggedStream = new OutputStreamWrapper();
+        PrintStream ps = new PrintStream(loggedStream);
+        try (BasicFastqWriter fqw = new BasicFastqWriter(ps)) {
+            for (int i = 0; i < 10000; i++) {
+                fqw.write(new FastqRecord("name", "NNNN", null, "...."));
+            }
+        }
+        // flush()/close() results in two flushes
+        Assert.assertTrue(loggedStream.flushCalled <= 2);
+    }
+}

--- a/src/test/java/htsjdk/samtools/fastq/BasicFastqWriterTest.java
+++ b/src/test/java/htsjdk/samtools/fastq/BasicFastqWriterTest.java
@@ -1,5 +1,6 @@
 package htsjdk.samtools.fastq;
 
+import htsjdk.HtsjdkTest;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
### Description

`PrintStream.checkError()` is called on every write(). Since this flushes the underlying stream, performance when writing fastq files is very poor.

This change defers the call to `checkError()` to `flush()` and `close()` operations.