### PR TITLE
removed redundant code that sets the secondary alignment flag for a r…

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -455,13 +455,6 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
             end2.setSecondaryAlignment(true);
         }
 
-        if (record1NonPrimary) {
-            end1.setSecondaryAlignment(true);
-        }
-        if (record2NonPrimary) {
-            end2.setSecondaryAlignment(true);
-        }
-
         // set mate info
         SamPairUtil.setMateInfo(end1, end2, true);
 


### PR DESCRIPTION
…eadpair

### Description

Short:
Removed duplicate code fragment that had no effect.

Long:
When adding a new read pair to a SAMRecord using the addPair() method in SAMRecordSetBuilder,
the parameters "record1NonPrimary" as well as "record2NonPrimary" are checked to set the 
secondary alignment flag of the SAM record. This code fragment for both reads was duplicated with 
no effect. The duplicate is removed in this PR.
