### PR TITLE
SamReaderFactory opens non-regular File and Path the same way

### DIFF
--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -100,7 +100,9 @@ public abstract class SamReaderFactory {
     public SamReader open(final Path path,
             Function<SeekableByteChannel, SeekableByteChannel> dataWrapper,
             Function<SeekableByteChannel, SeekableByteChannel> indexWrapper) {
-        final SamInputResource r = SamInputResource.of(path, dataWrapper);
+        final SamInputResource r = dataWrapper == null
+                ? SamInputResource.of(path)
+                : SamInputResource.of(path, dataWrapper);
         final Path indexMaybe = SamFiles.findIndex(path);
         if (indexMaybe != null) r.index(indexMaybe, indexWrapper);
         return open(r);

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -333,6 +333,17 @@ public class SamReaderFactoryTest extends HtsjdkTest {
         }
     }
 
+    @Test
+    public void testOpenIrregularPath() throws IOException {
+        // See: htsjdk.samtools.SamInputResource.of(java.nio.file.Path)
+        // Related to https://github.com/samtools/htsjdk/issues/1716
+        final File irregularFile = new File("/dev/null");
+        try (final SamReader fileReader = SamReaderFactory.makeDefault().open(irregularFile);
+             final SamReader pathReader = SamReaderFactory.makeDefault().open(irregularFile.toPath())) {
+            Assert.assertEquals(fileReader.getResourceDescription(), pathReader.getResourceDescription());
+        }
+    }
+
     @DataProvider(name = "URIFallbackProvider")
     public Object[][] URIFallbackProvider() throws MalformedURLException {
         return new Object[][]{


### PR DESCRIPTION
### Description

To close #1716, copies the logic from here:

https://github.com/samtools/htsjdk/blob/127f3de750acb6a59fe1ceb5865ebbaee938847f/src/main/java/htsjdk/samtools/SamInputResource.java#L159-L161


### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [x] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
