### PR TITLE
fix: catch UnsatisfiedLinkError when loading snappy native library

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SnappyLoaderInternal.java
+++ b/src/main/java/htsjdk/samtools/util/SnappyLoaderInternal.java
@@ -44,7 +44,7 @@ class SnappyLoaderInternal {
          * IOException: potentially thrown by the `test.write` and `test.close` calls.
          * SnappyError: potentially thrown for a variety of reasons by Snappy.
          */
-        catch (final ExceptionInInitializerError | IllegalStateException | IOException | SnappyError e) {
+        catch (final ExceptionInInitializerError | UnsatisfiedLinkError | IllegalStateException | IOException | SnappyError e) {
             logger.warn(e, "Snappy native library failed to load.");
         }
         snappyAvailable = tmpSnappyAvailable;


### PR DESCRIPTION
Add `UnsatisfiedLinkError` to the catch clause in `tryToLoadSnappy()` to handle cases where native library loading fails.

This can occur when snappy-java 1.1.10.8+ incorrectly detects musl libc (by checking for `/lib/ld-musl-x86_64.so.1`) and loads the musl-compiled native library on a glibc system.

Reported in fulcrumgenomics/fgbio#1127.