### PR TITLE
Update two remaining out of date dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,10 @@ jacocoTestReport {
 }
 
 dependencies {
-    implementation "commons-logging:commons-logging:1.1.1"
+    implementation 'commons-logging:commons-logging:1.2'
     implementation "org.xerial.snappy:snappy-java:1.1.10.1"
     implementation "org.apache.commons:commons-compress:1.22"
-    implementation 'org.tukaani:xz:1.8'
+    implementation 'org.tukaani:xz:1.9'
     implementation "org.json:json:20230618"
 
     implementation 'org.openjdk.nashorn:nashorn-core:15.4'


### PR DESCRIPTION
These were not updated in the last update because they didn't have any CVE's listed but we might as well move them forward.