### PR TITLE
convert Runtime exceptions in the CRAM code into CRAMExceptions (also…

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/build/CRAMReferenceRegion.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CRAMReferenceRegion.java
@@ -27,6 +27,7 @@ package htsjdk.samtools.cram.build;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.cram.CRAMException;
 import htsjdk.samtools.cram.ref.CRAMReferenceSource;
 import htsjdk.samtools.cram.ref.ReferenceContext;
 
@@ -47,7 +48,7 @@ public class CRAMReferenceRegion {
      */
     public CRAMReferenceRegion(final CRAMReferenceSource cramReferenceSource, final SAMFileHeader samFileHeader) {
         if (cramReferenceSource == null) {
-            throw new IllegalArgumentException("A valid reference must be supplied to retrieve records from the CRAM stream.");
+            throw new CRAMException("A valid reference must be supplied to retrieve records from the CRAM stream.");
         }
         this.referenceSource = cramReferenceSource;
         this.samFileHeader = samFileHeader;
@@ -73,7 +74,7 @@ public class CRAMReferenceRegion {
                 final SAMSequenceRecord sequence = samFileHeader.getSequence(referenceIndex);
                 referenceBases = referenceSource.getReferenceBases(sequence, true);
                 if (referenceBases == null) {
-                    throw new IllegalArgumentException(
+                    throw new CRAMException(
                             String.format(
                                     "A reference must be supplied (reference sequence %s not found).",
                                     sequence));


### PR DESCRIPTION
… runtime)

In the cram code the code throws an IllegalArgumentException when asked about the bases when a reference was not provided. This PR changes it to a CRAMException to be more informative and consistent.