### PR TITLE
Remove low-value progress logging message

### DIFF
--- a/src/main/java/htsjdk/samtools/util/AbstractProgressLogger.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractProgressLogger.java
@@ -95,9 +95,6 @@ abstract public class AbstractProgressLogger implements ProgressLoggerInterface 
     protected synchronized boolean record(final String chrom, final int pos, final String rname) {
         if (chrom != null && chrom.equals(lastChrom) && pos < lastPos) {
             countNonIncreasing++;
-            if (countNonIncreasing == PRINT_READ_NAME_THRESHOLD) {
-                log("Seen many non-increasing record positions. Printing Read-names as well.");
-            }
         } else {
             lastChrom = chrom;
         }


### PR DESCRIPTION
### Description

I think printing read names for non-coordinate sorted data is useful, but the log message that "Seen many non-increasing record positions. Printing Read-names as well" is not that useful confusing to both developers and users, especially in an API.  I'd be fine with it being at the debug level.  I just don't want to see this message in my logs every time I use a progress logger that doesn't feed coordinate-sorted data.