### PR TITLE
Adding PL Tag 'DNBSEQ' as the Platform/Technology for BGI/MGI.

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
@@ -59,9 +59,11 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
 
     /* Platform values for the @RG-PL tag */
     public enum PlatformValue {
-        BGI, CAPILLARY, LS454, ILLUMINA,
-        SOLID, HELICOS, IONTORRENT, 
-        ONT, PACBIO, OTHER
+        CAPILLARY, LS454, ILLUMINA,
+        SOLID, HELICOS, IONTORRENT,
+        ONT, PACBIO, DNBSEQ, OTHER,
+        @Deprecated
+        BGI
     }
 
     public static final Set<String> STANDARD_TAGS =


### PR DESCRIPTION
Adding PL Tag 'DNBSEQ' as the Platform/Technology for BGI/MGI.  Leaving BGI as a deprecated enum.

### Description

According to the SAM file spec, the proper PL tag for read groups generated on BGI/MGI technology is 'DNBSEQ'. 
We have reports of a ValidateSamFile error caused by this issue: 
https://github.com/broadinstitute/picard/issues/1661

### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
