### PR TITLE
Add an option to SAMFileWriter to disable checking of ordering or rec…

### DIFF
--- a/src/main/java/htsjdk/samtools/AsyncSAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/AsyncSAMFileWriter.java
@@ -44,6 +44,11 @@ class AsyncSAMFileWriter extends AbstractAsyncWriter<SAMRecord> implements SAMFi
 		this.underlyingWriter.setProgressLogger(progress);
 	}
 
+    @Override
+    public void setSortOrderChecking(boolean check) {
+        this.underlyingWriter.setSortOrderChecking(check);
+    }
+
     /**
      * Adds an alignment to the queue to be written.  Will re-throw any exception that was received when
      * writing prior record(s) to the underlying SAMFileWriter.

--- a/src/main/java/htsjdk/samtools/SAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriter.java
@@ -43,6 +43,11 @@ public interface SAMFileWriter extends Closeable {
 	 */
 	void setProgressLogger(final ProgressLoggerInterface progress);
 
+	/** If true writers that are writing pre-sorted records should check the order during writing. */
+	default void setSortOrderChecking(final boolean check) {
+		// no-op
+	}
+
     /**
      * Must be called to flush or file will likely be defective. 
      */

--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -28,7 +28,7 @@ import htsjdk.samtools.util.SortingCollection;
 
 import java.io.File;
 import java.io.StringWriter;
-import java.util.function.Supplier;
+import static htsjdk.samtools.SAMFileHeader.SortOrder;
 
 /**
  * Base class for implementing SAM writer with any underlying format.
@@ -92,6 +92,22 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
         }
         this.sortOrder = sortOrder;
         this.presorted = presorted;
+        setSortOrderChecking(this.sortOrderChecker != null);
+    }
+
+    @Override
+    public void setSortOrderChecking(boolean check) {
+        final boolean doCheck = check &&
+                this.presorted &&
+                this.sortOrder != SAMFileHeader.SortOrder.unsorted &&
+                this.sortOrder != SortOrder.unknown;
+
+        if (doCheck) {
+            this.sortOrderChecker = new SAMSortOrderChecker(this.sortOrder);
+        }
+        else {
+            this.sortOrderChecker = null;
+        }
     }
 
     /**
@@ -141,19 +157,18 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
             throw new IllegalArgumentException("A non-null SAMFileHeader is required for a writer");
         }
         this.header = header;
-        if (sortOrder == null) {
-             sortOrder = SAMFileHeader.SortOrder.unsorted;
+        if (this.sortOrder == null) {
+             this.sortOrder = SAMFileHeader.SortOrder.unsorted;
         }
-        header.setSortOrder(sortOrder);
+        header.setSortOrder(this.sortOrder);
 
         writeHeader(header);
 
-        if (presorted) {
-            if (sortOrder.equals(SAMFileHeader.SortOrder.unsorted)) {
-                presorted = false;
-            } else {
-                sortOrderChecker = new SAMSortOrderChecker(sortOrder);
+        if (this.presorted) {
+            if (this.sortOrder.equals(SAMFileHeader.SortOrder.unsorted)) {
+                this.presorted = false;
             }
+            setSortOrderChecking(true);
         } else if (!sortOrder.equals(SAMFileHeader.SortOrder.unsorted)) {
             alignmentSorter = SortingCollection.newInstance(SAMRecord.class,
                     new BAMRecordCodec(header), sortOrder.getComparatorInstance(), maxRecordsInRam, tmpDir);
@@ -189,12 +204,14 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter
     }
 
     private void assertPresorted(final SAMRecord alignment) {
-        final SAMRecord prev = sortOrderChecker.getPreviousRecord();
-        if (!sortOrderChecker.isSorted(alignment)) {
-            throw new IllegalArgumentException("Alignments added out of order in SAMFileWriterImpl.addAlignment for " +
-                    getFilename() + ". Sort order is " + this.sortOrder + ". Offending records are at ["
-                    + sortOrderChecker.getSortKey(prev) + "] and ["
-                    + sortOrderChecker.getSortKey(alignment) + "]");
+        if (this.sortOrderChecker != null) {
+            if (!sortOrderChecker.isSorted(alignment)) {
+                final SAMRecord prev = sortOrderChecker.getPreviousRecord();
+                throw new IllegalArgumentException("Alignments added out of order in SAMFileWriterImpl.addAlignment for " +
+                        getFilename() + ". Sort order is " + this.sortOrder + ". Offending records are at ["
+                        + sortOrderChecker.getSortKey(prev) + "] and ["
+                        + sortOrderChecker.getSortKey(alignment) + "]");
+            }
         }
     }
 


### PR DESCRIPTION
…ords when presorted=true.

### Description

This change adds a method to SAMFileWriter (not the factory) to enable/disable the code that checks that records are added in order when specifying a sort order and that the data is pre-sorted.  The reasons for doing this are two-fold:

1. When processing a queryname sorted file produced by `samtools sort -n` the difference of opinion in what constitutes `queryname` sort order causes HTSJDK to throw an exception when trying to write the file out while retaining the sort order in the header.  This is a non-trivial pain point.
2. It will increase performance (perhaps only a little) 