### PR TITLE
Validate that SAM header tag keys are exactly 2 characters long

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
+++ b/src/main/java/htsjdk/samtools/SAMTextHeaderCodec.java
@@ -316,6 +316,12 @@ public class SAMTextHeaderCodec {
                             SAMValidationError.Type.HEADER_TAG_MULTIPLY_DEFINED, null);
                     continue;
                 }
+                if (keyAndValue[0].length() != 2) {
+                    reportErrorParsingLine("Problem parsing " + HEADER_LINE_START + mHeaderRecordType +
+                            " key:value pair " + keyAndValue[0] + ":<value> key is not two characters",
+                            SAMValidationError.Type.HEADER_TAG_INVALID_KEY, null);
+                    continue;
+                }
                 validateSortOrderValue(keyAndValue);
                 mKeyValuePairs.put(keyAndValue[0], keyAndValue[1]);
             }

--- a/src/main/java/htsjdk/samtools/SAMValidationError.java
+++ b/src/main/java/htsjdk/samtools/SAMValidationError.java
@@ -235,7 +235,10 @@ public class SAMValidationError implements Serializable {
         CG_TAG_FOUND_IN_ATTRIBUTES,
 
         /** One or more reference sequences in the dictionary are too long for BAI indexing. */
-        REF_SEQ_TOO_LONG_FOR_BAI(Severity.WARNING);
+        REF_SEQ_TOO_LONG_FOR_BAI(Severity.WARNING),
+
+        /** Header tag key contains invalid characters or is not length two */
+        HEADER_TAG_INVALID_KEY;
 
 
         public final Severity severity;

--- a/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileHeaderTest.java
@@ -99,6 +99,26 @@ public class SAMFileHeaderTest extends HtsjdkTest {
         Assert.assertNull(header.getSequence("chr2"));
     }
 
+    @DataProvider
+    public Object[][] dataForInvalidTagKeyTests() {
+        return new Object[][] {
+                {"@RG\tID:A1\tPL:ILLUMINA\tLNID:1\tSM:A2", "key is not two characters"},
+                {"@RG\tID:A1\tSM:A2", ""}
+        };
+    }
+
+    @Test(dataProvider = "dataForInvalidTagKeyTests")
+    public void testInvalidTagKey(String samHeader, String expected) {
+        SAMTextHeaderCodec codec = new SAMTextHeaderCodec();
+        SAMFileHeader header = codec.decode(BufferedLineReader.fromString(samHeader), null);
+        String validationErrors = header.getValidationErrors().toString();
+        if (expected.isEmpty()) {
+            Assert.assertEquals(validationErrors, "[]");
+        } else {
+            Assert.assertTrue(validationErrors.contains(expected));
+        }
+    }
+
     @Test
     public void testWrongTag() {
         String[] testData = new String[]{


### PR DESCRIPTION
### Description

As reported in #1477, the SAM specification (§1.3) requires that the keys of header tagged fields match
`/^[A-Za-z][A-Za-z0-9]$/`, but HTSJDK even accepts keys that are not two characters in length.

This PR adds header tag key checking to `SAMTextHeaderCodec`'s validation. It adds a new `HEADER_TAG_INVALID_KEY` entry to `SAMValidationError`, described as representing keys invalid due to either containing invalid characters or being the wrong length. This PR implements a length check but does not implement an alphanumeric character check.

You may prefer to either remove the future intention from the `HEADER_TAG_INVALID_KEY` documentation comment or to implement a character validity check (and add further test cases).

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
