### PR TITLE
.vcf.bgz as a valid vcf extension in FileExtensions

### DIFF
--- a/src/main/java/htsjdk/beta/codecs/variants/vcf/VCFCodec.java
+++ b/src/main/java/htsjdk/beta/codecs/variants/vcf/VCFCodec.java
@@ -32,7 +32,7 @@ public abstract class VCFCodec implements VariantsCodec {
         {
             add(FileExtensions.VCF);
             add(FileExtensions.COMPRESSED_VCF);
-            add(".vcf.bgz");
+            add(FileExtensions.COMPRESSED_VCF_BGZ);
         }
     };
 

--- a/src/main/java/htsjdk/beta/plugin/variants/VariantsBundle.java
+++ b/src/main/java/htsjdk/beta/plugin/variants/VariantsBundle.java
@@ -206,7 +206,7 @@ public class VariantsBundle extends Bundle implements Serializable {
             final String ext = extension.get();
             if (ext.equals(FileExtensions.VCF)) {
                 return Optional.of(new Tuple<>(BundleResourceType.CT_VARIANT_CONTEXTS, BundleResourceType.FMT_VARIANTS_VCF));
-            } else if (ext.equals(FileExtensions.COMPRESSED_VCF)) {
+            } else if (ext.equals(FileExtensions.COMPRESSED_VCF) || ext.equals(FileExtensions.COMPRESSED_VCF_BGZ)) {
                 return Optional.of(new Tuple<>(BundleResourceType.CT_VARIANT_CONTEXTS, BundleResourceType.FMT_VARIANTS_VCF));
             }
         }

--- a/src/main/java/htsjdk/samtools/util/FileExtensions.java
+++ b/src/main/java/htsjdk/samtools/util/FileExtensions.java
@@ -65,9 +65,10 @@ public final class FileExtensions {
     public static final String VCF = ".vcf";
     public static final String VCF_INDEX = TRIBBLE_INDEX;
     public static final String BCF = ".bcf";
+    public static final String COMPRESSED_VCF_BGZ = ".vcf.bgz"; // suffix used by gnomad see https://gnomad.broadinstitute.org/data#v4
     public static final String COMPRESSED_VCF = ".vcf.gz";
     public static final String COMPRESSED_VCF_INDEX = ".tbi";
-    public static final List<String> VCF_LIST = Collections.unmodifiableList(Arrays.asList(VCF, COMPRESSED_VCF, BCF));
+    public static final List<String> VCF_LIST = Collections.unmodifiableList(Arrays.asList(VCF, COMPRESSED_VCF, COMPRESSED_VCF_BGZ, BCF));
 
     public static final String INTERVAL_LIST = ".interval_list";
     public static final String COMPRESSED_INTERVAL_LIST = ".interval_list.gz";

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -159,7 +159,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         try (BlockCompressedInputStream bcis = new BlockCompressedInputStream(fakeVCFFile);
                 FileInputStream fis = new FileInputStream(fakeVCFFile)) {
             AsciiLineReaderIterator iterator =
-                    new AsciiLineReaderIterator(new AsciiLineReader(".vcf.gz".equals(extension) ? bcis : fis));
+                    new AsciiLineReaderIterator(new AsciiLineReader(FileExtensions.COMPRESSED_VCF.equals(extension) || FileExtensions.COMPRESSED_VCF_BGZ.equals(extension) ? bcis : fis));
             int counter = 0;
             while (iterator.hasNext()) {
                 VariantContext context = codec.decode(iterator.next());

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -90,7 +90,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     public void testBasicWriteAndRead(final String extension) throws IOException {
         final File fakeVCFFile = File.createTempFile("testBasicWriteAndRead.", extension, tempDir);
         fakeVCFFile.deleteOnExit();
-        if (FileExtensions.COMPRESSED_VCF.equals(extension)) {
+        if (FileExtensions.COMPRESSED_VCF.equals(extension) || FileExtensions.COMPRESSED_VCF_BGZ.equals(extension)) {
             new File(fakeVCFFile.getAbsolutePath() + FileExtensions.VCF_INDEX);
         } else {
             Tribble.indexFile(fakeVCFFile).deleteOnExit();
@@ -136,7 +136,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     public void testWriteAndReadVCFHeaderless(final String extension) throws IOException {
         final File fakeVCFFile = File.createTempFile("testWriteAndReadVCFHeaderless.", extension, tempDir);
         fakeVCFFile.deleteOnExit();
-        if (FileExtensions.COMPRESSED_VCF.equals(extension)) {
+        if (FileExtensions.COMPRESSED_VCF.equals(extension) || FileExtensions.COMPRESSED_VCF_BGZ.equals(extension)) {
             new File(fakeVCFFile.getAbsolutePath() + ".tbi");
         } else {
             Tribble.indexFile(fakeVCFFile).deleteOnExit();
@@ -300,7 +300,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
         final File vcf = new File(tempDir, "test" + extension);
         final String indexExtension;
-        if (extension.equals(FileExtensions.COMPRESSED_VCF)) {
+        if (extension.equals(FileExtensions.COMPRESSED_VCF) || extension.equals(FileExtensions.COMPRESSED_VCF_BGZ)) {
             indexExtension = FileExtensions.TABIX_INDEX;
         } else {
             indexExtension = FileExtensions.TRIBBLE_INDEX;
@@ -333,7 +333,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
                 // TODO: BCF doesn't work because header is not properly constructed.
                 // {".bcf"},
                 {FileExtensions.VCF},
-                {FileExtensions.COMPRESSED_VCF}
+                {FileExtensions.COMPRESSED_VCF},
+                {FileExtensions.COMPRESSED_VCF_BGZ}
         };
     }
 


### PR DESCRIPTION
### Description

VCF suppliers like gnomad, provide VCF with the vcf.bgz extension (eg https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/vcf/exomes/gnomad.exomes.v4.1.sites.chr1.vcf.bgz ) . This PR adds vcf.bgz as a valid extension, defined as  COMPRESSED_VCF_BGZ

### Things to think about before submitting:
- [X] Make sure your changes compile and new tests pass locally.
- [X] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [X] Extended the README / documentation, if necessary
- [X] Check your code style.
- [X] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
