### PR TITLE
Remove validateArg call with a high invocation count when writing CRAM.

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/compression/rans/RANSEncodingSymbol.java
+++ b/src/main/java/htsjdk/samtools/cram/compression/rans/RANSEncodingSymbol.java
@@ -24,8 +24,6 @@
  */
 package htsjdk.samtools.cram.compression.rans;
 
-import htsjdk.utils.ValidationUtils;
-
 import java.nio.ByteBuffer;
 
 final class RANSEncodingSymbol {
@@ -69,8 +67,6 @@ final class RANSEncodingSymbol {
     }
 
     public int putSymbol(int r, final ByteBuffer byteBuffer) {
-        ValidationUtils.validateArg(xMax != 0, "can't encode symbol with freq=0");
-
         // re-normalize
         int x = r;
         if (x >= xMax) {


### PR DESCRIPTION
The containing method gets called frequently, and the validateArg call shows up as a hotspot (3-4%) when profiling writing CRAM .

