### PR TITLE
Change try-finally to try-with-resources in MetricsFile.write

### DIFF
--- a/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
+++ b/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
@@ -132,21 +132,10 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
      * @param f a File into which to write the metrics
      */
     public void write(final File f) {
-        FileWriter w = null;
-        try {
-            w = new FileWriter(f);
+        try (FileWriter w = new FileWriter(f)) {
             write(w);
-        }
-        catch (IOException ioe) {
+        } catch (IOException ioe) {
             throw new SAMException("Could not write metrics to file: " + f.getAbsolutePath(), ioe);
-        }
-        finally {
-            if (w != null) {
-                try {
-                    w.close();
-                } catch (IOException e) {
-                }
-            }
         }
     }
 


### PR DESCRIPTION
### Description

There's a weird failure state in CrosscheckFingerPrints where it ends without an exception but writes no metrics.  One possible explanation is that the order of exception suppression is suppressing the causal exception and then we're discarding the new exception.

This cleans up the code and changes the order of suppression to match what we want.