### PR TITLE
Add IntervalFileFeature for common interface to name in bed or interval_list

### DIFF
--- a/src/main/java/htsjdk/samtools/util/Interval.java
+++ b/src/main/java/htsjdk/samtools/util/Interval.java
@@ -24,7 +24,7 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
-import htsjdk.tribble.Feature;
+import htsjdk.tribble.IntervalFileFeature;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collection;
@@ -34,7 +34,7 @@ import java.util.Collection;
  *
  * @author Tim Fennell
  */
-public class Interval implements Comparable<Interval>, Cloneable, Feature {
+public class Interval implements Comparable<Interval>, Cloneable, IntervalFileFeature {
     private final boolean negativeStrand;
     private final String name;
     private final String contig;

--- a/src/main/java/htsjdk/samtools/util/Interval.java
+++ b/src/main/java/htsjdk/samtools/util/Interval.java
@@ -24,7 +24,7 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
-import htsjdk.tribble.IntervalFileFeature;
+import htsjdk.tribble.NamedFeature;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.Collection;
@@ -34,7 +34,7 @@ import java.util.Collection;
  *
  * @author Tim Fennell
  */
-public class Interval implements Comparable<Interval>, Cloneable, IntervalFileFeature {
+public class Interval implements Comparable<Interval>, Cloneable, NamedFeature {
     private final boolean negativeStrand;
     private final String name;
     private final String contig;

--- a/src/main/java/htsjdk/tribble/IntervalFileFeature.java
+++ b/src/main/java/htsjdk/tribble/IntervalFileFeature.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2013 The Broad Institute
+ * Copyright (c) 2023 The Broad Institute
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,33 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package htsjdk.tribble.bed;
+package htsjdk.tribble;
 
-import htsjdk.tribble.IntervalFileFeature;
-import htsjdk.tribble.annotation.Strand;
-
-import java.awt.*;
 
 /**
- * @author jrobinso
- * @date Dec 24, 2009
- *
- * BED feature start and end positions must adhere to the Feature interval specifications.
- * This is different than the 0-based representation in a BED file.  This conversion is handled by {@link BEDCodec}.
- * Anyone writing a bed file should be aware of this difference.
+ * An interface for features provided via an interval file, e.g. bed or interval_list.
+ * Provides a common interface for accessing the name column for both of these file types.
  */
-public interface BEDFeature extends IntervalFileFeature {
-    Strand getStrand();
+public interface IntervalFileFeature extends Feature {
+    String getName();
 
-    String getType();
-
-    Color getColor();
-
-    String getDescription();
-
-    java.util.List<FullBEDFeature.Exon> getExons();
-
-    float getScore();
-
-    String getLink();
 }

--- a/src/main/java/htsjdk/tribble/IntervalFileFeature.java
+++ b/src/main/java/htsjdk/tribble/IntervalFileFeature.java
@@ -30,5 +30,4 @@ package htsjdk.tribble;
  */
 public interface IntervalFileFeature extends Feature {
     String getName();
-
 }

--- a/src/main/java/htsjdk/tribble/NamedFeature.java
+++ b/src/main/java/htsjdk/tribble/NamedFeature.java
@@ -28,6 +28,6 @@ package htsjdk.tribble;
  * An interface for features provided via an interval file, e.g. bed or interval_list.
  * Provides a common interface for accessing the name column for both of these file types.
  */
-public interface IntervalFileFeature extends Feature {
+public interface NamedFeature extends Feature {
     String getName();
 }

--- a/src/main/java/htsjdk/tribble/bed/BEDFeature.java
+++ b/src/main/java/htsjdk/tribble/bed/BEDFeature.java
@@ -23,7 +23,7 @@
  */
 package htsjdk.tribble.bed;
 
-import htsjdk.tribble.IntervalFileFeature;
+import htsjdk.tribble.NamedFeature;
 import htsjdk.tribble.annotation.Strand;
 
 import java.awt.*;
@@ -36,7 +36,7 @@ import java.awt.*;
  * This is different than the 0-based representation in a BED file.  This conversion is handled by {@link BEDCodec}.
  * Anyone writing a bed file should be aware of this difference.
  */
-public interface BEDFeature extends IntervalFileFeature {
+public interface BEDFeature extends NamedFeature {
     Strand getStrand();
 
     String getType();


### PR DESCRIPTION
### Description

This short PR adds an `IntervalFileFeature` interface which extends the `Feature` interface to include a `getName` method common to both lines in bed files and interval_list files. This allows you to be able to parse and work with bed and interval_list file lines uniformly when you need to access metadata in the `name` field. This will be used in an upcoming change in GATK.