### PR TITLE
Add a getIDs method to VariantContext

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -831,9 +831,26 @@ public class VariantContext implements HtsRecord, Feature, Serializable {
         return !hasID();
     }
 
+    /**
+     * @return the ID field of the record, this be {@linkplain VCFConstants#EMPTY_ID_FIELD}, a single ID, or a semi-colon
+     * separated list of ID's
+     */
     public String getID() {
         return ID;
     }
+
+    /**
+     *
+     * @return a list of IDs for this record, possibly empty but never null
+     */
+    public List<String> getIDs(){
+        if(hasID()){
+            return ParsingUtils.split(getID(), VCFConstants.ID_FIELD_SEPARATOR_CHAR);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
 
     // ---------------------------------------------------------------------------------------------------------
     //

--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -832,25 +832,25 @@ public class VariantContext implements HtsRecord, Feature, Serializable {
     }
 
     /**
-     * @return the ID field of the record, this be {@linkplain VCFConstants#EMPTY_ID_FIELD}, a single ID, or a semi-colon
-     * separated list of ID's
+     * @return the ID field of the record, this may be {@linkplain VCFConstants#EMPTY_ID_FIELD}, a single ID, or a semi-colon
+     * separated list of IDs
      */
     public String getID() {
         return ID;
     }
 
     /**
+     * Splits the ID field into its individual IDs.
      *
      * @return a list of IDs for this record, possibly empty but never null
      */
-    public List<String> getIDs(){
-        if(hasID()){
+    public List<String> getIDs() {
+        if (hasID()) {
             return ParsingUtils.split(getID(), VCFConstants.ID_FIELD_SEPARATOR_CHAR);
         } else {
             return Collections.emptyList();
         }
     }
-
 
     // ---------------------------------------------------------------------------------------------------------
     //
@@ -1407,8 +1407,8 @@ public class VariantContext implements HtsRecord, Feature, Serializable {
     }
 
     public void validateRSIDs(Set<String> rsIDs) {
-        if (rsIDs != null && hasID()) {
-            for (String id : getID().split(VCFConstants.ID_FIELD_SEPARATOR)) {
+        if (rsIDs != null) {
+            for (String id : getIDs()) {
                 if (id.startsWith("rs") && !rsIDs.contains(id))
                     throw new TribbleException.InternalCodecException(String.format(
                             "the rsID %s for the record at position %s:%d is not in dbSNP",

--- a/src/main/java/htsjdk/variant/vcf/VCFConstants.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFConstants.java
@@ -73,17 +73,17 @@ public final class VCFConstants {
 
     // separators
     public static final String FORMAT_FIELD_SEPARATOR = ":";
-    public static final char   GENOTYPE_FIELD_SEPARATOR_CHAR = ':';
-    public static final String GENOTYPE_FIELD_SEPARATOR = String.valueOf(GENOTYPE_FIELD_SEPARATOR_CHAR);
-    public static final char   FIELD_SEPARATOR_CHAR = '\t';
-    public static final String FIELD_SEPARATOR = String.valueOf(FIELD_SEPARATOR_CHAR);
+    public static final String GENOTYPE_FIELD_SEPARATOR = ":";
+    public static final char GENOTYPE_FIELD_SEPARATOR_CHAR = ':';
+    public static final String FIELD_SEPARATOR = "\t";
+    public static final char FIELD_SEPARATOR_CHAR = '\t';
     public static final String FILTER_CODE_SEPARATOR = ";";
-    public static final char   INFO_FIELD_ARRAY_SEPARATOR_CHAR = ',';
-    public static final String INFO_FIELD_ARRAY_SEPARATOR = String.valueOf(INFO_FIELD_ARRAY_SEPARATOR_CHAR);
-    public static final char   ID_FIELD_SEPARATOR_CHAR = ';';
-    public static final String ID_FIELD_SEPARATOR = String.valueOf(ID_FIELD_SEPARATOR_CHAR);
-    public static final char   INFO_FIELD_SEPARATOR_CHAR = ';';
-    public static final String INFO_FIELD_SEPARATOR = String.valueOf(INFO_FIELD_ARRAY_SEPARATOR_CHAR);
+    public static final String INFO_FIELD_ARRAY_SEPARATOR = ",";
+    public static final char INFO_FIELD_ARRAY_SEPARATOR_CHAR = ',';
+    public static final String ID_FIELD_SEPARATOR = ";";
+    public static final char ID_FIELD_SEPARATOR_CHAR = ';';
+    public static final String INFO_FIELD_SEPARATOR = ";";
+    public static final char INFO_FIELD_SEPARATOR_CHAR = ';';
     public static final String UNPHASED = "/";
     public static final String PHASED = "|";
     public static final String PHASED_SWITCH_PROB_v3 = "\\";

--- a/src/main/java/htsjdk/variant/vcf/VCFConstants.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFConstants.java
@@ -73,16 +73,17 @@ public final class VCFConstants {
 
     // separators
     public static final String FORMAT_FIELD_SEPARATOR = ":";
-    public static final String GENOTYPE_FIELD_SEPARATOR = ":";
-    public static final char GENOTYPE_FIELD_SEPARATOR_CHAR = ':';
-    public static final String FIELD_SEPARATOR = "\t";
-    public static final char FIELD_SEPARATOR_CHAR = '\t';
+    public static final char   GENOTYPE_FIELD_SEPARATOR_CHAR = ':';
+    public static final String GENOTYPE_FIELD_SEPARATOR = String.valueOf(GENOTYPE_FIELD_SEPARATOR_CHAR);
+    public static final char   FIELD_SEPARATOR_CHAR = '\t';
+    public static final String FIELD_SEPARATOR = String.valueOf(FIELD_SEPARATOR_CHAR);
     public static final String FILTER_CODE_SEPARATOR = ";";
-    public static final String INFO_FIELD_ARRAY_SEPARATOR = ",";
-    public static final char INFO_FIELD_ARRAY_SEPARATOR_CHAR = ',';
-    public static final String ID_FIELD_SEPARATOR = ";";
-    public static final String INFO_FIELD_SEPARATOR = ";";
-    public static final char INFO_FIELD_SEPARATOR_CHAR = ';';
+    public static final char   INFO_FIELD_ARRAY_SEPARATOR_CHAR = ',';
+    public static final String INFO_FIELD_ARRAY_SEPARATOR = String.valueOf(INFO_FIELD_ARRAY_SEPARATOR_CHAR);
+    public static final char   ID_FIELD_SEPARATOR_CHAR = ';';
+    public static final String ID_FIELD_SEPARATOR = String.valueOf(ID_FIELD_SEPARATOR_CHAR);
+    public static final char   INFO_FIELD_SEPARATOR_CHAR = ';';
+    public static final String INFO_FIELD_SEPARATOR = String.valueOf(INFO_FIELD_ARRAY_SEPARATOR_CHAR);
     public static final String UNPHASED = "/";
     public static final String PHASED = "|";
     public static final String PHASED_SWITCH_PROB_v3 = "\\";

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1913,20 +1913,20 @@ public class VariantContextUnitTest extends VariantBaseTest {
                 context.getAttributeAsStringList("MissingList", "empty").isEmpty());
     }
 
-
     @DataProvider
-    public Object[][] getVariantsWithID(){
-        final VariantContextBuilder vcb = new VariantContextBuilder("test", "chr1", 10L, 10L, Arrays.asList(Allele.REF_A, Allele.ALT_C));
-        return new Object[][]{
-                {vcb.noID().make(), Collections.<String>emptyList()},
-                {vcb.id(".").make(), Collections.<String>emptyList()},
-                {vcb.id("rs128").make(), Collections.singletonList("rs128")},
-                {vcb.id("1;2;rs128;soManyIDs").make(), Arrays.asList("1", "2", "rs128", "soManyIDs")}
+    public Object[][] getVariantsWithID() {
+        final VariantContextBuilder vcb =
+                new VariantContextBuilder("test", "chr1", 10L, 10L, Arrays.asList(Allele.REF_A, Allele.ALT_C));
+        return new Object[][] {
+            {vcb.noID().make(), Collections.<String>emptyList()},
+            {vcb.id(".").make(), Collections.<String>emptyList()},
+            {vcb.id("rs128").make(), Collections.singletonList("rs128")},
+            {vcb.id("1;2;rs128;soManyIDs").make(), Arrays.asList("1", "2", "rs128", "soManyIDs")}
         };
     }
-    
+
     @Test(dataProvider = "getVariantsWithID")
-    public void testGetIDs(VariantContext vc, List<String> expectedIDs){
+    public void testGetIDs(VariantContext vc, List<String> expectedIDs) {
         Assert.assertEquals(vc.getIDs(), expectedIDs);
     }
 }

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -1912,4 +1912,21 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Assert.assertTrue(
                 context.getAttributeAsStringList("MissingList", "empty").isEmpty());
     }
+
+
+    @DataProvider
+    public Object[][] getVariantsWithID(){
+        final VariantContextBuilder vcb = new VariantContextBuilder("test", "chr1", 10L, 10L, Arrays.asList(Allele.REF_A, Allele.ALT_C));
+        return new Object[][]{
+                {vcb.noID().make(), Collections.<String>emptyList()},
+                {vcb.id(".").make(), Collections.<String>emptyList()},
+                {vcb.id("rs128").make(), Collections.singletonList("rs128")},
+                {vcb.id("1;2;rs128;soManyIDs").make(), Arrays.asList("1", "2", "rs128", "soManyIDs")}
+        };
+    }
+    
+    @Test(dataProvider = "getVariantsWithID")
+    public void testGetIDs(VariantContext vc, List<String> expectedIDs){
+        Assert.assertEquals(vc.getIDs(), expectedIDs);
+    }
 }


### PR DESCRIPTION
* This returns a List of IDs instead of a single String.
* Fixes https://github.com/samtools/htsjdk/issues/1506

@BoscoSuent this was quick so I added it, it should fix your issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new accessor to retrieve all IDs parsed from a variant record’s ID field.
  * Introduced a character constant for the ID-field separator.
* **Bug Fixes**
  * Enhanced strict dbSNP rsID validation to rely on the standardized ID parsing behavior.
* **Tests**
  * Added unit tests covering records with no ID, “.”, a single rsID, and multiple semicolon-delimited IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->