### PR TITLE
Fix race condition in SamRecordDuplicateComparator

### DIFF
--- a/src/main/java/htsjdk/samtools/DuplicateSetIterator.java
+++ b/src/main/java/htsjdk/samtools/DuplicateSetIterator.java
@@ -52,7 +52,6 @@ public class DuplicateSetIterator implements CloseableIterator<DuplicateSet> {
     public DuplicateSetIterator(final CloseableIterator<SAMRecord> iterator, final SAMFileHeader header) {
         this(iterator, header, false);
     }
-
     public DuplicateSetIterator(final CloseableIterator<SAMRecord> iterator,
                                 final SAMFileHeader header,
                                 final boolean preSorted) {
@@ -76,7 +75,7 @@ public class DuplicateSetIterator implements CloseableIterator<DuplicateSet> {
                                 final boolean preSorted,
                                 final SAMRecordDuplicateComparator comparator,
                                 final Log log) {
-        this.comparator = (comparator == null) ? new SAMRecordDuplicateComparator(Collections.singletonList(header)) : comparator;
+        this.comparator = (comparator == null) ? new SAMRecordDuplicateComparator(header) : comparator;
 
         if (preSorted) {
             this.wrappedIterator = iterator;

--- a/src/main/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
@@ -26,6 +26,8 @@ package htsjdk.samtools;
 import htsjdk.samtools.DuplicateScoringStrategy.ScoringStrategy;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
@@ -63,24 +65,24 @@ public class SAMRecordDuplicateComparator implements SAMRecordComparator, Serial
 
     @Deprecated // This results in sort order depending on the order in which the headers are listed.  Will be removed in future version.
     public SAMRecordDuplicateComparator(final List<SAMFileHeader> headers) {
-        for (final SAMFileHeader header : headers) {
-            populateLibraryIds(header);
-        }
+        populateLibraryIds(headers);
     }
 
     public SAMRecordDuplicateComparator(final SAMFileHeader header) {
-        populateLibraryIds(header);
+        populateLibraryIds(Collections.singletonList(header));
     }
 
-    private void populateLibraryIds(final SAMFileHeader header) {
+    private void populateLibraryIds(final List<SAMFileHeader> headers) {
         final SortedSet<String> libraryNameOrder = new TreeSet<>();
         libraryNameOrder.add(UNKNOWN_LIBRARY_STRING);
 
         // Determine order of library names
-        for (final SAMReadGroupRecord readGroup : header.getReadGroups()) {
-            final String libraryName = readGroup.getLibrary();
-            if (null != libraryName) {
-                libraryNameOrder.add(libraryName);
+        for (final SAMFileHeader header : headers) {
+            for (final SAMReadGroupRecord readGroup : header.getReadGroups()) {
+                final String libraryName = readGroup.getLibrary();
+                if (null != libraryName) {
+                    libraryNameOrder.add(libraryName);
+                }
             }
         }
 
@@ -131,7 +133,7 @@ public class SAMRecordDuplicateComparator implements SAMRecordComparator, Serial
     /** Get the library ID for the given SAM record. */
     private short getLibraryId(final SAMRecord rec) {
         if (this.libraryIds.size() == 0) {
-            populateLibraryIds(rec.getHeader());
+            populateLibraryIds(Arrays.asList(rec.getHeader()));
         }
         final String library = getLibraryName(rec);
         return updateLibraryId(library);

--- a/src/main/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
@@ -99,7 +99,7 @@ public class SAMRecordDuplicateComparator implements SAMRecordComparator, Serial
     /**
      * Populates the set of transient attributes on SAMRecords if they are not already there.
      */
-    private void populateTransientAttributes(final SAMRecord... recs) {
+    synchronized private void populateTransientAttributes(final SAMRecord... recs) {
         for (final SAMRecord rec : recs) {
             if (rec.getTransientAttribute(Attr.LibraryId) != null) continue;
             rec.setTransientAttribute(Attr.LibraryId, getLibraryId(rec));

--- a/src/main/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordDuplicateComparator.java
@@ -111,13 +111,17 @@ public class SAMRecordDuplicateComparator implements SAMRecordComparator, Serial
     /** Get the library ID for the given SAM record. */
     private short getLibraryId(final SAMRecord rec) {
         final String library = getLibraryName(rec);
+        return updateLibraryId(library);
+    }
+
+    private synchronized short updateLibraryId(final String library) {
         Short libraryId = this.libraryIds.get(library);
 
         if (libraryId == null) {
+            System.out.println("library id is null" + this.nextLibraryId);
             libraryId = this.nextLibraryId++;
             this.libraryIds.put(library, libraryId);
         }
-
         return libraryId;
     }
 

--- a/src/test/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
@@ -25,15 +25,11 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloserUtil;
-import htsjdk.samtools.util.Histogram;
-import htsjdk.samtools.util.ProgressLogger;
-import htsjdk.samtools.SAMFileHeader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/test/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Random;
 
 /**
  * The tests listed here are not exhaustive, and duplicate some of the work found in Picard's MarkDuplicates test classes.
@@ -243,19 +244,20 @@ public class SAMRecordDuplicateComparatorTest extends HtsjdkTest {
         // Generates synthetic data that is unsorted, it sorts the data, then validates that it was sorted correctly
 
         // Generate synthetic data
-        SAMRecordSetBuilder randomSetOfRecords = new SAMRecordSetBuilder(false, SAMFileHeader.SortOrder.unsorted, true);
+        final SAMRecordSetBuilder randomSetOfRecords = new SAMRecordSetBuilder(false, SAMFileHeader.SortOrder.unsorted, true);
         final SAMReadGroupRecord readGroupRecord = new SAMReadGroupRecord("testing_read_group_id");
         readGroupRecord.setSample("test_sample_name");
         randomSetOfRecords.setReadGroup(readGroupRecord);
 
         // The choice of 100000 iterations was done to be large enough to trigger a race condition in htsjdk 2.23.0 and earlier
         // with a probability > 90%.  Larger numbers of iterations could be used to increase the probability of failure.
+        final Random rand = new Random();
         for (int i = 0;i < 100000;i++) {
-            randomSetOfRecords.addPair("readname" + i, 1, (int) Math.random() * 1000 + 1, (int) Math.random() * 1000 + 1);
+            randomSetOfRecords.addPair("readname" + i, 1, rand.nextInt(1000) + 1, rand.nextInt(1000) + 1);
         }
 
         // Sort Bam
-        File sortedBam = File.createTempFile("testOut",".bam");
+        final File sortedBam = File.createTempFile("testOut",".bam");
         final SamReader reader = randomSetOfRecords.getSamReader();
                 // SamReaderFactory.makeDefault().referenceSequence(Defaults.REFERENCE_FASTA).open(input);
         reader.getFileHeader().setSortOrder(SAMFileHeader.SortOrder.duplicate);

--- a/src/test/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
@@ -251,7 +251,7 @@ public class SAMRecordDuplicateComparatorTest extends HtsjdkTest {
 
         // The choice of 100000 iterations was done to be large enough to trigger a race condition in htsjdk 2.23.0 and earlier
         // with a probability > 90%.  Larger numbers of iterations could be used to increase the probability of failure.
-        final Random rand = new Random();
+        final Random rand = new Random(42);
         for (int i = 0;i < 100000;i++) {
             randomSetOfRecords.addPair("readname" + i, 1, rand.nextInt(1000) + 1, rand.nextInt(1000) + 1);
         }


### PR DESCRIPTION
### Description

The getLibraryId function of SAMRecordDuplicateComparator.java can create race conditions when run multithreaded.

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [x] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
