### PR TITLE
Added GVCF mode for VariantContext type determination

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1480,7 +1480,7 @@ public class VariantContext implements Feature, Serializable {
         // If all alt alleles are NON_REF alleles and ignoreNonRef is true, type will still be null. Therefore, if we
         // have only seen NON_REFs, choose SYMBOLIC
         if (type == null && nonRefAlleleFound) {
-            return Type.SYMBOLIC;
+            return Type.NO_VARIATION;
         }
         return type;
     }

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -104,6 +104,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Allele TA = Allele.create("TA");
         Allele TC = Allele.create("TC");
         Allele symbolic = Allele.create("<FOO>");
+        Allele nonRef = Allele.create(Allele.NON_REF_STRING, false);
 
         // test REF
         List<Allele> alleles = Arrays.asList(Tref);
@@ -170,6 +171,43 @@ public class VariantContextUnitTest extends VariantBaseTest {
         alleles = Arrays.asList(Tref, symbolic);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(), VariantContext.Type.SYMBOLIC);
+
+        // test ignoreNonRef
+        alleles = Arrays.asList(Aref, nonRef);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(false), VariantContext.Type.SYMBOLIC);
+
+        alleles = Arrays.asList(Aref, nonRef, symbolic);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(false), VariantContext.Type.SYMBOLIC);
+
+        alleles = Arrays.asList(Aref, nonRef, symbolic);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.SYMBOLIC);
+
+        alleles = Arrays.asList(Aref, nonRef);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.SYMBOLIC);
+
+        alleles = Arrays.asList(Aref, C, nonRef);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.SNP);
+
+        alleles = Arrays.asList(Aref, nonRef, C);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.SNP);
+
+        alleles = Arrays.asList(Aref, AT, nonRef);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.INDEL);
+
+        alleles = Arrays.asList(Aref, C, TC, nonRef);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.MIXED);
+
+        alleles = Arrays.asList(Aref, C, symbolic, nonRef);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.MIXED);
     }
 
     @Test

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -108,109 +108,190 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
         // test REF
         List<Allele> alleles = Arrays.asList(Tref);
+        List<Allele> allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         VariantContext vc = snpBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.NO_VARIATION);
+        VariantContext vcWithNonRef = snpBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        VariantContext.Type expectedType = VariantContext.Type.NO_VARIATION;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         // test SNPs
         alleles = Arrays.asList(Tref, A);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = snpBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.SNP);
+        vcWithNonRef = snpBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.SNP;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(Tref, A, C);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = snpBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.SNP);
+        vcWithNonRef = snpBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.SNP;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         // test MNPs
         alleles = Arrays.asList(ACref, TA);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = snpBuilder.alleles(alleles).stop(snpLocStop+1).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.MNP);
+        vcWithNonRef = snpBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.MNP;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(ATCref, CAT, Allele.create("GGG"));
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop+2).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.MNP);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.MNP;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         // test INDELs
         alleles = Arrays.asList(Aref, ATC);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.INDEL);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.INDEL;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(ATCref, A);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop+2).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.INDEL);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.INDEL;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(Tref, TA, TC);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.INDEL);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.INDEL;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(ATCref, A, AC);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop+2).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.INDEL);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.INDEL;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(ATCref, A, Allele.create("ATCTC"));
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop+2).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.INDEL);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.INDEL;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         // test MIXED
         alleles = Arrays.asList(TAref, T, TC);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop+1).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.MIXED);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.MIXED;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(TAref, T, AC);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop+1).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.MIXED);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.MIXED;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(ACref, ATC, AT);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop+1).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.MIXED);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.MIXED;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         alleles = Arrays.asList(Aref, T, symbolic);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.MIXED);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.MIXED;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
 
         // test SYMBOLIC
         alleles = Arrays.asList(Tref, symbolic);
+        allelesWithNonRef = new ArrayList<>(alleles);
+        allelesWithNonRef.add(Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(), VariantContext.Type.SYMBOLIC);
+        vcWithNonRef = basicBuilder.alleles(allelesWithNonRef).stop(snpLocStop).make();
+        expectedType = VariantContext.Type.SYMBOLIC;
+        Assert.assertEquals(vc.getType(), expectedType);
+        Assert.assertEquals(vcWithNonRef.getType(true), expectedType);
+    }
 
-        // test ignoreNonRef
-        alleles = Arrays.asList(Aref, nonRef);
+    @Test
+    public void testDetermineTypesIgnoringNonRef() {
+        Allele AT = Allele.create("AT");
+        Allele TC = Allele.create("TC");
+        Allele symbolic = Allele.create("<FOO>");
+
+        List<Allele> alleles = Arrays.asList(Allele.REF_A, Allele.NON_REF_ALLELE);
+        VariantContext vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(false), VariantContext.Type.SYMBOLIC);
+
+        alleles = Arrays.asList(Allele.REF_A, Allele.NON_REF_ALLELE, symbolic);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(false), VariantContext.Type.SYMBOLIC);
 
-        alleles = Arrays.asList(Aref, nonRef, symbolic);
-        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(false), VariantContext.Type.SYMBOLIC);
-
-        alleles = Arrays.asList(Aref, nonRef, symbolic);
+        alleles = Arrays.asList(Allele.REF_A, Allele.NON_REF_ALLELE, symbolic);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(true), VariantContext.Type.SYMBOLIC);
 
-        alleles = Arrays.asList(Aref, nonRef);
+        alleles = Arrays.asList(Allele.REF_A, Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(true), VariantContext.Type.SYMBOLIC);
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.NO_VARIATION);
 
-        alleles = Arrays.asList(Aref, C, nonRef);
-        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
-        Assert.assertEquals(vc.getType(true), VariantContext.Type.SNP);
-
-        alleles = Arrays.asList(Aref, nonRef, C);
+        alleles = Arrays.asList(Allele.REF_A, Allele.ALT_C, Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(true), VariantContext.Type.SNP);
 
-        alleles = Arrays.asList(Aref, AT, nonRef);
+        alleles = Arrays.asList(Allele.REF_A, Allele.NON_REF_ALLELE, Allele.ALT_C);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.SNP);
+
+        alleles = Arrays.asList(Allele.REF_A, AT, Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(true), VariantContext.Type.INDEL);
 
-        alleles = Arrays.asList(Aref, C, TC, nonRef);
+        alleles = Arrays.asList(Allele.REF_A, Allele.ALT_C, TC, Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(true), VariantContext.Type.MIXED);
 
-        alleles = Arrays.asList(Aref, C, symbolic, nonRef);
+        alleles = Arrays.asList(Allele.REF_A, Allele.ALT_C, symbolic, Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(true), VariantContext.Type.MIXED);
 
         // Assure that the caching of the variant type is not persistent between ignoreNonRef being true and false
-        alleles = Arrays.asList(Aref, C, nonRef);
+        alleles = Arrays.asList(Allele.REF_A, Allele.ALT_C, Allele.NON_REF_ALLELE);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(), VariantContext.Type.MIXED);
         Assert.assertEquals(vc.getType(true), VariantContext.Type.SNP);

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -208,6 +208,13 @@ public class VariantContextUnitTest extends VariantBaseTest {
         alleles = Arrays.asList(Aref, C, symbolic, nonRef);
         vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
         Assert.assertEquals(vc.getType(true), VariantContext.Type.MIXED);
+
+        // Assure that the caching of the variant type is not persistent between ignoreNonRef being true and false
+        alleles = Arrays.asList(Aref, C, nonRef);
+        vc = basicBuilder.alleles(alleles).stop(snpLocStop).make();
+        Assert.assertEquals(vc.getType(), VariantContext.Type.MIXED);
+        Assert.assertEquals(vc.getType(true), VariantContext.Type.SNP);
+        Assert.assertEquals(vc.getType(), VariantContext.Type.MIXED);
     }
 
     @Test


### PR DESCRIPTION
Related to https://github.com/broadinstitute/gatk/issues/7111

- Usually, NON_REF alleles will be considered SYMBOLIC. Therefore, if a VariantContext contains the alleles `A*,C,<NON_REF>`, the resulting type would be MIXED. For GVCF files, however, it would be helpful that this would be considered a SNP. When true is passed as the optional argument `ignoreNonRef` to `VariantContext.getType()` NON_REF alleles will be ignored for type determination. If only NON_REF alleles are seen at a given site, the type will remain to be SYMBOLIC.
- Default behavior will not change. This type determination is only performed if `true` is passed for the optional `ignoreNonRef` argument to `VariantContext.getType()`
- Moderate refactoring of VariantContext type determination
  - This was necessary because the type caching needs to distinguish between ignoreNonRef being true or false
  - Changed return type of `determineType` and `determinePolymorphicType` from `void` to `VariantContext.Type`, otherwise multiple code branches would be necessary depending on which caching variable to set
  - Added unit test to catch if the cache separation works
- Added unit tests
