### PR TITLE
Fix SamLocusIterator so that read position is not incorrectly offset …

### DIFF
--- a/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/SamLocusIterator.java
@@ -136,8 +136,10 @@ public class SamLocusIterator extends AbstractLocusIterator<SamLocusIterator.Rec
                 // insertions are included in the previous base
                 if (dontCheckQualities || baseQualities.length == 0 || baseQualities[readBase] >= minQuality){
                     accumulator.get(baseAccIndex - 1).addInserted(rec, readBase);
-                    readBase += e.getLength();
                 }
+                // Always advance past inserted bases regardless of quality check,
+                // otherwise subsequent CIGAR positions will be misaligned.
+                readBase += e.getLength();
             } else if (operator.equals(CigarOperator.D)) {
                 // accumulate for each position that spans the deletion
                 for (int i = 0; i < e.getLength(); i++) {

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -813,4 +813,43 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
         }
     }
 
+    /**
+     * Test that when an insertion fails the base quality check, readBase is still
+     * advanced so that subsequent insertions in the same read are reported at the
+     * correct offset. Previously, failing the BQ check left readBase un-advanced,
+     * causing all subsequent CIGAR positions to be misaligned.
+     *
+     * CIGAR: 10M1I1M1I10M (read length 23)
+     * Quality string assigns BQ=5 to the first inserted base (pos 10) and BQ=30
+     * to the second inserted base (pos 12). With a cutoff of 20, only the second
+     * insertion should be reported, and it should be at read offset 12 (not 11).
+     */
+    @Test
+    public void testInsertionBqFailureDoesNotShiftSubsequentOffsets() {
+        final SAMRecordSetBuilder builder = getRecordBuilder();
+        final int startPosition = 165;
+
+        // Build quality string: 23 bases, all BQ=30 except position 10 (first insertion) = BQ=5
+        final char[] quals = new char[23];
+        java.util.Arrays.fill(quals, '?');  // '?' = ASCII 63 - 33 = BQ 30
+        quals[10] = '&';                     // '&' = ASCII 38 - 33 = BQ 5
+
+        builder.addFrag("record0", 0, startPosition, false, false,
+                "10M1I1M1I10M", new String(quals), 30);
+
+        final SamLocusIterator sli = createSamLocusIterator(builder);
+        sli.setIncludeIndels(true);
+        sli.setQualityScoreCutoff(20);
+
+        for (final SamLocusIterator.LocusInfo li : sli) {
+            for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
+                // The second insertion's first base is at read offset 12.
+                // Before the fix, the drifted readBase would report offset 11.
+                Assert.assertEquals(rao.getOffset(), 12,
+                        "Insertion reported at wrong read offset — " +
+                        "readBase drift from prior BQ-failed insertion");
+            }
+        }
+    }
+
 }

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -818,7 +818,7 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
     /**
      * Test that when an insertion fails the base quality check, readBase is still
      * advanced so that subsequent insertions in the same read are reported at the
-     * correct offset. 
+     * correct offset.
      *
      * CIGAR: 10M1I1M1I10M (read length 23)
      * Quality string assigns BQ=5 to the first inserted base (pos 10) and BQ=30

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -27,6 +27,8 @@ import htsjdk.samtools.SAMRecordSetBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.List;
+
 /**
  * @author alecw@broadinstitute.org
  * @author Mariia_Zueva@epam.com, EPAM Systems, Inc. <www.epam.com>
@@ -840,14 +842,18 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
         sli.setIncludeIndels(true);
         sli.setQualityScoreCutoff(20);
 
-        for (final SamLocusIterator.LocusInfo li : sli) {
-            for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
-                // The second insertion's first base is at read offset 12.
-                Assert.assertEquals(rao.getOffset(), 12,
-                        "Insertion reported at wrong read offset — " +
-                        "readBase drift from prior BQ-failed insertion");
-            }
+        final List<SamLocusIterator.RecordAndOffset> insertions =
+                sli.stream().flatMap(l -> l.getInsertedInRecord().stream()).toList();
+
+        // The first insertion should be skipped by the BQ check, but the second
+        // insertion should come through
+        Assert.assertEquals(insertions.size(), 1);
+
+        for (final SamLocusIterator.RecordAndOffset rao : insertions) {
+            // The second insertion's first base is at read offset 12.
+            Assert.assertEquals(rao.getOffset(), 12,
+                    "Insertion reported at wrong read offset — " +
+                    "readBase drift from prior BQ-failed insertion");
         }
     }
-
 }

--- a/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/SamLocusIteratorTest.java
@@ -816,13 +816,12 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
     /**
      * Test that when an insertion fails the base quality check, readBase is still
      * advanced so that subsequent insertions in the same read are reported at the
-     * correct offset. Previously, failing the BQ check left readBase un-advanced,
-     * causing all subsequent CIGAR positions to be misaligned.
+     * correct offset. 
      *
      * CIGAR: 10M1I1M1I10M (read length 23)
      * Quality string assigns BQ=5 to the first inserted base (pos 10) and BQ=30
      * to the second inserted base (pos 12). With a cutoff of 20, only the second
-     * insertion should be reported, and it should be at read offset 12 (not 11).
+     * insertion should be reported, and it should be at read offset 12.
      */
     @Test
     public void testInsertionBqFailureDoesNotShiftSubsequentOffsets() {
@@ -844,7 +843,6 @@ public class SamLocusIteratorTest extends AbstractLocusIteratorTestTemplate {
         for (final SamLocusIterator.LocusInfo li : sli) {
             for (final SamLocusIterator.RecordAndOffset rao : li.getInsertedInRecord()) {
                 // The second insertion's first base is at read offset 12.
-                // Before the fix, the drifted readBase would report offset 11.
                 Assert.assertEquals(rao.getOffset(), 12,
                         "Insertion reported at wrong read offset — " +
                         "readBase drift from prior BQ-failed insertion");


### PR DESCRIPTION
…after transiting insertions that fail the base quality check.

### Description

This fixes a bug in SamLocusIterator where during accumulation of indels, the position in the read (`readBase`) was incorrectly failling to count indels that failed a base quality check.  The result of this is that indels later in the read were then accumulated with incorrect read offsets.

This affects any tool that uses the pileup engine with a base quality filter _and_ cares about indels!

The added test fails without the accompanying change to SamLocusIterator.