### PR TITLE
add file format to index is required error message

### DIFF
--- a/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/TribbleIndexedFeatureReader.java
@@ -92,7 +92,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
         if (requireIndex) {
             this.loadIndex();
             if (!this.hasIndex()) {
-                throw new TribbleException("An index is required, but none found.");
+                throw new TribbleException("An index is required, but none found with file ending .idx");
             }
         }
 
@@ -132,7 +132,7 @@ public class TribbleIndexedFeatureReader<T extends Feature, SOURCE> extends Abst
             if (requireIndex) {
                 this.loadIndex();
                 if (!this.hasIndex()) {
-                    throw new TribbleException("An index is required, but none found.");
+                    throw new TribbleException("An index is required, but none found with file ending .idx");
                 }
             }
         }


### PR DESCRIPTION
### Description

When index file is absent, htsjdk errors with "An index is required, but none found" message
More details [here](https://github.com/samtools/htsjdk/issues/1512)

## Fix
Error message specifies the expected index file format "An index is required, but none found with file ending .idx".