### PR TITLE
Minor optimization and fix to BlockCompressedOutputStream

### DIFF
--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -116,10 +116,6 @@ public class BlockCompressedOutputStream
     private long mBlockAddress = 0;
     private GZIIndex.GZIIndexer indexer;
 
-
-    // Really a local variable, but allocate once to reduce GC burden.
-    private final byte[] singleByteArray = new byte[1];
-
     /**
      * Uses default compression level, which is 5 unless changed by setCompressionLevel
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -308,6 +308,19 @@ public class BlockCompressedOutputStream
     }
 
     /**
+     * Writes the specified byte to this output stream. The general contract for write is that one byte is written
+     * to the output stream. The byte to be written is the eight low-order bits of the argument b.
+     * The 24 high-order bits of b are ignored.
+     * @param bite
+     * @throws IOException
+     */
+    @Override
+    public void write(final int bite) throws IOException {
+        uncompressedBuffer[numUncompressedBytes++] = (byte) bite;
+        if (numUncompressedBytes == uncompressedBuffer.length) deflateBlock();
+    }
+
+    /**
      * WARNING: flush() affects the output format, because it causes the current contents of uncompressedBuffer
      * to be compressed and written, even if it isn't full.  Unless you know what you're doing, don't call flush().
      * Instead, call close(), which will flush any unwritten data before closing the underlying stream.
@@ -351,19 +364,6 @@ public class BlockCompressedOutputStream
                 BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) {
             throw new IOException("Terminator block not found after closing BGZF file " + this.file);
         }
-    }
-
-    /**
-     * Writes the specified byte to this output stream. The general contract for write is that one byte is written
-     * to the output stream. The byte to be written is the eight low-order bits of the argument b.
-     * The 24 high-order bits of b are ignored.
-     * @param bite
-     * @throws IOException
-     */
-    @Override
-    public void write(final int bite) throws IOException {
-        singleByteArray[0] = (byte)bite;
-        write(singleByteArray);
     }
 
     /** Encode virtual file pointer

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -358,11 +358,15 @@ public class BlockCompressedOutputStream
         if (indexer != null) {
             indexer.close();
         }
-        // Can't re-open something that is not a regular file, e.g. a named pipe or an output stream
-        if (this.file == null || !Files.isRegularFile(this.file)) return;
-        if (BlockCompressedInputStream.checkTermination(this.file) !=
-                BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) {
-            throw new IOException("Terminator block not found after closing BGZF file " + this.file);
+
+        // If a terminator block was written, ensure that it's there and valid
+        if (writeTerminatorBlock) {
+            // Can't re-open something that is not a regular file, e.g. a named pipe or an output stream
+            if (this.file == null || !Files.isRegularFile(this.file)) return;
+            if (BlockCompressedInputStream.checkTermination(this.file) !=
+                    BlockCompressedInputStream.FileTermination.HAS_TERMINATOR_BLOCK) {
+                throw new IOException("Terminator block not found after closing BGZF file " + this.file);
+            }
         }
     }
 

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -307,16 +307,9 @@ public class BlockCompressedOutputStream
         }
     }
 
-    /**
-     * Writes the specified byte to this output stream. The general contract for write is that one byte is written
-     * to the output stream. The byte to be written is the eight low-order bits of the argument b.
-     * The 24 high-order bits of b are ignored.
-     * @param bite
-     * @throws IOException
-     */
     @Override
-    public void write(final int bite) throws IOException {
-        uncompressedBuffer[numUncompressedBytes++] = (byte) bite;
+    public void write(final int b) throws IOException {
+        uncompressedBuffer[numUncompressedBytes++] = (byte) b;
         if (numUncompressedBytes == uncompressedBuffer.length) deflateBlock();
     }
 

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
@@ -104,7 +104,7 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
             bcos.write('\n');
         }
 
-        bcos.close();
+        bcos.close(false);
 
         final List<String> lines = new ArrayList<>();
         IOUtil.readLines(f).forEachRemaining(lines::add);

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
@@ -84,6 +84,37 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
         Assert.assertEquals(bcis2.read(buffer), -1, "Should be end of file");
     }
 
+    @Test
+    public void testWriteSingleBytes() throws Exception {
+        final File f = File.createTempFile("BCOST.", ".gz");
+        f.deleteOnExit();
+        final String s  = "Hello, I am a test string, and I will be written out one painful byte at a time.";
+        final byte[] bs = s.getBytes();
+        final int iterations = BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE * 2 / bs.length;
+
+        final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(f);
+        for (int i=0; i<iterations; ++i) {
+            for (final byte b : bs) {
+                bcos.write(b);
+            }
+            bcos.write('\n');
+
+            // Also write as a byte[]
+            bcos.write(bs);
+            bcos.write('\n');
+        }
+
+        bcos.close();
+
+        final List<String> lines = new ArrayList<>();
+        IOUtil.readLines(f).forEachRemaining(lines::add);
+
+        Assert.assertEquals(lines.size(), iterations * 2);
+        for (final String line : lines) {
+            Assert.assertEquals(line, s);
+        }
+    }
+
     @DataProvider(name = "seekReadExceptionsData")
     private Object[][] seekReadExceptionsData()
     {


### PR DESCRIPTION
### Description

Some minor tweaking to make things faster when calling `write(int bite)` on BlockCompressedOutputStream.

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [x] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
