### PR TITLE
add predicate to GFF3Codec to give a chance to filter out some unused attributes

### DIFF
--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -9,9 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 public class Gff3BaseData {
-    static final String ID_ATTRIBUTE_KEY = "ID";
-    static final String NAME_ATTRIBUTE_KEY = "Name";
-    private static final String ALIAS_ATTRIBUTE_KEY = "Alias";
     private final String contig;
     private final String source;
     private final String type;
@@ -38,9 +35,9 @@ public class Gff3BaseData {
         this.phase = phase;
         this.strand = strand;
         this.attributes = copyAttributesSafely(attributes);
-        this.id = Gff3Codec.extractSingleAttribute(attributes.get(ID_ATTRIBUTE_KEY));
-        this.name = Gff3Codec.extractSingleAttribute(attributes.get(NAME_ATTRIBUTE_KEY));
-        this.aliases = attributes.getOrDefault(ALIAS_ATTRIBUTE_KEY, Collections.emptyList());
+        this.id = Gff3Codec.extractSingleAttribute(attributes.get(Gff3Constants.ID_ATTRIBUTE_KEY));
+        this.name = Gff3Codec.extractSingleAttribute(attributes.get(Gff3Constants.NAME_ATTRIBUTE_KEY));
+        this.aliases = attributes.getOrDefault(Gff3Constants.ALIAS_ATTRIBUTE_KEY, Collections.emptyList());
         this.hashCode = computeHashCode();
     }
 

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Map;
 
 public class Gff3BaseData {
-    private static final String ID_ATTRIBUTE_KEY = "ID";
-    private static final String NAME_ATTRIBUTE_KEY = "Name";
+    static final String ID_ATTRIBUTE_KEY = "ID";
+    static final String NAME_ATTRIBUTE_KEY = "Name";
     private static final String ALIAS_ATTRIBUTE_KEY = "Alias";
     private final String contig;
     private final String source;

--- a/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Codec.java
@@ -72,7 +72,7 @@ public class Gff3Codec extends AbstractFeatureCodec<Gff3Feature, LineIterator> {
 
     private int currentLine = 0;
 
-    /** give a chance filter out some keys in the EXTRA_FIELDS column */
+    /** Optional filter to remove keys from the EXTRA_FIELDS column */
     private Predicate<String> filterOutAttribute = KEY -> false;
     
     public Gff3Codec() {

--- a/src/main/java/htsjdk/tribble/gff/Gff3Constants.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Constants.java
@@ -10,4 +10,7 @@ public class Gff3Constants {
      public static final String UNDEFINED_FIELD_VALUE = ".";
      public static final String PARENT_ATTRIBUTE_KEY = "Parent";
      public final static char END_OF_LINE_CHARACTER = '\n';
+     public static final String ID_ATTRIBUTE_KEY = "ID";
+     public static final String NAME_ATTRIBUTE_KEY = "Name";
+     public static final String ALIAS_ATTRIBUTE_KEY = "Alias";
 }

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 
@@ -69,6 +70,26 @@ public class Gff3CodecTest extends HtsjdkTest {
         Assert.assertEquals(countTotalFeatures, expectedTotalFeatures);
     }
 
+    @Test(dataProvider = "basicDecodeDataProvider")
+    public void codecFilterExtraFieldTest(final Path inputGff3, final int expectedTotalFeatures) throws IOException {
+        final Gff3Codec codec = new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW);
+        Assert.assertTrue(codec.canDecode(inputGff3.toAbsolutePath().toString()));
+        final Set<String> skip_attributes = new HashSet<>(Arrays.asList("version","rank","biotype","transcript_support_level","mgi_id","havana_gene","tag"));
+        codec.setExtraFieldPredicate(S -> !skip_attributes.contains(S));
+        final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(inputGff3.toAbsolutePath().toString(), null,codec, false);
+        int countTotalFeatures = 0;
+        for (final Gff3Feature feature : reader.iterator()) {
+            for(final String key : skip_attributes) {
+                Assert.assertTrue(feature.getAttribute(key).isEmpty());
+            }
+            countTotalFeatures++;
+        }
+
+        Assert.assertEquals(countTotalFeatures, expectedTotalFeatures);
+    }
+
+    
+    
     @Test(dataProvider = "basicDecodeDataProvider")
     public void basicShallowDecodeTest(final Path inputGff3, final int expectedTotalFeatures) throws IOException {
         Assert.assertTrue((new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW)).canDecode(inputGff3.toAbsolutePath().toString()));

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 
@@ -71,11 +70,11 @@ public class Gff3CodecTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "basicDecodeDataProvider")
-    public void codecFilterExtraFieldTest(final Path inputGff3, final int expectedTotalFeatures) throws IOException {
-        final Gff3Codec codec = new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW);
-        Assert.assertTrue(codec.canDecode(inputGff3.toAbsolutePath().toString()));
+    public void codecFilterOutFieldsTest(final Path inputGff3, final int expectedTotalFeatures) throws IOException {
         final Set<String> skip_attributes = new HashSet<>(Arrays.asList("version","rank","biotype","transcript_support_level","mgi_id","havana_gene","tag"));
-        codec.setExtraFieldPredicate(S -> !skip_attributes.contains(S));
+        final Gff3Codec codec = new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW).
+                setFilterOutAttribute(S->skip_attributes.contains(S));
+        Assert.assertTrue(codec.canDecode(inputGff3.toAbsolutePath().toString()));
         final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(inputGff3.toAbsolutePath().toString(), null,codec, false);
         int countTotalFeatures = 0;
         for (final Gff3Feature feature : reader.iterator()) {

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -72,8 +72,7 @@ public class Gff3CodecTest extends HtsjdkTest {
     @Test(dataProvider = "basicDecodeDataProvider")
     public void codecFilterOutFieldsTest(final Path inputGff3, final int expectedTotalFeatures) throws IOException {
         final Set<String> skip_attributes = new HashSet<>(Arrays.asList("version","rank","biotype","transcript_support_level","mgi_id","havana_gene","tag"));
-        final Gff3Codec codec = new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW).
-                setFilterOutAttribute(S->skip_attributes.contains(S));
+        final Gff3Codec codec = new Gff3Codec(Gff3Codec.DecodeDepth.SHALLOW, S->skip_attributes.contains(S));
         Assert.assertTrue(codec.canDecode(inputGff3.toAbsolutePath().toString()));
         final AbstractFeatureReader<Gff3Feature, LineIterator> reader = AbstractFeatureReader.getFeatureReader(inputGff3.toAbsolutePath().toString(), null,codec, false);
         int countTotalFeatures = 0;


### PR DESCRIPTION
### Description

When using a GFF3Reader with DecodeDepth==DEEP, it may use a large amount of memory with attributes that will never be used ("version" ,"tag", etc...). This PR gives the GFF3Codec a chance to set a `Predicate<String>` to only keep a defined set of attributes.



the private attribute of ID_ATTRIBUTE_KEY and NAME_ATTRIBUTE_KEY Gff3BaseData was removed to check if the predicate does not remove them.

a new method `setFilterOutAttribute` was added to GFF3Codec

the `static` attribute of GFF3Codec.parseLine was removed

I added a test codecFilterOutFieldsTest


### Things to think about before submitting:
- [X] Make sure your changes compile and new tests pass locally.
- [X] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [X] Extended the README / documentation, if necessary
- [X] Check your code style.
- [X] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
