### PR TITLE
Fix error message typo in CRAMLazyReferenceSource

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/ref/CRAMLazyReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/CRAMLazyReferenceSource.java
@@ -38,7 +38,7 @@ public class CRAMLazyReferenceSource implements CRAMReferenceSource {
     @Override
     public byte[] getReferenceBases(final SAMSequenceRecord sequenceRecord, final boolean tryNameVariants) {
         throw new IllegalArgumentException(
-                String.format("A reference must be supplied that includes the reference sequence for %s).",
+                String.format("A reference must be supplied that includes the reference sequence for %s.",
                         sequenceRecord.getSequenceName()));
     }
 


### PR DESCRIPTION
Fix slightly misleading rogue paren following contig name in error message.