### PR TITLE
Implementation of a SAMRecord comparator that matches samtools' queryname sort order.

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparator.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools;
+
+import java.io.Serializable;
+
+/**
+ * Comparator for natural "queryname" (i.e. SO:queryname SS:natural) ordering of SAMRecords.
+ */
+public class SAMRecordQueryNameNaturalComparator extends SAMRecordQueryNameComparator implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /** Compares two strings in a "natural" order. */
+    protected int compare(final String a, final String b) {
+        final int lenA = a.length(), lenB = b.length();
+        int ia = 0, ib = 0;
+
+        while (ia < lenA && ib < lenB) {
+            final char chA = a.charAt(ia);
+            final char chB = b.charAt(ib);
+            final boolean aIsDigit = Character.isDigit(chA);
+            final boolean bIsDigit = Character.isDigit(chB);
+            ia += 1;
+            ib += 1;
+
+            if (aIsDigit && bIsDigit) {
+                long numA = Character.digit(chA, 10);
+                int digitsA = 1;
+                while (ia < lenA && Character.isDigit(a.charAt(ia))) {
+                    numA *= 10;
+                    numA += Character.digit(a.charAt(ia), 10);
+                    ia += 1;
+                    digitsA += 1;
+                }
+
+                long numB = Character.digit(chB, 10);
+                int digitsB = 1;
+                while (ib < lenB && Character.isDigit(b.charAt(ib))) {
+                    numB *= 10;
+                    numB += Character.digit(b.charAt(ib), 10);
+                    ib += 1;
+                    digitsB += 1;
+                }
+
+                int comp = Long.compare(numA, numB);
+                if (comp == 0) comp = digitsB - digitsA; // more leading zeros sorts first
+                if (comp != 0) return comp;
+            }
+            else {
+                final int comp = Character.compare(chA, chB);
+                if (comp != 0) return comp;
+            }
+        }
+
+        // The strings are equal until one or both are out of characters to difference
+        // is solely based on length
+        return lenA - lenB;
+    }
+
+    /**
+     * Less stringent compare method than the regular compare.  If the two records
+     * are equal enough that their ordering in a sorted SAM file would be arbitrary,
+     * this method returns 0.
+     *
+     * @return negative if samRecord1 < samRecord2,  0 if equal, else positive
+     */
+    @Override
+    public int fileOrderCompare(final SAMRecord samRecord1, final SAMRecord samRecord2) {
+        return compare(samRecord1.getReadName(), samRecord2.getReadName());
+    }
+}

--- a/src/main/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparator.java
@@ -45,9 +45,9 @@ public class SAMRecordQueryNameNaturalComparator extends SAMRecordQueryNameCompa
      * Compares two read names using natural ordering, matching htslib's {@code strnum_cmp}.
      *
      * <p>Maximal runs of ASCII digits are compared as numbers; all other characters are compared by
-     * their code point. When two numeric runs have the same value, the run with more leading zeros
-     * sorts first. Because the comparison never parses a run into a number, it is correct (and matches
-     * samtools) for numeric runs of arbitrary length.</p>
+     * their code point. Leading zeros are ignored, so numeric runs with the same value compare equal
+     * (e.g. {@code 8}, {@code 08} and {@code 008}), matching samtools. Because the comparison never
+     * parses a run into a number, it is correct for numeric runs of arbitrary length.</p>
      *
      * @return a negative number if {@code a < b}, zero if they are equal, a positive number if {@code a > b}
      */
@@ -94,11 +94,9 @@ public class SAMRecordQueryNameNaturalComparator extends SAMRecordQueryNameCompa
                     return 1; // a's numeric run is longer, so it is the larger number
                 } else if (bHasDigit) {
                     return -1; // b's numeric run is longer, so it is the larger number
-                } else if (ia != ib) {
-                    // Equal numeric value but a different number of leading zeros; more zeros sorts first.
-                    return ia < ib ? 1 : -1;
                 }
-                // Otherwise the two runs are identical (including leading zeros); keep comparing after them.
+                // Otherwise the two runs have the same numeric value. Leading zeros do not affect the
+                // ordering (matching samtools), so we simply keep comparing the characters that follow.
             } else {
                 if (chA != chB) return chA - chB;
                 ia++;

--- a/src/main/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparator.java
@@ -26,67 +26,106 @@ package htsjdk.samtools;
 import java.io.Serializable;
 
 /**
- * Comparator for natural "queryname" (i.e. SO:queryname SS:natural) ordering of SAMRecords.
+ * Comparator for natural "queryname" ordering of SAMRecords, matching the order that samtools/htslib
+ * produce for a queryname-natural sort (i.e. SAM {@code @HD SO:queryname SS:queryname:natural}).
+ *
+ * <p>Read names are compared so that maximal runs of digits are ordered by numeric value rather than
+ * lexicographically, so e.g. {@code read2} sorts before {@code read10}. Everything else (the pairing,
+ * strand, secondary/supplementary and {@code HI} tie-breaking) is inherited unchanged from
+ * {@link SAMRecordQueryNameComparator}; only the read-name comparison differs.</p>
+ *
+ * <p>The read-name comparison is a faithful port of htslib's {@code strnum_cmp}. It walks the two
+ * names digit-by-digit rather than parsing numeric runs into integers, so it produces the same result
+ * as samtools even for numeric runs too large to fit in a {@code long}.</p>
  */
 public class SAMRecordQueryNameNaturalComparator extends SAMRecordQueryNameComparator implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    /** Compares two strings in a "natural" order. */
-    protected int compare(final String a, final String b) {
-        final int lenA = a.length(), lenB = b.length();
-        int ia = 0, ib = 0;
+    /**
+     * Compares two read names using natural ordering, matching htslib's {@code strnum_cmp}.
+     *
+     * <p>Maximal runs of ASCII digits are compared as numbers; all other characters are compared by
+     * their code point. When two numeric runs have the same value, the run with more leading zeros
+     * sorts first. Because the comparison never parses a run into a number, it is correct (and matches
+     * samtools) for numeric runs of arbitrary length.</p>
+     *
+     * @return a negative number if {@code a < b}, zero if they are equal, a positive number if {@code a > b}
+     */
+    public static int compareNatural(final String a, final String b) {
+        final int lenA = a.length();
+        final int lenB = b.length();
+        int ia = 0;
+        int ib = 0;
 
         while (ia < lenA && ib < lenB) {
             final char chA = a.charAt(ia);
             final char chB = b.charAt(ib);
-            final boolean aIsDigit = Character.isDigit(chA);
-            final boolean bIsDigit = Character.isDigit(chB);
-            ia += 1;
-            ib += 1;
 
-            if (aIsDigit && bIsDigit) {
-                long numA = Character.digit(chA, 10);
-                int digitsA = 1;
-                while (ia < lenA && Character.isDigit(a.charAt(ia))) {
-                    numA *= 10;
-                    numA += Character.digit(a.charAt(ia), 10);
-                    ia += 1;
-                    digitsA += 1;
+            if (isDigit(chA) && isDigit(chB)) {
+                // Skip leading zeros in each run so equal-value runs agree on their significant digits.
+                while (ia < lenA && a.charAt(ia) == '0') ia++;
+                while (ib < lenB && b.charAt(ib) == '0') ib++;
+
+                // Skip the digits that the two runs have in common.
+                while (ia < lenA
+                        && ib < lenB
+                        && isDigit(a.charAt(ia))
+                        && isDigit(b.charAt(ib))
+                        && a.charAt(ia) == b.charAt(ib)) {
+                    ia++;
+                    ib++;
                 }
 
-                long numB = Character.digit(chB, 10);
-                int digitsB = 1;
-                while (ib < lenB && Character.isDigit(b.charAt(ib))) {
-                    numB *= 10;
-                    numB += Character.digit(b.charAt(ib), 10);
-                    ib += 1;
-                    digitsB += 1;
-                }
+                final boolean aHasDigit = ia < lenA && isDigit(a.charAt(ia));
+                final boolean bHasDigit = ib < lenB && isDigit(b.charAt(ib));
 
-                int comp = Long.compare(numA, numB);
-                if (comp == 0) comp = digitsB - digitsA; // more leading zeros sorts first
-                if (comp != 0) return comp;
-            }
-            else {
-                final int comp = Character.compare(chA, chB);
-                if (comp != 0) return comp;
+                if (aHasDigit && bHasDigit) {
+                    // Both runs still have digits at the first differing position. The run with more
+                    // remaining digits is the larger number; if they are the same length, the differing
+                    // digit decides.
+                    int i = 0;
+                    while (ia + i < lenA && ib + i < lenB && isDigit(a.charAt(ia + i)) && isDigit(b.charAt(ib + i))) {
+                        i++;
+                    }
+                    if (ia + i < lenA && isDigit(a.charAt(ia + i))) return 1;
+                    if (ib + i < lenB && isDigit(b.charAt(ib + i))) return -1;
+                    return a.charAt(ia) - b.charAt(ib);
+                } else if (aHasDigit) {
+                    return 1; // a's numeric run is longer, so it is the larger number
+                } else if (bHasDigit) {
+                    return -1; // b's numeric run is longer, so it is the larger number
+                } else if (ia != ib) {
+                    // Equal numeric value but a different number of leading zeros; more zeros sorts first.
+                    return ia < ib ? 1 : -1;
+                }
+                // Otherwise the two runs are identical (including leading zeros); keep comparing after them.
+            } else {
+                if (chA != chB) return chA - chB;
+                ia++;
+                ib++;
             }
         }
 
-        // The strings are equal until one or both are out of characters to difference
-        // is solely based on length
-        return lenA - lenB;
+        // One name is a prefix of the other (or they are equal); the longer name sorts last.
+        if (ia < lenA) return 1;
+        if (ib < lenB) return -1;
+        return 0;
+    }
+
+    /** Returns true if the character is an ASCII digit. Read names are ASCII per the SAM spec. */
+    private static boolean isDigit(final char c) {
+        return c >= '0' && c <= '9';
     }
 
     /**
-     * Less stringent compare method than the regular compare.  If the two records
-     * are equal enough that their ordering in a sorted SAM file would be arbitrary,
-     * this method returns 0.
+     * Compares the read names of the two records using natural ordering. This is the only part of the
+     * queryname comparison that differs from {@link SAMRecordQueryNameComparator}; the remaining
+     * tie-breaking is inherited.
      *
-     * @return negative if samRecord1 < samRecord2,  0 if equal, else positive
+     * @return negative if {@code samRecord1 < samRecord2}, 0 if their read names are equal, else positive
      */
     @Override
     public int fileOrderCompare(final SAMRecord samRecord1, final SAMRecord samRecord2) {
-        return compare(samRecord1.getReadName(), samRecord2.getReadName());
+        return compareNatural(samRecord1.getReadName(), samRecord2.getReadName());
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparatorTest.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Daniel Gomez-Sanchez
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package htsjdk.samtools;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.CollectionUtil;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SAMRecordQueryNameNaturalComparatorTest extends HtsjdkTest {
+    private final static SAMRecordQueryNameNaturalComparator COMPARATOR = new SAMRecordQueryNameNaturalComparator();
+
+    @Test
+    public void testCompareDifferentNames() throws Exception {
+        // Example names in order from the SAMv1 spec
+        final List<String> names = CollectionUtil.makeList(
+                "abc", "abc+5", "abc- 5", "abc.d", "abc03", "abc5",
+                "abc008", "abc08", "abc8", "abc17", "abc17.+",
+                "abc17.2", "abc17.d", "abc59", "abcd"
+        );
+        final List<String> sorted = names.stream().sorted(COMPARATOR::compare).collect(Collectors.toList());
+
+        Assert.assertEquals(sorted, names);
+    }
+
+}

--- a/src/test/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparatorTest.java
@@ -26,26 +26,144 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CollectionUtil;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class SAMRecordQueryNameNaturalComparatorTest extends HtsjdkTest {
-    private final static SAMRecordQueryNameNaturalComparator COMPARATOR = new SAMRecordQueryNameNaturalComparator();
+    private static final SAMRecordQueryNameNaturalComparator COMPARATOR = new SAMRecordQueryNameNaturalComparator();
 
-    @Test
-    public void testCompareDifferentNames() throws Exception {
-        // Example names in order from the SAMv1 spec
-        final List<String> names = CollectionUtil.makeList(
-                "abc", "abc+5", "abc- 5", "abc.d", "abc03", "abc5",
-                "abc008", "abc08", "abc8", "abc17", "abc17.+",
-                "abc17.2", "abc17.d", "abc59", "abcd"
-        );
-        final List<String> sorted = names.stream().sorted(COMPARATOR::compare).collect(Collectors.toList());
-
-        Assert.assertEquals(sorted, names);
+    /** Convenience wrapper returning the sign (-1/0/1) of a natural read-name comparison. */
+    private static int cmp(final String a, final String b) {
+        return Integer.signum(SAMRecordQueryNameNaturalComparator.compareNatural(a, b));
     }
 
+    @Test
+    public void specExampleSortsInDocumentedOrder() {
+        // The worked example of natural ordering from the SAMv1 specification, already in sorted order.
+        final List<String> names = CollectionUtil.makeList(
+                "abc", "abc+5", "abc- 5", "abc.d", "abc03", "abc5", "abc008", "abc08", "abc8", "abc17", "abc17.+",
+                "abc17.2", "abc17.d", "abc59", "abcd");
+
+        final List<String> shuffled = new ArrayList<>(names);
+        Collections.reverse(shuffled); // start from a non-sorted order so sorting does real work
+        shuffled.sort(SAMRecordQueryNameNaturalComparator::compareNatural);
+
+        Assert.assertEquals(shuffled, names);
+    }
+
+    @Test
+    public void numericRunsCompareByValueNotLexicographically() {
+        // The whole point of natural ordering: read2 < read10 even though "10" < "2" lexicographically.
+        Assert.assertEquals(cmp("read2", "read10"), -1);
+        Assert.assertEquals(cmp("read10", "read2"), 1);
+        Assert.assertEquals(cmp("read9", "read10"), -1);
+    }
+
+    @Test
+    public void pureNumericNamesSortByValue() {
+        Assert.assertEquals(cmp("2", "10"), -1);
+        Assert.assertEquals(cmp("10", "100"), -1);
+        Assert.assertEquals(cmp("100", "99"), 1);
+    }
+
+    @Test
+    public void moreLeadingZerosSortFirstAmongEqualValues() {
+        // All three have numeric value 8; the one with the most leading zeros sorts first.
+        Assert.assertEquals(cmp("x008", "x08"), -1);
+        Assert.assertEquals(cmp("x08", "x8"), -1);
+        Assert.assertEquals(cmp("x008", "x8"), -1);
+    }
+
+    @Test
+    public void leadingZeroRunsWithEqualValueButDifferentDigitsAreOrdered() {
+        // "010" (value 10) vs "09" (value 9): compared by value, not by the leading zero.
+        Assert.assertEquals(cmp("010", "09"), 1);
+        // "00" and "0" are both zero; more leading zeros sorts first.
+        Assert.assertEquals(cmp("00", "0"), -1);
+    }
+
+    @Test
+    public void largeNumericRunsDoNotOverflow() {
+        // Numeric runs beyond Long.MAX_VALUE (9223372036854775807) must still order by value.
+        // A run parsed into a long would overflow here; the digit-by-digit comparison must not.
+        final String twoPow64 = "read18446744073709551616"; // 2^64, 20 digits
+        Assert.assertEquals(cmp("read9", twoPow64), -1, "single digit must sort before a 20-digit number");
+        Assert.assertEquals(cmp(twoPow64, "read9"), 1);
+
+        // Two 20-digit numbers differing only in the final digit.
+        Assert.assertEquals(cmp("read18446744073709551616", "read18446744073709551617"), -1);
+
+        // A 21-digit number is larger than any 20-digit number.
+        Assert.assertEquals(cmp("read99999999999999999999", "read100000000000000000000"), -1);
+    }
+
+    @Test
+    public void equalNamesCompareEqual() {
+        Assert.assertEquals(cmp("read1", "read1"), 0);
+        Assert.assertEquals(cmp("abc17.2", "abc17.2"), 0);
+        Assert.assertEquals(cmp("", ""), 0);
+    }
+
+    @Test
+    public void shorterPrefixSortsBeforeLongerName() {
+        Assert.assertEquals(cmp("abc", "abc0"), -1);
+        Assert.assertEquals(cmp("abc", "abcd"), -1);
+        Assert.assertEquals(cmp("read", "read1"), -1);
+    }
+
+    @Test
+    public void emptyNameSortsBeforeAnyNonEmptyName() {
+        Assert.assertEquals(cmp("", "a"), -1);
+        Assert.assertEquals(cmp("a", ""), 1);
+    }
+
+    @Test
+    public void comparisonIsAntisymmetric() {
+        final List<String> names = CollectionUtil.makeList(
+                "abc", "abc03", "abc8", "abc08", "read2", "read10", "read18446744073709551616", "", "abc17.2");
+        for (final String a : names) {
+            for (final String b : names) {
+                Assert.assertEquals(cmp(a, b), -cmp(b, a), "antisymmetry violated for '" + a + "' vs '" + b + "'");
+            }
+        }
+    }
+
+    @Test
+    public void recordLevelComparisonUsesNaturalReadNameOrder() {
+        // Confirm the natural ordering is wired through compare(SAMRecord, SAMRecord) via fileOrderCompare.
+        final SAMFileHeader header = new SAMFileHeader();
+        final SAMRecord read2 = unmapped(header, "read2");
+        final SAMRecord read10 = unmapped(header, "read10");
+
+        Assert.assertTrue(COMPARATOR.compare(read2, read10) < 0);
+        Assert.assertTrue(COMPARATOR.compare(read10, read2) > 0);
+        Assert.assertEquals(COMPARATOR.fileOrderCompare(read2, read10), -1);
+    }
+
+    @Test
+    public void inheritedPairTieBreakStillApplies() {
+        // With identical read names, the inherited queryname tie-breaking still orders first-of-pair
+        // before second-of-pair.
+        final SAMFileHeader header = new SAMFileHeader();
+        final SAMRecord first = unmapped(header, "q");
+        first.setReadPairedFlag(true);
+        first.setFirstOfPairFlag(true);
+        final SAMRecord second = unmapped(header, "q");
+        second.setReadPairedFlag(true);
+        second.setSecondOfPairFlag(true);
+
+        Assert.assertEquals(COMPARATOR.fileOrderCompare(first, second), 0, "same read name compares equal");
+        Assert.assertTrue(COMPARATOR.compare(first, second) < 0, "first of pair sorts before second of pair");
+        Assert.assertTrue(COMPARATOR.compare(second, first) > 0);
+    }
+
+    private static SAMRecord unmapped(final SAMFileHeader header, final String name) {
+        final SAMRecord record = new SAMRecord(header);
+        record.setReadName(name);
+        record.setReadUnmappedFlag(true);
+        return record;
+    }
 }

--- a/src/test/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordQueryNameNaturalComparatorTest.java
@@ -41,11 +41,12 @@ public class SAMRecordQueryNameNaturalComparatorTest extends HtsjdkTest {
     }
 
     @Test
-    public void specExampleSortsInDocumentedOrder() {
-        // The worked example of natural ordering from the SAMv1 specification, already in sorted order.
+    public void mixedNamesSortInNaturalOrder() {
+        // A set of names with a single, unambiguous natural ordering (no leading-zero ties, which
+        // samtools treats as equal). Numeric runs order by value: abc03 (3) < abc5 (5) < abc8 (8) < abc17 (17).
         final List<String> names = CollectionUtil.makeList(
-                "abc", "abc+5", "abc- 5", "abc.d", "abc03", "abc5", "abc008", "abc08", "abc8", "abc17", "abc17.+",
-                "abc17.2", "abc17.d", "abc59", "abcd");
+                "abc", "abc+5", "abc- 5", "abc.d", "abc03", "abc5", "abc8", "abc17", "abc17.+", "abc17.2", "abc17.d",
+                "abc59", "abcd");
 
         final List<String> shuffled = new ArrayList<>(names);
         Collections.reverse(shuffled); // start from a non-sorted order so sorting does real work
@@ -70,19 +71,20 @@ public class SAMRecordQueryNameNaturalComparatorTest extends HtsjdkTest {
     }
 
     @Test
-    public void moreLeadingZerosSortFirstAmongEqualValues() {
-        // All three have numeric value 8; the one with the most leading zeros sorts first.
-        Assert.assertEquals(cmp("x008", "x08"), -1);
-        Assert.assertEquals(cmp("x08", "x8"), -1);
-        Assert.assertEquals(cmp("x008", "x8"), -1);
+    public void leadingZerosDoNotAffectOrder() {
+        // Numeric runs with equal value compare equal regardless of leading zeros, matching samtools.
+        Assert.assertEquals(cmp("x008", "x08"), 0);
+        Assert.assertEquals(cmp("x08", "x8"), 0);
+        Assert.assertEquals(cmp("x008", "x8"), 0);
+        // All-zero runs are likewise equal regardless of how many zeros.
+        Assert.assertEquals(cmp("00", "0"), 0);
     }
 
     @Test
-    public void leadingZeroRunsWithEqualValueButDifferentDigitsAreOrdered() {
+    public void runsWithDifferentValuesAreOrderedRegardlessOfLeadingZeros() {
         // "010" (value 10) vs "09" (value 9): compared by value, not by the leading zero.
         Assert.assertEquals(cmp("010", "09"), 1);
-        // "00" and "0" are both zero; more leading zeros sorts first.
-        Assert.assertEquals(cmp("00", "0"), -1);
+        Assert.assertEquals(cmp("007", "8"), -1);
     }
 
     @Test


### PR DESCRIPTION
@nh13, @lbergelson I put this together mostly for fun - it's a comparator that will sort read names the same way samtools does.  I'm not really sure what the best way to integrate this is in HTSJDK though.  Thoughts?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added natural sorting for SAM record read names.
  * Numeric portions of read names are compared by numeric value, including very large numbers.
  * Leading zeros do not affect numeric ordering.
  * Existing tie-breaking behavior is preserved when read names match.

* **Tests**
  * Added comprehensive coverage for mixed names, numeric ordering, prefixes, empty names, large values, and record-level comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->