### PR TITLE
Adding additional java versions to our test matrix and toolchains

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,15 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 17, 21]
         experimental: [false]
+        include:
+           - java: 23
+             experimental: true
       fail-fast: false
     continue-on-error: ${{ matrix.experimental }}
     name: Java ${{ matrix.Java }} build and test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up java ${{ matrix.Java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.Java }}
           distribution: 'adopt'
@@ -39,7 +42,7 @@ jobs:
         run: ./gradlew test jacocoTestReport
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.Java }}
           path: build/reports/tests
@@ -48,9 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Tests that require external APIs
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -65,7 +68,7 @@ jobs:
 #        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-external-apis
           path: build/reports/tests
@@ -74,9 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     name: FTP tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -91,7 +94,7 @@ jobs:
 #        run: bash <(curl -s https://raw.githubusercontent.com/broadinstitute/codecov-bash-uploader/main/codecov-verified.bash)
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-ftp
           path: build/reports/tests
@@ -99,9 +102,9 @@ jobs:
     runs-on: ubuntu-latest
     name: SpotBugs
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -112,7 +115,7 @@ jobs:
         run: ./gradlew spotBugsMain spotBugsTest
       - name: Upload spotBugs Report
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: spotBugs-Report
           path: build/reports/spotbugs

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(23)
     }
     withJavadocJar()
     withSourcesJar()
@@ -64,6 +67,7 @@ defaultTasks 'jar'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
+    options.release.set(17)
 }
 
 tasks.withType(Javadoc).configureEach {


### PR DESCRIPTION
* Add 17, 21, 22, 23 to our toolchains list
* Github actions tests on  17, 21, 23 (experimental)
* Set compiler release target to 17 so that libaries built with newer javas still target 17
* Update github actions to use actions v4 instead of deprecated v3 variants
