### PR TITLE
removing codecov from github actions until we can migrate to the new uploader

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
         run: scripts/htsget-scripts/start-htsget-test-server.sh
       - name: Run tests
         run: ./gradlew test jacocoTestReport
-      - name: Upload to codecov
-        run:  bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
+#      - name: Upload to codecov
+#        run:  bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
@@ -66,8 +66,8 @@ jobs:
         run: ./gradlew compileJava
       - name: Run tests
         run: ./gradlew testFTP jacocoTestReport
-      - name: Upload to codecov
-        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
+#      - name: Upload to codecov
+#        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
@@ -92,8 +92,8 @@ jobs:
         run: ./gradlew compileJava
       - name: Run tests
         run: ./gradlew testFTP jacocoTestReport
-      - name: Upload to codecov
-        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
+#      - name: Upload to codecov
+#        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Codecov has deprecated their old bash uploader.  

See https://about.codecov.io/blog/introducing-codecovs-new-uploader/

This disables it so we don't fail tests until we can fix the problem.