### PR TITLE
Fix IOUtil.unrollPaths for http paths with query parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation 'com.google.jimfs:jimfs:1.1'
     testImplementation "com.google.guava:guava:31.1-jre"
     testImplementation "org.apache.commons:commons-lang3:3.7"
+    testImplementation "org.broadinstitute:http-nio:0.1.0-rc1"
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ dependencies {
     testImplementation 'com.google.jimfs:jimfs:1.1'
     testImplementation "com.google.guava:guava:31.1-jre"
     testImplementation "org.apache.commons:commons-lang3:3.7"
-    testImplementation "org.broadinstitute:http-nio:0.1.0-rc1"
 }
 
 java {

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1182,7 +1182,7 @@ public class IOUtil {
 
         while (!stack.empty()) {
             final Path p = stack.pop();
-            final String name = p.toString();
+            final String name = p.getFileName().toString();
             boolean matched = false;
 
             for (final String ext : extensions) {

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -450,6 +450,7 @@ public class IOUtilTest extends HtsjdkTest {
 
     static final String level1 = "Level1.fofn";
     static final String level2 = "Level2.fofn";
+    static final String fofnHttpQueryParams = "FofnWithHttpQueryParams.fofn";
 
     @DataProvider
     public Object[][] fofnData() throws IOException {
@@ -460,11 +461,16 @@ public class IOUtilTest extends HtsjdkTest {
         Path fofnPath2 = inMemoryFileSystem.getPath(level2);
         Files.copy(TEST_DATA_DIR.resolve(level2), fofnPath2);
 
+        Path withHttpPath = inMemoryFileSystem.getPath(fofnHttpQueryParams);
+        Files.copy(TEST_DATA_DIR.resolve(fofnHttpQueryParams), withHttpPath);
+
         return new Object[][]{
                 {TEST_DATA_DIR + "/" + level1, new String[]{".vcf", ".vcf.gz"}, 2},
                 {TEST_DATA_DIR + "/" + level2, new String[]{".vcf", ".vcf.gz"}, 4},
                 {fofnPath1.toUri().toString(), new String[]{".vcf", ".vcf.gz"}, 2},
-                {fofnPath2.toUri().toString(), new String[]{".vcf", ".vcf.gz"}, 4}
+                {fofnPath2.toUri().toString(), new String[]{".vcf", ".vcf.gz"}, 4},
+                //test http links witht query parameters are handled correctly
+                {withHttpPath.toUri().toString(), new String[]{".vcf", ".vcf.gz"}, 4}
         };
     }
 

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -469,8 +469,10 @@ public class IOUtilTest extends HtsjdkTest {
                 {TEST_DATA_DIR + "/" + level2, new String[]{".vcf", ".vcf.gz"}, 4},
                 {fofnPath1.toUri().toString(), new String[]{".vcf", ".vcf.gz"}, 2},
                 {fofnPath2.toUri().toString(), new String[]{".vcf", ".vcf.gz"}, 4},
-                //test http links witht query parameters are handled correctly
-                {withHttpPath.toUri().toString(), new String[]{".vcf", ".vcf.gz"}, 4}
+                //test http links with query parameters are handled correctly
+                //test disabled until NIO http provider is integrated
+                //see https://github.com/samtools/htsjdk/issues/1689
+                //{withHttpPath.toUri().toString(), new String[]{".vcf", ".vcf.gz"}, 4}
         };
     }
 

--- a/src/test/resources/htsjdk/samtools/io/FofnWithHttpQueryParams.fofn
+++ b/src/test/resources/htsjdk/samtools/io/FofnWithHttpQueryParams.fofn
@@ -1,0 +1,3 @@
+src/test/resources/htsjdk/samtools/io/Level1.fofn
+http://www.example.com/blurg.vcf
+http://www.example.com/blurg.vcf?huh=bleep,bloop


### PR DESCRIPTION
* Query parameters in an http path were breaking extension detection