### PR TITLE
Check base qualities before accumulating inserted bases in SamLocusIterator

### DIFF
--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -301,38 +301,33 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
             builder.addFrag("record" + i, 0, startPosition, true, false, "10M3I17M3I3M", qualityString, 10);
         }
         final int insStart1 = 174;
-        final int insStart2 = 194;
-        // test both for include indels and do not include indels
-        for (final boolean incIndels : new boolean[] {false, true}) {
-            final SamLocusIterator sli = createSamLocusIterator(builder);
-            sli.setIncludeIndels(incIndels);
-            sli.setQualityScoreCutoff(10);
-            // make sure we accumulated depth for each position
-            int pos = startPosition;
-            for (final SamLocusIterator.LocusInfo li : sli) {
-                Assert.assertEquals(li.getPosition(), pos++);
-                // make sure we are accumulating normal coverage
-                Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
-                // Check the correct assignment of the alignment type
-                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
-                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
-                }
-                Assert.assertEquals(li.size(), coverage);
+        final SamLocusIterator sli = createSamLocusIterator(builder);
+        sli.setQualityScoreCutoff(10);
+        sli.includeIndels = true;
+        // make sure we accumulated depth for each position
+        int pos = startPosition;
+        for (final SamLocusIterator.LocusInfo li : sli) {
+            Assert.assertEquals(li.getPosition(), pos++);
+            // make sure we are accumulating normal coverage
+            Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
+            // Check the correct assignment of the alignment type
+            for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+            }
+            Assert.assertEquals(li.size(), coverage);
 
-                // make sure that we are not accumulating deletions
-                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
-                if (incIndels && li.getPosition() == insStart1) {
-                    Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
-                    // Check the correct assignment of the alignment type
-                    for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
-                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
-                    }
-                } else if (incIndels && li.getPosition() == insStart2){
-                    // Second insertion should not be included because base quality is less than qualityScoreCutoff
-                    Assert.assertEquals(li.getInsertedInRecord().size(), 0);
-                } else {
-                    Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+            // make sure that we are not accumulating deletions
+            Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+            if (li.getPosition() == insStart1) {
+                Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
                 }
+            }
+            // Second insertion should not be included because base quality is less than qualityScoreCutoff
+            else {
+                Assert.assertEquals(li.getInsertedInRecord().size(), 0);
             }
         }
     }

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -328,7 +328,7 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                         Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
                     }
                 } else if (incIndels && li.getPosition() == insStart2){
-                    // Second insertion should not be included because base quality < 10
+                    // Second insertion should not be included because base quality is less than qualityScoreCutoff
                     Assert.assertEquals(li.getInsertedInRecord().size(), 0);
                 } else {
                     Assert.assertEquals(li.getInsertedInRecord().size(), 0);

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -332,7 +332,7 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
                 else if ((qualityScoreCutoff == 0) && (li.getPosition() == insStart2)) {
                     Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
                 }
-                else{
+                else {
                     Assert.assertEquals(li.getInsertedInRecord().size(), 0);
                 }
             }

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -301,33 +301,40 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
             builder.addFrag("record" + i, 0, startPosition, true, false, "10M3I17M3I3M", qualityString, 10);
         }
         final int insStart1 = 174;
-        final SamLocusIterator sli = createSamLocusIterator(builder);
-        sli.setQualityScoreCutoff(10);
-        sli.includeIndels = true;
-        // make sure we accumulated depth for each position
-        int pos = startPosition;
-        for (final SamLocusIterator.LocusInfo li : sli) {
-            Assert.assertEquals(li.getPosition(), pos++);
-            // make sure we are accumulating normal coverage
-            Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
-            // Check the correct assignment of the alignment type
-            for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
-                Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
-            }
-            Assert.assertEquals(li.size(), coverage);
-
-            // make sure that we are not accumulating deletions
-            Assert.assertEquals(li.getDeletedInRecord().size(), 0);
-            if (li.getPosition() == insStart1) {
-                Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
+        final int insStart2 = 191;
+        for (final int qualityScoreCutoff : new int[] {0, 10}){
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setQualityScoreCutoff(10);
+            sli.setQualityScoreCutoff(qualityScoreCutoff);
+            sli.includeIndels = true;
+            // make sure we accumulated depth for each position
+            int pos = startPosition;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                Assert.assertEquals(li.getPosition(), pos++);
+                // make sure we are accumulating normal coverage
+                Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
                 // Check the correct assignment of the alignment type
-                for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
-                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
                 }
-            }
-            // Second insertion should not be included because base quality is less than qualityScoreCutoff
-            else {
-                Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+                Assert.assertEquals(li.size(), coverage);
+
+                // make sure that we are not accumulating deletions
+                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                if (li.getPosition() == insStart1) {
+                    Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
+                    // Check the correct assignment of the alignment type
+                    for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+                    }
+                }
+                // Second insertion should only be included when cutoff is 0 because base quality is 9
+                else if ((qualityScoreCutoff == 0) && (li.getPosition() == insStart2)) {
+                    Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
+                }
+                else{
+                    Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+                }
             }
         }
     }

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -288,6 +288,57 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
     }
 
     /**
+     * Test insertion quality filter
+     */
+    @Test
+    public void testInsertionQualityFilter() {
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        // add records up to coverage for the test in that position
+        final int startPosition = 165;
+        String qualityString = "++++++++++,,,+++++++++++++++++***+++";
+        for (int i = 0; i < coverage; i++) {
+            // add a negative-strand fragment mapped on chrM with base quality of 10
+            builder.addFrag("record" + i, 0, startPosition, true, false, "10M3I17M3I3M", qualityString, 10);
+        }
+        final int insStart1 = 174;
+        final int insStart2 = 194;
+        // test both for include indels and do not include indels
+        for (final boolean incIndels : new boolean[] {false, true}) {
+            final SamLocusIterator sli = createSamLocusIterator(builder);
+            sli.setIncludeIndels(incIndels);
+            sli.setQualityScoreCutoff(10);
+            // make sure we accumulated depth for each position
+            int pos = startPosition;
+            for (final SamLocusIterator.LocusInfo li : sli) {
+                Assert.assertEquals(li.getPosition(), pos++);
+                // make sure we are accumulating normal coverage
+                Assert.assertEquals(li.getRecordAndOffsets().size(), coverage);
+                // Check the correct assignment of the alignment type
+                for (final SamLocusIterator.RecordAndOffset rao : li.getRecordAndOffsets()) {
+                    Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Match);
+                }
+                Assert.assertEquals(li.size(), coverage);
+
+                // make sure that we are not accumulating deletions
+                Assert.assertEquals(li.getDeletedInRecord().size(), 0);
+                if (incIndels && li.getPosition() == insStart1) {
+                    Assert.assertEquals(li.getInsertedInRecord().size(), coverage);
+                    // Check the correct assignment of the alignment type
+                    for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                        Assert.assertEquals(rao.getAlignmentType(), SamLocusIterator.RecordAndOffset.AlignmentType.Insertion);
+                    }
+                } else if (incIndels && li.getPosition() == insStart2){
+                    // Second insertion should not be included because base quality < 10
+                    Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+                } else {
+                    Assert.assertEquals(li.getInsertedInRecord().size(), 0);
+                }
+            }
+        }
+    }
+
+
+    /**
      * Test an insertion at the start of the read, with both including or not indels
      */
     @Test


### PR DESCRIPTION
### Description

Updated `accumulateIndels` in `SamLocusIterator` to check if bases in an insertion have base quality >= `qualityScoreCutoff` before adding them to the accumulator. The motivation for this change is that insertions should be filtered and accumulated consistently with matching bases.

### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
