### PR TITLE
Yp add context to exception

### DIFF
--- a/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
+++ b/src/main/java/htsjdk/variant/vcf/AbstractVCFCodec.java
@@ -141,6 +141,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
         Set<VCFHeaderLine> metaData = new LinkedHashSet<VCFHeaderLine>();
         Set<String> sampleNames = new LinkedHashSet<String>();
         int contigCounter = 0;
+        int headerLineCounter = 1;
         // iterate over all the passed in strings
         for ( String str : headerStrings ) {
             if ( !str.startsWith(VCFHeader.METADATA_INDICATOR) ) {
@@ -189,13 +190,13 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
 
             } else {
                 if ( str.startsWith(VCFConstants.INFO_HEADER_START) ) {
-                    final VCFInfoHeaderLine info = new VCFInfoHeaderLine(str.substring(7), version);
+                    final VCFInfoHeaderLine info = new VCFInfoHeaderLine(str.substring(7), version, headerLineCounter);
                     metaData.add(info);
                 } else if ( str.startsWith(VCFConstants.FILTER_HEADER_START) ) {
                     final VCFFilterHeaderLine filter = new VCFFilterHeaderLine(str.substring(9), version);
                     metaData.add(filter);
                 } else if ( str.startsWith(VCFConstants.FORMAT_HEADER_START) ) {
-                    final VCFFormatHeaderLine format = new VCFFormatHeaderLine(str.substring(9), version);
+                    final VCFFormatHeaderLine format = new VCFFormatHeaderLine(str.substring(9), version, headerLineCounter);
                     metaData.add(format);
                 } else if ( str.startsWith(VCFConstants.CONTIG_HEADER_START) ) {
                     final VCFContigHeaderLine contig = new VCFContigHeaderLine(str.substring(9), version, VCFConstants.CONTIG_HEADER_START.substring(2), contigCounter++);
@@ -215,6 +216,7 @@ public abstract class AbstractVCFCodec extends AsciiFeatureCodec<VariantContext>
                         metaData.add(new VCFHeaderLine(str.substring(2, equals), str.substring(equals+1)));
                 }
             }
+            headerLineCounter++;
         }
 
         setVCFHeader(new VCFHeader(version, metaData, sampleNames), version);

--- a/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFCompoundHeaderLine.java
@@ -202,7 +202,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
      * @param lineType     the header line type
      *
      */
-    protected VCFCompoundHeaderLine(String line, VCFHeaderVersion version, SupportedHeaderLineType lineType) {
+    protected VCFCompoundHeaderLine(String line, VCFHeaderVersion version, SupportedHeaderLineType lineType, Integer lineNumber) {
         super(lineType.toString(), "");
 
         final ArrayList<String> expectedTags = new ArrayList(Arrays.asList("ID", "Number", "Type", "Description"));
@@ -240,7 +240,7 @@ public abstract class VCFCompoundHeaderLine extends VCFHeaderLine implements VCF
             throw new TribbleException(mapping.get("Type") + " is not a valid type in the VCF specification (note that types are case-sensitive)");
         }
         if (type == VCFHeaderLineType.Flag && !allowFlagValues())
-            throw new IllegalArgumentException("Flag is an unsupported type for this kind of field");
+            throw new IllegalArgumentException("Flag is an unsupported type for this kind of field at line number "+ lineNumber);
 
         description = mapping.get("Description");
         if (description == null && ALLOW_UNBOUND_DESCRIPTIONS) // handle the case where there's no description provided

--- a/src/main/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
@@ -47,7 +47,7 @@ public class VCFFormatHeaderLine extends VCFCompoundHeaderLine {
     }
 
     public VCFFormatHeaderLine(String line, VCFHeaderVersion version, Integer lineNumber) {
-            super(line, version, SupportedHeaderLineType.FORMAT, lineNumber);
+        super(line, version, SupportedHeaderLineType.FORMAT, lineNumber);
     }
     // format fields do not allow flag values (that wouldn't make much sense, how would you encode this in the genotype).
     @Override

--- a/src/main/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
@@ -46,10 +46,9 @@ public class VCFFormatHeaderLine extends VCFCompoundHeaderLine {
         super(name, count, type, description, SupportedHeaderLineType.FORMAT);
     }
 
-    public VCFFormatHeaderLine(String line, VCFHeaderVersion version, Integer lineNumber) { {
-        super(line, version, SupportedHeaderLineType.FORMAT, lineNumber);
+    public VCFFormatHeaderLine(String line, VCFHeaderVersion version, Integer lineNumber) {
+            super(line, version, SupportedHeaderLineType.FORMAT, lineNumber);
     }
-
     // format fields do not allow flag values (that wouldn't make much sense, how would you encode this in the genotype).
     @Override
     boolean allowFlagValues() {

--- a/src/main/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFormatHeaderLine.java
@@ -46,8 +46,8 @@ public class VCFFormatHeaderLine extends VCFCompoundHeaderLine {
         super(name, count, type, description, SupportedHeaderLineType.FORMAT);
     }
 
-    public VCFFormatHeaderLine(String line, VCFHeaderVersion version) {
-        super(line, version, SupportedHeaderLineType.FORMAT);
+    public VCFFormatHeaderLine(String line, VCFHeaderVersion version, Integer lineNumber) { {
+        super(line, version, SupportedHeaderLineType.FORMAT, lineNumber);
     }
 
     // format fields do not allow flag values (that wouldn't make much sense, how would you encode this in the genotype).

--- a/src/main/java/htsjdk/variant/vcf/VCFInfoHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFInfoHeaderLine.java
@@ -52,8 +52,8 @@ public class VCFInfoHeaderLine extends VCFCompoundHeaderLine {
         super(name, count, type, description, SupportedHeaderLineType.INFO, source, version);
     }
 
-    public VCFInfoHeaderLine(String line, VCFHeaderVersion version) {
-        super(line, version, SupportedHeaderLineType.INFO);
+    public VCFInfoHeaderLine(String line, VCFHeaderVersion version, Integer lineNumber) {
+        super(line, version, SupportedHeaderLineType.INFO, lineNumber);
     }
 
     // info fields allow flag values

--- a/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
@@ -39,7 +39,8 @@ public class VCFCompoundHeaderLineUnitTest extends VariantBaseTest {
     @Test
     public void supportsVersionFields() {
         final String line = "<ID=FOO,Number=1,Type=Float,Description=\"foo\",Version=3>";
-        new VCFInfoHeaderLine(line, VCFHeaderVersion.VCF4_2);
+        final Integer lineNumber = 5;
+        new VCFInfoHeaderLine(line, VCFHeaderVersion.VCF4_2, lineNumber);
         // if we don't support version fields then we should fail before we ever get here
         Assert.assertTrue(true);
     }


### PR DESCRIPTION
### Description

When an invalid header line is present in a VCF file, htsjdk errors without specific details. More details [here](https://github.com/samtools/htsjdk/issues/1565)

## Fix
Adding the line number of the VCF file's invalid line to the error message.