### PR TITLE
Minor improvements to AbstractLocusIterator

### DIFF
--- a/src/main/java/htsjdk/samtools/util/IntervalListReferenceSequenceMask.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalListReferenceSequenceMask.java
@@ -46,9 +46,7 @@ public class IntervalListReferenceSequenceMask implements ReferenceSequenceMask 
 
     public IntervalListReferenceSequenceMask(final IntervalList intervalList) {
         this.header = intervalList.getHeader();
-        final boolean isSorted = intervalList.getHeader().getSortOrder() == SAMFileHeader.SortOrder.coordinate;
-        final IntervalList sortedIntervalList = isSorted ? intervalList : intervalList.sorted();
-        final List<Interval> uniqueIntervals = sortedIntervalList.uniqued().getIntervals();
+        final List<Interval> uniqueIntervals = intervalList.uniqued().getIntervals();
         if (uniqueIntervals.isEmpty()) {
             lastSequenceIndex = -1;
             lastPosition = 0;
@@ -57,7 +55,7 @@ public class IntervalListReferenceSequenceMask implements ReferenceSequenceMask 
             lastSequenceIndex = header.getSequenceIndex((lastInterval.getContig()));
             lastPosition = lastInterval.getEnd();
         }
-        intervalIterator = new PeekableIterator<Interval>(uniqueIntervals.iterator());
+        intervalIterator = new PeekableIterator<>(uniqueIntervals.iterator());
     }
 
     /**


### PR DESCRIPTION
* Use SequenceUtil to compare dictionaries
* Remove redundant sorting

@michaelgatzen Could you take a look at this? It turns out that IntervalList.uniqued() also sorts so I removed the other sorting, no good way to avoid it entirely.
I also switched the dictionary check to a more standard method that I hadn't known about, but it's now consistent with how other dictionary matching in CollectWgsMetrics is done.