### PR TITLE
Update to a version of snappy that natively supports apple silicon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ htsjdk.iws
 atlassian-ide-plugin.xml
 /htsjdk.version.properties
 /test-output/
+.DS_Store
 
 #intellij
 .idea/

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ jacocoTestReport {
 dependencies {
     compile "org.apache.commons:commons-jexl:2.1.1"
     compile "commons-logging:commons-logging:1.1.1"
-    compile "org.xerial.snappy:snappy-java:1.1.7.3"
+    compile "org.xerial.snappy:snappy-java:1.1.8.4"
     compile "org.apache.commons:commons-compress:1.19"
     compile 'org.tukaani:xz:1.8'
     compile "gov.nih.nlm.ncbi:ngs-java:2.9.0"


### PR DESCRIPTION
### Description

Running HTSJDK-based apps on Apple Silicon currently fails if the snappy support is used.  Upgrading to the latest version of snappy fixes this as it is aware of and bundles a dylib for Apple Silicon.

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [ ] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
