### PR TITLE
Update to new version of the snappy compatible with M1 macs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ jacocoTestReport {
 dependencies {
     compile "org.apache.commons:commons-jexl:2.1.1"
     compile "commons-logging:commons-logging:1.1.1"
-    compile "org.xerial.snappy:snappy-java:1.1.7.3"
+    compile "org.xerial.snappy:snappy-java:1.1.8.4"
     compile "org.apache.commons:commons-compress:1.19"
     compile 'org.tukaani:xz:1.8'
     compile "gov.nih.nlm.ncbi:ngs-java:2.9.0"


### PR DESCRIPTION
* update org.xerial.snappy:snappy-java 1.1.7.3-> 1.1.8.4
* This updates to a newer version of snappy which bundles code for M1 Macs.