### PR TITLE
Gff3Writer : give a chance to implement a custom way to escape strings

### DIFF
--- a/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
@@ -68,9 +68,9 @@ public class Gff3Writer implements Closeable {
 
     private void writeFirstEightFields(final Gff3Feature feature) throws IOException {
         writeJoinedByDelimiter(Gff3Constants.FIELD_DELIMITER, this::tryToWrite, Arrays.asList(
-                encodeString(feature.getContig()),
-                encodeString(feature.getSource()),
-                encodeString(feature.getType()),
+                escapeString(feature.getContig()),
+                escapeString(feature.getSource()),
+                escapeString(feature.getType()),
                 Integer.toString(feature.getStart()),
                 Integer.toString(feature.getEnd()),
                 feature.getScore() < 0 ? Gff3Constants.UNDEFINED_FIELD_VALUE : Double.toString(feature.getScore()),
@@ -92,7 +92,7 @@ public class Gff3Writer implements Closeable {
         try {
             tryToWrite(key);
             out.write(Gff3Constants.KEY_VALUE_SEPARATOR);
-            writeJoinedByDelimiter(Gff3Constants.VALUE_DELIMITER, v -> tryToWrite(encodeString(v)), values);
+            writeJoinedByDelimiter(Gff3Constants.VALUE_DELIMITER, v -> tryToWrite(escapeString(v)), values);
         } catch (final IOException ex) {
             throw new TribbleException("error writing out key value pair " + key + " " + values);
         }
@@ -121,6 +121,16 @@ public class Gff3Writer implements Closeable {
         out.write(Gff3Constants.FIELD_DELIMITER);
         writeAttributes(feature.getAttributes());
         out.write(Gff3Constants.END_OF_LINE_CHARACTER);
+    }
+
+    /***
+     * escape a String.
+     * Default behavior is to call {@link #encodeString(String)}
+     * @param s the string to be escaped
+     * @return the escaped string
+     */
+    protected String escapeString(final String s) {
+        return encodeString(s);
     }
 
     static String encodeString(final String s) {


### PR DESCRIPTION
### Description

the Gff3Writer escapes strings as UTF8. While the format is **correct**, it produces strings that are not expected by some gff3 parsers. For example: it would generate a line like:

```
chr1	ucsc	exon	11869	12227	.	+	.	Parent=transcript%3ANR_148357.t1;Name=NR_148357;biotype=misc_RNA;exon_id=NR_148357%3AE0
```

which is not recognized by "bcftools csq" because it doesn't look for "Parent=transcript%3A" but for "Parent=transcript:"

```
[csq.c:729 gff_id_parse] Could not parse the line, "Parent=transcript:" not present: chr1	ucsc	exon	11869	12227	.	+	.	Parent=transcript%3ANR_148357.t1;Name=NR_148357;biotype=misc_RNA;exon_id=NR_148357%3AE0
```

this PR just  adds a new **protected** method `escapeString` which invokes `encodeString`. It can be overriden to implement a custom way to escape the strings.

PS: for now, travis-ci is too slow on my side, I cannot validate the code.

### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [X] Check your code style.
- [X] Write a clear commit title and message
