### PR TITLE
Introduce non-throwing version validation methods for VCFHeaderLine

### DIFF
--- a/src/main/java/htsjdk/tribble/TribbleException.java
+++ b/src/main/java/htsjdk/tribble/TribbleException.java
@@ -24,6 +24,8 @@
 package htsjdk.tribble;
 
 
+import htsjdk.variant.vcf.VCFHeaderVersion;
+
 /**
  * @author Aaron
  *
@@ -84,6 +86,12 @@ public class TribbleException extends RuntimeException {
     // capture other internal codec exceptions
     public static class InternalCodecException extends TribbleException {
         public InternalCodecException(String message) { super (message); }
+    }
+
+    public static class VCFVersionValidationFailure extends TribbleException {
+        public VCFVersionValidationFailure(final VCFHeaderVersion version, final String f) {
+            super(String.format("VCF version validation for version %s failed with error: %s", version, f));
+        }
     }
 
     // //////////////////////////////////////////////////////////////////////

--- a/src/main/java/htsjdk/variant/vcf/VCFAltHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFAltHeaderLine.java
@@ -1,7 +1,6 @@
 package htsjdk.variant.vcf;
 
 import htsjdk.samtools.util.Log;
-import htsjdk.tribble.TribbleException;
 
 import java.util.*;
 
@@ -39,19 +38,24 @@ public class VCFAltHeaderLine extends VCFSimpleHeaderLine {
      * Validate that this header line conforms to the target version.
      */
     @Override
-    public void validateForVersion(final VCFHeaderVersion vcfTargetVersion) {
-        super.validateForVersion(vcfTargetVersion);
+    public Optional<String> getValidationError(final VCFHeaderVersion vcfTargetVersion) {
+        final Optional<String> superError = super.getValidationError(vcfTargetVersion);
+        if (superError.isPresent()) {
+            return superError;
+        }
 
         //TODO: Should we validate/constrain these to match the 4.3 spec constraints ?
         if (!vcfTargetVersion.isAtLeastAsRecentAs(VCFHeaderVersion.VCF4_0)) {
             final String message = String.format("%s header lines are not allowed in VCF version %s headers",
-                    getKey(),
-                    vcfTargetVersion.toString());
+                getKey(),
+                vcfTargetVersion);
             if (VCFUtils.isStrictVCFVersionValidation()) {
-                throw new TribbleException.InvalidHeader(message);
+                return Optional.of(message);
             } else {
                 logger.warn(message);
             }
         }
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFContigHeaderLine.java
@@ -32,6 +32,7 @@ import htsjdk.tribble.TribbleException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
@@ -189,16 +190,22 @@ public class VCFContigHeaderLine extends VCFSimpleHeaderLine {
      * Validate that this header line conforms to the target version.
      */
     @Override
-    public void validateForVersion(final VCFHeaderVersion vcfTargetVersion) {
-        super.validateForVersion(vcfTargetVersion);
+    public Optional<String> getValidationError(final VCFHeaderVersion vcfTargetVersion) {
+        final Optional<String> superError = super.getValidationError(vcfTargetVersion);
+        if (superError.isPresent()) {
+            return superError;
+        }
+
         if (vcfTargetVersion.isAtLeastAsRecentAs(VCFHeaderVersion.VCF4_3)) {
              if (!VALID_CONTIG_ID_PATTERN.matcher(getID()).matches()) {
-                String message = String.format("Contig headerLineID \"%s\" in \"%s\" header line doesn't conform to VCF contig ID restrictions" ,
-                        getID(),
-                        getKey());
-                throw new TribbleException.InvalidHeader(message);
+                return Optional.of(String.format("Contig headerLineID \"%s\" in \"%s\" header line doesn't conform to VCF contig ID restrictions" ,
+                    getID(),
+                    getKey()
+                ));
             }
         }
+
+        return Optional.empty();
     }
 
     public Integer getContigIndex() {

--- a/src/main/java/htsjdk/variant/vcf/VCFInfoHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFInfoHeaderLine.java
@@ -102,6 +102,11 @@ public class VCFInfoHeaderLine extends VCFCompoundHeaderLine {
     }
 
     @Override
+    protected boolean validHeaderID(final String id) {
+        return super.validHeaderID(id) || id.equals(VCFConstants.THOUSAND_GENOMES_KEY);
+    }
+
+    @Override
     public boolean shouldBeAddedToDictionary() {
         return true;
     }

--- a/src/main/java/htsjdk/variant/vcf/VCFMetaHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFMetaHeaderLine.java
@@ -1,8 +1,7 @@
 package htsjdk.variant.vcf;
 
-import htsjdk.tribble.TribbleException;
-
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A class representing META fields in the VCF header.
@@ -27,15 +26,15 @@ public class VCFMetaHeaderLine extends VCFSimpleHeaderLine {
      * Validate that this header line conforms to the target version.
      */
     @Override
-    public void validateForVersion(final VCFHeaderVersion vcfTargetVersion) {
+    public Optional<String> getValidationError(final VCFHeaderVersion vcfTargetVersion) {
         if (!vcfTargetVersion.isAtLeastAsRecentAs(VCFHeaderVersion.VCF4_3)) {
-            throw new TribbleException.InvalidHeader(
-                    String.format("%s header lines are not allowed in VCF version %s headers",
-                            getKey(),
-                            vcfTargetVersion.toString())
-            );
+            return Optional.of(String.format("%s header lines are not allowed in VCF version %s headers",
+                getKey(),
+                vcfTargetVersion
+            ));
         }
-        super.validateForVersion(vcfTargetVersion);
+
+        return super.getValidationError(vcfTargetVersion);
     }
 
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFPedigreeHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFPedigreeHeaderLine.java
@@ -1,8 +1,7 @@
 package htsjdk.variant.vcf;
 
-import htsjdk.tribble.TribbleException;
-
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A class representing PEDIGREE fields in the VCF header. Applicable starting with version VCFv4.3.
@@ -33,20 +32,23 @@ public class VCFPedigreeHeaderLine extends VCFSimpleHeaderLine {
      * Validate that this header line conforms to the target version.
      */
     @Override
-    public void validateForVersion(final VCFHeaderVersion vcfTargetVersion) {
+    public Optional<String> getValidationError(final VCFHeaderVersion vcfTargetVersion) {
         if (!vcfTargetVersion.isAtLeastAsRecentAs(VCFHeaderVersion.VCF4_3)) {
             // previous to VCFv4.3, the PEDIGREE line did not have an ID. Such lines are not modeled by this
             // class (since it is derived from VCFSimpleHeaderLine). Therefore instances of this class always
             // represent VCFv4.3 or higher. So throw if the requested version is less than 4.3.
             final String message = String.format("%s header lines are not allowed in VCF version %s headers",
-                    getKey(),
-                    vcfTargetVersion);
+                getKey(),
+                vcfTargetVersion
+            );
             if (VCFUtils.isStrictVCFVersionValidation()) {
-                throw new TribbleException.InvalidHeader(message);
+                return Optional.of(message);
             } else {
                 logger.warn(message);
             }
         }
+
+        return Optional.empty();
     }
 
 }

--- a/src/main/java/htsjdk/variant/vcf/VCFSampleHeaderLine.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFSampleHeaderLine.java
@@ -1,8 +1,7 @@
 package htsjdk.variant.vcf;
 
-import htsjdk.tribble.TribbleException;
-
 import java.util.Map;
+import java.util.Optional;
 
 /**
  */
@@ -27,18 +26,25 @@ public class VCFSampleHeaderLine extends VCFSimpleHeaderLine {
      * Validate that this header line conforms to the target version.
      */
     @Override
-    public void validateForVersion(final VCFHeaderVersion vcfTargetVersion) {
-        super.validateForVersion(vcfTargetVersion);
+    public Optional<String> getValidationError(final VCFHeaderVersion vcfTargetVersion) {
+        final Optional<String> superError = super.getValidationError(vcfTargetVersion);
+        if (superError.isPresent()) {
+            return superError;
+        }
+
         if (!vcfTargetVersion.isAtLeastAsRecentAs(VCFHeaderVersion.VCF4_0)) {
             final String message = String.format("%s header lines are not allowed in VCF version %s headers",
-                    getKey(),
-                    vcfTargetVersion.toString());
+                getKey(),
+                vcfTargetVersion
+            );
             if (VCFUtils.isStrictVCFVersionValidation()) {
-                throw new TribbleException.InvalidHeader(message);
+                return Optional.of(message);
             } else {
                 logger.warn(message);
             }
         }
+
+        return Optional.empty();
     }
 
 }

--- a/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFCompoundHeaderLineUnitTest.java
@@ -74,6 +74,27 @@ public class VCFCompoundHeaderLineUnitTest extends VariantBaseTest {
         Assert.assertEquals(headerline.getGenericFieldValue(attribute), expectedValue);
     }
 
+    @DataProvider (name = "invalidIDs")
+    public Object[][] getInvalidLines() {
+        return new Object[][] {
+            // ID cannot start with number
+            {"<ID=1A,Number=A,Type=Integer,Description=\"foo\">"},
+            // ID cannot start with '.''
+            {"<ID=.A,Number=A,Type=Integer,Description=\"foo\">"},
+            // Test that IDs with the special thousand genomes key as a prefix are rejected
+            // The thousand genomes key is only accepted for VCFInfoHeaderLine and is tested in VCFInfoHeaderLineUnitTest
+            {"<ID=1000GA,Number=A,Type=Integer,Description=\"foo\">"},
+            // Contains invalid character '&'
+            {"<ID=A&,Number=A,Type=Integer,Description=\"foo\">"},
+        };
+    }
+
+    @Test(dataProvider = "invalidIDs", expectedExceptions = TribbleException.VCFVersionValidationFailure.class)
+    public void testGetValidationError(final String lineString) {
+        // TODO change to VCFHeader.DEFAULT_VCF_VERSION
+        new VCFInfoHeaderLine(lineString, VCFHeaderVersion.VCF4_3);
+    }
+
     @DataProvider (name = "headerLineTypes")
     public Object[][] getHeaderLineTypes() {
         return new Object[][] {

--- a/src/test/java/htsjdk/variant/vcf/VCFContigHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFContigHeaderLineUnitTest.java
@@ -34,6 +34,25 @@ public class VCFContigHeaderLineUnitTest extends HtsjdkTest {
         Assert.assertEquals(headerline.getID(), expectedIDString);
     }
 
+    @DataProvider(name = "invalidIDs")
+    public Object[][] getInvalidIDs() {
+        return new Object[][]{
+            // IDs cannot start with '*'
+            {"<ID=*a>"},
+            // IDs cannot start with '='
+            // The parser cannot handle attributes starting with '=' so we cannot express this test case
+            // {"<ID==a>"},
+            // IDs cannot contain '{'
+            {"<ID=1{>"},
+        };
+    }
+
+    @Test(dataProvider = "invalidIDs", expectedExceptions = TribbleException.VCFVersionValidationFailure.class)
+    public void testInvalidIDs(final String lineString) {
+        // TODO change to VCFHeader.DEFAULT_VCF_VERSION
+        new VCFContigHeaderLine(lineString, VCFHeaderVersion.VCF4_3, 1);
+    }
+
     @Test(expectedExceptions=TribbleException.class)
     public void testRejectNegativeIndex() {
         new VCFContigHeaderLine("<ID=contig1,length=100>", VCFHeader.DEFAULT_VCF_VERSION, -1);

--- a/src/test/java/htsjdk/variant/vcf/VCFFormatHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFFormatHeaderLineUnitTest.java
@@ -2,6 +2,7 @@ package htsjdk.variant.vcf;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.tribble.TribbleException;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderLineUnitTest.java
@@ -136,7 +136,7 @@ public class VCFHeaderLineUnitTest extends VariantBaseTest {
         };
     }
 
-    @Test(dataProvider="incompatibleVersions", expectedExceptions=TribbleException.class)
+    @Test(dataProvider="incompatibleVersions", expectedExceptions=TribbleException.VCFVersionValidationFailure.class)
     public void testValidateForVersionFails(final VCFHeaderVersion vcfVersion, final VCFHeaderVersion incompatibleVersion) {
         VCFHeaderLine headerLine = new VCFHeaderLine(vcfVersion.getFormatString(), vcfVersion.getVersionString());
         headerLine.validateForVersion(incompatibleVersion);

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -557,7 +557,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         Assert.assertEquals(vcfHeader.getVCFHeaderVersion(), VCFHeaderVersion.VCF4_1);
     }
 
-    @Test(expectedExceptions = TribbleException.InvalidHeader.class)
+    @Test(expectedExceptions = TribbleException.VCFVersionValidationFailure.class)
     public void testConstructorWithInvalidLineForVersion() {
         final Set<VCFHeaderLine> metaDataSet = VCFHeaderUnitTestData.getV42HeaderLinesWITHOUTFormatString(); // this (4.2) header is compatible with all 4.x versions
         metaDataSet.add(VCFHeader.makeHeaderVersionLine(VCFHeaderVersion.VCF4_2));
@@ -567,7 +567,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         new VCFHeader(metaDataSet, Collections.emptySet());
     }
 
-    @Test(expectedExceptions = TribbleException.InvalidHeader.class)
+    @Test(expectedExceptions = TribbleException.VCFVersionValidationFailure.class)
     public void testAddMetaDataLineInvalidForVersion() {
         final Set<VCFHeaderLine> metaDataSet = VCFHeaderUnitTestData.getV42HeaderLinesWITHOUTFormatString(); // this (4.2) header is compatible with all 4.x versions
         metaDataSet.add(VCFHeader.makeHeaderVersionLine(VCFHeaderVersion.VCF4_2));

--- a/src/test/java/htsjdk/variant/vcf/VCFInfoHeaderLineUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFInfoHeaderLineUnitTest.java
@@ -62,6 +62,17 @@ public class VCFInfoHeaderLineUnitTest extends HtsjdkTest {
         };
     }
 
+    @Test
+    public void testAllow1000GKey() {
+        final VCFInfoHeaderLine line = new VCFInfoHeaderLine(
+            "INFO=<ID=1000G,Number=0,Type=Flag,Description=1000G>",
+            VCFHeader.DEFAULT_VCF_VERSION
+        );
+
+        // TODO change to VCFHeader.DEFAULT_VCF_VERSION
+        Assert.assertFalse(line.getValidationError(VCFHeaderVersion.VCF4_3).isPresent());
+    }
+
     @Test(dataProvider = "mergeIncompatibleInfoLines", expectedExceptions= TribbleException.class)
     public void testMergeIncompatibleInfoLines(
             final VCFInfoHeaderLine infoHeaderLine1,

--- a/src/test/java/htsjdk/variant/vcf/VCFMetaDataLinesUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFMetaDataLinesUnitTest.java
@@ -229,29 +229,6 @@ public class VCFMetaDataLinesUnitTest extends HtsjdkTest {
         Assert.assertEquals(md.getFormatHeaderLine(testData.getTestFormatLines().get(0).getID()), testData.getTestFormatLines().get(0));
     }
 
-    @DataProvider(name="conflictingVCFVersions")
-    public Object[][] vcfVersions() {
-        return new Object[][]{
-                {VCFHeaderVersion.VCF4_0},
-                {VCFHeaderVersion.VCF4_1},
-                {VCFHeaderVersion.VCF4_3}
-        };
-    }
-
-    @Test(dataProvider="conflictingVCFVersions", expectedExceptions = TribbleException.class)
-    public void testValidateMetaDataLinesConflictingVersion(final VCFHeaderVersion vcfVersion) {
-        final VCFHeaderUnitTestData unitTestData = new VCFHeaderUnitTestData();
-        final VCFMetaDataLines md = unitTestData.getTestMetaDataLines(); // contains a VCFv42 fileformat line
-        md.validateMetaDataLines(vcfVersion);
-    }
-
-    @Test(dataProvider="conflictingVCFVersions", expectedExceptions = TribbleException.class)
-    public void testValidateMetaDataLineConflictingVersion(final VCFHeaderVersion vcfVersion) {
-        final VCFHeaderUnitTestData unitTestData = new VCFHeaderUnitTestData();
-        final VCFMetaDataLines md = unitTestData.getTestMetaDataLines(); // contains a VCFv42 fileformat line
-        md.getMetaDataInInputOrder().forEach(hl -> hl.validateForVersion(vcfVersion));
-    }
-
     @Test
     public void testAddRemoveVersionLine() {
         final VCFHeaderUnitTestData unitTestData = new VCFHeaderUnitTestData();


### PR DESCRIPTION
* VCFMetaDataLines::getValidationErrors returns a map from line -> error useful for checking if version transition would succeed before doing transition
* Add tests for validating header lines
* Add TribbleException.VCFVersionValidationFailure

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Things to think about before submitting:
- [ ] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [ ] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
