### PR TITLE
add ReferenceSequenceFile.getSubsequenceAt(final Locatable locatable ) shortcut to getSubsequenceAt(loc.getContig(), loc.getStart(), loc.getEnd())

### DIFF
--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFile.java
@@ -25,6 +25,7 @@
 package htsjdk.samtools.reference;
 
 import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.util.Locatable;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -80,7 +81,17 @@ public interface ReferenceSequenceFile extends Closeable {
      * @throws UnsupportedOperationException if !sIndexed.
      */
     public ReferenceSequence getSubsequenceAt( String contig, long start, long stop );
-    
+
+    /**
+     * Gets the subsequence of the contig in the locatable. Shortcut to <code>getSubsequenceAt(locatable.getContig(), locatable.getStart(), locatable.getEnd());</code>
+     * @param locatable the interval to retrieve.
+     * @return The partial reference sequence associated with this location.
+     * @throws UnsupportedOperationException if !sIndexed.
+     */
+    public default ReferenceSequence getSubsequenceAt(final Locatable locatable ) {
+        return getSubsequenceAt(locatable.getContig(), locatable.getStart(), locatable.getEnd());
+    }
+
     /**
      * @return Reference name, file name, or something other human-readable representation.
      */

--- a/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
+++ b/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
@@ -30,6 +30,7 @@ import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.GZIIndex;
 import htsjdk.samtools.util.IOUtil;
+import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.StringUtil;
 import org.testng.Assert;
@@ -138,6 +139,21 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
         System.err.printf("testFirstSequence runtime: %dms%n", (endTime - startTime)) ;
     }
 
+    @Test(dataProvider="homosapiens")
+    public void testSubsequenceAtLocatable(AbstractIndexedFastaSequenceFile sequenceFile) {
+        long startTime = System.currentTimeMillis();
+        ReferenceSequence sequence = sequenceFile.getSubsequenceAt(new Interval("chrM",1,firstBasesOfChrM.length()));
+        long endTime = System.currentTimeMillis();
+
+        Assert.assertEquals(sequence.getName(),"chrM","Sequence contig is not correct");
+        Assert.assertEquals(sequence.getContigIndex(),0,"Sequence contig index is not correct");
+        Assert.assertEquals(StringUtil.bytesToString(sequence.getBases()),firstBasesOfChrM,"First n bases of chrM are incorrect");
+
+        CloserUtil.close(sequenceFile);
+
+        System.err.printf("testSubsequenceAtLocatable runtime: %dms%n", (endTime - startTime)) ;
+    }
+    
     @Test(dataProvider="homosapiens")
     public void testFirstSequenceExtended(AbstractIndexedFastaSequenceFile sequenceFile) {
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
### Description
A small PR that adds a default method to ReferenceSequenceFile.java 

```
getSubsequenceAt(final Locatable loc )
```

shortcut to

```
getSubsequenceAt(loc.getContig(), loc.getStart(), loc.getEnd())
```


### Things to think about before submitting:
- [X] Make sure your changes compile and new tests pass locally
- [X] Add new tests or update existing ones:
- [X] Extended the README / documentation, if necessary
- [X] Check your code style.
- [X] Write a clear commit title and message
