### PR TITLE
Fix genotype validation error message

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -379,7 +379,7 @@ public class VariantContext implements Feature, Serializable {
                     for (int j = 0, size = alleles.size(); j < size; j++) {
                         final Allele gAllele = alleles.get(j);
                         if (!variantContext.hasAllele(gAllele) && gAllele.isCalled()) {
-                            throw new IllegalStateException("Allele in genotype " + gAllele + " not in the variant context " + alleles);
+                            throw new IllegalStateException("Allele in genotype " + gAllele + " not in the variant context " + variantContext.getAlleles());
                         }
                     }
                 }


### PR DESCRIPTION
Actually report the VC alleles as the VC alleles, not the genotype alleles. Current error message is incorrect and not helpful.