### PR TITLE
Remove deprecation from Allele.acceptableAlleleBases

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -26,6 +26,7 @@
 package htsjdk.variant.variantcontext;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Immutable representation of an allele.
@@ -285,7 +286,6 @@ public interface Allele extends Comparable<Allele>, Serializable {
      * @param bases  bases representing a reference allele
      * @return true if the bases represent the well formatted allele
      */
-    @Deprecated
     static boolean acceptableAlleleBases(String bases) {
         return acceptableAlleleBases(bases.getBytes(), true);
     }
@@ -295,16 +295,14 @@ public interface Allele extends Comparable<Allele>, Serializable {
      * @param isReferenceAllele is a reference allele
      * @return true if the bases represent the well formatted allele
      */
-    @Deprecated
     static boolean acceptableAlleleBases(String bases, boolean isReferenceAllele) {
-        return acceptableAlleleBases(bases.getBytes(), isReferenceAllele);
+        return acceptableAlleleBases(bases.getBytes(StandardCharsets.UTF_8), isReferenceAllele);
     }
 
     /**
      * @param bases  bases representing a reference allele
      * @return true if the bases represent the well formatted allele
      */
-    @Deprecated
     static boolean acceptableAlleleBases(byte[] bases) {
         return acceptableAlleleBases(bases, true);
     }
@@ -315,7 +313,6 @@ public interface Allele extends Comparable<Allele>, Serializable {
      * @param isReferenceAllele true if a reference allele
      * @return true if the bases represent the well formatted allele
      */
-    @Deprecated
     static boolean acceptableAlleleBases(byte[] bases, boolean isReferenceAllele) {
         if ( wouldBeNullAllele(bases) )
             return false;

--- a/src/main/java/htsjdk/variant/variantcontext/SimpleAllele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/SimpleAllele.java
@@ -76,7 +76,7 @@ public class SimpleAllele implements Allele {
         this.bases = bases;
 
         if ( ! Allele.acceptableAlleleBases(bases, isRef) )
-            throw new IllegalArgumentException("Unexpected base in allele bases '" + new String(bases, StandardCharsets.UTF_8)+"'");
+            throw new IllegalArgumentException("Unexpected base in allele bases '" + new String(bases)+"'");
     }
 
     protected SimpleAllele(final String bases, final boolean isRef) {

--- a/src/main/java/htsjdk/variant/variantcontext/SimpleAllele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/SimpleAllele.java
@@ -76,7 +76,7 @@ public class SimpleAllele implements Allele {
         this.bases = bases;
 
         if ( ! Allele.acceptableAlleleBases(bases, isRef) )
-            throw new IllegalArgumentException("Unexpected base in allele bases \'" + new String(bases)+"\'");
+            throw new IllegalArgumentException("Unexpected base in allele bases '" + new String(bases, StandardCharsets.UTF_8)+"'");
     }
 
     protected SimpleAllele(final String bases, final boolean isRef) {


### PR DESCRIPTION
* These methods were deprecated in 3.0.0, it seems like that was probably a mistake
  since there is no obvious replacement for this useful functionality.

* fixes #1623 
