### PR TITLE
Speed up BCF2 and SeekableStream integration tests

### DIFF
--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamGZIPinputStreamIntegrationTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamGZIPinputStreamIntegrationTest.java
@@ -111,8 +111,10 @@ public class SeekableStreamGZIPinputStreamIntegrationTest extends HtsjdkTest {
     @DataProvider
     public Iterator<Object[]> compressedVcfsToTest() throws Exception {
         final List<Object[]> data = new ArrayList<>();
-        final int nSmallRecords = 1000000;
-        for (int firstRecordLength = 1000; firstRecordLength <= 10000; firstRecordLength+=1000) {
+        // 100K records is sufficient to exercise multi-block BGZF boundaries and detect the
+        // GZIPInputStream available() bug. 5 first-record-length variants cover the range.
+        final int nSmallRecords = 100_000;
+        for (int firstRecordLength = 1000; firstRecordLength <= 9000; firstRecordLength += 2000) {
             data.add(new Object[]{createBgzipVcfsWithVariableSize(firstRecordLength, nSmallRecords), nSmallRecords+1});
         }
         return data.iterator();

--- a/src/test/java/htsjdk/variant/bcf2/BCF2EncoderDecoderUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2EncoderDecoderUnitTest.java
@@ -120,24 +120,18 @@ public class BCF2EncoderDecoderUnitTest extends VariantBaseTest {
             primitives.add(new BCF2TypedValue(null, type));
         }
 
+        // One representative per type plus one null per non-CHAR type. Reducing from 17 to 9
+        // values cuts the 3-way cartesian product from 4913 to 729 test sequences while still
+        // covering all type combinations and null handling.
         forCombinations.add(new BCF2TypedValue(10, BCF2Type.INT8));
-        forCombinations.add(new BCF2TypedValue(100, BCF2Type.INT8));
-        forCombinations.add(new BCF2TypedValue(-100, BCF2Type.INT8));
-        forCombinations.add(new BCF2TypedValue(-128, BCF2Type.INT16));    // first value in range
-        forCombinations.add(new BCF2TypedValue( 128, BCF2Type.INT16));    // first value in range
-        forCombinations.add(new BCF2TypedValue(-100000, BCF2Type.INT32));
+        forCombinations.add(new BCF2TypedValue(-128, BCF2Type.INT16));
         forCombinations.add(new BCF2TypedValue(100000, BCF2Type.INT32));
-        forCombinations.add(new BCF2TypedValue(0.0, BCF2Type.FLOAT));
         forCombinations.add(new BCF2TypedValue(1.23e6, BCF2Type.FLOAT));
-        forCombinations.add(new BCF2TypedValue(-1.23e6, BCF2Type.FLOAT));
-        forCombinations.add(new BCF2TypedValue("S", BCF2Type.CHAR));
         forCombinations.add(new BCF2TypedValue("ABCDEFGHIJKLMNOPQRSTUVWXYZ", BCF2Type.CHAR));
-        forCombinations.add(new BCF2TypedValue("ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ", BCF2Type.CHAR));
-
-        // missing values
-        for ( BCF2Type type : BCF2Type.values() ) {
-            forCombinations.add(new BCF2TypedValue(null, type));
-        }
+        forCombinations.add(new BCF2TypedValue(null, BCF2Type.INT8));
+        forCombinations.add(new BCF2TypedValue(null, BCF2Type.INT16));
+        forCombinations.add(new BCF2TypedValue(null, BCF2Type.INT32));
+        forCombinations.add(new BCF2TypedValue(null, BCF2Type.FLOAT));
     }
 
     // --------------------------------------------------------------------------------


### PR DESCRIPTION
The test suite run time is dominated by a handful of classes whose combined method/test runtime are >> 1 minute each.  I'm tackling the CRAM tests that offend, which is most of them, on my cram branch.  But these two also stick out.

BCF2EncoderDecoderUnitTest (106s → <1s):
  Reduce the forCombinations list from 17 to 9 values (one representative
  per BCF2 type plus one null per non-CHAR type). This cuts the 3-way
  cartesian product from 17^3=4913 to 9^3=729 test sequences while still
  covering all type combinations and null handling. Total tests: 13848 → 1588.

SeekableStreamGZIPinputStreamIntegrationTest (82s → 4s):
  Reduce from 1M to 100K VCF records per test file (sufficient to exercise
  multi-block BGZF boundaries) and from 10 to 5 first-record-length
  variants. Total tests: 20 → 10.

Full suite: 21,909 tests pass in 2m12s (was ~5m with 34,189 tests).


### Things to think about before submitting:
- [x] Make sure your changes compile and new tests pass locally.
- [x] Add new tests or update existing ones:
  - A bug fix should include a test that previously would have failed and passes now.
  - New features should come with new tests that exercise and validate the new functionality.
- [ ] Extended the README / documentation, if necessary
- [x] Check your code style.
- [x] Write a clear commit title and message
  - The commit message should describe what changed and is targeted at htsjdk developers
  - Breaking changes should be mentioned in the commit message.
