### PR TITLE
Allow the BAM index to be up to 5 seconds older than the BAM before e…

### DIFF
--- a/src/main/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/BAMFileReader.java
@@ -175,10 +175,12 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
         throws IOException {
         this(useAsynchronousIO ? new AsyncBlockCompressedInputStream(file, inflaterFactory) : new BlockCompressedInputStream(file, inflaterFactory),
                 indexFile!=null ? indexFile : SamFiles.findIndex(file), eagerDecode, useAsynchronousIO, file.getAbsolutePath(), validationStringency, samRecordFactory);
-        if (mIndexFile != null && mIndexFile.lastModified() < file.lastModified()) {
+
+        if (mIndexFile != null && mIndexFile.lastModified() < file.lastModified() - 5000) {
             System.err.println("WARNING: BAM index file " + mIndexFile.getAbsolutePath() +
                     " is older than BAM " + file.getAbsolutePath());
         }
+
         // Provide better error message when there is an error reading.
         mStream.setInputFileName(file.getAbsolutePath());
     }


### PR DESCRIPTION
…mitting the "WARNING: BAM index file ... is older than BAM " message.


### Description

HTSJDK itself when writing a BAM and indexing it will frequently leave an mtime on the index that is slightly older than the BAM itself, and this causes a lot of spurious warnings.  This is a simple attempt to fix those.

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [ ] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
