### PR TITLE
Fix CRAM BAI creation error message.

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/BAIEntry.java
+++ b/src/main/java/htsjdk/samtools/cram/BAIEntry.java
@@ -57,7 +57,7 @@ public class BAIEntry implements Comparable<BAIEntry> {
                 ((alignmentSpan.getAlignmentStart() != 0 && alignmentSpan.getAlignmentStart() != -1) ||
                         (alignmentSpan.getAlignmentSpan() != 0 && alignmentSpan.getAlignmentSpan() != 1)))) {
             throw new CRAMException(
-                    String.format("Attempt to unmapped with non zero alignment start (%d) or span (%d)",
+                    String.format("Attempt to create a bai entry for an unmapped slice with unexpected alignment start (%d) or span (%d) values",
                             alignmentSpan.getAlignmentStart(),
                             alignmentSpan.getAlignmentSpan()));
         }


### PR DESCRIPTION
Fix the not entirely useful CRAM error message that was reported in Picard https://github.com/broadinstitute/picard/issues/1624. Its still pretty cryptic for an end user, since it indicates an internal error or malformed input, but at least its now more precise.