### PR TITLE
Add QuietTestWrapper to suppress excessive test output that exceeds CI log size threshold.

### DIFF
--- a/src/test/java/htsjdk/samtools/cram/build/ContainerFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/ContainerFactoryTest.java
@@ -5,6 +5,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordQueryNameComparator;
 import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.*;
+import htsjdk.samtools.util.QuietTestWrapper;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -18,13 +19,6 @@ import java.util.stream.Stream;
 
 public class ContainerFactoryTest extends HtsjdkTest {
 
-    // wrapper class to suppress expansion/serialization of lists of records during test execution
-    private static class RecordSupplier implements Supplier<List<SAMRecord>> {
-        final List<SAMRecord> samRecords;
-        public RecordSupplier(final List<SAMRecord> samRecords) { this.samRecords = samRecords; }
-        @Override public List<SAMRecord> get() { return samRecords; }
-    }
-
     @DataProvider(name="singleContainerSliceDistribution")
     private Object[][] getSingleContainerSliceDistribution() {
         final int RECORDS_PER_SLICE = 100;
@@ -33,35 +27,35 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 // expected record count/slice, expected slice refContexts,
                 {
                         // 1 full single-ref slice with 1 rec
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(1, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(1, 0)),
                         RECORDS_PER_SLICE, 1,
                         new ReferenceContext(0),
                         1, Arrays.asList(1), Arrays.asList(new ReferenceContext(0))
                 },
                 {
                         // 1 full single-ref slice with 1 rec, but allow > 1 slices/container
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(1, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(1, 0)),
                         RECORDS_PER_SLICE, 2,
                         new ReferenceContext(0),
                         1, Arrays.asList(1), Arrays.asList(new ReferenceContext(0))
                 },
                 {
                         // 1 full single-ref slice with RECORDS_PER_SLICE - 1 records
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE - 1, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE - 1, 0)),
                         RECORDS_PER_SLICE, 1,
                         new ReferenceContext(0),
                         1, Arrays.asList(RECORDS_PER_SLICE - 1), Arrays.asList(new ReferenceContext(0))
                 },
                 {
                         // 1 full single-ref slice with RECORDS_PER_SLICE records
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE, 0)),
                         RECORDS_PER_SLICE, 1,
                         new ReferenceContext(0),
                         1, Arrays.asList(RECORDS_PER_SLICE), Arrays.asList(new ReferenceContext(0))
                 },
                 {
                         // 2 single-ref slices, one with RECORDS_PER_SLICE records, one with 1 record
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE + 1, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE + 1, 0)),
                         RECORDS_PER_SLICE, 2,
                         new ReferenceContext(0),
                         2, Arrays.asList(RECORDS_PER_SLICE, 1),
@@ -69,7 +63,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 },
                 {
                         // 2 single-ref slices, one with RECORDS_PER_SLICE records, one with RECORDS_PER_SLICE - 1
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped((RECORDS_PER_SLICE * 2) - 1, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped((RECORDS_PER_SLICE * 2) - 1, 0)),
                         RECORDS_PER_SLICE, 2,
                         new ReferenceContext(0),
                         2, Arrays.asList(RECORDS_PER_SLICE, RECORDS_PER_SLICE - 1),
@@ -77,7 +71,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 },
                 {
                         // 2 full single-ref slices, each with RECORDS_PER_SLICE records
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 2, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 2, 0)),
                         RECORDS_PER_SLICE, 2,
                         new ReferenceContext(0),
                         2, Arrays.asList(RECORDS_PER_SLICE, RECORDS_PER_SLICE),
@@ -85,7 +79,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 },
                 {
                         // 3 single-ref slices, two with RECORDS_PER_SLICE records, one with 1 record
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped((RECORDS_PER_SLICE * 2) + 1, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped((RECORDS_PER_SLICE * 2) + 1, 0)),
                         RECORDS_PER_SLICE, 3,
                         new ReferenceContext(0),
                         3, Arrays.asList(RECORDS_PER_SLICE, RECORDS_PER_SLICE, 1),
@@ -96,7 +90,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 },
                 {
                         // 3 full single-ref slices, each with RECORDS_PER_SLICE records
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 3, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 3, 0)),
                         RECORDS_PER_SLICE, 3,
                         new ReferenceContext(0),
                         3, Arrays.asList(RECORDS_PER_SLICE, RECORDS_PER_SLICE, RECORDS_PER_SLICE),
@@ -106,35 +100,35 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 // now repeat the tests, but using unmapped records
                 {
                         // 1 full single-ref (unmapped) slice with 1 rec
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsUnmapped(1)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsUnmapped(1)),
                         RECORDS_PER_SLICE, 1,
                         ReferenceContext.UNMAPPED_UNPLACED_CONTEXT,
                         1, Arrays.asList(1), Arrays.asList(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT)
                 },
                 {
                         // 1 full single-ref (unmapped) slice with 1 rec, but allow > 1 slices/container
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsUnmapped(1)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsUnmapped(1)),
                         RECORDS_PER_SLICE, 2,
                         ReferenceContext.UNMAPPED_UNPLACED_CONTEXT,
                         1, Arrays.asList(1), Arrays.asList(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT)
                 },
                 {
                         // 1 full single-ref (unmapped) slice with RECORDS_PER_SLICE - 1 records
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE - 1)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE - 1)),
                         RECORDS_PER_SLICE, 1,
                         ReferenceContext.UNMAPPED_UNPLACED_CONTEXT,
                         1, Arrays.asList(RECORDS_PER_SLICE - 1), Arrays.asList(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT)
                 },
                 {
                         // 1 full single-ref (unmapped) slice with RECORDS_PER_SLICE records
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE)),
                         RECORDS_PER_SLICE, 1,
                         ReferenceContext.UNMAPPED_UNPLACED_CONTEXT,
                         1, Arrays.asList(RECORDS_PER_SLICE), Arrays.asList(ReferenceContext.UNMAPPED_UNPLACED_CONTEXT)
                 },
                 {
                         // 2 single-ref (unmapped) slices, one with RECORDS_PER_SLICE records, one with 1 record
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE + 1)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE + 1)),
                         RECORDS_PER_SLICE, 2,
                         ReferenceContext.UNMAPPED_UNPLACED_CONTEXT,
                         2, Arrays.asList(RECORDS_PER_SLICE, 1),
@@ -142,7 +136,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 },
                 {
                         // 2 full single-ref (unmapped) slices, each with RECORDS_PER_SLICE records
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE * 2)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE * 2)),
                         RECORDS_PER_SLICE, 2,
                         ReferenceContext.UNMAPPED_UNPLACED_CONTEXT,
                         2, Arrays.asList(RECORDS_PER_SLICE, RECORDS_PER_SLICE),
@@ -150,7 +144,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 },
                 {
                         // 3 full single-ref (unmapped) slices, each with RECORDS_PER_SLICE records
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE * 3)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE * 3)),
                         RECORDS_PER_SLICE, 3,
                         ReferenceContext.UNMAPPED_UNPLACED_CONTEXT,
                         3, Arrays.asList(RECORDS_PER_SLICE, RECORDS_PER_SLICE, RECORDS_PER_SLICE),
@@ -165,7 +159,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 // reference context would be more correctly called a "placed" reference context
                 {
                         // 1 full single-ref mapped slice with RECORDS_PER_SLICE records
-                        new RecordSupplier(Stream.of(
+                        new QuietTestWrapper<>(Stream.of(
                                 Collections.singletonList(CRAMStructureTestHelper.createSAMRecordUnmappedPlaced(0, 1)),
                                 CRAMStructureTestHelper.createSAMRecordsMapped((RECORDS_PER_SLICE / 2) - 2, 0),
                                 Collections.singletonList(CRAMStructureTestHelper.createSAMRecordUnmappedPlaced(0, 1)))
@@ -179,7 +173,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 // now queryname sorted
                 {
                         // 1 full single-ref slice with RECORDS_PER_SLICE-1 records
-                        new RecordSupplier(CRAMStructureTestHelper.createQueryNameSortedSAMRecords(RECORDS_PER_SLICE - 1,0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createQueryNameSortedSAMRecords(RECORDS_PER_SLICE - 1,0)),
                         RECORDS_PER_SLICE, 1,
                         new ReferenceContext(0),
                         1, Arrays.asList(RECORDS_PER_SLICE - 1),
@@ -187,7 +181,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 },
                 {
                         // 2 full single-ref slices, one with with RECORDS_PER_SLICE records and one record
-                        new RecordSupplier(CRAMStructureTestHelper.createQueryNameSortedSAMRecords(RECORDS_PER_SLICE + 1,0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createQueryNameSortedSAMRecords(RECORDS_PER_SLICE + 1,0)),
                         RECORDS_PER_SLICE, 2,
                         new ReferenceContext(0),
                         2, Arrays.asList(RECORDS_PER_SLICE, 1),
@@ -196,7 +190,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 {
                         // use a small number of records from multiple (not coordinate-ordered) reference contexts to
                         // force creation of a multi-ref container
-                        new RecordSupplier(Stream.of(
+                        new QuietTestWrapper<>(Stream.of(
                                 CRAMStructureTestHelper.createQueryNameSortedSAMRecords(2,1),
                                 CRAMStructureTestHelper.createQueryNameSortedSAMRecords(2,0),
                                 CRAMStructureTestHelper.createQueryNameSortedSAMRecords(2,1))
@@ -214,7 +208,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleContainerSliceDistribution")
     public void testSingleContainerSliceDistribution(
-            final Supplier<List<SAMRecord>> samRecordSupplier,
+            final QuietTestWrapper<List<SAMRecord>> samRecordSupplier,
             final int readsPerSlice,
             final int slicesPerContainer,
             final ReferenceContext expectedContainerReferenceContext,
@@ -257,21 +251,21 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 // expected slices per container
                 {
                         // this generates two containers since it has two containers worth of records mapped to a single ref
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 2, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 2, 0)),
                         RECORDS_PER_SLICE, 1,
                         2, Arrays.asList(RECORDS_PER_SLICE, RECORDS_PER_SLICE),
                         Arrays.asList(new ReferenceContext(0), new ReferenceContext(0)),
                         Arrays.asList(1, 1)
                 },
                 {
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 3 + 1, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 3 + 1, 0)),
                         RECORDS_PER_SLICE, 2,
                         2, Arrays.asList(RECORDS_PER_SLICE * 2, RECORDS_PER_SLICE+ 1),
                         Arrays.asList(new ReferenceContext(0), new ReferenceContext(0)),
                         Arrays.asList(2, 2)
                 },
                 {
-                        new RecordSupplier(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 4, 0)),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 4, 0)),
                         RECORDS_PER_SLICE, 2,
                         2, Arrays.asList(RECORDS_PER_SLICE * 2, RECORDS_PER_SLICE * 2),
                         Arrays.asList(new ReferenceContext(0), new ReferenceContext(0)),
@@ -280,7 +274,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 {
                         // this generates one container because although it has records mapped to two different reference
                         // contigs, there aren't enough records to reach the minimum single ref threshold
-                        new RecordSupplier(Stream.of(
+                        new QuietTestWrapper<>(Stream.of(
                                 CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE - 1, 0),
                                 CRAMStructureTestHelper.createSAMRecordsMapped(1, 1))
                                 .flatMap(List::stream)
@@ -293,7 +287,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 {
                         // this generates one container because it has some mapped (but not enough to reach the
                         // minimum single ref threshold), and one unmapped
-                        new RecordSupplier(Stream.of(
+                        new QuietTestWrapper<>(Stream.of(
                                 CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE - 1, 0),
                                 CRAMStructureTestHelper.createSAMRecordsUnmapped(1))
                                 .flatMap(List::stream)
@@ -305,7 +299,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 },
                 {
                         // this generates two containers since it has some mapped and one unmapped
-                        new RecordSupplier(Stream.of(
+                        new QuietTestWrapper<>(Stream.of(
                                 CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE * 2, 0),
                                 CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE))
                                 .flatMap(List::stream)
@@ -318,7 +312,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                 {
                         // this generates two containers since it has some mapped, but not enough to emit a single
                         // ref container, and one unmapped, which goes into a second container
-                        new RecordSupplier(Stream.of(
+                        new QuietTestWrapper<>(Stream.of(
                                 CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE / 2, 0),
                                 CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE))
                                 .flatMap(List::stream)
@@ -334,7 +328,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                         // even though we allow 2 slices/container, this generates two containers since it has
                         // some mapped and one unmapped, and we won't emit a second single-ref slice into the
                         // first container once we've emitted the multi-ref slice!
-                        new RecordSupplier(Stream.of(
+                        new QuietTestWrapper<>(Stream.of(
                                 CRAMStructureTestHelper.createSAMRecordsMapped(RECORDS_PER_SLICE / 2, 0),
                                 CRAMStructureTestHelper.createSAMRecordsUnmapped(RECORDS_PER_SLICE))
                                 .flatMap(List::stream)
@@ -353,7 +347,7 @@ public class ContainerFactoryTest extends HtsjdkTest {
                         // use records from multiple (not coordinate-ordered) reference contexts to
                         // force creation of one multi-ref (after name sorting, the first container has a mix of
                         // ref 0 and ref 1), and one single ref container
-                        new RecordSupplier(Stream.of(
+                        new QuietTestWrapper<>(Stream.of(
                                 CRAMStructureTestHelper.createQueryNameSortedSAMRecords(RECORDS_PER_SLICE/2,1),
                                 CRAMStructureTestHelper.createQueryNameSortedSAMRecords(RECORDS_PER_SLICE/2,0),
                                 CRAMStructureTestHelper.createQueryNameSortedSAMRecords(RECORDS_PER_SLICE,1))

--- a/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/ContainerTest.java
@@ -10,6 +10,7 @@ import htsjdk.samtools.cram.common.CramVersions;
 import htsjdk.samtools.cram.common.CRAMVersion;
 import htsjdk.samtools.cram.io.CountingInputStream;
 import htsjdk.samtools.cram.ref.ReferenceContext;
+import htsjdk.samtools.util.QuietTestWrapper;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -27,23 +28,23 @@ public class ContainerTest extends HtsjdkTest {
     private Object[][] singleContainerAlignmentContextData() {
         return new Object[][]{
                 {
-                        CRAMStructureTestHelper.createSAMRecordsMapped(
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(
                                 TEST_RECORD_COUNT,
-                                CRAMStructureTestHelper.REFERENCE_SEQUENCE_ZERO),
+                                CRAMStructureTestHelper.REFERENCE_SEQUENCE_ZERO)),
                         new AlignmentContext(
                                 new ReferenceContext(CRAMStructureTestHelper.REFERENCE_SEQUENCE_ZERO), 1,
                                 TEST_RECORD_COUNT + CRAMStructureTestHelper.READ_LENGTH - 1)
                 },
                 {
-                        CRAMStructureTestHelper.createSAMRecordsMapped(
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsMapped(
                                 TEST_RECORD_COUNT,
-                                CRAMStructureTestHelper.REFERENCE_SEQUENCE_ONE),
+                                CRAMStructureTestHelper.REFERENCE_SEQUENCE_ONE)),
                         new AlignmentContext(
                                 new ReferenceContext(CRAMStructureTestHelper.REFERENCE_SEQUENCE_ONE), 1,
                                 TEST_RECORD_COUNT + CRAMStructureTestHelper.READ_LENGTH - 1)
                 },
                 {
-                        CRAMStructureTestHelper.createSAMRecordsUnmapped(TEST_RECORD_COUNT),
+                        new QuietTestWrapper<>(CRAMStructureTestHelper.createSAMRecordsUnmapped(TEST_RECORD_COUNT)),
                         AlignmentContext.UNMAPPED_UNPLACED_CONTEXT
                 },
         };
@@ -51,8 +52,9 @@ public class ContainerTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleContainerAlignmentContextData")
     public void testSingleContainerAlignmentContext(
-            final List<SAMRecord> samRecords,
+            final QuietTestWrapper<List<SAMRecord>> samRecordsSupplier,
             final AlignmentContext expectedAlignmentContext) {
+        final List<SAMRecord> samRecords = samRecordsSupplier.get();
         final CRAMEncodingStrategy encodingStrategy = new CRAMEncodingStrategy()
                 // in order to set reads/slice to a small number, we must do the same for minimumSingleReferenceSliceSize
                 .setMinimumSingleReferenceSliceSize(samRecords.size())
@@ -85,11 +87,11 @@ public class ContainerTest extends HtsjdkTest {
         allRecords.addAll(CRAMStructureTestHelper.createSAMRecordsUnmapped(TEST_RECORD_COUNT));
 
         return new Object[][]{
-                { bothReferenceSequenceRecords,
+                { new QuietTestWrapper(bothReferenceSequenceRecords),
                         Arrays.asList(
                             CRAMStructureTestHelper.REFERENCE_SEQUENCE_ZERO,
                             CRAMStructureTestHelper.REFERENCE_SEQUENCE_ONE) },
-                { allRecords,
+                { new QuietTestWrapper(allRecords),
                         Arrays.asList(
                                 CRAMStructureTestHelper.REFERENCE_SEQUENCE_ZERO,
                                 CRAMStructureTestHelper.REFERENCE_SEQUENCE_ONE,
@@ -99,8 +101,9 @@ public class ContainerTest extends HtsjdkTest {
 
     @Test(dataProvider = "multiContainerAlignmentContextData")
     public void testMultiContainerAlignmentContext(
-            final List<SAMRecord> samRecords,
+            final QuietTestWrapper<List<SAMRecord>> samRecordsSupplier,
             final List<ReferenceContext> referenceContexts) {
+        final List<SAMRecord> samRecords = samRecordsSupplier.get();
         final CRAMEncodingStrategy encodingStrategy = new CRAMEncodingStrategy()
                 .setSlicesPerContainer(1)
                 .setReadsPerSlice(samRecords.size());
@@ -208,11 +211,11 @@ public class ContainerTest extends HtsjdkTest {
 
         return new Object[][]{
                 {
-                        CRAMStructureTestHelper.createSAMRecordsMapped(TEST_RECORD_COUNT,
-                                CRAMStructureTestHelper.REFERENCE_SEQUENCE_ZERO),
+                        new QuietTestWrapper(CRAMStructureTestHelper.createSAMRecordsMapped(TEST_RECORD_COUNT,
+                                CRAMStructureTestHelper.REFERENCE_SEQUENCE_ZERO)),
                 },
                 {
-                        CRAMStructureTestHelper.createSAMRecordsUnmapped(TEST_RECORD_COUNT),
+                        new QuietTestWrapper(CRAMStructureTestHelper.createSAMRecordsUnmapped(TEST_RECORD_COUNT)),
                 },
 
                 // The records in these next two tests are unmapped but only "half" placed: they have either
@@ -231,7 +234,8 @@ public class ContainerTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getRecordsTestCases")
-    public void getRecordsTest(final List<SAMRecord> originalRecords) {
+    public void getRecordsTest(final QuietTestWrapper<List<SAMRecord>> originalRecordsSupplier) {
+        final List<SAMRecord> originalRecords = originalRecordsSupplier.get();
         final long dummyByteOffset = 0;
         final ContainerFactory containerFactory = new ContainerFactory(
                 CRAMStructureTestHelper.SAM_FILE_HEADER,

--- a/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
@@ -246,15 +246,11 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
     }
 
     // test case wrapper to reduce spammy TestNG output during test execution
-    private static class SAMSequenceDictionaryWrapper {
-        final SAMSequenceDictionary dictionary;
-        public SAMSequenceDictionaryWrapper(final SAMSequenceDictionary dictionary) {
-            this.dictionary = dictionary;
-        }
-
+    private static class SAMSequenceDictionaryWrapper extends QuietTestWrapper<SAMSequenceDictionary>{
+        public SAMSequenceDictionaryWrapper(final SAMSequenceDictionary dictionary) { super(dictionary);}
         @Override
         public String toString() {
-            return String.format("%d/%d", dictionary.size(),dictionary.getReferenceLength());
+            return String.format("%d/%d", get().size(),get().getReferenceLength());
         }
     }
 
@@ -263,7 +259,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
                            final boolean withDescriptions, final int defaultBpl,
                            final int minBpl, final int maxBpl, final int seed, final boolean gzipped)
             throws IOException, GeneralSecurityException, URISyntaxException {
-        final SAMSequenceDictionary dictionary = dictionaryWrapper.dictionary;
+        final SAMSequenceDictionary dictionary = dictionaryWrapper.get();
         final Map<String, byte[]> bases = new LinkedHashMap<>(dictionary.getSequences().size());
         final Map<String, Integer> bpl = new LinkedHashMap<>(dictionary.getSequences().size());
         final Random rdn = new Random(seed);

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedInputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedInputStreamTest.java
@@ -15,7 +15,6 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.zip.Inflater;
 
 public class BlockCompressedInputStreamTest extends HtsjdkTest {
@@ -156,7 +155,7 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
         tempFile.deleteOnExit();
         final List<String> linesWritten = writeTempBlockCompressedFileForInflaterTest(tempFile);
         // wrap our expected output in a lambda to prevent massive string expansion of the test params during test execution
-        final Supplier<List<String>> expectedOutputSupplier = () -> linesWritten;
+        final QuietTestWrapper<List<String>> expectedOutputSupplier = new QuietTestWrapper<>(linesWritten);
 
         final InflaterFactory countingInflaterFactory = new CountingInflaterFactory();
 
@@ -176,7 +175,7 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
 
     @Test(dataProvider = "customInflaterInput", singleThreaded = true)
     public void testCustomInflater(final CheckedExceptionInputStreamSupplier bcisSupplier,
-                                   final Supplier<List<String>> expectedOutputSupplier,
+                                   final QuietTestWrapper<List<String>> expectedOutputSupplier,
                                    final int expectedInflateCalls,
                                    final InflaterFactory customDefaultInflaterFactory) throws Exception
     {

--- a/src/test/java/htsjdk/samtools/util/QuietTestWrapper.java
+++ b/src/test/java/htsjdk/samtools/util/QuietTestWrapper.java
@@ -1,0 +1,19 @@
+package htsjdk.samtools.util;
+
+import java.util.function.Supplier;
+
+/**
+ * Wrapper class used to suppress toString() serialization of large test cases such as
+ * List&lt;SAMRecord&gt;, which when emitted into the CI server output log result in
+ * excessive test output, exceeding the CI server's log output size.
+ */
+public class QuietTestWrapper<T> implements Supplier<T> {
+    final T testData;
+
+    public QuietTestWrapper(final T testCaseData) { this.testData = testCaseData; }
+
+    @Override public T get() { return testData; }
+
+    @Override public String toString() { return "Output suppressed by QuietWrapper"; }
+}
+


### PR DESCRIPTION
We're close to exceeding the the travis threshold for maximum test log size, since TestNG serialize test method arguments, and they wind up in the travis log. I have branches that add new tests that are failing because of this, so we're pretty close to the max already.

If a data provider generates lots of test data (i.e., `List<SAMRecord>`), the log gets pretty big. This PR adds a new class to use with test methods that have arguments with large serialized representation; adds it to a couple of verbose tests; and updates some existing test that already used a similar strategy. 

Now instead of seeing megabytes of this:

![image](https://user-images.githubusercontent.com/10062863/109864721-3044f780-7c31-11eb-8178-f1ac77a9166b.png)


You see this:
![image](https://user-images.githubusercontent.com/10062863/109864542-f542c400-7c30-11eb-87eb-56580407890f.png)

