### PR TITLE
Invaliding out of date SAMRecord.mAlignmentBlocks cache

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -599,6 +599,7 @@ public class SAMRecord implements Cloneable, Locatable, Serializable {
         mAlignmentStart = value;
         // Clear cached alignment end
         mAlignmentEnd = NO_ALIGNMENT_START;
+        mAlignmentBlocks = null;
     }
 
     /**

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -1181,4 +1181,14 @@ public class SAMRecordUnitTest extends HtsjdkTest {
         Assert.assertEquals(attribute.getClass(), expectedClass);
         Assert.assertEquals(Array.getLength(attribute), 0);
     }
+
+    @Test
+    public void testAlignmentBlockCacheInvalidation() {
+        final SAMRecord rec = createTestRecordHelper();
+
+        rec.getAlignmentBlocks();
+        Assert.assertEquals(1, rec.getAlignmentBlocks().get(0).getReferenceStart());
+        rec.setAlignmentStart(100);
+        Assert.assertEquals(100, rec.getAlignmentBlocks().get(0).getReferenceStart());
+    }
 }


### PR DESCRIPTION
### Description

SAMRecord.mAlignmentBlocks cache field is not invalidated when changing the alignment start.
This causes processes using this field (such as NM tag calculation) to return an incorrect result.

### Things to think about before submitting:
- [X] Make sure your changes compile and new tests pass locally.
- [X] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [N/A] Extended the README / documentation, if necessary
- [X] Check your code style.
- [X] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
