### PR TITLE
two methods for Genotype: HasRefAllele HasAltAllele

### DIFF
--- a/src/main/java/htsjdk/variant/variantcontext/Allele.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Allele.java
@@ -431,5 +431,8 @@ public interface Allele extends Comparable<Allele>, Serializable {
 
     int length();
 
+    /**
+     *  @return true if Allele is either {@code <NON_REF>} or {@code <*>}
+     */
     boolean isNonRefAllele();
 }

--- a/src/main/java/htsjdk/variant/variantcontext/Genotype.java
+++ b/src/main/java/htsjdk/variant/variantcontext/Genotype.java
@@ -78,6 +78,20 @@ public abstract class Genotype implements Comparable<Genotype>, Serializable {
     public abstract List<Allele> getAlleles();
 
     /**
+     * @return true if any allele is REF
+     */
+    public boolean hasRefAllele() {
+        return getAlleles().stream().anyMatch(A->A.isReference());
+    };
+
+    /**
+     * @return true if any allele is ALT, (NO_CALL are ignored)
+     */
+    public boolean hasAltAllele() {
+        return getAlleles().stream().anyMatch(A->!(A.isReference() || A.isNoCall()));
+    };
+
+    /**
      * Returns how many times allele appears in this genotype object?
      *
      * @param allele

--- a/src/test/java/htsjdk/variant/variantcontext/GenotypeUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/GenotypeUnitTest.java
@@ -31,6 +31,7 @@ package htsjdk.variant.variantcontext;
 
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.vcf.VCFConstants;
+import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -69,6 +70,28 @@ public class GenotypeUnitTest extends VariantBaseTest {
         Assert.assertTrue(makeGB().make().hasAnyAttribute(VCFConstants.GENOTYPE_FILTER_KEY), "hasAnyAttribute(GENOTYPE_FILTER_KEY) should return true");
         Assert.assertFalse(makeGB().filter("").make().isFiltered(), "empty filters should count as unfiltered");
         Assert.assertEquals(makeGB().filter("").make().getFilters(), null, "empty filter string should result in null filters");
+    }
+    
+    @Test
+    public void testHasAltAllele() {
+        Assert.assertTrue(GenotypeBuilder.create("s", Arrays.asList(A)).hasAltAllele());
+        Assert.assertTrue(GenotypeBuilder.create("s", Arrays.asList(A,Aref)).hasAltAllele());
+        Assert.assertTrue(GenotypeBuilder.create("s", Arrays.asList(A,Allele.NO_CALL)).hasAltAllele());
+        Assert.assertFalse(GenotypeBuilder.create("s", Arrays.asList(Aref)).hasAltAllele());
+        Assert.assertFalse(GenotypeBuilder.create("s", Arrays.asList(Aref,Aref)).hasAltAllele());
+        Assert.assertFalse(GenotypeBuilder.create("s", Arrays.asList(Allele.NO_CALL,Allele.NO_CALL)).hasAltAllele());
+        Assert.assertTrue(GenotypeBuilder.create("s", Arrays.asList(Allele.NON_REF_ALLELE)).hasAltAllele());
+        Assert.assertTrue(GenotypeBuilder.create("s", Arrays.asList(Allele.SPAN_DEL)).hasAltAllele());
+    }
+
+    @Test
+    public void testHasRefAllele() {
+        Assert.assertFalse(GenotypeBuilder.create("s", Arrays.asList(A)).hasRefAllele());
+        Assert.assertTrue(GenotypeBuilder.create("s", Arrays.asList(A,Aref)).hasRefAllele());
+        Assert.assertFalse(GenotypeBuilder.create("s", Arrays.asList(A,Allele.NO_CALL)).hasRefAllele());
+        Assert.assertTrue(GenotypeBuilder.create("s", Arrays.asList(Aref)).hasRefAllele());
+        Assert.assertTrue(GenotypeBuilder.create("s", Arrays.asList(Aref,Aref)).hasRefAllele());
+        Assert.assertFalse(GenotypeBuilder.create("s", Arrays.asList(Allele.NO_CALL,Allele.NO_CALL)).hasRefAllele());
     }
 
 //    public Genotype(String sampleName, List<Allele> alleles, double negLog10PError, Set<String> filters, Map<String, ?> attributes, boolean isPhased) {


### PR DESCRIPTION
### Description

I wrote two new functions for `Genotype` : `hasAltAllele` and `testHasRefAllele` because I often need to detect whether an ALT allele (or a REF) is present in a Genotype whatever is the genotype ploidy

I also copied a javadoc from SimpleAllele to Allele.

### Things to think about before submitting:
- [X] Make sure your changes compile and new tests pass locally.
- [X] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [X] Extended the README / documentation, if necessary
- [x] Check your code style.
- [X] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
