### PR TITLE
SamUtils PairOrientation is confusingly ambiguous about paired reads needing to map to the same contig

### DIFF
--- a/src/main/java/htsjdk/samtools/SamPairUtil.java
+++ b/src/main/java/htsjdk/samtools/SamPairUtil.java
@@ -62,7 +62,7 @@ public class SamPairUtil {
      * @param record the record for which the pair orientation is requested
      * @return PairOrientation of the given SAMRecord.
      * @throws IllegalArgumentException If the record is not a paired read, or
-     * one or both reads are unmapped, or is the two records do are not mapped to the
+     * one or both reads are unmapped, or if the two records are not mapped to the
      * same reference.
      *
      * NOTA BENE: This is NOT the orientation byte as used in Picard's MarkDuplicates. For that please look
@@ -73,14 +73,15 @@ public class SamPairUtil {
         final boolean readIsOnReverseStrand = record.getReadNegativeStrandFlag();
 
         if(record.getReadUnmappedFlag() || !record.getReadPairedFlag() || record.getMateUnmappedFlag()) {
-            throw new IllegalArgumentException("Invalid SAMRecord: " + record.getReadName() + ". This method only works for SAMRecords " +
-                    "that are paired reads with both reads aligned.");
+            throw new IllegalArgumentException("Invalid SAMRecord: " + record.getReadName() +
+                    ". This method only works for SAMRecords that are paired reads with both reads aligned.");
         }
 
         if (!record.getReferenceIndex().equals(record.getMateReferenceIndex())) {
-            throw new IllegalArgumentException("Invalid SAMRecord: " + record.getReadName() + ". This method only works for SAMRecords " +
-                    "that are paired reads with both reads aligned to the same reference. Found difference references:" +
-                    record.getReferenceName() + " and " + record.getMateReferenceName() + ".");
+            throw new IllegalArgumentException("Invalid SAMRecord: " + record.getReadName() +
+                    ". This method only works for SAMRecords that are paired reads with both reads aligned to the" +
+                    " same reference. Found difference references:" + record.getReferenceName() + " and " +
+                    record.getMateReferenceName() + ".");
         }
 
         if(readIsOnReverseStrand == record.getMateNegativeStrandFlag() )  {


### PR DESCRIPTION
- Improved documentation to clarify that PairOrientation (in SamUtils) pertains only to reads on the same contig.
- Now getPairOrientation will throw an exception if thrown when the two reads are mapped to different contigs
- Added tests to verify that the exception is thrown in the 4 cases specified.

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [x] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
