### PR TITLE
Added ULTIMA and ELEMENT as valid value for RG-PL according to SAM spec.

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMReadGroupRecord.java
@@ -61,13 +61,26 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
     public enum PlatformValue {
         /** @deprecated Use {@linkplain PlatformValue#DNBSEQ} instead. */
         @Deprecated BGI,
+
+        /** Capillary */
         CAPILLARY,
         
         /** MGI/BGI */
         DNBSEQ,
+
+        /** Element Biosciences */
+        ELEMENT,
+
+        /** Helicos Biosciences */
         HELICOS,
+
+        /** Illumina */
         ILLUMINA,
+
+        /** Iontorrent */
         IONTORRENT,
+
+        /** 454 Life Sciences */
         LS454,
 
         /** Oxford Nanopore */
@@ -78,7 +91,12 @@ public class SAMReadGroupRecord extends AbstractSAMHeaderRecord
 
         /** Pacific Biotechnology */
         PACBIO,
-        SOLID
+
+        /** Life Technologies */
+        SOLID,
+
+        /** Ultima Genomics */
+        ULTIMA
     }
 
     public static final Set<String> STANDARD_TAGS =


### PR DESCRIPTION
### Description

The [SAM Spec](https://samtools.github.io/hts-specs/SAMv1.pdf) allows for two additional values for PL inside Read Groups than currently implemented. I added both (`ELEMENT` and `ULTIMA`), in particular so the Ultima pipelines can be updated to use this for their read group values. I also cleaned up the formatting a bit to help readability of the code / comments.
