### PR TITLE
Update commons compress to a 1.26.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ jacocoTestReport {
 dependencies {
     implementation 'commons-logging:commons-logging:1.3.0'
     implementation "org.xerial.snappy:snappy-java:1.1.10.5"
-    implementation "org.apache.commons:commons-compress:1.25.0"
+    implementation 'org.apache.commons:commons-compress:1.26.0'
     implementation 'org.tukaani:xz:1.9'
     implementation "org.json:json:20231013"
     implementation 'org.openjdk.nashorn:nashorn-core:15.4'


### PR DESCRIPTION
update to a newer version of commons-compress to fix a vulnerability