### PR TITLE
Fix LTF8 9-byte write bug: wrong bit shift (>> 28 instead of >> 24)

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/io/LTF8.java
+++ b/src/main/java/htsjdk/samtools/cram/io/LTF8.java
@@ -195,7 +195,7 @@ public class LTF8 {
             outputStream.write((int) ((value >> 48) & 0xFF));
             outputStream.write((int) ((value >> 40) & 0xFF));
             outputStream.write((int) ((value >> 32) & 0xFF));
-            outputStream.write((int) ((value >> 28) & 0xFF));
+            outputStream.write((int) ((value >> 24) & 0xFF));
             outputStream.write((int) ((value >> 16) & 0xFF));
             outputStream.write((int) ((value >> 8) & 0xFF));
             outputStream.write((int) (value & 0xFF));

--- a/src/test/java/htsjdk/samtools/cram/io/LTF8Test.java
+++ b/src/test/java/htsjdk/samtools/cram/io/LTF8Test.java
@@ -72,32 +72,49 @@ public class LTF8Test extends HtsjdkTest {
     }
 
     /**
-     * Tests the 9-byte (full 64-bit) LTF8 encoding with a value where bits [35:32] differ from
+     * Tests the 9-byte (full 64-bit) LTF8 encoding with values where bits [35:32] differ from
      * bits [27:24], which exposes the >> 28 vs >> 24 bug in writeUnsignedLTF8.
-     *
-     * For 0x0123456789ABCDEFL:
-     *   (value >> 28) & 0xFF == 0x78  (wrong, old behavior)
-     *   (value >> 24) & 0xFF == 0x89  (correct)
      *
      * The 9-byte encoding writes a 0xFF prefix followed by bytes at shifts 56,48,40,32,24,16,8,0.
      */
-    @Test
-    public void testNineByteEncodingWithDistinctBitsAt24And28() throws IOException {
-        final long value = 0x0123456789ABCDEFL;
-
-        // Expected encoding: 0xFF prefix + 8 bytes at shifts 56,48,40,32,24,16,8,0
-        final byte[] expectedBytes = {
-            (byte) 0xFF,
-            (byte) 0x01, // >> 56
-            (byte) 0x23, // >> 48
-            (byte) 0x45, // >> 40
-            (byte) 0x67, // >> 32
-            (byte) 0x89, // >> 24  (would be 0x78 with the >> 28 bug)
-            (byte) 0xAB, // >> 16
-            (byte) 0xCD, // >> 8
-            (byte) 0xEF, // >> 0
+    @DataProvider(name = "nineByteEncodings")
+    public static Object[][] nineByteEncodingsProvider() {
+        return new Object[][] {
+            // Value with a leading zero byte
+            {
+                0x0123456789ABCDEFL,
+                new byte[] {
+                    (byte) 0xFF,
+                    (byte) 0x01, // >> 56
+                    (byte) 0x23, // >> 48
+                    (byte) 0x45, // >> 40
+                    (byte) 0x67, // >> 32
+                    (byte) 0x89, // >> 24  (would be 0x78 with the >> 28 bug)
+                    (byte) 0xAB, // >> 16
+                    (byte) 0xCD, // >> 8
+                    (byte) 0xEF, // >> 0
+                }
+            },
+            // Value without a leading zero byte
+            {
+                0xFEDCBA9876543210L,
+                new byte[] {
+                    (byte) 0xFF,
+                    (byte) 0xFE, // >> 56
+                    (byte) 0xDC, // >> 48
+                    (byte) 0xBA, // >> 40
+                    (byte) 0x98, // >> 32
+                    (byte) 0x76, // >> 24  (would be 0x87 with the >> 28 bug)
+                    (byte) 0x54, // >> 16
+                    (byte) 0x32, // >> 8
+                    (byte) 0x10, // >> 0
+                }
+            },
         };
+    }
 
+    @Test(dataProvider = "nineByteEncodings")
+    public void testNineByteEncodingWithDistinctBitsAt24And28(final long value, final byte[] expectedBytes) throws IOException {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             final int bitsWritten = LTF8.writeUnsignedLTF8(value, baos);
             Assert.assertEquals(bitsWritten, 72);

--- a/src/test/java/htsjdk/samtools/cram/io/LTF8Test.java
+++ b/src/test/java/htsjdk/samtools/cram/io/LTF8Test.java
@@ -71,6 +71,47 @@ public class LTF8Test extends HtsjdkTest {
         }
     }
 
+    /**
+     * Tests the 9-byte (full 64-bit) LTF8 encoding with a value where bits [35:32] differ from
+     * bits [27:24], which exposes the >> 28 vs >> 24 bug in writeUnsignedLTF8.
+     *
+     * For 0x0123456789ABCDEFL:
+     *   (value >> 28) & 0xFF == 0x78  (wrong, old behavior)
+     *   (value >> 24) & 0xFF == 0x89  (correct)
+     *
+     * The 9-byte encoding writes a 0xFF prefix followed by bytes at shifts 56,48,40,32,24,16,8,0.
+     */
+    @Test
+    public void testNineByteEncodingWithDistinctBitsAt24And28() throws IOException {
+        final long value = 0x0123456789ABCDEFL;
+
+        // Expected encoding: 0xFF prefix + 8 bytes at shifts 56,48,40,32,24,16,8,0
+        final byte[] expectedBytes = {
+            (byte) 0xFF,
+            (byte) 0x01, // >> 56
+            (byte) 0x23, // >> 48
+            (byte) 0x45, // >> 40
+            (byte) 0x67, // >> 32
+            (byte) 0x89, // >> 24  (would be 0x78 with the >> 28 bug)
+            (byte) 0xAB, // >> 16
+            (byte) 0xCD, // >> 8
+            (byte) 0xEF, // >> 0
+        };
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            final int bitsWritten = LTF8.writeUnsignedLTF8(value, baos);
+            Assert.assertEquals(bitsWritten, 72);
+
+            final byte[] actualBytes = baos.toByteArray();
+            Assert.assertEquals(actualBytes, expectedBytes, "9-byte LTF8 encoded bytes do not match expected");
+
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(actualBytes)) {
+                final long decoded = LTF8.readUnsignedLTF8(bais);
+                Assert.assertEquals(decoded, value, "Round-trip encode/decode mismatch for 9-byte LTF8 value");
+            }
+        }
+    }
+
     @Test(expectedExceptions = RuntimeEOFException.class)
     public void emptyStreamTest() throws IOException {
         try (InputStream emptyStream = new ByteArrayInputStream(new byte[0])) {


### PR DESCRIPTION
The writeUnsignedLTF8(long, OutputStream) method incorrectly shifts by 28 bits instead of 24 bits when encoding byte 5 of a 9-byte LTF8 value. This causes data corruption for values requiring the full 9-byte encoding (values >= 2^56 with certain bit patterns).

The 9-byte encoding should write bytes at shifts:
  56, 48, 40, 32, 24, 16, 8, 0
but the code wrote:
  56, 48, 40, 32, 28, 16, 8, 0

The corresponding read path (readUnsignedLTF8) correctly uses << 24, so the reader and writer disagreed for affected values.

The correct behavior is confirmed by htslib's reference implementation:
  https://github.com/samtools/htslib/blob/master/cram/cram_io.c#L364-L373

Existing tests did not catch this because their 9-byte test values (-4757, Long.MAX_VALUE, -1) have identical nibbles at bit positions 28 and 24, masking the bug. A targeted test with value 0x0123456789ABCDEF is added to exercise the difference.

### Description

Please explain the changes you made here.
Explain the **motivation** for making this change. What existing problem does the pull request solve?

### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
