### PR TITLE
Expose the ability to encode a Genotoype into a GT field

### DIFF
--- a/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
@@ -3,6 +3,7 @@ package htsjdk.variant.vcf;
 import htsjdk.HtsjdkTest;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.variantcontext.Allele;
+import htsjdk.variant.variantcontext.Genotype;
 import htsjdk.variant.variantcontext.GenotypeBuilder;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
@@ -133,6 +134,20 @@ public class VCFEncoderTest extends HtsjdkTest {
         baseGT.noAttributes();
 
         return tests.toArray(new Object[][]{});
+    }
+
+    @Test
+    public void testEncodeGT(){
+        final VariantContextBuilder vcb = new VariantContextBuilder("test",
+                "chr?", 100, 100,
+                Arrays.asList(Allele.REF_A, Allele.ALT_T, Allele.create("TC")));
+        final Genotype g1 = new GenotypeBuilder("s1", Arrays.asList(Allele.REF_A, Allele.REF_A)).make();
+        final Genotype g2 = new GenotypeBuilder("s2", Arrays.asList(Allele.ALT_T, Allele.create("TC"))).make();
+        vcb.genotypes(g1, g2);
+        final VariantContext vc = vcb.make();
+
+        Assert.assertEquals(VCFEncoder.encodeGtField(vc, g1), "0/0");
+        Assert.assertEquals(VCFEncoder.encodeGtField(vc, g2), "1/2");
     }
 
     @Test(dataProvider = "MissingFormatTestData")

--- a/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFEncoderTest.java
@@ -11,6 +11,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -148,6 +149,26 @@ public class VCFEncoderTest extends HtsjdkTest {
 
         Assert.assertEquals(VCFEncoder.encodeGtField(vc, g1), "0/0");
         Assert.assertEquals(VCFEncoder.encodeGtField(vc, g2), "1/2");
+    }
+
+    @Test
+    public void testsWriteGtField() throws IOException {
+        final VariantContextBuilder vcb = new VariantContextBuilder("test",
+                "chr?", 100, 100,
+                Arrays.asList(Allele.REF_A, Allele.ALT_T, Allele.create("TC")));
+        final Genotype g1 = new GenotypeBuilder("s1", Arrays.asList(Allele.REF_A, Allele.REF_A)).make();
+        final Genotype g2 = new GenotypeBuilder("s2", Arrays.asList(Allele.ALT_T, Allele.create("TC"))).make();
+        vcb.genotypes(g1, g2);
+        final VariantContext vc = vcb.make();
+        final Map<Allele, String> alleleStringMap = VCFEncoder.buildAlleleStrings(vc);
+
+        final StringBuilder b1 = new StringBuilder();
+        VCFEncoder.writeGtField(alleleStringMap, b1, g1 );
+        Assert.assertEquals(b1.toString(), "0/0");
+
+        final StringBuilder b2 = new StringBuilder();
+        VCFEncoder.writeGtField(alleleStringMap, b2, g2);
+        Assert.assertEquals(b2.toString(), "1/2");
     }
 
     @Test(dataProvider = "MissingFormatTestData")


### PR DESCRIPTION
* Expose two public methods in VCFEncoder writeGtField and encodeGtField
* Supports https://github.com/broadinstitute/gatk/issues/8160 but seems like a useful thing to be able to do in general
* minor breaking change in VCFEncoder, made methods formatVCFField and buildAlleleStrings static
  It is unlikely anyone overrides either of these methods so it should not be a problem.