### PR TITLE
Update snappy-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ jacocoTestReport {
 dependencies {
     implementation 'commons-logging:commons-logging:1.2'
     implementation "org.xerial.snappy:snappy-java:1.1.10.5"
-    implementation "org.apache.commons:commons-compress:1.22"
+    implementation "org.apache.commons:commons-compress:1.24.0"
     implementation 'org.tukaani:xz:1.9'
     implementation "org.json:json:20230618"
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ jacocoTestReport {
 
 dependencies {
     implementation 'commons-logging:commons-logging:1.2'
-    implementation "org.xerial.snappy:snappy-java:1.1.10.1"
+    implementation "org.xerial.snappy:snappy-java:1.1.10.5"
     implementation "org.apache.commons:commons-compress:1.22"
     implementation 'org.tukaani:xz:1.9'
     implementation "org.json:json:20230618"


### PR DESCRIPTION
@lbergelson: snappy-java is an HTSJDK dependency that received a DoS CVE report last week: https://github.com/advisories/GHSA-55g7-9cwv-5qfv. This PR bumps the version.
