### PR TITLE
Validating the codecov script when downloading.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
     fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
   - echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'";
     echo "JAVA_HOME='$JAVA_HOME'";
     if [ "$TRAVIS_BRANCH" == "master" ]; then


### PR DESCRIPTION
* Switching to use a wrapper around the codecov script that performs validation in order to prevent data breaches in the future.
