### PR TITLE
Beta implementation of Bundles.

### DIFF
--- a/src/main/java/htsjdk/beta/io/IOPathUtils.java
+++ b/src/main/java/htsjdk/beta/io/IOPathUtils.java
@@ -1,0 +1,82 @@
+package htsjdk.beta.io;
+
+import htsjdk.io.HtsPath;
+import htsjdk.io.IOPath;
+import htsjdk.samtools.util.RuntimeIOException;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class IOPathUtils {
+
+    /**
+     * Create a temporary file using a given name prefix and name suffix and return a {@link java.nio.file.Path}.
+     * @param prefix
+     * @param suffix
+     * @return temp File that will be deleted on exit
+     * @throws IOException
+     */
+    public static IOPath createTempPath(final String prefix, final String suffix) {
+        try {
+            final File tempFile = File.createTempFile(prefix, suffix);
+            tempFile.deleteOnExit();
+            return new HtsPath(tempFile.getAbsolutePath());
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /**
+     * Convert a Path to an IOPath, returning null if input was null.
+     *
+     * @param toConvert Path to convert to IOPath
+     * @return a Path, or null if the input was null.
+     */
+    public static IOPath toIOPath(Path toConvert){
+        return null == toConvert ? null : new HtsPath(toConvert.toUri().toString());
+    }
+
+    /**
+     * Return the entire contents of an IOPath as a string.
+     *
+     * @param ioPath
+     * @return a UTF-8 string representation of the file contents
+     */
+    public static String getStringFromPath(final IOPath ioPath) {
+        try {
+            final StringWriter stringWriter = new StringWriter();
+            //TODO: the UTF-8 encoding of these should be codified somewhere else...
+            Files.lines(ioPath.toPath(), StandardCharsets.UTF_8).forEach(
+                    line -> {
+                        stringWriter.write(line);
+                        stringWriter.append("\n");
+                    });
+            return stringWriter.toString();
+        } catch (final IOException e) {
+            throw new RuntimeException(
+                    String.format("Failed to read from: %s", ioPath.getRawInputString()),
+                    e);
+        }
+    }
+
+    /**
+     * Write a String to an IOPath.
+     *
+     * @param ioPath path where contents should be written
+     * @param contents a UTF-8 string to be written
+     */
+    public static void writeStringToPath(final IOPath ioPath, final String contents) {
+        try (final BufferedOutputStream bos = new BufferedOutputStream(ioPath.getOutputStream())) {
+            bos.write(contents.getBytes());
+        } catch (final IOException e) {
+            throw new RuntimeException(
+                    String.format("Failed to write to: %s", ioPath.getRawInputString()),
+                    e);
+        }
+    }
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/Bundle.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/Bundle.java
@@ -1,0 +1,128 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.io.IOPath;
+import htsjdk.utils.ValidationUtils;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An immutable collection of related resources (a primary resource, such as "reads", "variants",
+ * "features", or "reference"), plus zero or more related companion resources ("index", "dictionary",
+ * "MD5", etc.).
+ *
+ * Each resource in a {@link Bundle} is represented by a {@link BundleResource}, which in turn describes
+ * a binding mechanism for that resource (such as an {@link IOPath} in the case of a URI, Path or file
+ * name; or an input or output stream), and a "content type" string that is unique within that
+ * {@link Bundle}. Any string can be used as a content type. Predefined content type strings are defined
+ * in {@link BundleResourceType}.
+ *
+ * A {@link Bundle} must have one resource that is designated as the "primary" resource, specified
+ * by a content type string. A resource with "primary content type" is is guaranteed to be present in
+ * the {@link Bundle}.
+ *
+ * Since each resource in a {@link Bundle} has a content type that is unique within that {@link Bundle},
+ * a Bundle can not be used to represent a list of similar items where each item is equivalent to
+ * each other item (i.e., a list of shards, where each shard in the list is equivalent to each other
+ * shard). Rather {@link Bundle}s are used to represent related resources where each resource has a unique
+ * character or role  relative to the other resources (i.e., a "reads" resource and a corresponding "index"
+ * resource).
+ *
+ * Bundles that contain only serializable ({@link IOPathResource}) resources may be serialized to, and
+ * deserialized from JSON.
+ */
+public class Bundle implements Iterable<BundleResource>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String, BundleResource> resources = new LinkedHashMap<>();
+    private final String primaryContentType;
+
+    /**
+     * @param primaryContentType the content type of the primary resource in this bundle. may not be null.
+     *                           a resource with this content type must be included in resources
+     * @param resources resources to include in this bundle, may not be null or empty
+     */
+    public Bundle(final String primaryContentType, final Collection<BundleResource> resources) {
+        ValidationUtils.nonNull(primaryContentType, "primary content type");
+        ValidationUtils.validateArg(primaryContentType.length() > 0,
+                "A non-zero length primary resource content type must be provided");
+        ValidationUtils.nonNull(resources, "resource collection");
+        ValidationUtils.nonEmpty(resources,"resource collection");
+
+        resources.forEach(r -> {
+            if (null != this.resources.putIfAbsent(r.getContentType(), r)) {
+                throw new IllegalArgumentException(
+                        String.format("Attempt to add a duplicate resource for bundle key: %s", r.getContentType()));
+            }
+        });
+        this.primaryContentType = primaryContentType;
+
+        // validate that the primary resource actually exists in the resources
+        if (!this.resources.containsKey(primaryContentType)) {
+            throw new IllegalArgumentException(
+                    String.format("Primary resource content type %s is not present in the resource list",
+                            primaryContentType));
+        }
+    }
+
+    /**
+     * Return the BundleResource for the provided targetContentType string.
+     *
+     * @param targetContentType the content type to be retrieved from the bundle
+     * @return an Optional<BundleResource> that contains the targetContent type
+     */
+    public Optional<BundleResource> get(final String targetContentType) {
+        ValidationUtils.nonNull(targetContentType, "target content string");
+        return Optional.ofNullable(resources.get(targetContentType));
+    }
+
+    /**
+     * Return the primary content type for this bundle.
+     * @return the primary content type for this bundle
+     */
+    public String getPrimaryContentType() { return primaryContentType; }
+
+    /**
+     * Return the primary {@link BundleResource} for this bundle.
+     * @return the primary {@link BundleResource} for this bundle.
+     */
+    public BundleResource getPrimaryResource() {
+        return resources.get(primaryContentType);
+    }
+
+    /**
+     * Get the collection of resources from this {@link Bundle}.
+     */
+    public Collection<BundleResource> getResources() {
+        return resources.values();
+    }
+
+    /**
+     * Obtain an iterator of BundleResources for this bundle.
+     * @return iterator of BundleResources for this bundle.
+     */
+    @Override
+    public Iterator<BundleResource> iterator() { return resources.values().iterator(); }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Bundle that = (Bundle) o;
+
+        if (!resources.equals(that.resources)) return false;
+        return primaryContentType.equals(that.primaryContentType);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = resources.hashCode();
+        result = 31 * result + primaryContentType.hashCode();
+        return result;
+    }
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/BundleBuilder.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/BundleBuilder.java
@@ -1,0 +1,69 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.utils.ValidationUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Bundle}s.
+ */
+public final class BundleBuilder {
+
+    private final List<BundleResource> resources = new ArrayList<>();
+    private String primaryResource;
+
+    /**
+     * Start a new bundle builder.
+     */
+    public BundleBuilder() { }
+
+    /**
+     * Add the primary resource to the bundle. The content type of resource will be the bundle's primary key.
+     *
+     * @param resource the resource which will be the primary resource for the bundle
+     * @return this {@link BundleBuilder}
+     */
+    public BundleBuilder addPrimary(final BundleResource resource) {
+        ValidationUtils.nonNull(resource, "resource");
+        if (primaryResource != null) {
+                throw new IllegalStateException(String.format(
+                        "Can't add primary resource %s to a bundle that already has primary resource %s",
+                        resource.getContentType(),
+                        primaryResource));
+        }
+        primaryResource = resource.getContentType();
+        addSecondary(resource);
+        return this;
+    }
+
+    /**
+     * Add a (non-primary) resource to the bundle.
+     *
+     * @param resource the resource to be added
+     * @return this {@link BundleBuilder}
+     */
+    public BundleBuilder addSecondary(final BundleResource resource) {
+        ValidationUtils.nonNull(resource, "resource");
+        resources.add(resource);
+        return this;
+    }
+
+    /**
+     * Create a bundle from accumulated builder state, and reset the builder state. At least one (primary)
+     * resource must have been previously added to create a valid bundle.
+     *
+     * @return a {@link Bundle}.
+     */
+    public Bundle build() {
+        if (primaryResource == null) {
+            throw new IllegalStateException("A bundle must have a primary resource.");
+        }
+        final Bundle bundle = new Bundle(primaryResource, resources);
+        primaryResource = null;
+        resources.clear();
+        return bundle;
+    }
+}
+
+

--- a/src/main/java/htsjdk/beta/plugin/bundle/BundleJSON.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/BundleJSON.java
@@ -1,0 +1,213 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.io.HtsPath;
+import htsjdk.io.IOPath;
+import htsjdk.samtools.util.Log;
+import htsjdk.utils.ValidationUtils;
+import mjson.Json;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+//TODO: We need to publish the used for these Bundles schema once its finalized.
+
+/**
+ * Methods for serializing and deserializing Bundles to and from JSON strings.
+ */
+public class BundleJSON {
+    public static final String BUNDLE_EXTENSION = ".json";
+    private static final Log LOG = Log.getInstance(BundleJSON.class);
+
+    public static final String JSON_PROPERTY_SCHEMA_NAME      = "schemaName";
+    public static final String JSON_PROPERTY_SCHEMA_VERSION   = "schemaVersion";
+    public static final String JSON_PROPERTY_PRIMARY          = "primary";
+    public static final String JSON_PROPERTY_PATH             = "path";
+    public static final String JSON_PROPERTY_SUB_CONTENT_TYPE = "subtype";
+    public static final String JSON_SCHEMA_NAME               = "htsbundle";
+    public static final String JSON_SCHEMA_VERSION            = "0.1.0"; // TODO: bump this to 1.0.0
+
+    final private static Set<String> TOP_LEVEL_PROPERTIES = Collections.unmodifiableSet(
+            new HashSet<String>() {{
+                add(JSON_PROPERTY_SCHEMA_NAME);
+                add(JSON_PROPERTY_SCHEMA_VERSION);
+                add(JSON_PROPERTY_PRIMARY);
+        }});
+
+    /**
+     * Serialize this bundle to a JSON string representation. All resources in the bundle must
+     * be {@link IOPathResource}s for serialization to succeed. Stream resources cannot be serialized.
+     *
+     * @param bundle the {@link Bundle} to serialize to JSON
+     * @return a JSON string representation of this bundle
+     * @throws IllegalArgumentException if any resource in bundle is not an IOPathResources.
+     */
+    public static String toJSON(final Bundle bundle) {
+        final Json outerJSON = Json.object()
+                .set(JSON_PROPERTY_SCHEMA_NAME, JSON_SCHEMA_NAME)
+                .set(JSON_PROPERTY_SCHEMA_VERSION, JSON_SCHEMA_VERSION)
+                .set(JSON_PROPERTY_PRIMARY, bundle.getPrimaryContentType());
+
+        bundle.forEach(bundleResource -> {
+            final Optional<IOPath> resourcePath = bundleResource.getIOPath();
+            if (!resourcePath.isPresent()) {
+                throw new IllegalArgumentException("Bundle resource requires a valid path to be serialized");
+            }
+
+            // generate JSON for each bundle resource
+            final Json resourceJSON = Json.object().set(JSON_PROPERTY_PATH, resourcePath.get().getURIString());
+            if (bundleResource.getContentSubType().isPresent()) {
+                resourceJSON.set(JSON_PROPERTY_SUB_CONTENT_TYPE, bundleResource.getContentSubType().get());
+            }
+            outerJSON.set(bundleResource.getContentType(), resourceJSON);
+        });
+
+        return prettyPrintJSON(outerJSON);
+    }
+
+    /**
+     * Create a Bundle from jsonString.
+     *
+     * @param jsonString a valid JSON string conforming to the bundle schema
+     * @return a {@link Bundle} created from jsonString
+     */
+    public static Bundle toBundle(final String jsonString) {
+        return toBundle(ValidationUtils.nonEmpty(jsonString, "resource list"), HtsPath::new);
+    }
+
+    /**
+     * Create a Bundle from jsonString using a custom class that implements {@link IOPath} for all resources.
+     *
+     * @param jsonString a valid JSON string conforming to the bundle schema
+     * @param ioPathConstructor a function that takes a string and returns an IOPath-derived class of type <T>
+     * @param <T> the IOPath-derived type to use for IOPathResources
+     * @return  a newly created {@link Bundle}
+     */
+    public static <T extends IOPath> Bundle toBundle(
+            final String jsonString,
+            final Function<String, T> ioPathConstructor) {
+        ValidationUtils.nonEmpty(jsonString, "JSON string");
+        ValidationUtils.nonNull(ioPathConstructor, "IOPath-derived class constructor");
+
+        final List<BundleResource> resources  = new ArrayList<>();
+        String primaryContentType;
+
+        try {
+            final Json jsonDocument = Json.read(jsonString);
+            if (jsonDocument == null || jsonString.length() < 1) {
+                throw new IllegalArgumentException(
+                        String.format("JSON file parsing failed %s", jsonString));
+            }
+
+            // validate the schema name
+            final String schemaName = getPropertyAsString(JSON_PROPERTY_SCHEMA_NAME, jsonDocument);
+            if (!schemaName.equals(JSON_SCHEMA_NAME)) {
+                throw new IllegalArgumentException(
+                        String.format("Expected bundle schema name %s but found %s", JSON_SCHEMA_NAME, schemaName));
+            }
+
+            // validate the schema version
+            final String schemaVersion = getPropertyAsString(JSON_PROPERTY_SCHEMA_VERSION, jsonDocument);
+            if (!schemaVersion.equals(JSON_SCHEMA_VERSION)) {
+                throw new IllegalArgumentException(String.format("Expected bundle schema version %s but found %s",
+                        JSON_SCHEMA_VERSION, schemaVersion));
+            }
+            primaryContentType = getPropertyAsString(JSON_PROPERTY_PRIMARY, jsonDocument);
+
+            jsonDocument.asJsonMap().forEach((String contentType, Json jsonDoc) -> {
+                if (!TOP_LEVEL_PROPERTIES.contains(contentType)) {
+                    final Json subContentType = jsonDoc.at(JSON_PROPERTY_SUB_CONTENT_TYPE);
+                    final IOPathResource ioPathResource = new IOPathResource(
+                            ioPathConstructor.apply(getPropertyAsString(JSON_PROPERTY_PATH, jsonDoc)),
+                            contentType,
+                            subContentType == null ?
+                                    null :
+                                    getPropertyAsString(JSON_PROPERTY_SUB_CONTENT_TYPE, jsonDoc));
+                    resources.add(ioPathResource);
+                }
+            });
+            if (resources.isEmpty()) {
+                LOG.warn("Empty resource bundle found: ", jsonString);
+            }
+        } catch (Json.MalformedJsonException | java.lang.UnsupportedOperationException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return new Bundle(primaryContentType, resources);
+    }
+
+    // Simple pretty-printer to produce indented JSON strings from a Json document. Note that
+    // this is not generalized and will only work on Json documents produced by BundleJSON::toJSON.
+    private static String prettyPrintJSON(final Json jsonDocument) {
+        final StringBuilder sb = new StringBuilder();
+        final String TOP_LEVEL_PROPERTY_FORMAT = "  \"%s\":\"%s\"";
+
+        try {
+            sb.append("{\n");
+
+            // schema name
+            final String schemaName = getPropertyAsString(JSON_PROPERTY_SCHEMA_NAME, jsonDocument);
+            sb.append(String.format(TOP_LEVEL_PROPERTY_FORMAT, JSON_PROPERTY_SCHEMA_NAME, schemaName));
+            sb.append(",\n");
+
+            // schema version
+            final String schemaVersion = getPropertyAsString(JSON_PROPERTY_SCHEMA_VERSION, jsonDocument);
+            sb.append(String.format(TOP_LEVEL_PROPERTY_FORMAT, JSON_PROPERTY_SCHEMA_VERSION, schemaVersion));
+            sb.append(",\n");
+
+            // primary
+            final String primary = getPropertyAsString(JSON_PROPERTY_PRIMARY, jsonDocument);
+            sb.append(String.format(TOP_LEVEL_PROPERTY_FORMAT, JSON_PROPERTY_PRIMARY, primary));
+            sb.append(",\n");
+
+            final List<String> formattedResources = new ArrayList<>();
+            jsonDocument.asJsonMap().forEach((String contentType, Json jsonDoc) -> {
+                if (!TOP_LEVEL_PROPERTIES.contains(contentType)) {
+                    final Json subContentType = jsonDoc.at(JSON_PROPERTY_SUB_CONTENT_TYPE);
+                    final StringBuilder resSB = new StringBuilder();
+                    if (subContentType != null) {
+                        resSB.append(String.format("{\"%s\":\"%s\",\"%s\":\"%s\"}",
+                                JSON_PROPERTY_PATH,
+                                getPropertyAsString(JSON_PROPERTY_PATH, jsonDoc),
+                                JSON_PROPERTY_SUB_CONTENT_TYPE,
+                                getPropertyAsString(JSON_PROPERTY_SUB_CONTENT_TYPE, jsonDoc)));
+                    } else {
+                        resSB.append(String.format("{\"%s\":\"%s\"}",
+                                JSON_PROPERTY_PATH,
+                                getPropertyAsString(JSON_PROPERTY_PATH, jsonDoc)));
+                    }
+                    formattedResources.add(String.format("  \"%s\":%s", contentType, resSB.toString()));
+                }
+            });
+            sb.append(formattedResources.stream().collect(Collectors.joining(",\n", "", "\n")));
+            sb.append("}\n");
+        } catch (Json.MalformedJsonException | java.lang.UnsupportedOperationException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return sb.toString();
+    }
+
+    // return the value of propertyName from jsonDocument as a String value
+    private static String getPropertyAsString(final String propertyName, final Json jsonDocument) {
+        final Json propertyValue = jsonDocument.at(propertyName);
+        if (propertyValue == null) {
+            throw new IllegalArgumentException(
+                    String.format("JSON bundle is missing the required property %s (%s)",
+                            propertyName,
+                            jsonDocument.toString()));
+        } else if (!propertyValue.isString()) {
+            throw new IllegalArgumentException(
+                    String.format("Expected string value for bundle property %s but found %s",
+                            propertyName,
+                            propertyValue.toString()));
+        }
+        return propertyValue.asString();
+    }
+
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/BundleResource.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/BundleResource.java
@@ -1,0 +1,62 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.io.IOPath;
+import htsjdk.samtools.seekablestream.SeekableStream;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Optional;
+
+/**
+ * Interface defined for bundle resource objects that may be included in a {@link Bundle}.
+ */
+public interface BundleResource {
+    /**
+     * @return the display name for this resource
+     */
+    String getDisplayName();
+
+    /**
+     * @return the content type for this resource
+     */
+    String getContentType();
+
+    /**
+     * @return the content subtype for this resource, or Optional.empty if not present
+     */
+    Optional<String> getContentSubType();
+
+    /**
+     * @return an IOPath for this resource, or Optional.empty if not present
+     */
+    Optional<IOPath> getIOPath();
+
+    /**
+     * @return an {@link InputStream} for this resource, or Optional.empty if {@link
+     * BundleResource#isInput()} is false for this resource
+     */
+    Optional<InputStream> getInputStream();
+
+    /**
+     * @return an {@link OutputStream} for this resource, or Optional.empty if {@link
+     * BundleResource#isOutput()} is false for this resource
+     */
+    Optional<OutputStream> getOutputStream();
+
+    /**
+     * @return an {@link SeekableStream} for this resource, or Optional.empty if this is
+     * an not an {@link BundleResource#isInput()}, or is an InputResource for which
+     * no {@link SeekableStream} can be obtained
+     */
+    Optional<SeekableStream> getSeekableStream();
+
+    /**
+     * @return true if an InputStream can be obtained via {@link #getInputStream()} on this resource
+     */
+    boolean isInput();
+
+    /**
+     * @return true if an OutputStream can be obtained via {@link #getOutputStream()} on this resource
+     */
+    boolean isOutput();
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/BundleResourceBase.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/BundleResourceBase.java
@@ -1,0 +1,102 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.io.IOPath;
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.utils.ValidationUtils;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * Base class for {@link BundleResource} implementations.
+ */
+public abstract class BundleResourceBase implements BundleResource, Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String displayName;
+    private final String contentType;
+    private final String contentSubType;
+
+    /**
+     *
+     * @param displayName A user-recognizable name for this resource. Used for error messages. May not be null or
+     *                    0 length.
+     * @param contentType The content type for this resource. Can be any string, but it must be unique within a
+     *                    given bundle. May not be null or zero length.
+     * @param contentSubType The (optional) content subtype for this resource. Can be any string, i.e, "BAM" for
+     *                       a resource with content type "READS". Predefined content subtype strings are defined
+     *                       in {@link BundleResourceType}.
+     */
+    public BundleResourceBase(
+            final String displayName,
+            final String contentType,
+            final String contentSubType) {
+        ValidationUtils.nonEmpty(displayName, "display name");
+        ValidationUtils.nonEmpty(contentType, "content type");
+        this.displayName = displayName;
+        this.contentType = contentType;
+        this.contentSubType = contentSubType;
+    }
+
+    @Override
+    public String getDisplayName() { return displayName; }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public Optional<String> getContentSubType() {
+        return Optional.ofNullable(contentSubType);
+    }
+
+    @Override
+    public Optional<IOPath> getIOPath() { return Optional.empty(); }
+
+    @Override
+    public Optional<InputStream> getInputStream() { return Optional.empty(); }
+
+    @Override
+    public Optional<OutputStream> getOutputStream() { return Optional.empty(); }
+
+    @Override
+    public Optional<SeekableStream> getSeekableStream() { return Optional.empty(); }
+
+    @Override
+    public boolean isInput() { return false; }
+
+    @Override
+    public boolean isOutput() { return false; }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "%s (%s): %s/%s",
+                getClass().getSimpleName(),
+                getDisplayName(),
+                getContentType(),
+                getContentSubType().orElse("NONE"));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BundleResource)) return false;
+
+        BundleResourceBase that = (BundleResourceBase) o;
+
+        if (!displayName.equals(that.displayName)) return false;
+        if (!contentType.equals(that.contentType)) return false;
+        return contentSubType != null ? contentSubType.equals(that.contentSubType) : that.contentSubType == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = displayName.hashCode();
+        result = 31 * result + contentType.hashCode();
+        result = 31 * result + (contentSubType != null ? contentSubType.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/BundleResourceType.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/BundleResourceType.java
@@ -1,0 +1,39 @@
+package htsjdk.beta.plugin.bundle;
+
+/**
+ * Namespace for a standard constants to specify content type and content subtype in resources in a {@link Bundle}.
+ */
+public class BundleResourceType {
+
+    /**
+     * predefined content types
+     */
+    public static final String READS = "READS";
+    public static final String LINEAR_REFERENCE = "LINEAR_REFERENCE";
+    public static final String REFERENCE_DICTIONARY = "REFERENCE_DICTIONARY";
+    public static final String VARIANTS = "VARIANTS";
+    public static final String FEATURES = "FEATURES";
+    public static final String READS_INDEX = "READS_INDEX";
+
+    /**
+     * predefined content subtypes
+     */
+    public static final String SUB_TYPE_UNKNOWN = "UNKNOWN";
+
+    /**
+     * content subtypes for content type {@link BundleResourceType#READS}
+     */
+    public static final String READS_SAM = "SAM";
+    public static final String READS_BAM = "BAM";
+    public static final String READS_CRAM = "CRAM";
+    public static final String READS_SRA = "SRA";
+    public static final String READS_HTSGET_BAM = "HTSGET_BAM";
+
+    /**
+     * content subtypes for content type {@link BundleResourceType#READS_INDEX}
+     */
+    public static final String READS_INDEX_BAI = "BAI";
+    public static final String READS_INDEX_CRAI = "CRAI";
+    public static final String READS_INDEX_CSI = "CSI";
+
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/IOPathResource.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/IOPathResource.java
@@ -1,0 +1,86 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.io.IOPath;
+import htsjdk.samtools.seekablestream.SeekablePathStream;
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.RuntimeIOException;
+import htsjdk.utils.ValidationUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * An bundle resource backed by an {@link IOPath}.
+ */
+public class IOPathResource extends BundleResourceBase {
+    private static final long serialVersionUID = 1L;
+    private final IOPath ioPath;
+
+    /**
+     * @param ioPath The IOPath for this resource. May not be null.
+     * @param contentType The content type for this resource. May not be null or 0-length.
+     */
+    public IOPathResource(final IOPath ioPath, final String contentType) {
+        this(ioPath, contentType,null);
+    }
+
+    /**
+     * @param ioPath The IOPath for this resource. May not be null.
+     * @param contentType The content type for this resource. May not be mull or 0-length.
+     * @param contentSubType The content subtype for this resource. May not be null or 0-length.
+     */
+    public IOPathResource(final IOPath ioPath, final String contentType, final String contentSubType) {
+        super(ValidationUtils.nonNull(ioPath, "ioPath").getRawInputString(),
+                contentType,
+                contentSubType);
+        this.ioPath = ioPath;
+    }
+
+    @Override
+    public Optional<IOPath> getIOPath() { return Optional.of(ioPath); }
+
+    @Override
+    public Optional<InputStream> getInputStream() {
+        return Optional.of(ioPath.getInputStream());
+    }
+
+    @Override
+    public Optional<OutputStream> getOutputStream() { return Optional.of(ioPath.getOutputStream()); }
+
+    @Override
+    public boolean isInput() { return true; }
+
+    @Override
+    public boolean isOutput() { return true; }
+
+    @Override
+    public Optional<SeekableStream> getSeekableStream() {
+        try {
+            return Optional.of(new SeekablePathStream(getIOPath().get().toPath()));
+        } catch (final IOException e) {
+            throw new RuntimeIOException(toString(), e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        IOPathResource that = (IOPathResource) o;
+
+        return ioPath.equals(that.ioPath);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + ioPath.hashCode();
+        return result;
+    }
+
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/InputStreamResource.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/InputStreamResource.java
@@ -1,0 +1,68 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.utils.ValidationUtils;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+/**
+ * An input resource backed by an {@link java.io.InputStream}.
+ */
+public class InputStreamResource extends BundleResourceBase {
+    private static final long serialVersionUID = 1L;
+    private final InputStream inputStream;
+
+    /**
+     * @param inputStream The {@link InputStream} to use for this resource. May not be null.
+     * @param displayName The display name for this resource. May not be null or 0-length.
+     * @param contentType The content type for this resource. May not be null or 0-length.
+     */
+    public InputStreamResource(final InputStream inputStream, final String displayName, final String contentType) {
+        this(inputStream, displayName, contentType, null);
+    }
+
+    /**
+     * @param inputStream The {@link InputStream} to use for this resource. May not be null.
+     * @param displayName The display name for this resource. May not be null or 0-length.
+     * @param contentType The content type for this resource. May not be null or 0-length.
+     * @param contentSubType The content subtype for this resource. May not be null or 0-length.
+     */
+    public InputStreamResource(
+            final InputStream inputStream,
+            final String displayName,
+            final String contentType,
+            final String contentSubType) {
+        super(displayName, contentType, contentSubType);
+        ValidationUtils.nonNull(inputStream, "input stream");
+        this.inputStream = inputStream;
+    }
+
+    @Override
+    public Optional<InputStream> getInputStream() { return Optional.of(inputStream); }
+
+    @Override
+    public boolean isInput() { return true; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof InputStreamResource)) return false;
+        if (!super.equals(o)) return false;
+
+        InputStreamResource that = (InputStreamResource) o;
+
+        return getInputStream().equals(that.getInputStream());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + getInputStream().hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: %s", super.toString(), inputStream);
+    }
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/OutputStreamResource.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/OutputStreamResource.java
@@ -1,0 +1,70 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.utils.ValidationUtils;
+
+import java.io.OutputStream;
+import java.util.Optional;
+
+/**
+ * An output resource backed by an {@link java.io.OutputStream}.
+ */
+public class OutputStreamResource extends BundleResourceBase {
+    private static final long serialVersionUID = 1L;
+    private final OutputStream outputStream;
+
+    /**
+     * @param outputStream The {@link OutputStream} to use for this resource. May not be null.
+     * @param displayName The display name for this resource. May not be null or 0-length.
+     * @param contentType The content type for this resource. May not be null or 0-length.
+     */
+    public OutputStreamResource(final OutputStream outputStream, final String displayName, final String contentType) {
+        this(outputStream, displayName, contentType, null);
+    }
+
+    /**
+     * @param outputStream The {@link OutputStream} to use for this resource. May not be null.
+     * @param displayName The display name for this resource. May not be null or 0-length.
+     * @param contentType The content type for this resource. May not be null or 0-length.
+     * @param contentSubType The content subtype for this resource. May not be null or 0-length.
+     */
+    public OutputStreamResource(
+            final OutputStream outputStream,
+            final String displayName,
+            final String contentType,
+            final String contentSubType) {
+        super(displayName, contentType, contentSubType);
+        ValidationUtils.nonNull(outputStream, "output stream");
+        this.outputStream = outputStream;
+    }
+
+    @Override
+    public Optional<OutputStream> getOutputStream() {
+        return Optional.of(outputStream);
+    }
+
+    @Override
+    public boolean isOutput() { return true; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OutputStreamResource)) return false;
+        if (!super.equals(o)) return false;
+
+        OutputStreamResource that = (OutputStreamResource) o;
+
+        return getOutputStream().equals(that.getOutputStream());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + getOutputStream().hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: %s", super.toString(), outputStream);
+    }
+}

--- a/src/main/java/htsjdk/beta/plugin/bundle/SeekableStreamResource.java
+++ b/src/main/java/htsjdk/beta/plugin/bundle/SeekableStreamResource.java
@@ -1,0 +1,68 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.utils.ValidationUtils;
+
+import java.util.Optional;
+
+/**
+ * An input resource backed by a {@link htsjdk.samtools.seekablestream.SeekableStream}.
+ */
+public class SeekableStreamResource extends InputStreamResource {
+    private static final long serialVersionUID = 1L;
+    private final SeekableStream seekableStream;
+
+    /**
+     * @param seekableStream The {@link SeekableStream} to use for this resource. May not be null.
+     * @param displayName The display name for this resource. May not be null or 0-length.
+     * @param contentType The content type for this resource. May not be null or 0-length.
+     */
+    public SeekableStreamResource(final SeekableStream seekableStream, final String displayName, final String contentType) {
+        this(seekableStream, displayName, contentType, null);
+    }
+
+    /**
+     * @param seekableStream The {@link SeekableStream} to use for this resource. May not be null.
+     * @param displayName The display name for this resource. May not be null or 0-length.
+     * @param contentType The content type for this resource. May not be null or 0-length.
+     * @param contentSubType The content subtype for this resource. May not be null or 0-length.
+     */
+    public SeekableStreamResource(
+            final SeekableStream seekableStream,
+            final String displayName,
+            final String contentType,
+            final String contentSubType) {
+        super(seekableStream, displayName, contentType, contentSubType);
+        ValidationUtils.nonNull(seekableStream, "seekable input stream");
+        this.seekableStream = seekableStream;
+    }
+
+    @Override
+    public Optional<SeekableStream> getSeekableStream() { return Optional.of(seekableStream); }
+
+    @Override
+    public boolean isInput() { return true; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SeekableStreamResource)) return false;
+        if (!super.equals(o)) return false;
+
+        SeekableStreamResource that = (SeekableStreamResource) o;
+
+        return getSeekableStream().equals(that.getSeekableStream());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + getSeekableStream().hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s: %s", super.toString(), seekableStream);
+    }
+}

--- a/src/main/java/htsjdk/beta/plugin/package-info.java
+++ b/src/main/java/htsjdk/beta/plugin/package-info.java
@@ -1,0 +1,4 @@
+@BetaPackage
+package htsjdk.beta.plugin;
+
+import htsjdk.utils.BetaPackage;

--- a/src/main/java/htsjdk/beta/plugin/reads/ReadsBundle.java
+++ b/src/main/java/htsjdk/beta/plugin/reads/ReadsBundle.java
@@ -1,0 +1,198 @@
+package htsjdk.beta.plugin.reads;
+
+import htsjdk.beta.io.IOPathUtils;
+import htsjdk.beta.plugin.bundle.BundleJSON;
+import htsjdk.io.HtsPath;
+import htsjdk.io.IOPath;
+import htsjdk.beta.plugin.bundle.BundleResourceType;
+import htsjdk.beta.plugin.bundle.Bundle;
+import htsjdk.beta.plugin.bundle.BundleBuilder;
+import htsjdk.beta.plugin.bundle.IOPathResource;
+import htsjdk.beta.plugin.bundle.BundleResource;
+import htsjdk.samtools.SamFiles;
+import htsjdk.samtools.util.FileExtensions;
+import htsjdk.samtools.util.Log;
+import htsjdk.samtools.util.Tuple;
+import htsjdk.utils.ValidationUtils;
+
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * A {@link Bundle} specifically for reads and reads-related resources. A {@link ReadsBundle} has a
+ * primary resource with content type "READS"; and an optional index resource. ReadsBundles
+ * can also contain other resources.
+ *
+ * {@link ReadsBundle} is primarily a convenience wrapper for the common case where a {@link Bundle}
+ * contains read and related resources backed by {@link IOPathResource}s. It mainly provides convenient
+ * constructors, and validation for JSON interconversions. For reads sources that are backed by streams or
+ * other {@link BundleResource} types, the {@link Bundle} and {@link BundleBuilder} classes can be used
+ * directly.
+ *
+ * @param <T> The type to use when creating a {@link ReadsBundle} new IOPathResources for a {@link ReadsBundle}.
+ *           Note that resources that are put into a {@link ReadsBundle} using the {{@link #ReadsBundle(Collection)}}
+ *           constructor may have tIOPathResources that do not conform to this type.
+ */
+public class ReadsBundle<T extends IOPath> extends Bundle implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private static final Log LOG = Log.getInstance(ReadsBundle.class);
+
+    /**
+     * Return a {@link ReadsBundle} containing only a reads resource.
+     *
+     * @param reads An {@link IOPath}-derived object that represents a source of reads.
+     */
+    public ReadsBundle(final T reads) {
+        this(Arrays.asList(toInputResource(
+                BundleResourceType.READS,
+                ValidationUtils.nonNull(reads, BundleResourceType.READS))));
+    }
+
+    /**
+     * Return a {@link ReadsBundle} containing only reads and an index.
+     *
+     * @param reads An {@link IOPath}-derived object that represents a source of reads.
+     */
+    public ReadsBundle(final T reads, final T index) {
+        this(Arrays.asList(
+                toInputResource(BundleResourceType.READS, ValidationUtils.nonNull(reads, BundleResourceType.READS)),
+                toInputResource(
+                        BundleResourceType.READS_INDEX,
+                        ValidationUtils.nonNull(index, BundleResourceType.READS_INDEX))));
+    }
+
+    /**
+     * Create a {@link ReadsBundle} using the resources in an existing bundle. A resource with content type
+     * "READS" must be present in the resources, or this constructor will throw.
+     *
+     * Note that this constructor allows existing {@link IOPathResource}s that do not conform to the type
+     * {@link T} to be included in the resulting {@link ReadsBundle}.
+     *
+     * @param resources collection of {@link BundleResource}. the collection must include a resource with
+     *                 content type "READS".
+     * @throws IllegalArgumentException if no resource with content type "READS" is included in the
+     * input {@link BundleResource} collection
+     */
+    protected ReadsBundle(final Collection<BundleResource> resources) {
+        super(BundleResourceType.READS, resources);
+    }
+
+   /**
+     * @return the READS {@link BundleResource} for this {@link ReadsBundle}
+     */
+    public BundleResource getReads() {
+        return get(BundleResourceType.READS).get();
+    }
+
+    /**
+     * Get the optional INDEX resource for this {@link ReadsBundle}.
+     *
+     * @return the optional INDEX {@link BundleResource} for this {@link ReadsBundle}, or Optional.empty if
+     * no index resource is present in the bundle.
+     */
+    public Optional<BundleResource> getIndex() {
+        return get(BundleResourceType.READS_INDEX);
+    }
+
+    /**
+     * Create a {@link ReadsBundle} from a JSON string contained in jsonPath.
+     *
+     * @param jsonPath the path to a file that contains {@link Bundle} serialized to JSON. The bundle
+     *                 must contain a resource with content type READS.
+     * @return a {@link ReadsBundle} created from jsonPath
+     */
+    public static ReadsBundle<IOPath> getReadsBundleFromPath(final IOPath jsonPath) {
+        return getReadsBundleFromString(IOPathUtils.getStringFromPath(jsonPath));
+    }
+
+    /**
+     * Create a {@link ReadsBundle} from a JSON string.
+     *
+     * @param jsonString the jsonString to use to create the {@link ReadsBundle}
+     * @return a {@link ReadsBundle}
+     */
+    public static ReadsBundle<IOPath> getReadsBundleFromString(final String jsonString) {
+        return getReadsBundleFromString(jsonString, HtsPath::new);
+    }
+
+    /**
+     * Create a {@link ReadsBundle} from a JSON string with all IOPathResources using an IOPath-derived
+     * class of type T.
+     * @param jsonString the string to use to create the {@link ReadsBundle}
+     * @param ioPathConstructor a function that takes a string and returns an IOPath-derived class of type <T>
+     * @param <T> the type of
+     * @return a newly created {@link ReadsBundle}
+     */
+    public static <T extends IOPath> ReadsBundle<T> getReadsBundleFromString(
+            final String jsonString,
+            final Function<String, T> ioPathConstructor) {
+        return new ReadsBundle<>(BundleJSON.toBundle(jsonString, ioPathConstructor).getResources());
+    }
+
+    /**
+     * Find the companion index for a reads source, and create a new {@link ReadsBundle} containing the
+     * reads and the companion index, if one can be found.
+     * @param reads the reads source to use
+     * @param ioPathConstructor a function that takes a string and returns an IOPath-derived class of type <T>
+     * @param <T> the IOPath-derived type of the IOPathResources in the new bundle
+     * @return a {@link ReadsBundle} containing reads and companion index, if it canbe found
+     */
+    public static <T extends IOPath> ReadsBundle<T> resolveIndex(
+            final T reads,
+            final Function<String, T> ioPathConstructor) {
+        final Path index = SamFiles.findIndex(reads.toPath());
+        if (index == null) {
+            return new ReadsBundle<>(reads);
+        }
+        return new ReadsBundle<T>(reads, ioPathConstructor.apply(index.toUri().toString()));
+    }
+
+    public static boolean looksLikeAReadsBundle(final IOPath rawReadPath) {
+        return rawReadPath.getURI().getPath().endsWith(BundleJSON.BUNDLE_EXTENSION);
+    }
+
+    private static <T extends IOPath> IOPathResource toInputResource(final String providedContentType, final T ioPath) {
+        ValidationUtils.nonNull(ioPath, "ioPath");
+        final Optional<Tuple<String, String>> typePair = getInferredContentTypes(ioPath);
+        if (typePair.isPresent()) {
+            if (providedContentType != null && !typePair.get().a.equals(providedContentType)) {
+                LOG.warn(String.format(
+                        "Provided content type \"%s\" for \"%s\" doesn't match derived content type \"%s\"",
+                        providedContentType,
+                        ioPath.getRawInputString(),
+                        typePair.get().a));
+            }
+            return new IOPathResource(
+                    ioPath,
+                    providedContentType,  // prefer the provided content type
+                    typePair.get().b);
+        } else {
+            return new IOPathResource(
+                    ioPath,
+                    providedContentType);
+        }
+    }
+
+    //try to infer the contentType/contentSubType, i.e., READS/BAM from an IOPath
+    private static <T extends IOPath> Optional<Tuple<String, String>> getInferredContentTypes(final T ioPath) {
+        ValidationUtils.nonNull(ioPath, "ioPath");
+        final Optional<String> extension = ioPath.getExtension();
+        if (extension.isPresent()) {
+            final String ext = extension.get();
+            if (ext.equals(FileExtensions.BAM)) {
+                return Optional.of(new Tuple<>(BundleResourceType.READS, BundleResourceType.READS_BAM));
+            } else if (ext.equals(FileExtensions.CRAM)) {
+                return Optional.of(new Tuple<>(BundleResourceType.READS, BundleResourceType.READS_CRAM));
+            } else if (ext.equals((FileExtensions.SAM))) {
+                return Optional.of(new Tuple<>(BundleResourceType.READS, BundleResourceType.READS_SAM));
+            }
+            //TODO: else SRA, htsget,...
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/htsjdk/utils/BetaPackage.java
+++ b/src/main/java/htsjdk/utils/BetaPackage.java
@@ -1,0 +1,19 @@
+package htsjdk.utils;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation indicating that an entire package is release level "BETA", is not yet part of the published API,
+ * and is subject to change.
+ */
+@Target(ElementType.PACKAGE)
+@Retention(RetentionPolicy.SOURCE)
+@Inherited
+@Documented
+public @interface BetaPackage {
+}

--- a/src/test/java/htsjdk/beta/plugin/bundle/BundleJSONTest.java
+++ b/src/test/java/htsjdk/beta/plugin/bundle/BundleJSONTest.java
@@ -1,0 +1,266 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.io.HtsPath;
+import htsjdk.io.IOPath;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class BundleJSONTest extends HtsjdkTest {
+    @DataProvider(name = "roundTripJSON")
+    public Object[][] getRoundTripJSON() {
+        final IOPathResource CUSTOM_RESOURCE =
+                new IOPathResource(new HtsPath("file://myreads.CUSTOM"),"CUSTOM");
+
+        return new Object[][]{
+                // NOTE that these JSON strings contain the resources in the same order as they're serialized by
+                // mjson so that we can validate conversions in both directions.
+                //
+                // The strings need to contain path strings that are full URIs, since that's what the JSON
+                // serializer for bundles uses when serializing IOPaths as JSON.
+
+                // json string, primary key, corresponding array of resources
+
+                {
+                        "{\n" +
+                                "  \"schemaName\":\"htsbundle\",\n" +
+                                "  \"schemaVersion\":\"0.1.0\",\n" +
+                                "  \"primary\":\"READS\",\n" +
+                                "  \"READS\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.readsWithContentSubType) +
+                                "\",\"subtype\":\"BAM\"}\n" +
+                                "}\n",
+                        BundleResourceType.READS,
+                        Arrays.asList(BundleResourceTestData.readsWithContentSubType)
+                },
+                {
+                        "{\n" +
+                                "  \"schemaName\":\"htsbundle\",\n" +
+                                "  \"schemaVersion\":\"0.1.0\",\n" +
+                                "  \"primary\":\"READS\",\n" +
+                                "  \"READS\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.readsNoContentSubType) + "\"}\n" +
+                                "}\n",
+                        BundleResourceType.READS,
+                        Arrays.asList(BundleResourceTestData.readsNoContentSubType)
+                },
+                {
+                        "{\n" +
+                                "  \"schemaName\":\"htsbundle\",\n" +
+                                "  \"schemaVersion\":\"0.1.0\",\n" +
+                                "  \"primary\":\"READS\",\n" +
+                                "  \"READS_INDEX\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.indexWithContentSubType) +
+                                "\",\"subtype\":\"BAI\"},\n" +
+                                "  \"READS\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.readsWithContentSubType) +
+                                "\",\"subtype\":\"BAM\"}\n" +
+                                "}\n",
+                        BundleResourceType.READS,
+                        Arrays.asList(
+                                BundleResourceTestData.readsWithContentSubType,
+                                BundleResourceTestData.indexWithContentSubType)
+                },
+                {
+                        "{\n" +
+                                "  \"schemaName\":\"htsbundle\",\n" +
+                                "  \"schemaVersion\":\"0.1.0\",\n" +
+                                "  \"primary\":\"READS\",\n" +
+                                "  \"READS_INDEX\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.indexWithContentSubType) +
+                                "\",\"subtype\":\"BAI\"},\n" +
+                                "  \"READS\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.readsNoContentSubType) +
+                                "\"}\n" +
+                                "}\n",
+                        BundleResourceType.READS,
+                        Arrays.asList(
+                                BundleResourceTestData.readsNoContentSubType,
+                                BundleResourceTestData.indexWithContentSubType)
+                },
+                {
+                        "{\n" +
+                                "  \"schemaName\":\"htsbundle\",\n" +
+                                "  \"schemaVersion\":\"0.1.0\",\n" +
+                                "  \"primary\":\"READS\",\n" +
+                                "  \"READS_INDEX\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.indexNoContentSubType) +
+                                "\"},\n" +
+                                "  \"READS\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.readsWithContentSubType) +
+                                "\",\"subtype\":\"BAM\"}\n" +
+                                "}\n",
+                        BundleResourceType.READS,
+                        Arrays.asList(
+                                BundleResourceTestData.readsWithContentSubType,
+                                BundleResourceTestData.indexNoContentSubType) },
+                {
+                        "{\n" +
+                                "  \"schemaName\":\"htsbundle\",\n" +
+                                "  \"schemaVersion\":\"0.1.0\",\n" +
+                                "  \"primary\":\"READS\",\n" +
+                                "  \"READS_INDEX\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.indexNoContentSubType) + "\"},\n" +
+                                "  \"READS\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.readsNoContentSubType) + "\"}\n" +
+                                "}\n",
+                        BundleResourceType.READS,
+                        Arrays.asList(
+                                BundleResourceTestData.readsNoContentSubType,
+                                BundleResourceTestData.indexNoContentSubType)
+                },
+
+                // bundle with a single resource that has a custom content type
+                {
+                        "{\n" +
+                                "  \"schemaName\":\"htsbundle\",\n" +
+                                "  \"schemaVersion\":\"0.1.0\",\n" +
+                                "  \"primary\":\"CUSTOM\",\n" +
+                                "  \"CUSTOM\":{\"path\":\"" + getURIStringFromIOPath(CUSTOM_RESOURCE) + "\"}\n" +
+                                "}\n",
+                        "CUSTOM",
+                        Arrays.asList(CUSTOM_RESOURCE)
+                },
+
+                // three resources, one of which is a custom content type
+                {
+                        "{\n" +
+                                "  \"schemaName\":\"htsbundle\",\n" +
+                                "  \"schemaVersion\":\"0.1.0\",\n" +
+                                "  \"primary\":\"READS\",\n" +
+                                "  \"READS_INDEX\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.indexNoContentSubType) +
+                                "\"},\n" +
+                                "  \"CUSTOM\":{\"path\":\"" + getURIStringFromIOPath(CUSTOM_RESOURCE) + "\"},\n" +
+                                "  \"READS\":{\"path\":\"" +
+                                getURIStringFromIOPath(BundleResourceTestData.readsNoContentSubType) +
+                                "\"}\n" +
+                                "}\n",
+                        "READS",
+                        Arrays.asList(
+                                BundleResourceTestData.readsNoContentSubType,
+                                BundleResourceTestData.indexNoContentSubType,
+                                CUSTOM_RESOURCE)
+                },
+        };
+    }
+
+    @Test(dataProvider = "roundTripJSON")
+    public void testRoundTripJSON(final String jsonString, final String primaryKey, final List<BundleResource> resources) {
+        final Bundle bundleFromResources = new Bundle(primaryKey, resources);
+        final String actualJSONString = BundleJSON.toJSON(bundleFromResources);
+        Assert.assertEquals(actualJSONString, jsonString);
+
+        // now recreate the bundle from JSON
+        final Bundle bundleFromJSON = BundleJSON.toBundle(jsonString);
+
+        Assert.assertNotNull(bundleFromJSON);
+        Assert.assertEquals(bundleFromJSON.getPrimaryContentType(), primaryKey);
+
+        resources.forEach(expectedResource -> {
+            final Optional<BundleResource> jsonResource = bundleFromJSON.get(expectedResource.getContentType());
+            Assert.assertTrue(jsonResource.isPresent());
+            Assert.assertEquals(jsonResource.get(), expectedResource);
+        });
+    }
+
+    @Test(dataProvider = "roundTripJSON")
+    public void testFromJSONValidWithPathOverride(final String jsonString, final String primaryKey, final List<BundleResource> expectedResources) {
+        final Bundle bundleFromJSON = BundleJSON.toBundle(jsonString, BundleResourceTestData.CustomHtsPath::new);
+        Assert.assertNotNull(bundleFromJSON);
+        Assert.assertEquals(bundleFromJSON.getPrimaryContentType(), primaryKey);
+        expectedResources.forEach(expectedResource -> {
+            final Optional<BundleResource> jsonResource = bundleFromJSON.get(expectedResource.getContentType());
+            Assert.assertTrue(jsonResource.isPresent());
+            //NOTE: we don't test the individual resources for equality here, since the expected resources
+            // don't have a custom path type, so a resource equality test would fail because the HtsPath
+            // equality test would fail. Instead we just verify that the classes resulting from JSON serialization
+            // use our custom HtsPath-derived class.
+            final IOPathResource ioPathResource = ((IOPathResource) jsonResource.get());
+            Assert.assertTrue(ioPathResource.getIOPath().isPresent());
+            final IOPath ioPath = ioPathResource.getIOPath().get();
+            Assert.assertEquals(ioPath.getClass().getSimpleName(), BundleResourceTestData.CustomHtsPath.class.getSimpleName());
+            // typecast just to make sure
+            final BundleResourceTestData.CustomHtsPath subClass = (BundleResourceTestData.CustomHtsPath) ioPath;
+        });
+    }
+
+    @DataProvider(name = "invalidBundleJSON")
+    public Object[][] getInvalidBundleJSON() {
+        return new Object[][]{
+                { null, "cannot be null" },
+                { "", "The string is empty" },
+
+                // missing schema name
+                { "{}" , "missing the required property schemaName" },
+
+                // still missing schema name
+                { "{\"schemaVersion\":\"0.1.0\"}", "missing the required property schemaName" },
+
+                // incorrect schema name
+                { "{\"schemaName\":\"bogusname\", \"schemaVersion\":\"0.1.0\"}", "Expected bundle schema name" },
+
+                // missing schema version
+                { "{\"schemaName\":\"htsbundle\"}", "missing the required property schemaVersion" },
+
+                // incorrect schema version
+                { "{\"schemaName\":\"htsbundle\", \"schemaVersion\":\"99.99.99\"}", "Expected bundle schema version" },
+
+                // missing primary property
+                { "{\"schemaVersion\":\"0.1.0\",\"schemaName\":\"htsbundle\",\"READS\":{\"path\":\"myreads" +
+                        ".bam\",\"subtype\":\"BAM\"}}",
+                        "missing the required property primary"},
+
+                // primary property is present, but the resource it specifies is not in the bundle
+                { "{\"schemaVersion\":\"0.1.0\",\"schemaName\":\"htsbundle\",\"READS\":{\"path\":\"myreads" +
+                        ".bam\",\"subtype\":\"BAM\"},\"primary\":\"MISSING_RESOURCE\"}",
+                        "not present in the resource list"},
+
+                // syntax error (missing quote in before schemaName
+                { "{\"schemaVersion\":\"0.1.0\",schemaName\":\"htsbundle\",\"READS\":{\"path\":\"myreads" +
+                        ".bam\",\"subtype\":\"BAM\"},\"primary\":\"READS\"}",
+                        "Invalid JSON near position: 25" },
+                // no enclosing {} -> UnsupportedOperationException (no text message)
+                {"\"schemaName\":\"htsbundle\", \"schemaVersion\":\"0.1.0\"",
+                        "", },
+        };
+    }
+
+    @Test(dataProvider = "invalidBundleJSON", expectedExceptions = IllegalArgumentException.class)
+    public void testFromJSONInvalid(final String jsonString, final String expectedMessageFragment) {
+        try {
+            BundleJSON.toBundle(jsonString);
+        } catch (final IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains(expectedMessageFragment));
+            throw e;
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testToJSONNonIOPath() throws IOException {
+        try (final InputStream is = new ByteArrayInputStream(new byte[0])) {
+            final Bundle bundle = new BundleBuilder()
+                    .addPrimary(new InputStreamResource(is,"displayName","contentType"))
+                    .build();
+            // can't serialize a resource that isn't backed by an IOPath
+            BundleJSON.toJSON(bundle);
+        } catch (final IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("Bundle resource requires a valid path to be serialized"));
+            throw e;
+        }
+    }
+
+    // get the URI String from an IOPath in an IOPath resource
+    final private String getURIStringFromIOPath(final IOPathResource resource) {
+        return resource.getIOPath().get().getURIString();
+    }
+
+}

--- a/src/test/java/htsjdk/beta/plugin/bundle/BundleResourceTest.java
+++ b/src/test/java/htsjdk/beta/plugin/bundle/BundleResourceTest.java
@@ -1,0 +1,172 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.HtsjdkTest;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class BundleResourceTest extends HtsjdkTest {
+
+    @DataProvider(name="inputOutputTestData")
+    public Object[][] getInputOutputTestData() {
+        return new Object[][]{
+                // bundle resource, isInput, isOutput
+                { BundleResourceTestData.readsWithContentSubType, true, true},
+                { new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName", BundleResourceType.READS), true, false},
+                { new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName", BundleResourceType.READS), false, true},
+        };
+    }
+
+    @Test(dataProvider = "inputOutputTestData")
+    public void testIsInputOutput(final BundleResource resource, final boolean expectedIsInput, final boolean expectedIsOutput) {
+        Assert.assertEquals(resource.isInput(), expectedIsInput);
+        Assert.assertEquals(resource.isOutput(), expectedIsOutput);
+    }
+
+    @DataProvider(name="resourceEqualityTestData")
+    public Object[][] getResourceEqualityTestData() {
+        return new Object[][]{
+
+                // equal
+                {
+                        BundleResourceTestData.readsWithContentSubType,
+                        BundleResourceTestData.readsWithContentSubType,
+                        true
+                },
+                {
+                        BundleResourceTestData.readsNoContentSubType,
+                        BundleResourceTestData.readsNoContentSubType,
+                        true
+                },
+                {
+                        new IOPathResource(BundleResourceTestData.READS_FILE, BundleResourceType.READS),
+                        new IOPathResource(BundleResourceTestData.READS_FILE, BundleResourceType.READS),
+                        true
+                },
+                {
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.READS),
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.READS),
+                        true
+                },
+                {
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.READS),
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.READS),
+                        true
+                },
+
+                // not equal
+                {
+                        new IOPathResource(BundleResourceTestData.READS_FILE, BundleResourceType.READS),
+                        new IOPathResource(BundleResourceTestData.READS_FILE, "NOTREADS"),
+                        false
+                },
+                {
+                        BundleResourceTestData.readsWithContentSubType,
+                        BundleResourceTestData.readsNoContentSubType,
+                        false
+                },
+                {
+                        BundleResourceTestData.indexWithContentSubType,
+                        BundleResourceTestData.readsNoContentSubType,
+                        false
+                },
+
+                // not equal inputstreams
+                {
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.READS),
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "differentDisplayName",
+                                BundleResourceType.READS),
+                        false
+                },
+                {
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.READS, BundleResourceType.READS_BAM),
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.READS),
+                        false
+                },
+                {
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.READS, BundleResourceType.READS_BAM),
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.READS, BundleResourceType.READS_CRAM),
+                        false
+                },
+                {
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.READS),
+                        new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName",
+                                BundleResourceType.VARIANTS),
+                        false
+                },
+
+                // not equal outputstreams
+                {
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.READS),
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "differentDisplayName",
+                                BundleResourceType.READS),
+                        false
+                },
+                {
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.READS, BundleResourceType.READS_BAM),
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.READS),
+                        false
+                },
+                {
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.READS, BundleResourceType.READS_BAM),
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.READS, BundleResourceType.READS_CRAM),
+                        false
+                },
+                {
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.READS),
+                        new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName",
+                                BundleResourceType.VARIANTS),
+                        false
+                },
+        };
+    }
+
+    @Test(dataProvider="resourceEqualityTestData")
+    public void testInputResourceEquality(
+            final BundleResource inputResource1,
+            final BundleResource inputResource2,
+            final boolean expectedEquals) {
+        Assert.assertEquals(inputResource1.equals(inputResource2), expectedEquals);
+        Assert.assertEquals(inputResource2.equals(inputResource1), expectedEquals);
+    }
+
+    @DataProvider(name="toStringTestData")
+    public Object[][] getToStringTestData() {
+        return new Object[][]{
+                {BundleResourceTestData.readsWithContentSubType, "IOPathResource (file://myreads.bam): READS/BAM"},
+                {BundleResourceTestData.readsNoContentSubType, "IOPathResource (file://myreads.bam): READS/NONE"},
+                {BundleResourceTestData.indexNoContentSubType, "IOPathResource (file://myreads.bai): READS_INDEX/NONE"},
+                {BundleResourceTestData.indexWithContentSubType, "IOPathResource (file://myreads.bai): READS_INDEX/BAI"},
+                {new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName", BundleResourceType.READS),
+                        "InputStreamResource (displayName): READS/NONE"},
+                {new InputStreamResource(BundleResourceTestData.fakeInputStream, "displayName", BundleResourceType.READS, BundleResourceType.READS_BAM),
+                        "InputStreamResource (displayName): READS/BAM"},
+                {new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName", BundleResourceType.READS),
+                        "OutputStreamResource (displayName): READS/NONE"},
+                {new OutputStreamResource(BundleResourceTestData.fakeOutputStream, "displayName", BundleResourceType.READS, BundleResourceType.READS_BAM),
+                        "OutputStreamResource (displayName): READS/BAM"},
+        };
+    }
+
+    @Test(dataProvider = "toStringTestData")
+    public void testToString(final BundleResource resource, final String expectedString) {
+        Assert.assertTrue(resource.toString().contains(expectedString));
+    }
+
+}

--- a/src/test/java/htsjdk/beta/plugin/bundle/BundleResourceTestData.java
+++ b/src/test/java/htsjdk/beta/plugin/bundle/BundleResourceTestData.java
@@ -1,0 +1,49 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.io.HtsPath;
+import htsjdk.io.IOPath;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class BundleResourceTestData {
+    public final static IOPath READS_FILE = new HtsPath("file://myreads.bam");
+    public final static IOPath READS_INDEX = new HtsPath("file://myreads.bai");
+
+    public static final IOPathResource readsWithContentSubType = new IOPathResource(
+            READS_FILE,
+            BundleResourceType.READS,
+            BundleResourceType.READS_BAM);
+    public static final IOPathResource readsNoContentSubType =new IOPathResource(
+            READS_FILE,
+            BundleResourceType.READS);
+    public static final IOPathResource indexWithContentSubType = new IOPathResource(
+            READS_INDEX,
+            BundleResourceType.READS_INDEX,
+            BundleResourceType.READS_INDEX_BAI);
+    public static final IOPathResource indexNoContentSubType = new IOPathResource(
+            READS_INDEX,
+            BundleResourceType.READS_INDEX);
+
+    public final static class CustomHtsPath extends HtsPath {
+        public CustomHtsPath(final String pathString) {
+            super(pathString);
+        }
+    }
+
+    // streams for making bundle resources that never need closing
+    public static final InputStream fakeInputStream = new InputStream() {
+        @Override
+        public int read() throws IOException {
+            throw new IllegalStateException();
+        }
+    };
+    public static final OutputStream fakeOutputStream = new OutputStream() {
+        @Override
+        public void write(int b) throws IOException {
+            throw new IllegalStateException();
+        }
+    };
+
+}

--- a/src/test/java/htsjdk/beta/plugin/bundle/BundleTest.java
+++ b/src/test/java/htsjdk/beta/plugin/bundle/BundleTest.java
@@ -1,0 +1,87 @@
+package htsjdk.beta.plugin.bundle;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.io.HtsPath;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
+// Example JSON :
+//{
+// "schemaName":"htsbundle",
+// "schemaVersion":"0.1.0",
+// "READS",
+// "READS_INDEX":{"path":"myFile.bai","subtype":"NONE"},
+// "READS":{"path":"myFile.bam","subtype":"NONE"}
+// }
+
+public class BundleTest extends HtsjdkTest {
+
+    @Test
+    public void testPrimaryResource() {
+        final String primaryKey = BundleResourceType.READS;
+        final IOPathResource ioPathResource = new IOPathResource(
+                new HtsPath("somefile.bam"),
+                BundleResourceType.READS);
+        final Bundle bundle = new Bundle(primaryKey, Collections.singletonList(ioPathResource));
+        Assert.assertEquals(bundle.getPrimaryContentType(), primaryKey);
+        Assert.assertEquals(bundle.getPrimaryResource(), ioPathResource);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNullPrimaryResource() {
+        new Bundle(null, Collections.singletonList(
+                new IOPathResource(new HtsPath("somefile.bam"), BundleResourceType.READS)));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testPrimaryResourceNotInBundle() {
+        // the primary resource is specified but the resource specified is not in the bundle
+        final String primaryKey = "MISSING_RESOURCE";
+        final IOPathResource ioPathResource = new IOPathResource(
+                new HtsPath("somefile.bam"),
+                BundleResourceType.READS);
+        try {
+            new Bundle(primaryKey, Collections.singletonList(ioPathResource));
+        } catch (final IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("not present in the resource list"));
+            throw e;
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testDuplicateResource() {
+        final String primaryKey = BundleResourceType.READS;
+        final IOPathResource ioPathResource = new IOPathResource(
+                new HtsPath("somefile.bam"),
+                BundleResourceType.READS);
+        try {
+            new Bundle(primaryKey, Arrays.asList(ioPathResource, ioPathResource));
+        } catch (final IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("Attempt to add a duplicate resource"));
+            throw e;
+        }
+    }
+
+    @Test
+    public void testResourceIterator() {
+        final Bundle bundle =
+                new BundleBuilder()
+                        .addPrimary(BundleResourceTestData.readsWithContentSubType)
+                        .addSecondary(BundleResourceTestData.indexNoContentSubType)
+                        .build();
+        final Iterator<BundleResource> it = bundle.iterator();
+        while (it.hasNext()) {
+            final BundleResource ir = it.next();
+            if (ir.getContentType().equals(BundleResourceType.READS)) {
+                Assert.assertEquals(ir, BundleResourceTestData.readsWithContentSubType);
+            } else {
+                Assert.assertEquals(ir, BundleResourceTestData.indexNoContentSubType);
+            }
+        }
+    }
+
+}

--- a/src/test/java/htsjdk/beta/plugin/reads/ReadsBundleTest.java
+++ b/src/test/java/htsjdk/beta/plugin/reads/ReadsBundleTest.java
@@ -1,0 +1,104 @@
+package htsjdk.beta.plugin.reads;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.beta.io.IOPathUtils;
+import htsjdk.beta.plugin.bundle.Bundle;
+import htsjdk.beta.plugin.bundle.BundleBuilder;
+import htsjdk.beta.plugin.bundle.BundleJSON;
+import htsjdk.beta.plugin.bundle.IOPathResource;
+import htsjdk.io.HtsPath;
+import htsjdk.io.IOPath;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ReadsBundleTest extends HtsjdkTest {
+
+    private final static String BAM_FILE = "reads.bam";
+    private final static String INDEX_FILE = "reads.bai";
+
+    @Test
+    public void testReadsBundleReadsOnly() {
+        final IOPath readsPath = new HtsPath(BAM_FILE);
+        final ReadsBundle<IOPath> readsBundle = new ReadsBundle(readsPath);
+
+        Assert.assertTrue(readsBundle.getReads().getIOPath().isPresent());
+        Assert.assertEquals(readsBundle.getReads().getIOPath().get(), readsPath);
+        Assert.assertFalse(readsBundle.getIndex().isPresent());
+    }
+
+    @Test
+    public void testReadsBundleReadsAndIndex() {
+        final IOPath readsPath = new HtsPath(BAM_FILE);
+        final IOPath indexPath = new HtsPath(INDEX_FILE);
+        final ReadsBundle<IOPath> readsBundle = new ReadsBundle(readsPath, indexPath);
+
+        Assert.assertTrue(readsBundle.getReads().getIOPath().isPresent());
+        Assert.assertEquals(readsBundle.getReads().getIOPath().get(), readsPath);
+
+        Assert.assertTrue(readsBundle.getIndex().isPresent());
+        Assert.assertTrue(readsBundle.getIndex().get().getIOPath().isPresent());
+        final IOPath actualIndexPath = readsBundle.getIndex().get().getIOPath().get();
+        Assert.assertEquals(actualIndexPath, indexPath);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNoReadsInSerializedBundle() {
+        final String vcfJSON = "{\"schemaVersion\":\"0.1.0\",\"schemaName\":\"htsbundle\",\"VARIANTS\":{\"path\":\"my.vcf\",\"subtype\":\"VCF\"},\"primary\":\"VARIANTS\"}";
+        try {
+            ReadsBundle.getReadsBundleFromString(vcfJSON);
+        } catch (final IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("not present in the resource list"));
+            throw e;
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNoReadsInResources() {
+        final Bundle bundleWithNoReads = new BundleBuilder()
+                .addPrimary(new IOPathResource(new HtsPath("notReads.txt"),"NOT_READS"))
+                .addSecondary(new IOPathResource(new HtsPath("alsoNotReads.txt"),"ALSO_NOT_READS"))
+                .build();
+        new ReadsBundle<>(bundleWithNoReads.getResources());
+    }
+
+    @DataProvider(name = "roundTripJSONTestData")
+    public Object[][] getRoundTripJSONTestData() {
+        return new Object[][]{
+                //NOTE that these JSON strings contain the resources in the same order that they're serialized by mjson
+                // so that we can use these cases to validate in both directions
+
+                // json string, primary key, corresponding array of resources
+                {
+                    "{\"schemaVersion\":\"0.1.0\",\"schemaName\":\"htsbundle\",\"READS\":{\"path\":\"" + BAM_FILE + "\",\"subtype\":\"BAM\"},\"primary\":\"READS\"}",
+                    new ReadsBundle<IOPath>(new HtsPath(BAM_FILE))
+                },
+        };
+    }
+
+    @Test(dataProvider="roundTripJSONTestData")
+    public void testReadWriteRoundTrip(
+            final String jsonString,
+            final ReadsBundle<IOPath> expectedReadsBundle)  {
+        final ReadsBundle<IOPath> bundleFromJSON = ReadsBundle.getReadsBundleFromString(jsonString);
+        Assert.assertEquals(bundleFromJSON, expectedReadsBundle);
+        Assert.assertEquals(bundleFromJSON.getPrimaryContentType(), expectedReadsBundle.getPrimaryContentType());
+        Assert.assertTrue(bundleFromJSON.getReads().getIOPath().isPresent());
+        Assert.assertEquals(bundleFromJSON.getReads().getIOPath().get(), expectedReadsBundle.getReads().getIOPath().get());
+    }
+
+    @Test(dataProvider="roundTripJSONTestData")
+    public void testGetReadsBundleFromPath(
+            final String jsonString,
+            final ReadsBundle<IOPath> expectedReadsBundle)  {
+        final IOPath jsonFilePath = IOPathUtils.createTempPath("reads", BundleJSON.BUNDLE_EXTENSION);
+        IOPathUtils.writeStringToPath(jsonFilePath, jsonString);
+        final ReadsBundle<IOPath> bundleFromPath = ReadsBundle.getReadsBundleFromPath(jsonFilePath);
+
+        Assert.assertEquals(bundleFromPath, expectedReadsBundle);
+        Assert.assertEquals(bundleFromPath.getPrimaryContentType(), expectedReadsBundle.getPrimaryContentType());
+        Assert.assertTrue(bundleFromPath.getReads().getIOPath().isPresent());
+        Assert.assertEquals(bundleFromPath.getReads().getIOPath().get(), expectedReadsBundle.getReads().getIOPath().get());
+    }
+
+}


### PR DESCRIPTION
`Bundle` is another component of the [CZI](https://github.com/samtools/htsjdk/issues/1482) work, and provides a way to group a set of companion resources (such as a reads/index tuple, or a reference/index/dictionary tuple) into a single object. Each resource in a bundle is backed by either a URI-based `IOPath`; an `InputStream`; a `SeekableStream`; or an `OutputStream`, and has an associated content type string. Each bundle has a single "primary" content type (i.e., "READS", or "VARIANTS", etc.). Bundles that consist of `IOPath`-backed resources can be serialized to and deserialized from JSON:

```
{
  "schemaName":"htsbundle",
  "schemaVersion":"0.1.0",
  "primary":"READS"
  "READS":{"path":"myreads.bam","subtype":"BAM"},
  "READS_INDEX":{"path":"myreads.bai","subtype":"BAI"},
}
```
Resources can be iterated via a `Bundle` iterator, or accessed directly by content type. This PR also includes a `ReadsBundle` specialization of `Bundle` class that provides a convenience layer over a raw bundle; others will follow.

This PR also includes a `Beta` package annotation that can be used to declare a package as containing code that is "beta"-level and subject to change, as well as a new top level `beta` package which is annotated with the `Beta` annotation. All new code is in the `beta` package.

