### PR TITLE
Silence AsciiLineReader warning when creating a FASTA sequence index

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceIndexCreator.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceIndexCreator.java
@@ -29,10 +29,13 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.GZIIndex;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.readers.AsciiLineReader;
+import htsjdk.tribble.readers.PositionalBufferedStream;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.zip.GZIPInputStream;
 
 /**
  * Static methods to create an {@link FastaSequenceIndex}.
@@ -66,6 +69,17 @@ public final class FastaSequenceIndexCreator {
     }
 
     /**
+     * Wrap only non-GZIP input streams as a positional buffered input stream for use in {@link AsciiLineReader#from(InputStream)}
+     *
+     * @param input the input stream.
+     *
+     * @return the input stream which is either a GZIP input stream or a position buffered stream.
+     */
+    private static InputStream optionallyWrapAsPositional(final InputStream input) {
+        if (input instanceof GZIPInputStream) { return input; } else { return new PositionalBufferedStream(input); }
+    }
+
+    /**
      * Builds a FastaSequenceIndex on the fly from a FASTA file.
      *
      * <p>Note: this also allows to create an index for a compressed file, but does not generate the
@@ -79,8 +93,8 @@ public final class FastaSequenceIndexCreator {
      * @throws SAMException for formatting errors.
      * @throws IOException  if an IO error occurs.
      */
-    public static FastaSequenceIndex buildFromFasta(final Path fastaFile) throws IOException {
-        try(final AsciiLineReader in = AsciiLineReader.from(IOUtil.openFileForReading(fastaFile))) {
+    public static FastaSequenceIndex buildFromFasta(final Path fastaFile) throws IOException, SAMException {
+        try(final AsciiLineReader in = AsciiLineReader.from(optionallyWrapAsPositional(IOUtil.openFileForReading(fastaFile)))) {
 
             // sanity check reference format:
             // 1. Non-empty file

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceIndexCreator.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceIndexCreator.java
@@ -76,7 +76,11 @@ public final class FastaSequenceIndexCreator {
      * @return the input stream which is either a GZIP input stream or a position buffered stream.
      */
     private static InputStream optionallyWrapAsPositional(final InputStream input) {
-        if (input instanceof GZIPInputStream) { return input; } else { return new PositionalBufferedStream(input); }
+        if (input instanceof GZIPInputStream) {
+            return input;
+        } else {
+            return new PositionalBufferedStream(input);
+        }
     }
 
     /**


### PR DESCRIPTION
### Description

The `AsciiLineReader.from()` method requires either a block-compressed or positional buffered input stream. If the input stream is neither, then a warning is emitted and the stream is wrapped in a positional buffered stream:

https://github.com/samtools/htsjdk/blob/7719274fe370a51a24e6067de21bbe7e18c160a9/src/main/java/htsjdk/tribble/readers/AsciiLineReader.java#L75-L95

I would like to silence the warning produced when creating a FASTA sequence index by pre-wrapping the stream in a positional buffered stream. This will make my logs that use this method cleaner and I can avoid these warnings:

```
WARNING 2021-08-05 19:54:23     AsciiLineReader Creating an indexable source for an AsciiFeatureCodec using a stream that is neither a PositionalBufferedStream nor a BlockCompressedInputStream
```

### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [x] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.

---

I will rely on CI testing as it looks like `htsjdk` might have tests that I cannot reproduce on my local (specifically htsget tests that ping servers).