### PR TITLE
Update snappy-java and migrate mjson to org.json to address CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,10 @@ jacocoTestReport {
 
 dependencies {
     implementation "commons-logging:commons-logging:1.1.1"
-    implementation "org.xerial.snappy:snappy-java:1.1.8.4"
+    implementation "org.xerial.snappy:snappy-java:1.1.10.1"
     implementation "org.apache.commons:commons-compress:1.22"
     implementation 'org.tukaani:xz:1.8'
-    implementation ('org.sharegov:mjson:1.4.1') {
-        exclude group: "junit"
-    }
+    implementation "org.json:json:20230227"
 
     implementation 'org.openjdk.nashorn:nashorn-core:15.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "org.xerial.snappy:snappy-java:1.1.10.1"
     implementation "org.apache.commons:commons-compress:1.22"
     implementation 'org.tukaani:xz:1.8'
-    implementation "org.json:json:20230227"
+    implementation "org.json:json:20230618"
 
     implementation 'org.openjdk.nashorn:nashorn-core:15.4'
 

--- a/src/main/java/htsjdk/beta/io/bundle/BundleJSON.java
+++ b/src/main/java/htsjdk/beta/io/bundle/BundleJSON.java
@@ -108,19 +108,19 @@ public class BundleJSON {
             }
 
             // validate the schema name
-            final String schemaName = jsonDocument.optString(JSON_PROPERTY_SCHEMA_NAME, null);
+            final String schemaName = getRequiredPropertyAsString(jsonDocument, JSON_PROPERTY_SCHEMA_NAME);
             if (!schemaName.equals(JSON_SCHEMA_NAME)) {
                 throw new IllegalArgumentException(
                         String.format("Expected bundle schema name %s but found %s", JSON_SCHEMA_NAME, schemaName));
             }
 
             // validate the schema version
-            final String schemaVersion = jsonDocument.optString(JSON_PROPERTY_SCHEMA_VERSION, null);
+            final String schemaVersion = getRequiredPropertyAsString(jsonDocument, JSON_PROPERTY_SCHEMA_VERSION);
             if (!schemaVersion.equals(JSON_SCHEMA_VERSION)) {
                 throw new IllegalArgumentException(String.format("Expected bundle schema version %s but found %s",
                         JSON_SCHEMA_VERSION, schemaVersion));
             }
-            primaryContentType = jsonDocument.optString(JSON_PROPERTY_PRIMARY, null);
+            primaryContentType = getRequiredPropertyAsString(jsonDocument, JSON_PROPERTY_PRIMARY);
 
             jsonDocument.keySet().forEach((String contentType) -> {
                 if (! (jsonDocument.get(contentType) instanceof JSONObject jsonDoc)) {
@@ -130,7 +130,7 @@ public class BundleJSON {
                 if (!TOP_LEVEL_PROPERTIES.contains(contentType)) {
                     final String format = jsonDoc.optString(JSON_PROPERTY_FORMAT, null);
                     final IOPathResource ioPathResource = new IOPathResource(
-                            ioPathConstructor.apply(jsonDoc.optString(JSON_PROPERTY_PATH, null)),
+                            ioPathConstructor.apply(getRequiredPropertyAsString(jsonDoc, JSON_PROPERTY_PATH)),
                             contentType,
                             format == null ?
                                     null :
@@ -146,5 +146,17 @@ public class BundleJSON {
         }
 
         return new Bundle(primaryContentType, resources);
+    }
+
+    private static String getRequiredPropertyAsString(JSONObject jsonDocument, String propertyName) {
+        final String propertyValue = jsonDocument.optString(propertyName, null);
+        if (propertyValue == null) {
+            throw new IllegalArgumentException(
+                    String.format("JSON bundle is missing the required property %s (%s)",
+                            propertyName,
+                            jsonDocument));
+        }
+
+        return propertyValue;
     }
 }

--- a/src/main/java/htsjdk/beta/io/bundle/BundleJSON.java
+++ b/src/main/java/htsjdk/beta/io/bundle/BundleJSON.java
@@ -128,7 +128,7 @@ public class BundleJSON {
                 }
 
                 if (!TOP_LEVEL_PROPERTIES.contains(contentType)) {
-                    final String format = jsonDoc.optString(JSON_PROPERTY_FORMAT);
+                    final String format = jsonDoc.optString(JSON_PROPERTY_FORMAT, null);
                     final IOPathResource ioPathResource = new IOPathResource(
                             ioPathConstructor.apply(getPropertyAsString(JSON_PROPERTY_PATH, jsonDoc)),
                             contentType,

--- a/src/main/java/htsjdk/beta/io/bundle/BundleJSON.java
+++ b/src/main/java/htsjdk/beta/io/bundle/BundleJSON.java
@@ -51,10 +51,10 @@ public class BundleJSON {
      * @throws IllegalArgumentException if any resource in bundle is not an IOPathResources.
      */
     public static String toJSON(final Bundle bundle) {
-        final JSONObject outerJSON = new JSONObject();
-        outerJSON.put(JSON_PROPERTY_SCHEMA_NAME, JSON_SCHEMA_NAME);
-        outerJSON.put(JSON_PROPERTY_SCHEMA_VERSION, JSON_SCHEMA_VERSION);
-        outerJSON.put(JSON_PROPERTY_PRIMARY, bundle.getPrimaryContentType());
+        final JSONObject outerJSON = new JSONObject()
+            .put(JSON_PROPERTY_SCHEMA_NAME, JSON_SCHEMA_NAME)
+            .put(JSON_PROPERTY_SCHEMA_VERSION, JSON_SCHEMA_VERSION)
+            .put(JSON_PROPERTY_PRIMARY, bundle.getPrimaryContentType());
 
         bundle.forEach(bundleResource -> {
             final Optional<IOPath> resourcePath = bundleResource.getIOPath();
@@ -102,25 +102,25 @@ public class BundleJSON {
 
         try {
             final JSONObject jsonDocument = new JSONObject(jsonString);
-            if (jsonDocument == null || jsonString.length() < 1) {
+            if (jsonString.length() < 1) {
                 throw new IllegalArgumentException(
                         String.format("JSON file parsing failed %s", jsonString));
             }
 
             // validate the schema name
-            final String schemaName = getPropertyAsString(JSON_PROPERTY_SCHEMA_NAME, jsonDocument);
+            final String schemaName = jsonDocument.optString(JSON_PROPERTY_SCHEMA_NAME, null);
             if (!schemaName.equals(JSON_SCHEMA_NAME)) {
                 throw new IllegalArgumentException(
                         String.format("Expected bundle schema name %s but found %s", JSON_SCHEMA_NAME, schemaName));
             }
 
             // validate the schema version
-            final String schemaVersion = getPropertyAsString(JSON_PROPERTY_SCHEMA_VERSION, jsonDocument);
+            final String schemaVersion = jsonDocument.optString(JSON_PROPERTY_SCHEMA_VERSION, null);
             if (!schemaVersion.equals(JSON_SCHEMA_VERSION)) {
                 throw new IllegalArgumentException(String.format("Expected bundle schema version %s but found %s",
                         JSON_SCHEMA_VERSION, schemaVersion));
             }
-            primaryContentType = getPropertyAsString(JSON_PROPERTY_PRIMARY, jsonDocument);
+            primaryContentType = jsonDocument.optString(JSON_PROPERTY_PRIMARY, null);
 
             jsonDocument.toMap().forEach((String contentType, Object jsonDocObj) -> {
                 if (! (jsonDocObj instanceof JSONObject jsonDoc)) {
@@ -130,11 +130,11 @@ public class BundleJSON {
                 if (!TOP_LEVEL_PROPERTIES.contains(contentType)) {
                     final String format = jsonDoc.optString(JSON_PROPERTY_FORMAT, null);
                     final IOPathResource ioPathResource = new IOPathResource(
-                            ioPathConstructor.apply(getPropertyAsString(JSON_PROPERTY_PATH, jsonDoc)),
+                            ioPathConstructor.apply(jsonDoc.optString(JSON_PROPERTY_PATH, null)),
                             contentType,
                             format == null ?
                                     null :
-                                    getPropertyAsString(JSON_PROPERTY_FORMAT, jsonDoc));
+                                    jsonDoc.optString(JSON_PROPERTY_FORMAT, null));
                     resources.add(ioPathResource);
                 }
             });
@@ -158,17 +158,17 @@ public class BundleJSON {
             sb.append("{\n");
 
             // schema name
-            final String schemaName = getPropertyAsString(JSON_PROPERTY_SCHEMA_NAME, jsonDocument);
+            final String schemaName = jsonDocument.optString(JSON_PROPERTY_SCHEMA_NAME, null);
             sb.append(String.format(TOP_LEVEL_PROPERTY_FORMAT, JSON_PROPERTY_SCHEMA_NAME, schemaName));
             sb.append(",\n");
 
             // schema version
-            final String schemaVersion = getPropertyAsString(JSON_PROPERTY_SCHEMA_VERSION, jsonDocument);
+            final String schemaVersion = jsonDocument.optString(JSON_PROPERTY_SCHEMA_VERSION, null);
             sb.append(String.format(TOP_LEVEL_PROPERTY_FORMAT, JSON_PROPERTY_SCHEMA_VERSION, schemaVersion));
             sb.append(",\n");
 
             // primary
-            final String primary = getPropertyAsString(JSON_PROPERTY_PRIMARY, jsonDocument);
+            final String primary = jsonDocument.optString(JSON_PROPERTY_PRIMARY, null);
             sb.append(String.format(TOP_LEVEL_PROPERTY_FORMAT, JSON_PROPERTY_PRIMARY, primary));
             sb.append(",\n");
 
@@ -184,13 +184,13 @@ public class BundleJSON {
                     if (format != null) {
                         resSB.append(String.format("{\"%s\":\"%s\",\"%s\":\"%s\"}",
                                 JSON_PROPERTY_PATH,
-                                getPropertyAsString(JSON_PROPERTY_PATH, jsonDoc),
+                                jsonDoc.optString(JSON_PROPERTY_PATH, null),
                                 JSON_PROPERTY_FORMAT,
-                                getPropertyAsString(JSON_PROPERTY_FORMAT, jsonDoc)));
+                                jsonDoc.optString(JSON_PROPERTY_FORMAT, null)));
                     } else {
                         resSB.append(String.format("{\"%s\":\"%s\"}",
                                 JSON_PROPERTY_PATH,
-                                getPropertyAsString(JSON_PROPERTY_PATH, jsonDoc)));
+                                jsonDoc.optString(JSON_PROPERTY_PATH, null)));
                     }
                     formattedResources.add(String.format("  \"%s\":%s", contentType, resSB.toString()));
                 }
@@ -203,23 +203,4 @@ public class BundleJSON {
 
         return sb.toString();
     }
-
-    // return the value of propertyName from jsonDocument as a String value
-    private static String getPropertyAsString(final String propertyName, final JSONObject jsonDocument) {
-        return jsonDocument.getString(propertyName);
-//        final JSONObject propertyValue = jsonDocument.at(propertyName);
-//        if (propertyValue == null) {
-//            throw new IllegalArgumentException(
-//                    String.format("JSON bundle is missing the required property %s (%s)",
-//                            propertyName,
-//                            jsonDocument.toString()));
-//        } else if (!propertyValue.isString()) {
-//            throw new IllegalArgumentException(
-//                    String.format("Expected string value for bundle property %s but found %s",
-//                            propertyName,
-//                            propertyValue.toString()));
-//        }
-//        return propertyValue.asString();
-    }
-
 }

--- a/src/main/java/htsjdk/samtools/util/htsget/HtsgetErrorResponse.java
+++ b/src/main/java/htsjdk/samtools/util/htsget/HtsgetErrorResponse.java
@@ -38,8 +38,8 @@ public class HtsgetErrorResponse {
             throw new IllegalStateException(new HtsgetMalformedResponseException("No htsget key found in response"));
         }
 
-        final String errorJson = htsget.optString("error");
-        final String messageJson = htsget.optString("message");
+        final String errorJson = htsget.optString("error", null);
+        final String messageJson = htsget.optString("message", null);
 
         return new HtsgetErrorResponse(errorJson, messageJson);
     }

--- a/src/main/java/htsjdk/samtools/util/htsget/HtsgetErrorResponse.java
+++ b/src/main/java/htsjdk/samtools/util/htsget/HtsgetErrorResponse.java
@@ -1,6 +1,8 @@
 package htsjdk.samtools.util.htsget;
 
 
+import org.json.JSONObject;
+
 /**
  * Class allowing deserialization from json htsget error response, as defined in https://samtools.github.io/hts-specs/htsget.html
  *
@@ -30,17 +32,15 @@ public class HtsgetErrorResponse {
     }
 
     public static HtsgetErrorResponse parse(final String s) {
-        final mjson.Json j = mjson.Json.read(s);
-        final mjson.Json htsget = j.at("htsget");
+        final JSONObject j = new JSONObject(s);
+        final JSONObject htsget = j.optJSONObject("htsget");
         if (htsget == null) {
             throw new IllegalStateException(new HtsgetMalformedResponseException("No htsget key found in response"));
         }
 
-        final mjson.Json errorJson = htsget.at("error");
-        final mjson.Json messageJson = htsget.at("message");
+        final String errorJson = htsget.optString("error");
+        final String messageJson = htsget.optString("message");
 
-        return new HtsgetErrorResponse(
-            errorJson == null ? null : errorJson.asString(),
-            messageJson == null ? null : messageJson.asString());
+        return new HtsgetErrorResponse(errorJson, messageJson);
     }
 }

--- a/src/main/java/htsjdk/samtools/util/htsget/HtsgetPOSTRequest.java
+++ b/src/main/java/htsjdk/samtools/util/htsget/HtsgetPOSTRequest.java
@@ -3,7 +3,8 @@ package htsjdk.samtools.util.htsget;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.util.Locatable;
 import htsjdk.samtools.util.RuntimeIOException;
-import mjson.Json;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -134,41 +135,41 @@ public class HtsgetPOSTRequest extends HtsgetRequest {
         return this.getEndpoint();
     }
 
-    public mjson.Json queryBody() {
-        final mjson.Json postBody = Json.object();
+    public JSONObject queryBody() {
+        final JSONObject postBody = new JSONObject();
         if (this.format != null) {
-            postBody.set("format", this.getFormat().toString());
+            postBody.put("format", this.getFormat().toString());
         }
         if (this.dataClass != null) {
-            postBody.set("class", this.getDataClass().toString());
+            postBody.put("class", this.getDataClass().toString());
         }
         if (!this.fields.isEmpty()) {
-            postBody.set(
+            postBody.put(
                 "fields",
-                Json.array(this.getFields().stream()
+                new JSONArray(this.getFields().stream()
                     .map(HtsgetRequestField::toString)
                     .toArray())
             );
         }
         if (!this.tags.isEmpty()) {
-            postBody.set("tags", Json.array(this.getTags().toArray()));
+            postBody.put("tags", new JSONArray(this.getTags().toArray()));
         }
         if (!this.notags.isEmpty()) {
-            postBody.set("notags", Json.array(this.getNoTags().toArray()));
+            postBody.put("notags", new JSONArray(this.getNoTags().toArray()));
         }
         if (!this.intervals.isEmpty()) {
-            postBody.set("regions", Json.array(
+            postBody.put("regions", new JSONArray(
                 this.intervals.stream()
                     .map(interval -> {
-                        final mjson.Json intervalJson = Json.object();
+                        final JSONObject intervalJson = new JSONObject();
                         if (interval != null && interval.getContig() != null) {
-                            intervalJson.set("referenceName", interval.getContig());
+                            intervalJson.put("referenceName", interval.getContig());
                             // Do not insert start and end for unmapped reads or if we are requesting the entire contig
                             if (!interval.getContig().equals(SAMRecord.NO_ALIGNMENT_REFERENCE_NAME)) {
                                 // getStart() - 1 is necessary as GA4GH standards use 0-based coordinates while Locatables are 1-based
-                                intervalJson.set("start", interval.getStart() - 1);
+                                intervalJson.put("start", interval.getStart() - 1);
                                 if (interval.getEnd() != Integer.MAX_VALUE && interval.getEnd() != -1) {
-                                    intervalJson.set("end", interval.getEnd());
+                                    intervalJson.put("end", interval.getEnd());
                                 }
                             }
                         }

--- a/src/main/java/htsjdk/samtools/util/htsget/HtsgetResponse.java
+++ b/src/main/java/htsjdk/samtools/util/htsget/HtsgetResponse.java
@@ -1,6 +1,8 @@
 package htsjdk.samtools.util.htsget;
 
 import htsjdk.samtools.util.RuntimeIOException;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -98,32 +100,32 @@ public class HtsgetResponse {
          * @param blockJson json value representing a block
          * @return parsed block object
          */
-        public static Block parse(final mjson.Json blockJson) {
-            final mjson.Json uriJson = blockJson.at("url");
+        public static Block parse(final JSONObject blockJson) {
+            final String uriJson = blockJson.optString("url");
             if (uriJson == null) {
                 throw new HtsgetMalformedResponseException("No URI found in Htsget data block: " +
                     blockJson.toString().substring(0, Math.min(100, blockJson.toString().length())));
             }
             final URI uri;
             try {
-                uri = new URI(uriJson.asString());
+                uri = new URI(uriJson);
             } catch (final URISyntaxException e) {
-                throw new HtsgetMalformedResponseException("Could not parse URI in Htsget data block: " + uriJson.asString(), e);
+                throw new HtsgetMalformedResponseException("Could not parse URI in Htsget data block: " + uriJson, e);
             }
 
-            final mjson.Json dataClassJson = blockJson.at("class");
+            final String dataClassJson = blockJson.optString("class");
             final HtsgetClass dataClass = dataClassJson == null
                 ? null
-                : HtsgetClass.valueOf(dataClassJson.asString().toLowerCase());
+                : HtsgetClass.valueOf(dataClassJson.toLowerCase());
 
 
-            final mjson.Json headersJson = blockJson.at("headers");
+            final JSONObject headersJson = blockJson.optJSONObject("headers");
             final Map<String, String> headers = headersJson == null
                 ? null
-                : headersJson.asJsonMap().entrySet().stream()
+                : headersJson.toMap().entrySet().stream()
                 .collect(Collectors.toMap(
                     Map.Entry::getKey,
-                    e -> e.getValue().asString()
+                    e -> e.getValue().toString()
                 ));
 
             return new Block(uri, headers, dataClass);
@@ -161,28 +163,30 @@ public class HtsgetResponse {
      * @return parsed HtsgetResponse object
      */
     public static HtsgetResponse parse(final String s) {
-        final mjson.Json j = mjson.Json.read(s);
-        final mjson.Json htsget = j.at("htsget");
+        final JSONObject j = new JSONObject(s);
+        final JSONObject htsget = j.optJSONObject("htsget");
         if (htsget == null) {
             throw new HtsgetMalformedResponseException("No htsget key found in response");
         }
 
-        final mjson.Json md5Json = htsget.at("md5");
-        final mjson.Json formatJson = htsget.at("format");
+        final String md5Json = htsget.optString("md5");
+        final String formatJson = htsget.optString("format");
 
-        final mjson.Json blocksJson = htsget.at("urls");
+        final JSONArray blocksJson = htsget.optJSONArray("urls");
         if (blocksJson == null) {
             throw new HtsgetMalformedResponseException("No urls field found in Htsget Response");
         }
 
-        final List<Block> blocks = blocksJson.asJsonList().stream()
+        final List<Block> blocks = blocksJson.toList().stream()
+            .filter(JSONObject.class::isInstance)
+            .map(JSONObject.class::cast)
             .map(Block::parse)
             .collect(Collectors.toList());
 
         return new HtsgetResponse(
-            formatJson == null ? null : HtsgetFormat.valueOf(formatJson.asString().toUpperCase()),
+            formatJson == null ? null : HtsgetFormat.valueOf(formatJson.toUpperCase()),
             blocks,
-            md5Json == null ? null : md5Json.asString()
+            md5Json
         );
     }
 

--- a/src/test/java/htsjdk/beta/io/bundle/BundleJSONTest.java
+++ b/src/test/java/htsjdk/beta/io/bundle/BundleJSONTest.java
@@ -3,6 +3,7 @@ package htsjdk.beta.io.bundle;
 import htsjdk.HtsjdkTest;
 import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
+import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -157,7 +158,7 @@ public class BundleJSONTest extends HtsjdkTest {
     public void testRoundTripJSON(final String jsonString, final String primaryKey, final List<BundleResource> resources) {
         final Bundle bundleFromResources = new Bundle(primaryKey, resources);
         final String actualJSONString = BundleJSON.toJSON(bundleFromResources);
-        Assert.assertEquals(actualJSONString, jsonString);
+        Assert.assertEquals(actualJSONString, new JSONObject(jsonString).toString(1));
 
         // now recreate the bundle from JSON
         final Bundle bundleFromJSON = BundleJSON.toBundle(jsonString);
@@ -227,7 +228,7 @@ public class BundleJSONTest extends HtsjdkTest {
                 // syntax error (missing quote in before schemaName
                 { "{\"schemaVersion\":\"0.1.0\",schemaName\":\"htsbundle\",\"ALIGNED_READS\":{\"path\":\"myreads" +
                         ".bam\",\"format\":\"BAM\"},\"primary\":\"ALIGNED_READS\"}",
-                        "Invalid JSON near position: 25" },
+                        "Expected a ':' after a key at 36" },
                 // no enclosing {} -> UnsupportedOperationException (no text message)
                 {"\"schemaName\":\"htsbundle\", \"schemaVersion\":\"0.1.0\"",
                         "", },

--- a/src/test/java/htsjdk/samtools/util/HtsgetRequestUnitTest.java
+++ b/src/test/java/htsjdk/samtools/util/HtsgetRequestUnitTest.java
@@ -135,11 +135,11 @@ public class HtsgetRequestUnitTest extends HtsjdkTest {
             new String[]{"tag2"}
         );
 
-        final JSONArray expectedRegions = new JSONArray();
-        expectedRegions.put(new JSONObject("{referenceName: \"chr1\", start: 0, end: 16}"));
-        expectedRegions.put(new JSONObject("{referenceName: \"chr1\", start: 16, end: 32}"));
-        expectedRegions.put(new JSONObject("{referenceName: \"chrM\", start: 0, end: 16}"));
-        expectedRegions.put(new JSONObject("{referenceName: \"chrM\", start: 16, end: 32}"));
+        final JSONArray expectedRegions = new JSONArray()
+            .put(new JSONObject("{referenceName: \"chr1\", start: 0, end: 16}"))
+            .put(new JSONObject("{referenceName: \"chr1\", start: 16, end: 32}"))
+            .put(new JSONObject("{referenceName: \"chrM\", start: 0, end: 16}"))
+            .put(new JSONObject("{referenceName: \"chrM\", start: 16, end: 32}"));
 
         Assert.assertEqualsNoOrder(
             postBody.getJSONArray("regions").toList(),

--- a/src/test/java/htsjdk/samtools/util/HtsgetRequestUnitTest.java
+++ b/src/test/java/htsjdk/samtools/util/HtsgetRequestUnitTest.java
@@ -2,6 +2,8 @@ package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.htsget.*;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -115,33 +117,33 @@ public class HtsgetRequestUnitTest extends HtsjdkTest {
                 new Interval("chrM", 17, 32))
             );
 
-        final mjson.Json postBody = req.queryBody();
+        final JSONObject postBody = req.queryBody();
 
-        Assert.assertEquals(postBody.at("format").asString(), "BAM");
-        Assert.assertEquals(postBody.at("class").asString(), "header");
+        Assert.assertEquals(postBody.getString("format"), "BAM");
+        Assert.assertEquals(postBody.getString("class"), "header");
 
         Assert.assertEqualsNoOrder(
-            postBody.at("fields").asList().stream().map(Object::toString).toArray(String[]::new),
+            postBody.getJSONArray("fields").toList().stream().map(Object::toString).toArray(String[]::new),
             new String[]{"QNAME", "CIGAR"}
         );
         Assert.assertEqualsNoOrder(
-            postBody.at("tags").asList().stream().map(Object::toString).toArray(String[]::new),
+            postBody.getJSONArray("tags").toList().stream().map(Object::toString).toArray(String[]::new),
             new String[]{"tag1", "tag3"}
         );
         Assert.assertEqualsNoOrder(
-            postBody.at("notags").asList().stream().map(Object::toString).toArray(String[]::new),
+            postBody.getJSONArray("notags").toList().stream().map(Object::toString).toArray(String[]::new),
             new String[]{"tag2"}
         );
 
-        final mjson.Json[] expectedRegions = new mjson.Json[]{
-            mjson.Json.object("referenceName", "chr1", "start", 0, "end", 16),
-            mjson.Json.object("referenceName", "chr1", "start", 16, "end", 32),
-            mjson.Json.object("referenceName", "chrM", "start", 0, "end", 16),
-            mjson.Json.object("referenceName", "chrM", "start", 16, "end", 32),
-        };
+        final JSONArray expectedRegions = new JSONArray();
+        expectedRegions.put(new JSONObject("{referenceName: \"chr1\", start: 0, end: 16}"));
+        expectedRegions.put(new JSONObject("{referenceName: \"chr1\", start: 16, end: 32}"));
+        expectedRegions.put(new JSONObject("{referenceName: \"chrM\", start: 0, end: 16}"));
+        expectedRegions.put(new JSONObject("{referenceName: \"chrM\", start: 16, end: 32}"));
+
         Assert.assertEqualsNoOrder(
-            postBody.at("regions").asJsonList().toArray(new mjson.Json[0]),
-            expectedRegions
+            postBody.getJSONArray("regions").toList(),
+            expectedRegions.toList()
         );
     }
 }


### PR DESCRIPTION
There are CVEs reported for mjson, which does not appear to be an actively maintained project:

https://nvd.nist.gov/vuln/detail/CVE-2023-34611
https://github.com/bolerio/mjson/issues/40

and also snappy-java:

https://nvd.nist.gov/vuln/detail/CVE-2023-34453
https://nvd.nist.gov/vuln/detail/CVE-2023-34455

the latest snappy-java has been patched.

This PR does two things:

- It updates to the latest snappy-java
- It migrates from mjson (which appears to be a dead project) to org.json. From what I can tell mjson wasnt being used for anything other than pretty basic JSON object manipulation. In theory these should function about the same.