### PR TITLE
improve gff: add Locatable to Gff3BaseData, add 'Optional<String> getAttr(key)' and 'hasAttribute'

### DIFF
--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -1,5 +1,6 @@
 package htsjdk.tribble.gff;
 
+import htsjdk.samtools.util.Locatable;
 import htsjdk.tribble.annotation.Strand;
 
 import java.util.ArrayList;
@@ -7,8 +8,9 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-public class Gff3BaseData {
+public class Gff3BaseData implements Locatable {
     private final String contig;
     private final String source;
     private final String type;
@@ -116,6 +118,7 @@ public class Gff3BaseData {
         return hash;
     }
 
+    @Override
     public String getContig() {
         return contig;
     }
@@ -128,10 +131,12 @@ public class Gff3BaseData {
         return type;
     }
 
+    @Override
     public int getStart() {
         return start;
     }
 
+    @Override
     public int getEnd() {
         return end;
     }
@@ -152,10 +157,45 @@ public class Gff3BaseData {
         return attributes;
     }
 
+    /** 
+     * get the values as List for the <tt>key</tt>, or an empty list if this <tt>key</tt> is not present
+     * 
+     * @param key key whose presence in this map is to be tested
+     * @return the values as List, or an empty list if this key is not present
+     */
     public List<String> getAttribute(final String key) {
         return attributes.getOrDefault(key, Collections.emptyList());
     }
 
+    /**
+     * Returns <tt>true</tt> if this record contains an attribute for the specified key.
+     * 
+     * @param key key whose presence in this map is to be tested
+     * @return <tt>true</tt> if this map contains an attribute for the specified key
+     */
+    public boolean hasAttribute(final String key) {
+        return attributes.containsKey(key);
+    }
+    
+    /**
+     * Most attributes in a GFF file are present just one time in a line, e.g. : <tt>gene_biotype</tt>,  <tt>gene_name</tt>, etc ...  
+     * This function returns an <tt>Optional.empty</tt> if the <tt>key</tt> is not present,
+     *  an <tt>Optional.of(value)</tt> if there is only one value associated to the <tt>key</tt>,
+     *  or it throws an <tt>IllegalArgumentException</tt> if there is more than one value.
+     * 
+     * @param key key whose presence in the attributes is to be tested
+     * @return <tt>Optional&lt;String&gt;</tt> if this map contains zero or one attribute for the specified key
+     * @throws IllegalArgumentException if there is more than one value
+     */
+    public Optional<String> getAttr(final String key) {
+        final List<String> atts = getAttribute(key);
+        switch(atts.size()) {
+            case 0 : return Optional.empty();
+            case 1 : return Optional.of(atts.get(0));
+            default : throw new IllegalArgumentException("getAttr cannot be called with key="+key+" because it contains more than one value " + String.join(", ", atts));
+        }
+    }
+    
     public String getId() {
         return id;
     }

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -187,7 +187,7 @@ public class Gff3BaseData implements Locatable {
      * @return <tt>Optional&lt;String&gt;</tt> if this map contains zero or one attribute for the specified key
      * @throws IllegalArgumentException if there is more than one value
      */
-    public Optional<String> getAttr(final String key) {
+    public Optional<String> getUniqueAttribute(final String key) {
         final List<String> atts = getAttribute(key);
         switch(atts.size()) {
             case 0 : return Optional.empty();

--- a/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3BaseData.java
@@ -192,7 +192,7 @@ public class Gff3BaseData implements Locatable {
         switch(atts.size()) {
             case 0 : return Optional.empty();
             case 1 : return Optional.of(atts.get(0));
-            default : throw new IllegalArgumentException("getAttr cannot be called with key="+key+" because it contains more than one value " + String.join(", ", atts));
+            default : throw new IllegalArgumentException("getUniqueAttribute cannot be called with key="+key+" because it contains more than one value " + String.join(", ", atts));
         }
     }
     

--- a/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
@@ -77,8 +77,8 @@ public interface Gff3Feature extends Feature {
      * @return <tt>Optional&lt;String&gt;</tt> if this map contains zero or one attribute for the specified key
      * @throws IllegalArgumentException if there is more than one value.
      */
-    default Optional<String> getAttr(final String key) {
-       return getBaseData().getAttr(key);
+    default Optional<String> getUniqueAttribute(final String key) {
+       return getBaseData().getUniqueAttribute(key);
     }
     
     default Map<String, List<String>> getAttributes() { return getBaseData().getAttributes();}

--- a/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Feature.java
@@ -5,6 +5,7 @@ import htsjdk.tribble.annotation.Strand;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -55,7 +56,31 @@ public interface Gff3Feature extends Feature {
     default List<String> getAttribute(final String key) {
         return getBaseData().getAttribute(key);
     }
+    
+    /**
+     * Returns <tt>true</tt> if this record contains an attribute for the specified key.
+     * 
+     * @param key key whose presence in this map is to be tested
+     * @return <tt>true</tt> if this map contains an attribute for the specified key
+     */
+    default boolean hasAttribute(final String key) {
+        return getBaseData().hasAttribute(key);
+    }
 
+    /**
+     * Most attributes in a GFF file are present just one time in a line, e.g. : <tt>gene_biotype</tt>,  <tt>gene_name</tt>, etc ...  
+     * This function returns an <tt>Optional.empty</tt> if the <tt>key</tt> is not present,
+     *  an <tt>Optional.of(value)</tt> if there is only one value associated to the <tt>key</tt>,
+     *  or it throws an <tt>IllegalArgumentException</tt> if there is more than one value.
+     * 
+     * @param key key whose presence in the attributes is to be tested
+     * @return <tt>Optional&lt;String&gt;</tt> if this map contains zero or one attribute for the specified key
+     * @throws IllegalArgumentException if there is more than one value.
+     */
+    default Optional<String> getAttr(final String key) {
+       return getBaseData().getAttr(key);
+    }
+    
     default Map<String, List<String>> getAttributes() { return getBaseData().getAttributes();}
 
     default String getID() { return getBaseData().getId();}

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -80,7 +80,7 @@ public class Gff3CodecTest extends HtsjdkTest {
             for(final String key : skip_attributes) {
                 Assert.assertTrue(feature.getAttribute(key).isEmpty());
                 Assert.assertFalse(feature.hasAttribute(key));
-                Assert.assertFalse(feature.getAttr(key).isPresent());
+                Assert.assertFalse(feature.getUniqueAttribute(key).isPresent());
             }
             countTotalFeatures++;
         }
@@ -203,8 +203,8 @@ public class Gff3CodecTest extends HtsjdkTest {
         Assert.assertEquals(feature.getAttribute("Another key"), Arrays.asList("Another=value", "And a second, value"));
         Assert.assertTrue(feature.hasAttribute("Another key"));
         Assert.assertTrue(feature.hasAttribute(Gff3Constants.ID_ATTRIBUTE_KEY));
-        Assert.assertTrue(feature.getAttr(Gff3Constants.ID_ATTRIBUTE_KEY).isPresent());
-        Assert.assertFalse(feature.getAttr("missing").isPresent());
+        Assert.assertTrue(feature.getUniqueAttribute(Gff3Constants.ID_ATTRIBUTE_KEY).isPresent());
+        Assert.assertFalse(feature.getUniqueAttribute("missing").isPresent());
     }
 
 

--- a/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3CodecTest.java
@@ -79,6 +79,8 @@ public class Gff3CodecTest extends HtsjdkTest {
         for (final Gff3Feature feature : reader.iterator()) {
             for(final String key : skip_attributes) {
                 Assert.assertTrue(feature.getAttribute(key).isEmpty());
+                Assert.assertFalse(feature.hasAttribute(key));
+                Assert.assertFalse(feature.getAttr(key).isPresent());
             }
             countTotalFeatures++;
         }
@@ -199,6 +201,10 @@ public class Gff3CodecTest extends HtsjdkTest {
         Assert.assertEquals(feature.getType(), "a region");
         Assert.assertEquals(feature.getID(), "this is the ID of this wacky feature^&%##$%*&>,. ,.");
         Assert.assertEquals(feature.getAttribute("Another key"), Arrays.asList("Another=value", "And a second, value"));
+        Assert.assertTrue(feature.hasAttribute("Another key"));
+        Assert.assertTrue(feature.hasAttribute(Gff3Constants.ID_ATTRIBUTE_KEY));
+        Assert.assertTrue(feature.getAttr(Gff3Constants.ID_ATTRIBUTE_KEY).isPresent());
+        Assert.assertFalse(feature.getAttr("missing").isPresent());
     }
 
 


### PR DESCRIPTION
### Description

This PR improves the GFF3 classes:

- 99%  the interesting attributes in a GFF3 file are unique (for example gene_biotype, gene_name, etc...) , so using the function `List<String> getAttribute(key)` can be cumbersome. This PR adds a new function  `Optional<String> getAttr(key)` , it returns an Optional if there is zero or one value. Otherwise an exception is thrown.
- I also added a function `hasAttribute` to test for the presence of an attribute.
- add `implements Locatable` to Gff3BaseData

### Things to think about before submitting:
- [X] Make sure your changes compile and new tests pass locally.
- [X] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [X] Extended the README / documentation, if necessary
- [X] Check your code style.
- [X] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
