### PR TITLE
Rename ByteArrayAlelle to SimpleAllele and make it public

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -26,7 +26,6 @@
 package htsjdk.variant.variantcontext;
 
 import java.io.Serializable;
-import java.util.Collection;
 
 /**
  * Immutable representation of an allele.
@@ -128,20 +127,20 @@ public interface Allele extends Comparable<Allele>, Serializable {
 
     String NON_REF_STRING = "<NON_REF>";
     String UNSPECIFIED_ALTERNATE_ALLELE_STRING = "<*>";
-    Allele REF_A = new ByteArrayAllele("A", true);
-    Allele ALT_A = new ByteArrayAllele("A", false);
-    Allele REF_C = new ByteArrayAllele("C", true);
-    Allele ALT_C = new ByteArrayAllele("C", false);
-    Allele REF_G = new ByteArrayAllele("G", true);
-    Allele ALT_G = new ByteArrayAllele("G", false);
-    Allele REF_T = new ByteArrayAllele("T", true);
-    Allele ALT_T = new ByteArrayAllele("T", false);
-    Allele REF_N = new ByteArrayAllele("N", true);
-    Allele ALT_N = new ByteArrayAllele("N", false);
-    Allele SPAN_DEL = new ByteArrayAllele(SPAN_DEL_STRING, false);
-    Allele NO_CALL = new ByteArrayAllele(NO_CALL_STRING, false);
-    Allele NON_REF_ALLELE = new ByteArrayAllele(NON_REF_STRING, false);
-    Allele UNSPECIFIED_ALTERNATE_ALLELE = new ByteArrayAllele(UNSPECIFIED_ALTERNATE_ALLELE_STRING, false);
+    Allele REF_A = new SimpleAllele("A", true);
+    Allele ALT_A = new SimpleAllele("A", false);
+    Allele REF_C = new SimpleAllele("C", true);
+    Allele ALT_C = new SimpleAllele("C", false);
+    Allele REF_G = new SimpleAllele("G", true);
+    Allele ALT_G = new SimpleAllele("G", false);
+    Allele REF_T = new SimpleAllele("T", true);
+    Allele ALT_T = new SimpleAllele("T", false);
+    Allele REF_N = new SimpleAllele("N", true);
+    Allele ALT_N = new SimpleAllele("N", false);
+    Allele SPAN_DEL = new SimpleAllele(SPAN_DEL_STRING, false);
+    Allele NO_CALL = new SimpleAllele(NO_CALL_STRING, false);
+    Allele NON_REF_ALLELE = new SimpleAllele(NON_REF_STRING, false);
+    Allele UNSPECIFIED_ALTERNATE_ALLELE = new SimpleAllele(UNSPECIFIED_ALTERNATE_ALLELE_STRING, false);
 
     // for simple deletion, e.g. "ALT==<DEL>" (note that the spec allows, for now at least, alt alleles like <DEL:ME>)
     @SuppressWarnings("unused")
@@ -188,7 +187,7 @@ public interface Allele extends Comparable<Allele>, Serializable {
                 default: throw new IllegalArgumentException("Illegal base [" + (char)bases[0] + "] seen in the allele");
             }
         } else {
-            return new ByteArrayAllele(bases.clone(), isRef);
+            return new SimpleAllele(bases.clone(), isRef);
         }
     }
 
@@ -372,12 +371,13 @@ public interface Allele extends Comparable<Allele>, Serializable {
      * (in which case the returned allele will be non-Ref).
      *
      * This method is efficient because it can skip the validation of the bases (since the original allele was already validated)
+
      *
      * @param allele  the allele from which to copy the bases
      * @param ignoreRefState  should we ignore the reference state of the input allele and use the default ref state?
      */
     static Allele create(Allele allele, boolean ignoreRefState) {
-        return new ByteArrayAllele(allele.getBases(), allele.isReference() && !ignoreRefState);
+        return new SimpleAllele(allele.getBases(), allele.isReference() && !ignoreRefState);
     }
 
     static boolean oneIsPrefixOfOther(final Allele a1, final Allele a2) {

--- a/src/main/java/htsjdk/variant/variantcontext/SimpleAllele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/SimpleAllele.java
@@ -27,13 +27,20 @@ package htsjdk.variant.variantcontext;
 
 import htsjdk.samtools.util.StringUtil;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-class ByteArrayAllele implements Allele {
+/**
+ *  An implementation of {@link Allele} which includes a byte[] of the bases in the allele or the symbolic name.
+ *
+ *  This has been made public in order to maintain backwards compatibilty and act as a base for classes which previously
+ *  subclassed Allele before it was converted into an interface.
+ *
+ *  Most users should create alleles using {@link Allele#create(byte)} instead of interacting with this class directly.
+ */
+public class SimpleAllele implements Allele {
 
-    private static long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     private static final byte[] EMPTY_ALLELE_BASES = new byte[0];
 
@@ -44,7 +51,7 @@ class ByteArrayAllele implements Allele {
     private byte[] bases = null;
 
     // no public way to create an allele
-    protected ByteArrayAllele(final byte[] bases, final boolean isRef) {
+    protected SimpleAllele(final byte[] bases, final boolean isRef) {
         // null alleles are no longer allowed
         if ( Allele.wouldBeNullAllele(bases) ) {
             throw new IllegalArgumentException("Null alleles are not supported");
@@ -73,7 +80,7 @@ class ByteArrayAllele implements Allele {
             throw new IllegalArgumentException("Unexpected base in allele bases \'" + new String(bases)+"\'");
     }
 
-    protected ByteArrayAllele(final String bases, final boolean isRef) {
+    protected SimpleAllele(final String bases, final boolean isRef) {
         this(bases.getBytes(), isRef);
     }
 
@@ -86,7 +93,7 @@ class ByteArrayAllele implements Allele {
      * @param allele  the allele from which to copy the bases
      * @param ignoreRefState  should we ignore the reference state of the input allele and use the default ref state?
      */
-    protected ByteArrayAllele(final ByteArrayAllele allele, final boolean ignoreRefState) {
+    protected SimpleAllele(final SimpleAllele allele, final boolean ignoreRefState) {
         this.bases = allele.bases;
         this.isRef = ignoreRefState ? false : allele.isRef;
         this.isNoCall = allele.isNoCall;
@@ -97,8 +104,8 @@ class ByteArrayAllele implements Allele {
     public boolean isPrefixOf(final Allele other) {
         if (other.length() < this.length()) {
             return false;
-        } else if (other instanceof ByteArrayAllele) {
-            final ByteArrayAllele baOther = (ByteArrayAllele) other;
+        } else if (other instanceof SimpleAllele) {
+            final SimpleAllele baOther = (SimpleAllele) other;
             return isPrefixOfBytes(baOther.bases);
         } else {
             return isPrefixOfBytes(other.getBases());
@@ -255,8 +262,8 @@ class ByteArrayAllele implements Allele {
             return -1;
         else if ( isNonReference() && other.isReference() ) 
             return 1;
-        else if (other instanceof ByteArrayAllele) {
-            final ByteArrayAllele baOther = (ByteArrayAllele) other;
+        else if (other instanceof SimpleAllele) {
+            final SimpleAllele baOther = (SimpleAllele) other;
             return compareBases(baOther.bases);
         } else {
             return compareBases(other.getBases());

--- a/src/main/java/htsjdk/variant/variantcontext/SimpleAllele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/SimpleAllele.java
@@ -33,10 +33,9 @@ import java.util.Arrays;
 /**
  *  An implementation of {@link Allele} which includes a byte[] of the bases in the allele or the symbolic name.
  *
- *  This has been made public in order to maintain backwards compatibilty and act as a base for classes which previously
- *  subclassed Allele before it was converted into an interface.
+ *  This has been made public as a base for classes which need to subclass Allele.
  *
- *  Most users should create alleles using {@link Allele#create(byte)} instead of interacting with this class directly.
+ *  Most users should create alleles using {@link Allele#create(byte[])} instead of interacting with this class directly.
  */
 public class SimpleAllele implements Allele {
 


### PR DESCRIPTION
* When we refactored Allele into an interface we made the implementation package protected.
* This caused problems for downstream tools which previously subclassed allele.
* Making the implementation public so that there is an equivalent class to subclass as a base
  for downstream implementations.