### PR TITLE
Deprecate OTHER as a PL value

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
@@ -59,11 +59,26 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
 
     /* Platform values for the @RG-PL tag */
     public enum PlatformValue {
-        CAPILLARY, LS454, ILLUMINA,
-        SOLID, HELICOS, IONTORRENT,
-        ONT, PACBIO, DNBSEQ, OTHER,
-        @Deprecated
-        BGI
+        /** @deprecated Use {@linkplain PlatformValue#DNBSEQ} instead. */
+        @Deprecated BGI,
+        CAPILLARY,
+        
+        /** MGI/BGI */
+        DNBSEQ,
+        HELICOS,
+        ILLUMINA,
+        IONTORRENT,
+        LS454,
+
+        /** Oxford Nanopore */
+        ONT,
+
+        /** @deprecated OTHER is not an official value.  It is recommended to omit PL if it is not in this list or is unknown. */
+        @Deprecated OTHER,
+
+        /** Pacific Biotechnology */
+        PACBIO,
+        SOLID
     }
 
     public static final Set<String> STANDARD_TAGS =


### PR DESCRIPTION
* Deprecate the PlatformValue OTHER since the spec advises omitting the PL field when the technology is not listed in the official ontology.
* A continuation of https://github.com/samtools/htsjdk/pull/1547 which deprecated BGI.
* Alphabetized the list of PL values and added clarifying comments to match the spec.

I kind of hate how I've formatted the new list but I'm not sure what a better way to do it is...