### PR TITLE
Adding Locales to String.format calls

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -41,6 +41,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -1280,11 +1281,11 @@ public final class SAMUtils {
         }
         final String oaValue;
         if (record.getReadUnmappedFlag()) {
-            oaValue = String.format("*,0,%s,*,%s,",
+            oaValue = String.format(Locale.US, "*,0,%s,*,%s,",
                     record.getReadNegativeStrandFlag() ? Strand.NEGATIVE : Strand.POSITIVE,
                     record.getMappingQuality());
         } else {
-            oaValue = String.format("%s,%s,%s,%s,%s,%s",
+            oaValue = String.format(Locale.US, "%s,%s,%s,%s,%s,%s",
                     record.getReferenceName(),
                     record.getAlignmentStart(),
                     record.getReadNegativeStrandFlag() ? Strand.NEGATIVE : Strand.POSITIVE,

--- a/src/main/java/htsjdk/samtools/SamFlagField.java
+++ b/src/main/java/htsjdk/samtools/SamFlagField.java
@@ -24,6 +24,8 @@
 
 package htsjdk.samtools;
 
+import java.util.Locale;
+
 /**
  * This determines how flag fields are represented in the SAM file.
  *
@@ -65,7 +67,7 @@ public enum SamFlagField {
     HEXADECIMAL {
         @Override
         public String format(final int flag) {
-            return String.format("%#x", flag);
+            return String.format(Locale.US, "%#x", flag);
         }
         @Override
         protected int parseWithoutValidation(final String flag) {
@@ -75,7 +77,7 @@ public enum SamFlagField {
     OCTAL {
         @Override
         public String format(final int flag) {
-            return String.format("%#o", flag);
+            return String.format(Locale.US, "%#o", flag);
         }
         @Override
         protected int parseWithoutValidation(final String flag) {

--- a/src/main/java/htsjdk/samtools/cram/digest/ContentDigests.java
+++ b/src/main/java/htsjdk/samtools/cram/digest/ContentDigests.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 
 public final class ContentDigests {
     public static final EnumSet<KNOWN_DIGESTS> ALL = EnumSet
@@ -101,7 +102,7 @@ public final class ContentDigests {
     private static String toHex(final byte[] bytes) {
         final StringBuilder sb = new StringBuilder();
         for (final byte t : bytes) {
-            sb.append(String.format("%02x", (0xFF & t)).toUpperCase()).append(
+            sb.append(String.format(Locale.US, "%02x", (0xFF & t)).toUpperCase()).append(
                     ' ');
         }
         return sb.toString();

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -206,7 +207,7 @@ public class ReferenceSource implements CRAMReferenceSource {
     }
 
     private byte[] findBasesByMD5(final String md5) {
-        final String url = String.format(Defaults.EBI_REFERENCE_SERVICE_URL_MASK, md5);
+        final String url = String.format(Locale.US, Defaults.EBI_REFERENCE_SERVICE_URL_MASK, md5);
 
         for (int i = 0; i < downloadTriesBeforeFailing; i++) {
             try (final InputStream is = new URL(url).openStream()) {

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedFilePointerUtil.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedFilePointerUtil.java
@@ -23,6 +23,8 @@
  */
 package htsjdk.samtools.util;
 
+import java.util.Locale;
+
 /**
  * Static for manipulating virtual file pointers in BGZF files.
  */
@@ -129,7 +131,7 @@ public class BlockCompressedFilePointerUtil {
      * @return {@code vfp} formatted as string in address:offset form
      */
     public static String asAddressOffsetString(final long vfp) {
-        return String.format("%d:%d",
+        return String.format(Locale.US,"%d:%d",
                 BlockCompressedFilePointerUtil.getBlockAddress(vfp),
                 BlockCompressedFilePointerUtil.getBlockOffset(vfp));
     }

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.*;
 import htsjdk.samtools.fastq.FastqConstants;
 import htsjdk.tribble.annotation.Strand;
 import htsjdk.utils.ValidationUtils;
+import jdk.vm.ci.meta.Local;
 
 import java.io.File;
 import java.math.BigInteger;
@@ -35,6 +36,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -927,7 +929,7 @@ public class SequenceUtil {
      * @return string representing the md5
      */
     public static String md5DigestToString(final byte[] digest) {
-        return String.format("%032x", new BigInteger(1, digest));
+        return String.format(Locale.US, "%032x", new BigInteger(1, digest));
     }
 
 

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -23,11 +23,17 @@
  */
 package htsjdk.samtools.util;
 
-import htsjdk.samtools.*;
+import htsjdk.samtools.AlignmentBlock;
+import htsjdk.samtools.Cigar;
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMException;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.fastq.FastqConstants;
-import htsjdk.tribble.annotation.Strand;
 import htsjdk.utils.ValidationUtils;
-import jdk.vm.ci.meta.Local;
 
 import java.io.File;
 import java.math.BigInteger;

--- a/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
@@ -13,9 +13,11 @@ import htsjdk.variant.variantcontext.writer.IntGenotypeFieldAccessors;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -27,7 +29,7 @@ public class VCFEncoder {
     /**
      * The encoding used for VCF files: ISO-8859-1. When writing VCF4.3 is implemented, this should change to UTF-8.
      */
-    public static final Charset VCF_CHARSET = Charset.forName("ISO-8859-1");
+    public static final Charset VCF_CHARSET = StandardCharsets.ISO_8859_1;
     private static final String QUAL_FORMAT_STRING = "%.2f";
     private static final String QUAL_FORMAT_EXTENSION_TO_TRIM = ".00";
 
@@ -200,7 +202,7 @@ public class VCFEncoder {
     }
 
     private static String formatQualValue(final double qual) {
-        String s = String.format(QUAL_FORMAT_STRING, qual);
+        String s = String.format(Locale.US, QUAL_FORMAT_STRING, qual);
         if (s.endsWith(QUAL_FORMAT_EXTENSION_TO_TRIM)) {
             s = s.substring(0, s.length() - QUAL_FORMAT_EXTENSION_TO_TRIM.length());
         }
@@ -273,7 +275,7 @@ public class VCFEncoder {
             format = "%.2f";
         }
 
-        return String.format(format, d);
+        return String.format(Locale.US, format, d);
     }
 
     static int countOccurrences(final char c, final String s) {


### PR DESCRIPTION
*Setting the local to US in String.format calls that are used to generate computer readable outputs.  Error messages are still written with the default local. 
*Fix for https://github.com/samtools/htsjdk/issues/1510