### PR TITLE
Update commons-compress to close vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compile "org.apache.commons:commons-jexl:2.1.1"
     compile "commons-logging:commons-logging:1.1.1"
     compile "org.xerial.snappy:snappy-java:1.1.8.4"
-    compile "org.apache.commons:commons-compress:1.19"
+    compile "org.apache.commons:commons-compress:1.22"
     compile 'org.tukaani:xz:1.8'
     compile "gov.nih.nlm.ncbi:ngs-java:2.9.0"
     compile ('org.sharegov:mjson:1.4.1') {


### PR DESCRIPTION
* org.apache.commons:commons-compress:1.19 -> 1.22