### PR TITLE
Refactoring VariantContextComparator

### DIFF
--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextComparatorUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextComparatorUnitTest.java
@@ -1,75 +1,65 @@
 package htsjdk.variant.variantcontext;
 
 import htsjdk.HtsjdkTest;
+import htsjdk.samtools.util.Locatable;
+import htsjdk.tribble.SimpleFeature;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Unit tests for VariantContextComparator.
  */
-public class VariantContextComparatorUnitTest extends HtsjdkTest {
-    private Allele refA, altG, altT;
+public class VariantContextComparatorUnitTest extends HtsjdkTest{
 
-    @BeforeSuite
-    public void before() {
-        refA = Allele.create("A", true);
-        altG = Allele.create("G", false);
-        altT = Allele.create("T", false);
+    private static final String CHR1 = "chr1" , CHR2 = "chr2";
+
+    @DataProvider
+    public Object[][] getVCs(){
+        final Locatable chr1_1_1 = new SimpleFeature(CHR1, 1, 1);
+        final Locatable chr1_11_11 = new SimpleFeature(CHR1, 11, 11);
+        final Locatable chr2_1_1 = new SimpleFeature(CHR2, 1, 1);
+        final Locatable chr2_10_10 = new SimpleFeature(CHR2, 10,10);
+        final VariantContext chr1_1_1_A_G = make(chr1_1_1, Allele.REF_A, Allele.ALT_G);
+        final VariantContext chr2_1_1_A_G = make(chr2_1_1, Allele.REF_A, Allele.ALT_G);
+
+        final VariantContext chr2_10_10_A_G = make(chr2_10_10, Allele.REF_A, Allele.ALT_G);
+        final VariantContext chr1_11_11_A_G = make(chr1_11_11, Allele.REF_A, Allele.ALT_G);
+        final VariantContext chr1_1_A = make(chr1_1_1, Allele.REF_A);
+        return new Object[][] {
+                {chr1_1_1_A_G, chr1_1_1_A_G, 0}, //identical should match
+                {chr1_1_1_A_G, chr2_1_1_A_G, -1}, //chr2 comes after chr1
+                {chr1_1_1_A_G, chr2_10_10_A_G, -1},
+                {chr1_11_11_A_G, chr2_10_10_A_G, -1}, //chr before pos
+                {chr1_11_11_A_G, chr1_1_1_A_G, 1},
+                {chr1_1_1_A_G, make(chr1_1_1, Allele.REF_A, Allele.ALT_T), -1}, //alleles sort lexicographichally
+                {make(chr1_1_1, Allele.REF_A, Allele.ALT_G, Allele.ALT_T), chr1_1_1_A_G, 1},//extra alleles sort after fewer
+                {chr1_1_1_A_G, make(chr1_1_1, Allele.REF_G, Allele.ALT_A), -1}, //mismatch ref takes precendence
+                {make(chr1_1_1, Allele.REF_T, Allele.ALT_C, Allele.create("AAA"), Allele.ALT_G),  // allele order doesn't matter
+                        make(chr1_1_1, Allele.REF_T, Allele.ALT_G, Allele.create("AAA"), Allele.ALT_C), 0},
+                {chr1_1_1_A_G, chr1_1_A, 1}, // no alt allele
+                {chr1_1_A, chr1_1_A, 0} // no alt alleles at all
+
+        };
     }
 
-    @Test
-    public void testVariantContextsWithSameSiteSortLexicographicallyByAlleleIdentical() {
-        final String contig = "chr1";
-        final VariantContextComparator comparator = new VariantContextComparator(Collections.singletonList(contig));
-        final VariantContextBuilder builder = new VariantContextBuilder("test", contig, 1, 1, Collections.emptyList());
-
-        final VariantContext variant1 = builder.alleles(Arrays.asList(refA, altG)).make();
-        final VariantContext variant2 = builder.alleles(Arrays.asList(refA, altG)).make();
-
-        final int compare = comparator.compare(variant1, variant2);
-        Assert.assertEquals(compare, 0); // TODO: What other criteria might we sort by to break this tie?
+    private static VariantContext make(Locatable pos, Allele ref, Allele ... alt){
+        final List<Allele> alleles = new ArrayList<>();
+        alleles.add(ref);
+        alleles.addAll(Arrays.asList(alt));
+        return new VariantContextBuilder("test", pos.getContig(), pos.getStart(), pos.getEnd(), alleles).make();
     }
 
-    @Test
-    public void testVariantContextsWithSameSiteSortLexicographicallyByAllele() {
-        final String contig = "chr1";
-        final VariantContextComparator comparator = new VariantContextComparator(Collections.singletonList(contig));
-        final VariantContextBuilder builder = new VariantContextBuilder("test", contig, 1, 1, Collections.emptyList());
-
-        final VariantContext variant1 = builder.alleles(Arrays.asList(refA, altG)).make();
-        final VariantContext variant2 = builder.alleles(Arrays.asList(refA, altT)).make();
-
-        final int compare = comparator.compare(variant1, variant2);
-        Assert.assertEquals(compare, -1);
-    }
-
-    @Test
-    public void testVariantContextsWithSameSiteSortLexicographicallyByAlleleThenExtraAllelesForFirstVariant() {
-        final String contig = "chr1";
-        final VariantContextComparator comparator = new VariantContextComparator(Collections.singletonList(contig));
-        final VariantContextBuilder builder = new VariantContextBuilder("test", contig, 1, 1, Collections.emptyList());
-
-        final VariantContext variant1 = builder.alleles(Arrays.asList(refA, altG, altT)).make();
-        final VariantContext variant2 = builder.alleles(Arrays.asList(refA, altG)).make();
-
-        final int compare = comparator.compare(variant1, variant2);
-        Assert.assertEquals(compare, 1);
-    }
-
-    @Test
-    public void testVariantContextsWithSameSiteSortLexicographicallyByAlleleThenExtraAllelesForSecondVariant() {
-        final String contig = "chr1";
-        final VariantContextComparator comparator = new VariantContextComparator(Collections.singletonList(contig));
-        final VariantContextBuilder builder = new VariantContextBuilder("test", contig, 1, 1, Collections.emptyList());
-
-        final VariantContext variant1 = builder.alleles(Arrays.asList(refA, altG)).make();
-        final VariantContext variant2 = builder.alleles(Arrays.asList(refA, altG, altT)).make();
-
-        final int compare = comparator.compare(variant1, variant2);
-        Assert.assertEquals(compare, -1);
+    @Test(dataProvider = "getVCs")
+    public void testVariantContextComparator(VariantContext left, VariantContext right, int expectedResult){
+        final VariantContextComparator comparator = new VariantContextComparator(Arrays.asList(CHR1, CHR2));
+        Assert.assertEquals(comparator.compare(left, right), expectedResult);
+        Assert.assertEquals(comparator.compare(right, left), -expectedResult); // make sure it's symmetrical
     }
 }


### PR DESCRIPTION
* Responding to my own pr comments on #1593
* doing some refactoring to use the Comparator.comparing API
* adding a few more tests

@clintval I might have gone a bit overboard on refactoring.  I really hate how normal comparators are written and like to rewrite them as the newer Comparator.comparing() chains so I did that. 

It's great that you added tests, I ended up condensing them into a single test case with a dataprovider and a few additional use cases.  I never would have bothered having any if you hadn't mad them in the first place though!