### PR TITLE
Fix temporary directory hijacking or temporary directory information disclosure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
         run: scripts/htsget-scripts/start-htsget-test-server.sh
       - name: Run tests
         run: ./gradlew test jacocoTestReport
-      - name: Upload to codecov
-        run:  bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
+#      - name: Upload to codecov
+#        run:  bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
@@ -66,8 +66,8 @@ jobs:
         run: ./gradlew compileJava
       - name: Run tests
         run: ./gradlew testFTP jacocoTestReport
-      - name: Upload to codecov
-        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
+#      - name: Upload to codecov
+#        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
@@ -92,8 +92,8 @@ jobs:
         run: ./gradlew compileJava
       - name: Run tests
         run: ./gradlew testFTP jacocoTestReport
-      - name: Upload to codecov
-        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
+#      - name: Upload to codecov
+#        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2

--- a/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
+++ b/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
@@ -56,7 +56,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
     /**
      * directory where files will go
      */
-    private final File workDir = IOUtil.createTempDir("CSPI.", null);
+    private final File workDir = IOUtil.createTempDir("CSPI.tmp").toFile();
     private int sequenceIndexOfMapInRam = INVALID_SEQUENCE_INDEX;
     private Map<KEY, REC> mapInRam = null;
     private final FileAppendStreamLRUCache outputStreams;

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -984,13 +984,7 @@ public class IOUtil {
      */
     public static File createTempDir(final String prefix, final String suffix) {
         try {
-            final File tmp = File.createTempFile(prefix, suffix);
-            if (!tmp.delete()) {
-                throw new SAMException("Could not delete temporary file " + tmp);
-            }
-            if (!tmp.mkdir()) {
-                throw new SAMException("Could not create temporary directory " + tmp);
-            }
+            final File tmp = Files.createTempDirectory(prefix + suffix).toFile();
             return tmp;
         } catch (IOException e) {
             throw new SAMException("Exception creating temporary directory.", e);

--- a/src/test/java/htsjdk/samtools/BAMMergerTest.java
+++ b/src/test/java/htsjdk/samtools/BAMMergerTest.java
@@ -222,7 +222,7 @@ public class BAMMergerTest extends HtsjdkTest {
 
     @Test
     public void test() throws IOException {
-        final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".", ".tmp").toPath();
+        final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp");
         IOUtil.deleteOnExit(outputDir);
 
         final Path outputBam = File.createTempFile(this.getClass().getSimpleName() + ".", ".bam").toPath();

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
@@ -271,11 +271,11 @@ public class CRAMFileWriterTest extends HtsjdkTest {
     public void test_roundtrip_many_reads() throws IOException {
 
         // Create the input file
-        final File outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".", ".tmp");
+        final File outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp").toFile();
         outputDir.deleteOnExit();
         final Path output = new File(outputDir, "input.cram").toPath();
         IOUtil.deleteOnExit(output);
-        final Path fastaDir = IOUtil.createTempDir("CRAMFileWriterTest", "").toPath();
+        final Path fastaDir = IOUtil.createTempDir("CRAMFileWriterTest");
         IOUtil.deleteOnExit(fastaDir);
         final Path newFasta = fastaDir.resolve("input.fasta");
         IOUtil.deleteOnExit(newFasta);

--- a/src/test/java/htsjdk/samtools/CRAMMergerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMMergerTest.java
@@ -193,7 +193,7 @@ public class CRAMMergerTest extends HtsjdkTest {
 
     @Test
     public void test() throws IOException {
-        final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".", ".tmp").toPath();
+        final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp");
         IOUtil.deleteOnExit(outputDir);
 
         final Path outputCram = File.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.CRAM).toPath();

--- a/src/test/java/htsjdk/samtools/reference/FastaSequenceIndexCreatorTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaSequenceIndexCreatorTest.java
@@ -63,7 +63,7 @@ public class FastaSequenceIndexCreatorTest extends HtsjdkTest {
     @Test(dataProvider = "indexedSequences")
     public void testCreate(final File indexedFile) throws Exception {
         // copy the file to index
-        final File tempDir = IOUtil.createTempDir("FastaSequenceIndexCreatorTest", "testCreate");
+        final File tempDir = IOUtil.createTempDir("FastaSequenceIndexCreatorTest.testCreate").toFile();
         final File copied = new File(tempDir, indexedFile.getName());
         copied.deleteOnExit();
         Files.copy(indexedFile.toPath(), copied.toPath());

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamFactoryTest.java
@@ -52,7 +52,7 @@ public class SeekableStreamFactoryTest extends HtsjdkTest {
         final File testBam =  new File(TEST_DATA_DIR, "BAMFileIndexTest/index_test.bam");
 
         //create a temp dir with a space in the name and copy the test file there
-        final File tempDir = IOUtil.createTempDir("test spaces", "");
+        final File tempDir = IOUtil.createTempDir("test spaces").toFile();
         Assert.assertTrue(tempDir.getAbsolutePath().contains(" "));
         tempDir.deleteOnExit();
         final File inputBam = new File(tempDir, "index_test.bam");

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -312,7 +312,7 @@ public class IOUtilTest extends HtsjdkTest {
 
     @Test(dataProvider = "fileNamesForDelete")
     public void testDeletePathLocal(final List<String> fileNames) throws Exception {
-        final File tmpDir = IOUtil.createTempDir("testDeletePath", "");
+        final Path tmpDir = IOUtil.createTempDir("testDeletePath");
         final List<Path> paths = createLocalFiles(tmpDir, fileNames);
         testDeletePaths(paths);
     }
@@ -341,7 +341,7 @@ public class IOUtilTest extends HtsjdkTest {
 
     @Test(dataProvider = "fileNamesForDelete")
     public void testDeleteArrayPathLocal(final List<String> fileNames) throws Exception {
-        final File tmpDir = IOUtil.createTempDir("testDeletePath", "");
+        final Path tmpDir = IOUtil.createTempDir("testDeletePath");
         final List<Path> paths = createLocalFiles(tmpDir, fileNames);
         testDeletePathArray(paths);
     }
@@ -365,12 +365,11 @@ public class IOUtilTest extends HtsjdkTest {
         paths.forEach(p -> Assert.assertFalse(Files.exists(p)));
     }
 
-    private static List<Path> createLocalFiles(final File tmpDir, final List<String> fileNames) throws Exception {
+    private static List<Path> createLocalFiles(final Path tmpDir, final List<String> fileNames) throws Exception {
         final List<Path> paths = new ArrayList<>(fileNames.size());
         for (final String f: fileNames) {
-            final File file = new File(tmpDir, f);
-            Assert.assertTrue(file.createNewFile(), "failed to create test file" +file);
-            paths.add(file.toPath());
+            final Path file = Files.createFile(tmpDir.resolve(f));
+            paths.add(file);
         }
         return paths;
     }

--- a/src/test/java/htsjdk/tribble/index/IndexFactoryTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexFactoryTest.java
@@ -166,7 +166,7 @@ public class IndexFactoryTest extends HtsjdkTest {
             final File inputVCF,
             final Interval queryInterval) throws IOException {
         // copy the original file and create the index for the copy
-        final File tempDir = IOUtil.createTempDir("testCreateTabixIndexFromVCF", null);
+        final File tempDir = IOUtil.createTempDir("testCreateTabixIndexFromVCF").toFile();
         tempDir.deleteOnExit();
         final File tmpVCF = new File(tempDir, inputVCF.getName());
         Files.copy(inputVCF, tmpVCF);
@@ -208,7 +208,7 @@ public class IndexFactoryTest extends HtsjdkTest {
     @Test(dataProvider = "bcfDataFactory")
     public void testCreateLinearIndexFromBCF(final File inputBCF) throws IOException {
         // copy the original file and create the index for the copy
-        final File tempDir = IOUtil.createTempDir("testCreateIndexFromBCF", null);
+        final File tempDir = IOUtil.createTempDir("testCreateIndexFromBCF").toFile();
         tempDir.deleteOnExit();
         final File tmpBCF = new File(tempDir, inputBCF.getName());
         Files.copy(inputBCF, tmpBCF);
@@ -250,7 +250,7 @@ public class IndexFactoryTest extends HtsjdkTest {
     @Test(dataProvider = "getRedirectFiles")
     public void testIndexRedirectedFiles(String input, IndexFactory.IndexType type) throws IOException {
         final VCFRedirectCodec codec = new VCFRedirectCodec();
-        final File dir = IOUtil.createTempDir("redirec-test", "dir");
+        final File dir = IOUtil.createTempDir("redirec-test.dir").toFile();
         try {
             final File tmpInput = new File(dir, new File(input).getName());
             Files.copy(new File(input), tmpInput);

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -131,7 +131,7 @@ public class IndexTest extends HtsjdkTest {
 
     @Test(dataProvider = "writeIndexData")
     public void testWriteBasedOnNonRegularFeatureFile(final File inputFile, final IndexFactory.IndexType type, final  FeatureCodec codec) throws Exception {
-        final File tmpFolder = IOUtil.createTempDir("NonRegultarFeatureFile", null);
+        final File tmpFolder = IOUtil.createTempDir("NonRegultarFeatureFile").toFile();
         // create the index
         final Index index = IndexFactory.createIndex(inputFile, codec, type);
         // try to write based on the tmpFolder

--- a/src/test/java/htsjdk/tribble/index/tabix/TabixIndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/tabix/TabixIndexTest.java
@@ -190,7 +190,7 @@ public class TabixIndexTest extends HtsjdkTest {
             final List<Interval> queryIntervals
     ) throws Exception {
         // copy the input file and create an index for the copy
-        final File tempDir = IOUtil.createTempDir("testBedTabixIndex", null);
+        final File tempDir = IOUtil.createTempDir("testBedTabixIndex.tmp").toFile();
         tempDir.deleteOnExit();
         final File tmpBed = new File(tempDir, inputBed.getName());
         Files.copy(inputBed, tmpBed);

--- a/src/test/java/htsjdk/variant/vcf/VCFFileReaderTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFFileReaderTest.java
@@ -110,7 +110,7 @@ public class VCFFileReaderTest extends HtsjdkTest {
         // Copy the input files into a temporary directory with embedded spaces in the name.
         // This test needs to include the associated .tbi file because we want to force execution
         // of the tabix code path.
-        final File tempDir = IOUtil.createTempDir("test spaces", "");
+        final File tempDir = IOUtil.createTempDir("test spaces").toFile();
         Assert.assertTrue(tempDir.getAbsolutePath().contains(" "));
         tempDir.deleteOnExit();
         final File inputVCF = new File(tempDir, "HiSeq.10000.vcf.bgz");

--- a/src/test/java/htsjdk/variant/vcf/VCFMergerTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFMergerTest.java
@@ -206,7 +206,7 @@ public class VCFMergerTest extends HtsjdkTest {
 
     @Test
     public void test() throws IOException {
-        final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".", ".tmp").toPath();
+        final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp");
         IOUtil.deleteOnExit(outputDir);
 
         final Path outputVcf = File.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.COMPRESSED_VCF).toPath();


### PR DESCRIPTION
And updated version of #1617 which fixes and also deprecates the method in question.