### PR TITLE
Support very large sequence dictionaries/headers

### DIFF
--- a/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
+++ b/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder; 
+import java.nio.charset. StandardCharsets; 
 
 /**
  * Implementation of LineReader that is a thin wrapper around BufferedReader.  On Linux, this is faster

--- a/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
+++ b/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
@@ -42,7 +42,7 @@ import java.nio.charset.CharsetEncoder;
  */
 public class BufferedLineReader extends LineNumberReader implements LineReader {
     
-    private static float MAX_BYTES_PER_CHAR_UTF8 = Charset.forName("UTF8").newEncoder().maxBytesPerChar();
+    private static final float MAX_BYTES_PER_CHAR_UTF8 = StandardCharsets.UTF_8.newEncoder().maxBytesPerChar();
 
     private static class StringBackedInputStream extends InputStream {
         private int idx = 0;

--- a/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
+++ b/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
@@ -41,6 +41,25 @@ import java.nio.charset.Charset;
  */
 public class BufferedLineReader extends LineNumberReader implements LineReader {
 
+    private static class StringBackedInputStream extends InputStream {
+        private int idx = 0;
+        private final String str;
+        private final int len;
+
+        StringBackedInputStream(String str) {
+            this.str = str;
+            this.len = str.length();
+        }
+
+        @Override
+        public int read() throws IOException {
+            if(idx >= len) {
+                return -1;
+            }
+            return (byte) str.charAt(idx++);
+        }
+    }
+
     public BufferedLineReader(final InputStream is) {
         this(is, Defaults.NON_ZERO_BUFFER_SIZE);
     }
@@ -54,7 +73,14 @@ public class BufferedLineReader extends LineNumberReader implements LineReader {
      * is necessary because the String is in unicode.
      */
     public static BufferedLineReader fromString(final String s) {
-        return new BufferedLineReader(new ByteArrayInputStream(s.getBytes()));
+        final InputStream is;
+        if (s.length() >= Integer.MAX_VALUE - 8) {
+           is = new StringBackedInputStream(s);
+        }
+        else {
+            is = new ByteArrayInputStream(s.getBytes());
+        }
+        return new BufferedLineReader(is);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
+++ b/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.nio.charset.Charset;
-import java.nio.charset. StandardCharsets; 
+import java.nio.charset.StandardCharsets; 
 
 /**
  * Implementation of LineReader that is a thin wrapper around BufferedReader.  On Linux, this is faster

--- a/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
+++ b/src/main/java/htsjdk/samtools/util/BufferedLineReader.java
@@ -56,7 +56,7 @@ public class BufferedLineReader extends LineNumberReader implements LineReader {
             if(idx >= len) {
                 return -1;
             }
-            return (byte) str.charAt(idx++);
+            return (int) str.charAt(idx++);
         }
     }
 


### PR DESCRIPTION
This PR is meant to start a discussion; nitpicks will be ignored.

When we have very large sequence headers, tools will fail with OOM.

Quoting @jacarey's issue 
> My issue was in a `readHeader`. BufferedLineReader fromString reads into a byte array of `len * max` bytes per char for UTF8, which in my case was greater than `2^31 -1`.


```bash
Exception in thread "main" java.lang.OutOfMemoryError: Requested array size exceeds VM limit
        at java.lang.StringCoding$StringEncoder.encode(StringCoding.java:300)
        at java.lang.StringCoding.encode(StringCoding.java:344)
        at java.lang.StringCoding.encode(StringCoding.java:387)
        at java.lang.String.getBytes(String.java:958)
        at htsjdk.samtools.util.BufferedLineReader.fromString(BufferedLineReader.java:57)
        at htsjdk.samtools.BAMFileReader.readHeader(BAMFileReader.java:667)
```

