### PR TITLE
Respect genotype filtering / FT tag when calculating AC/AN/AF

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
+++ b/src/main/java/htsjdk/variant/variantcontext/VariantContext.java
@@ -1133,8 +1133,10 @@ public class VariantContext implements Feature, Serializable {
         GenotypesContext genotypes = sampleIds.isEmpty() ? getGenotypes() : getGenotypes(sampleIds);
 
         for ( final Genotype g : genotypes) {
-            for ( final Allele a : g.getAlleles() )
-                n += a.isNoCall() ? 0 : 1;
+            if (!g.isFiltered()) {
+                for ( final Allele a : g.getAlleles() )
+                    n += a.isNoCall() ? 0 : 1;
+            }
         }
 
         return n;
@@ -1162,7 +1164,9 @@ public class VariantContext implements Feature, Serializable {
         GenotypesContext genotypes = sampleIds.isEmpty() ? getGenotypes() : getGenotypes(sampleIds);
 
         for ( final Genotype g : genotypes ) {
-            n += g.countAllele(a);
+            if (!g.isFiltered()) {
+                n += g.countAllele(a);
+            }
         }
 
         return n;

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -511,7 +511,6 @@ public class VariantContextUnitTest extends VariantBaseTest {
         List<Allele> alleles = Arrays.asList(Aref, T);
         Genotype g1 = GenotypeBuilder.create("AA", Arrays.asList(Aref, Aref));
         Genotype g2 = GenotypeBuilder.create("AT", Arrays.asList(Aref, T));
-
         VariantContext vc = new VariantContextBuilder("test", snpLoc, snpLocStart, snpLocStop, alleles).genotypes(g1, g2).make();
 
         Assert.assertTrue(vc.isNotFiltered());
@@ -536,6 +535,27 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Assert.assertEquals(3, vc.getFilters().size());
         Assert.assertTrue(vc.filtersWereApplied());
         Assert.assertNotNull(vc.getFiltersMaybeNull());
+    }
+
+    @Test
+    public void testGenotypeFilters() {
+        List<Allele> alleles = Arrays.asList(Aref, T);
+        Genotype homRef = GenotypeBuilder.create("homRef", Arrays.asList(Aref, Aref));
+        Genotype het = GenotypeBuilder.create("het", Arrays.asList(Aref, T));
+        VariantContext vc = new VariantContextBuilder("test", snpLoc, snpLocStart, snpLocStop, alleles).genotypes(homRef, het).make();
+
+        Assert.assertEquals(vc.getCalledChrCount(), 4);
+
+        Assert.assertEquals(vc.getCalledChrCount(Aref),3);
+        Assert.assertEquals(vc.getCalledChrCount(T),1);
+
+        Genotype filtered = new GenotypeBuilder(het).filter("X").make();
+        VariantContext filteredVc = new VariantContextBuilder(vc).genotypes(homRef, filtered).make();
+
+        Assert.assertEquals(filteredVc.getCalledChrCount(), 2);
+
+        Assert.assertEquals(filteredVc.getCalledChrCount(Aref),2);
+        Assert.assertEquals(filteredVc.getCalledChrCount(T),0);
     }
 
     @Test

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -540,6 +540,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
     @Test
     public void testGenotypeFilters() {
         List<Allele> alleles = Arrays.asList(Aref, T);
+        // These first two genotypes are PASS (this behavior is different for VC filtering than Genotype filtering)
         Genotype homRef = GenotypeBuilder.create("homRef", Arrays.asList(Aref, Aref));
         Genotype het = GenotypeBuilder.create("het", Arrays.asList(Aref, T));
         VariantContext vc = new VariantContextBuilder("test", snpLoc, snpLocStart, snpLocStop, alleles).genotypes(homRef, het).make();
@@ -549,6 +550,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
         Assert.assertEquals(vc.getCalledChrCount(Aref),3);
         Assert.assertEquals(vc.getCalledChrCount(T),1);
 
+        // Here we add a filter to a genotype so that it will not be included
         Genotype filtered = new GenotypeBuilder(het).filter("X").make();
         VariantContext filteredVc = new VariantContextBuilder(vc).genotypes(homRef, filtered).make();
 

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -538,7 +538,7 @@ public class VariantContextUnitTest extends VariantBaseTest {
     }
 
     @Test
-    public void testGenotypeFilters() {
+    public void testGenotypeCountsRespectGenotypeFilters() {
         List<Allele> alleles = Arrays.asList(Aref, T);
         // These first two genotypes are PASS (this behavior is different for VC filtering than Genotype filtering)
         Genotype homRef = GenotypeBuilder.create("homRef", Arrays.asList(Aref, Aref));


### PR DESCRIPTION
### Description

A gate has been added to the getCalledChrCount() method to not count filtered out genotypes.
This fixes a bug in which AC/AN/AF were calculated without respecting if the genotypes were filtered out (and therefore shouldn't be used for calculations)
Re Laura: "It’s probably pretty rare that a user had FT fields they ignored, but if so they should unfilter rather then have some janky arg to ignore FT in annotation."

A genotype filtering unit test has been added since getCalledChrCount() changes based on filtering


### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
