### PR TITLE
Allow multiple VCFSimpleHeaderLine of same type

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeader.java
@@ -373,6 +373,9 @@ public class VCFHeader implements Serializable {
             return addMetaDataLineMapLookupEntry(mFilterMetaData, filterLine.getID(), filterLine);
         } else if ( line instanceof VCFContigHeaderLine ) {
             return addContigMetaDataLineLookupEntry((VCFContigHeaderLine) line);
+        } else if ( line instanceof VCFSimpleHeaderLine ){
+            final VCFSimpleHeaderLine simpleLine = (VCFSimpleHeaderLine) line;
+            return addMetaDataLineMapLookupEntry(mOtherMetaData, simpleLine.getID(), simpleLine);
         } else {
             return addMetaDataLineMapLookupEntry(mOtherMetaData, line.getKey(), line);
         }

--- a/src/main/java/htsjdk/variant/vcf/VCFHeader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFHeader.java
@@ -375,7 +375,7 @@ public class VCFHeader implements Serializable {
             return addContigMetaDataLineLookupEntry((VCFContigHeaderLine) line);
         } else if ( line instanceof VCFSimpleHeaderLine ){
             final VCFSimpleHeaderLine simpleLine = (VCFSimpleHeaderLine) line;
-            return addMetaDataLineMapLookupEntry(mOtherMetaData, simpleLine.getID(), simpleLine);
+            return addMetaDataLineMapLookupEntry(mOtherMetaData, simpleLine.getKey() + ":" + simpleLine.getID(), simpleLine);
         } else {
             return addMetaDataLineMapLookupEntry(mOtherMetaData, line.getKey(), line);
         }
@@ -587,6 +587,20 @@ public class VCFHeader implements Serializable {
      */
     public VCFHeaderLine getOtherHeaderLine(final String key) {
         return mOtherMetaData.get(key);
+    }
+
+    /**
+     * @param key    the header key or field type
+     * @param id     the header id
+     * @return the meta data line, or null if there is none
+     */
+    public VCFSimpleHeaderLine getOtherHeaderLine(final String key, final String id) {
+        final VCFHeaderLine line = mOtherMetaData.get(key + ":" + id);
+        if (line instanceof VCFSimpleHeaderLine) {
+            return (VCFSimpleHeaderLine) line;
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -321,8 +321,8 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
 
         Assert.assertTrue(header.getOtherHeaderLines().contains(delLine), "DEL line not found in other header lines");
         Assert.assertTrue(header.getOtherHeaderLines().contains(insLine), "INS line not found in other header lines");
-        Assert.assertNotNull(header.getOtherHeaderLine("DEL"), "Lookup for DEL by key failed");
-        Assert.assertNotNull(header.getOtherHeaderLine("INS"), "Lookup for INS by key failed");
+        Assert.assertNotNull(header.getOtherHeaderLine("ALT", "DEL"), "Lookup for ALT:DEL by key failed");
+        Assert.assertNotNull(header.getOtherHeaderLine("ALT", "INS"), "Lookup for ALT:INS by key failed");
     }
 
     @Test

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -312,6 +312,20 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     }
 
     @Test
+    public void testVcfHeaderAddSimpleHeaderLine() {
+        final VCFHeader header = getHiSeqVCFHeader();
+        final VCFSimpleHeaderLine delLine = new VCFSimpleHeaderLine("ALT", "DEL", "Deletion relative to the reference");
+        final VCFSimpleHeaderLine insLine = new VCFSimpleHeaderLine("ALT", "INS", "Insertion of novel sequence relative to the reference");
+        header.addMetaDataLine(delLine);
+        header.addMetaDataLine(insLine);
+
+        Assert.assertTrue(header.getOtherHeaderLines().contains(delLine), "DEL line not found in other header lines");
+        Assert.assertTrue(header.getOtherHeaderLines().contains(insLine), "INS line not found in other header lines");
+        Assert.assertNotNull(header.getOtherHeaderLine("DEL"), "Lookup for DEL by key failed");
+        Assert.assertNotNull(header.getOtherHeaderLine("INS"), "Lookup for INS by key failed");
+    }
+
+    @Test
     public void testVCFHeaderAddMetaDataLineDoesNotDuplicateContigs() {
         File input = new File("src/test/resources/htsjdk/variant/ex2.vcf");
 
@@ -363,6 +377,22 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         final int numHeaderLinesBefore = header.getOtherHeaderLines().size();
         // readd the same header line
         header.addMetaDataLine(newHeaderLine);
+        final int numHeaderLinesAfter = header.getOtherHeaderLines().size();
+
+        // assert that we have the same number of other header lines before and after
+        Assert.assertEquals(numHeaderLinesBefore, numHeaderLinesAfter);
+    }
+
+    @Test
+    public void testVCFHeaderAddDuplicateSimpleHeaderLine() {
+        final VCFHeader header = getHiSeqVCFHeader();
+        final VCFSimpleHeaderLine delLine = new VCFSimpleHeaderLine("ALT", "DEL", "Deletion relative to the reference");
+        header.addMetaDataLine(delLine);
+        Assert.assertTrue(header.getOtherHeaderLines().contains(delLine), "DEL line not found in other header lines");
+
+        final int numHeaderLinesBefore = header.getOtherHeaderLines().size();
+        // readd the same header line
+        header.addMetaDataLine(delLine);
         final int numHeaderLinesAfter = header.getOtherHeaderLines().size();
 
         // assert that we have the same number of other header lines before and after

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -312,17 +312,17 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     }
 
     @Test
-    public void testVcfHeaderAddSimpleHeaderLine() {
+    public void testVcfHeaderAddIdHeaderLine() {
         final VCFHeader header = getHiSeqVCFHeader();
         final VCFSimpleHeaderLine delLine = new VCFSimpleHeaderLine("ALT", "DEL", "Deletion relative to the reference");
         final VCFSimpleHeaderLine insLine = new VCFSimpleHeaderLine("ALT", "INS", "Insertion of novel sequence relative to the reference");
         header.addMetaDataLine(delLine);
         header.addMetaDataLine(insLine);
 
-        Assert.assertTrue(header.getOtherHeaderLines().contains(delLine), "DEL line not found in other header lines");
-        Assert.assertTrue(header.getOtherHeaderLines().contains(insLine), "INS line not found in other header lines");
-        Assert.assertNotNull(header.getOtherHeaderLine("ALT", "DEL"), "Lookup for ALT:DEL by key failed");
-        Assert.assertNotNull(header.getOtherHeaderLine("ALT", "INS"), "Lookup for ALT:INS by key failed");
+        Assert.assertTrue(header.getIdHeaderLines().contains(delLine), "DEL line not found in ID header lines");
+        Assert.assertTrue(header.getIdHeaderLines().contains(insLine), "INS line not found in ID header lines");
+        Assert.assertNotNull(header.getIdHeaderLine("ALT", "DEL"), "Lookup for ALT/DEL by key failed");
+        Assert.assertNotNull(header.getIdHeaderLine("ALT", "INS"), "Lookup for ALT/INS by key failed");
     }
 
     @Test
@@ -384,16 +384,16 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     }
 
     @Test
-    public void testVCFHeaderAddDuplicateSimpleHeaderLine() {
+    public void testVCFHeaderAddDuplicateIdHeaderLine() {
         final VCFHeader header = getHiSeqVCFHeader();
         final VCFSimpleHeaderLine delLine = new VCFSimpleHeaderLine("ALT", "DEL", "Deletion relative to the reference");
         header.addMetaDataLine(delLine);
-        Assert.assertTrue(header.getOtherHeaderLines().contains(delLine), "DEL line not found in other header lines");
+        Assert.assertTrue(header.getIdHeaderLines().contains(delLine), "DEL line not found in ID header lines");
 
-        final int numHeaderLinesBefore = header.getOtherHeaderLines().size();
+        final int numHeaderLinesBefore = header.getIdHeaderLines().size();
         // readd the same header line
         header.addMetaDataLine(delLine);
-        final int numHeaderLinesAfter = header.getOtherHeaderLines().size();
+        final int numHeaderLinesAfter = header.getIdHeaderLines().size();
 
         // assert that we have the same number of other header lines before and after
         Assert.assertEquals(numHeaderLinesBefore, numHeaderLinesAfter);


### PR DESCRIPTION
### Description

Closes #277 
Closes #500 

Currently, it is not possible to add multiple `VCFSimpleHeaderLine`s to a VCFHeader if they are of the same type (see issues linked above). A specific example, is adding `ALT` lines, which are included in [4.2 spec](https://samtools.github.io/hts-specs/VCFv4.2.pdf) (that shows a header with multiple ALT lines on page 11).

To fix this, I added a new map and methods for working with `SimpleVCFHeaderLine`s that are not of the default types. 

I have seen another fix to this (#835), but it was closed due to large scope. I am hoping this change is small and useful enough to be considered. Thanks!

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [x] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
