### PR TITLE
Fixing htsget-server docker pull

### DIFF
--- a/scripts/htsget-scripts/start-htsget-test-server.sh
+++ b/scripts/htsget-scripts/start-htsget-test-server.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 
 set -e
+
+DOCKER_NAME='ga4gh/htsget-refserver'
+SERVER_VERSION='1.1.0'
+DOCKER_COORDINATE=${DOCKER_NAME}:${SERVER_VERSION}
+
 WORKING_DIR=/home/travis/build/samtools/htsjdk
-docker pull ga4gh/htsget-refserver:1.1.0
+docker pull ${DOCKER_COORDINATE}
 docker container run -d --name htsget-server -p 3000:3000 --env HTSGET_PORT=3000 --env HTSGET_HOST=http://127.0.0.1:3000 \
       -v $WORKING_DIR/src/test/resources/htsjdk/samtools/BAMFileIndexTest/:/data \
       -v $WORKING_DIR/scripts/htsget-scripts:/data/scripts \
-      ga4gh/htsget-ref:1.1.0 \
+      ${DOCKER_COORDINATE} \
       ./htsref -config /data/scripts/htsget_config.json
 docker container ls -a
 

--- a/scripts/htsget-scripts/start-htsget-test-server.sh
+++ b/scripts/htsget-scripts/start-htsget-test-server.sh
@@ -2,7 +2,7 @@
 
 set -e
 WORKING_DIR=/home/travis/build/samtools/htsjdk
-docker pull ga4gh/htsget-ref:1.1.0
+docker pull ga4gh/htsget-refserver:1.1.0
 docker container run -d --name htsget-server -p 3000:3000 --env HTSGET_PORT=3000 --env HTSGET_HOST=http://127.0.0.1:3000 \
       -v $WORKING_DIR/src/test/resources/htsjdk/samtools/BAMFileIndexTest/:/data \
       -v $WORKING_DIR/scripts/htsget-scripts:/data/scripts \


### PR DESCRIPTION
### Description

The name of the ga4gh reference server docker seems to have changed from ga4gh/htsget-ref to ga4gh/htsget-refserver.  This points to the working image name.