### PR TITLE
Replace toPath().toString() with getURIString()

### DIFF
--- a/src/main/java/htsjdk/beta/codecs/variants/vcf/VCFDecoder.java
+++ b/src/main/java/htsjdk/beta/codecs/variants/vcf/VCFDecoder.java
@@ -26,8 +26,10 @@ import htsjdk.variant.vcf.AbstractVCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
 
 import java.io.IOException;
+import java.nio.channels.SeekableByteChannel;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * InternalAPII
@@ -197,7 +199,7 @@ public abstract class VCFDecoder implements VariantsDecoder {
                     "The provided %s resource (%s) must be a readable/input resource",
                     BundleResourceType.CT_VARIANT_CONTEXTS,
                     variantsResource));
-        } else if (!variantsResource.getIOPath().isPresent()) {
+        } else if (variantsResource.getIOPath().isEmpty()) {
             throw new HtsjdkUnsupportedOperationException("VCF reader from stream not implemented");
         }
         final IOPath variantsIOPath = variantsResource.getIOPath().get();
@@ -207,24 +209,18 @@ public abstract class VCFDecoder implements VariantsDecoder {
         // matches the one that is automatically resolved, otherwise throw since the request will not be honored
         return AbstractFeatureReader.getFeatureReader(
                 variantsIOPath.getURIString(),
-                indexIOPath.isPresent() ?
-                        indexIOPath.get().getURIString() :
-                        null,
+                indexIOPath.map(IOPath::getURIString).orElse(null),
                 vcfCodec,
                 indexIOPath.isPresent(),
-                decoderOptions.getVariantsChannelTransformer().isPresent() ?
-                        decoderOptions.getVariantsChannelTransformer().get() :
-                        null,
-                decoderOptions.getIndexChannelTransformer().isPresent() ?
-                        decoderOptions.getIndexChannelTransformer().get() :
-                        null
+                decoderOptions.getVariantsChannelTransformer().orElse(null),
+                decoderOptions.getIndexChannelTransformer().orElse(null)
         );
     }
 
     // the underlying readers can't handle index streams, so  for now we can only handle IOPaths
     private static Optional<IOPath> getIndexIOPath(final Bundle inputBundle) {
         final Optional<BundleResource> optIndexResource = inputBundle.get(BundleResourceType.CT_VARIANTS_INDEX);
-        if (!optIndexResource.isPresent()) {
+        if (optIndexResource.isEmpty()) {
             return Optional.empty();
         }
         final BundleResource indexResource = optIndexResource.get();
@@ -234,7 +230,7 @@ public abstract class VCFDecoder implements VariantsDecoder {
                 BundleResourceType.CT_VARIANTS_INDEX,
                indexResource));
         }
-        if (!indexResource.getIOPath().isPresent()) {
+        if (indexResource.getIOPath().isEmpty()) {
             throw new HtsjdkUnsupportedOperationException("Reading a VCF index from a stream not implemented");
         }
         return indexResource.getIOPath();

--- a/src/main/java/htsjdk/beta/codecs/variants/vcf/VCFDecoder.java
+++ b/src/main/java/htsjdk/beta/codecs/variants/vcf/VCFDecoder.java
@@ -206,9 +206,9 @@ public abstract class VCFDecoder implements VariantsDecoder {
         //TODO: this resolves the index automatically. it should check to make sure the provided index
         // matches the one that is automatically resolved, otherwise throw since the request will not be honored
         return AbstractFeatureReader.getFeatureReader(
-                variantsIOPath.toPath().toString(),
+                variantsIOPath.getURIString(),
                 indexIOPath.isPresent() ?
-                        indexIOPath.get().toPath().toString() :
+                        indexIOPath.get().getURIString() :
                         null,
                 vcfCodec,
                 indexIOPath.isPresent(),


### PR DESCRIPTION
@cmnbroad This is a fix for an issue that @kshakir discovered.  It dropping the scheme because it's using toPath().toString() instead of either toPath().toUri().toString() or getURIString().  

I added a JIMFS test which fails without the changes.  In a second commit I refactored the code with the optionals a bit.  I think it's clearer.  