### PR TITLE
Zero len array

### DIFF
--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -1541,9 +1541,6 @@ public class SAMRecord implements HtsRecord, Cloneable, Locatable, Serializable 
         if (!value.getClass().isArray()) {
             throw new IllegalArgumentException("Non-array passed to setUnsignedArrayAttribute for tag " + tag);
         }
-        if (Array.getLength(value) == 0) {
-            throw new IllegalArgumentException("Empty array passed to setUnsignedArrayAttribute for tag " + tag);
-        }
         setAttribute(SAMTag.makeBinaryTag(tag), value, true);
     }
 

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -745,9 +745,6 @@ public class Slice {
      * @param value tag value
      */
     public void setAttribute(final String tag, final Object value) {
-        if (value != null && value.getClass().isArray() && Array.getLength(value) == 0) {
-            throw new IllegalArgumentException("Empty value passed for tag " + tag);
-        }
         setAttribute(SAMTag.makeBinaryTag(tag), value);
     }
 

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -736,38 +736,6 @@ public class Slice {
     }
 
     /**
-     * Hijacking attributes-related methods from SAMRecord:
-     */
-
-    /**
-     * Set a value for the tag.
-     * @param tag tag ID as a short integer as returned by {@link SAMTag#makeBinaryTag(String)}
-     * @param value tag value
-     */
-    public void setAttribute(final String tag, final Object value) {
-        setAttribute(SAMTag.makeBinaryTag(tag), value);
-    }
-
-    void setAttribute(final short tag, final Object value) {
-        setAttribute(tag, value, false);
-    }
-
-    void setAttribute(final short tag, final Object value, final boolean isUnsignedArray) {
-        if (value == null) {
-            if (this.sliceTags != null) this.sliceTags = this.sliceTags.remove(tag);
-        } else {
-            final SAMBinaryTagAndValue tmp;
-            if (!isUnsignedArray) {
-                tmp = new SAMBinaryTagAndValue(tag, value);
-            } else {
-                tmp = new SAMBinaryTagAndUnsignedArrayValue(tag, value);
-            }
-            if (this.sliceTags == null) this.sliceTags = tmp;
-            else this.sliceTags = this.sliceTags.insert(tmp);
-        }
-    }
-
-    /**
      * Uses a Multiple Reference Slice Alignment Reader to determine the reference spans of a MULTI_REF Slice.
      * Used for creating CRAI/BAI index entries.
      *

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -1124,6 +1124,19 @@ public class SAMRecordUnitTest extends HtsjdkTest {
         Assert.assertNull(record.getStringAttribute(ARRAY_TAG));
     }
 
+    @Test
+    public void test_setUnsignedArrayAttribute_empty_array() {
+        final SAMFileHeader header = new SAMFileHeader();
+        final SAMRecord record = new SAMRecord(header);
+        Assert.assertNull(record.getStringAttribute(ARRAY_TAG));
+        record.setUnsignedArrayAttribute(ARRAY_TAG, new int[0]);
+        Assert.assertNotNull(record.getUnsignedIntArrayAttribute(ARRAY_TAG));
+        Assert.assertEquals(record.getUnsignedIntArrayAttribute(ARRAY_TAG), new int[0]);
+        Assert.assertEquals(record.getAttribute(ARRAY_TAG), new char[0]);
+        record.setAttribute(ARRAY_TAG, null);
+        Assert.assertNull(record.getStringAttribute(ARRAY_TAG));
+    }
+
     private static Object[][] getEmptyArrays() {
         return new Object[][]{
                 {new int[0], int[].class},


### PR DESCRIPTION
PR https://github.com/samtools/htsjdk/pull/1194 removed a number of Array.getLength(value) == 0 checks when setting B-array tagged fields, as such empty tagged field values had recently been made explicitly valid in SAM/BAM/CRAM files.

Unfortunately the existing such check in setUnsignedArrayAttribute() was omitted from that PR and has now caused the issue raised in https://github.com/samtools/hts-specs/issues/728. Whatever additional problems might (but probably don't) exist elsewhere in the HTSJDK code for zero-length ML tags, this check for a generic zero-length array was incorrect and should be removed. A test case for setUnsignedArrayAttribute() has also been added.

In grepping for other candidates, I noticed one other potentially incorrect looking Array.getLength invocation.

This was in Slice::setAttribute(), which appears to set an optional tag in a Slice header. There are currently no such tags defined, so the question is somewhat moot but — as a separate commit for your consideration — I have also removed that check. (As there are no such tags currently defined, there are no test cases for these fields to which a test exercising this change could be added.)

--

Updated [jmarshall](https://github.com/samtools/htsjdk/commits?author=jmarshall) pull request to remove unused Slice::setAttribute() methods.

