### PR TITLE
Fix javadoc warnings across the codebase

### DIFF
--- a/src/main/java/htsjdk/beta/codecs/reads/bam/BAMEncoderOptions.java
+++ b/src/main/java/htsjdk/beta/codecs/reads/bam/BAMEncoderOptions.java
@@ -120,7 +120,7 @@ public class BAMEncoderOptions {
      * {@link htsjdk.samtools.util.BlockCompressedStreamConstants#DEFAULT_COMPRESSION_LEVEL}.
      * See {@link htsjdk.samtools.util.BlockCompressedStreamConstants#DEFAULT_COMPRESSION_LEVEL}
      *
-     * @return the compression level for these options, 1 <= compressionLevel <= 9
+     * @return the compression level for these options, {@code 1 <= compressionLevel <= 9}
      */
     public int getCompressionLevel() {
         return compressionLevel;
@@ -130,7 +130,7 @@ public class BAMEncoderOptions {
      * Set the compression level for these options. Defaults value is
      * {@link htsjdk.samtools.util.BlockCompressedStreamConstants#DEFAULT_COMPRESSION_LEVEL}.
      *
-     * @param compressionLevel the compression level for these options, 1 <= compressionLevel <= 9
+     * @param compressionLevel the compression level for these options, {@code 1 <= compressionLevel <= 9}
      * @return updated options
      */
     public BAMEncoderOptions setCompressionLevel(int compressionLevel) {

--- a/src/main/java/htsjdk/beta/plugin/HtsCodec.java
+++ b/src/main/java/htsjdk/beta/plugin/HtsCodec.java
@@ -76,7 +76,7 @@ import htsjdk.io.IOPath;
  *     <li> For {@link HtsContentType#ALIGNED_READS} codecs, see the {@link htsjdk.beta.plugin.reads} package </li>
  *     <li> For {@link HtsContentType#HAPLOID_REFERENCE} codecs, see the {@link htsjdk.beta.plugin.hapref} package </li>
  *     <li> For {@link HtsContentType#VARIANT_CONTEXTS} codecs, see the {@link htsjdk.beta.plugin.variants} package </li>
- *     <li> For {@link HtsContentType#FEATURES} codecs, see the {@link htsjdk.beta.plugin.features} package </li>
+ *     <li> For {@link HtsContentType#FEATURES} codecs, see the {@code htsjdk.beta.plugin.features} package </li>
  * </ul>
  * <p>
  * <H3>Example Content Type: Reads</H3>

--- a/src/main/java/htsjdk/beta/plugin/HtsContentType.java
+++ b/src/main/java/htsjdk/beta/plugin/HtsContentType.java
@@ -15,7 +15,7 @@ import htsjdk.beta.plugin.variants.VariantsFormats;
  *     <li> For {@link HtsContentType#HAPLOID_REFERENCE} codecs, see the {@link htsjdk.beta.plugin.hapref} package </li>
  *     <li> For {@link HtsContentType#ALIGNED_READS} codecs, see the {@link htsjdk.beta.plugin.reads} package </li>
  *     <li> For {@link HtsContentType#VARIANT_CONTEXTS} codecs, see the {@link htsjdk.beta.plugin.variants} package </li>
- *     <li> For {@link HtsContentType#FEATURES} codecs, see the {@link htsjdk.beta.plugin.features} package </li>
+ *     <li> For {@link HtsContentType#FEATURES} codecs, see the {@code htsjdk.beta.plugin.features} package </li>
  * </ul>
  * <p>
  * There can be many codecs for a given content type, each representing a different version of an
@@ -43,7 +43,7 @@ public enum HtsContentType {
     VARIANT_CONTEXTS,
 
     /**
-     * Features content type (see {@link htsjdk.beta.plugin.features} for related formats)
+     * Features content type (see {@code htsjdk.beta.plugin.features} for related formats)
      */
     FEATURES,
 }

--- a/src/main/java/htsjdk/io/HtsPath.java
+++ b/src/main/java/htsjdk/io/HtsPath.java
@@ -51,11 +51,11 @@ import java.nio.file.spi.FileSystemProvider;
  *
  * General syntax for an "absolute" URI:
  *
- *     <scheme>:<scheme-specific-part>
+ *     {@code <scheme>:<scheme-specific-part>}
  *
  * Many "hierarchical" URI schemes use this syntax:
  *
- *     <scheme>://<authority><path>?<query>
+ *     {@code <scheme>://<authority><path>?<query>}
  *
  * More specifically:
  *
@@ -64,7 +64,7 @@ import java.nio.file.spi.FileSystemProvider;
  *         net_path      = "//" authority [ abs_path ]
  *         abs_path      = "/"  path_segments
  *         opaque_part   = uric_no_slash *uric
- *         uric_no_slash = unreserved | escaped | ";" | "?" | ":" | "@" | "&" | "=" | "+" | "$" | ","
+ *         uric_no_slash = unreserved | escaped | ";" | "?" | ":" | "@" | "&amp;" | "=" | "+" | "$" | ","
  */
 public class HtsPath implements IOPath, Serializable {
     private static final long serialVersionUID = 1L;

--- a/src/main/java/htsjdk/io/IOPath.java
+++ b/src/main/java/htsjdk/io/IOPath.java
@@ -44,7 +44,7 @@ public interface IOPath {
      * Return true if this {code IOPath} can be resolved to an {@code java.nio} Path. If true, {@code #toPath()} can be
      * safely called.
      *
-     * There are cases where a valid URI with a valid scheme backed by an installed {@code java.nio File System
+     * There are cases where a valid URI with a valid scheme backed by an installed {@code java.nio} File System
      * still can't be turned into a {@code java.nio.file.Path}, i.e., the following specifies an invalid
      * authority "namenode":
      *

--- a/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
+++ b/src/main/java/htsjdk/samtools/AbstractSAMHeaderRecord.java
@@ -47,7 +47,7 @@ public abstract class AbstractSAMHeaderRecord implements Serializable {
      * Otherwise, the value will be converted to a String with toString.
      * @param key attribute name
      * @param value attribute value
-     * @deprecated Use {@link #setAttribute(String, String) instead
+     * @deprecated Use {@link #setAttribute(String, String)} instead
      */
     @Deprecated
     public void setAttribute(final String key, final Object value) {

--- a/src/main/java/htsjdk/samtools/Bin.java
+++ b/src/main/java/htsjdk/samtools/Bin.java
@@ -104,7 +104,7 @@ public class Bin implements Comparable<Bin> {
     /**
      * Compare two bins to see what ordering they should appear in.
      * @param other Other bin to which this bin should be compared.
-     * @return -1 if this < other, 0 if this == other, 1 if this > other.
+     * @return {@code -1 if this < other, 0 if this == other, 1 if this > other}.
      */
     @Override
     public int compareTo(final Bin other) {

--- a/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
+++ b/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
@@ -190,7 +190,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
     }
 
     /**
-     * @return number of elements stored in RAM.  Always <= size()
+     * @return number of elements stored in RAM.  Always {@code <= size()}
      */
     public int sizeInRam() {
         return mapInRam != null ? mapInRam.size() : 0;

--- a/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
+++ b/src/main/java/htsjdk/samtools/DuplicateScoringStrategy.java
@@ -126,7 +126,7 @@ public class DuplicateScoringStrategy {
      * If true is given to assumeMateCigar, then any score that can use the mate cigar to to compute the mate's score will return the score
      * computed on both ends.
      *
-     * We allow different scoring strategies. We return <0 if rec1 has a better strategy than rec2.
+     * We allow different scoring strategies. We return {@code <0} if rec1 has a better strategy than rec2.
      */
     public static int compare(
             final SAMRecord rec1,
@@ -156,7 +156,7 @@ public class DuplicateScoringStrategy {
      * pre-computed by computeDuplicateScore and stored in the "DS" tag.  If the scores are equal, we break
      * ties based on mapping quality (added to the mate's mapping quality if paired and mapped), then library/read name.
      *
-     * We allow different scoring strategies. We return <0 if rec1 has a better strategy than rec2.
+     * We allow different scoring strategies. We return {@code <0} if rec1 has a better strategy than rec2.
      */
     public static int compare(final SAMRecord rec1, final SAMRecord rec2, final ScoringStrategy scoringStrategy) {
         return compare(rec1, rec2, scoringStrategy, false);

--- a/src/main/java/htsjdk/samtools/GenomicIndexUtil.java
+++ b/src/main/java/htsjdk/samtools/GenomicIndexUtil.java
@@ -97,7 +97,7 @@ public class GenomicIndexUtil {
 
     /**
      * calculate the bin given an alignment in [beg,end)
-     * Described in "The Human Genome Browser at UCSC. Kent & al. doi: 10.1101/gr.229102 "
+     * Described in "The Human Genome Browser at UCSC. Kent &amp; al. doi: 10.1101/gr.229102 "
      * @param beg 0-based start of read (inclusive)
      * @param end 0-based end of read (exclusive)
      */
@@ -114,7 +114,7 @@ public class GenomicIndexUtil {
 
     /**
      * calculate the bin given an alignment in [beg,end)
-     * Described in "The Human Genome Browser at UCSC. Kent & al. doi: 10.1101/gr.229102 "
+     * Described in "The Human Genome Browser at UCSC. Kent &amp; al. doi: 10.1101/gr.229102 "
      * @param beg 0-based start of read (inclusive)
      * @param end 0-based end of read (exclusive)
      * @param minShift minimum bin width (2^minShift)

--- a/src/main/java/htsjdk/samtools/QueryInterval.java
+++ b/src/main/java/htsjdk/samtools/QueryInterval.java
@@ -14,7 +14,7 @@ public class QueryInterval implements Comparable<QueryInterval> {
     public final int referenceIndex;
     /** 1-based, inclusive */
     public final int start;
-    /** 1-based, inclusive.  If <= 0, implies that the interval goes to the end of the reference sequence */
+    /** 1-based, inclusive.  If {@code <= 0}, implies that the interval goes to the end of the reference sequence */
     public final int end;
 
     public QueryInterval(final int referenceIndex, final int start, final int end) {

--- a/src/main/java/htsjdk/samtools/SAMFileHeader.java
+++ b/src/main/java/htsjdk/samtools/SAMFileHeader.java
@@ -287,7 +287,7 @@ public class SAMFileHeader extends AbstractSAMHeaderRecord implements HtsHeader 
      * Otherwise, the value will be converted to a String with toString.
      * @param key attribute name
      * @param value attribute value
-     * @deprecated Use {@link #setAttribute(String, String) instead
+     * @deprecated Use {@link #setAttribute(String, String)} instead
      */
     @Deprecated
     @Override

--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -32,7 +32,7 @@ import java.io.StringWriter;
 
 /**
  * Base class for implementing SAM writer with any underlying format.
- * Mostly this manages accumulation & sorting of SAMRecords when appropriate,
+ * Mostly this manages accumulation and sorting of SAMRecords when appropriate,
  * and produces the text version of the header, since that seems to be a popular item
  * in both text and binary file formats.
  */

--- a/src/main/java/htsjdk/samtools/SAMLineParser.java
+++ b/src/main/java/htsjdk/samtools/SAMLineParser.java
@@ -215,7 +215,7 @@ public class SAMLineParser {
      *
      * @param line       line to parse
      * @param lineNumber line number in the file. If the line number is not known
-     *                   can be <=0.
+     *                   can be {@code <=0}.
      * @return a new SAMRecord object
      */
     public SAMRecord parseLine(final String line, final int lineNumber) {

--- a/src/main/java/htsjdk/samtools/SAMRecord.java
+++ b/src/main/java/htsjdk/samtools/SAMRecord.java
@@ -54,7 +54,7 @@ import java.util.Set;
  * in the sort order per the above paragraph.  Only if the mateUnmappedFlag is false can the mate reference name/index
  * and mate alignment start be interpreted as indicating the actual alignment position of the mate.
  * <p>
- * Note also that there are a number of getters & setters that are linked, i.e. they present different representations
+ * Note also that there are a number of getters and setters that are linked, i.e. they present different representations
  * of the same underlying data.  In these cases there is typically a representation that is preferred because it
  * ought to be faster than some other representation.  The following are the preferred representations:
  * </p><ul>
@@ -161,7 +161,7 @@ public class SAMRecord implements HtsRecord, Cloneable, Locatable, Serializable 
     public static final String NULL_QUALS_STRING = "*";
 
     /**
-     * abs(insertSize) must be <= this
+     * {@code abs(insertSize) <=} this
      */
     public static final int MAX_INSERT_SIZE = Integer.MAX_VALUE;
 
@@ -791,7 +791,7 @@ public class SAMRecord implements HtsRecord, Cloneable, Locatable, Serializable 
     }
 
     /**
-     * @return insert size (difference btw 5' end of read & 5' end of mate), if possible, else 0.
+     * @return insert size (difference btw 5' end of read and 5' end of mate), if possible, else 0.
      * Negative if mate maps to lower position than read.
      */
     public int getInferredInsertSize() {
@@ -1651,7 +1651,7 @@ public class SAMRecord implements HtsRecord, Cloneable, Locatable, Serializable 
     }
 
     /**
-     * an alias of {@link #getAlignmentStart()
+     * an alias of {@link #getAlignmentStart()}
      * @return 1-based inclusive leftmost position of the clipped sequence, or 0 if there is no position.
      */
     @Override

--- a/src/main/java/htsjdk/samtools/SAMRecordComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordComparator.java
@@ -34,7 +34,7 @@ public interface SAMRecordComparator extends Comparator<SAMRecord> {
      * Less stringent compare method than the regular compare.  If the two records
      * are equal enough that their ordering in a sorted SAM file would be arbitrary,
      * this method returns 0.
-     * @return negative if samRecord1 < samRecord2,  0 if equal, else positive
+     * @return negative if {@code samRecord1 < samRecord2}, 0 if equal, else positive
      */
     public int fileOrderCompare(SAMRecord samRecord1, SAMRecord samRecord2);
 }

--- a/src/main/java/htsjdk/samtools/SAMRecordCoordinateComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordCoordinateComparator.java
@@ -35,9 +35,9 @@ import java.io.Serializable;
  * which is decoded if coordinate and strand are equal.
  *
  * Extreme care must be taken to ensure the following:
- * if A == B, then B == A
- * if A < B, then B > A
- * if A < B && B < C, then A < C
+ * {@code if A == B, then B == A}
+ * {@code if A < B, then B > A}
+ * {@code if A < B && B < C, then A < C}
  *
  */
 public class SAMRecordCoordinateComparator implements SAMRecordComparator, Serializable {
@@ -81,7 +81,7 @@ public class SAMRecordCoordinateComparator implements SAMRecordComparator, Seria
      * this method returns 0.  If read is paired and unmapped, use the mate mapping to sort.
      * Records being compared must have non-null SAMFileHeaders.
      *
-     * @return negative if samRecord1 < samRecord2,  0 if equal, else positive
+     * @return negative if {@code samRecord1 < samRecord2}, 0 if equal, else positive
      */
     @Override
     public int fileOrderCompare(final SAMRecord samRecord1, final SAMRecord samRecord2) {

--- a/src/main/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordQueryNameComparator.java
@@ -74,7 +74,7 @@ public class SAMRecordQueryNameComparator implements SAMRecordComparator, Serial
      * are equal enough that their ordering in a sorted SAM file would be arbitrary,
      * this method returns 0.
      *
-     * @return negative if samRecord1 < samRecord2,  0 if equal, else positive
+     * @return negative if {@code samRecord1 < samRecord2}, 0 if equal, else positive
      */
     @Override
     public int fileOrderCompare(final SAMRecord samRecord1, final SAMRecord samRecord2) {

--- a/src/main/java/htsjdk/samtools/SAMSortOrderChecker.java
+++ b/src/main/java/htsjdk/samtools/SAMSortOrderChecker.java
@@ -39,7 +39,7 @@ public class SAMSortOrderChecker {
 
     /**
      * Check if given SAMRecord violates sort order relative to previous SAMRecord.
-     * @return True if sort order is unsorted, if this is the first record, or if previous <= rec.
+     * @return True if sort order is unsorted, if this is the first record, or if {@code previous <= rec}.
      */
     public boolean isSorted(final SAMRecord rec) {
         if (comparator == null) {

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -625,8 +625,8 @@ public final class SAMUtils {
     }
 
     /**
-     * @return negative if mapq1 < mapq2, etc.
-     * Note that MAPQ(0) < MAPQ(255) < MAPQ(1)
+     * @return negative if {@code mapq1 < mapq2}, etc.
+     * Note that {@code MAPQ(0) < MAPQ(255) < MAPQ(1)}
      */
     public static int compareMapqs(final int mapq1, final int mapq2) {
         if (mapq1 == mapq2) return 0;
@@ -1155,7 +1155,7 @@ public final class SAMUtils {
      * Checks if a long attribute value is within the allowed range of a 32-bit unsigned integer.
      *
      * @param value a long value to check
-     * @return true if value is >= 0 and <= {@link BinaryCodec#MAX_UINT}, and false otherwise
+     * @return true if value is {@code >= 0} and {@code <=} {@link BinaryCodec#MAX_UINT}, and false otherwise
      */
     public static boolean isValidUnsignedIntegerAttribute(long value) {
         return value >= 0 && value <= BinaryCodec.MAX_UINT;

--- a/src/main/java/htsjdk/samtools/cram/io/ITF8.java
+++ b/src/main/java/htsjdk/samtools/cram/io/ITF8.java
@@ -13,7 +13,7 @@ import java.nio.ByteBuffer;
  * ITF8 encodes ints as 1 to 5 bytes depending on the highest set bit.
  *
  * (using 1-based counting)
- * If highest bit < 8:
+ * If highest bit {@code < 8}:
  *      write out [bits 1-8]
  * Highest bit = 8-14:
  *      write a byte 1,0,[bits 9-14]

--- a/src/main/java/htsjdk/samtools/cram/structure/CRAMEncodingStrategy.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CRAMEncodingStrategy.java
@@ -138,7 +138,7 @@ public class CRAMEncodingStrategy {
      * switch to, and subsequently emit, a multiple reference slice, rather than a small single-reference
      * that contains fewer than this number of records.
      *
-     * This number must be <= the value for {@link #getReadsPerSlice}
+     * This number must be {@code <=} the value for {@link #getReadsPerSlice}
      *
      * @param minimumSingleReferenceSliceSize the minimum slice size
      * @return this strategy for chaining

--- a/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/CompressionHeader.java
@@ -80,11 +80,10 @@ public class CompressionHeader {
     }
 
     /**
-     * Read a COMPRESSION_HEADER Block from an InputStream and return its contents as a CompressionHeader.
+     * Read a COMPRESSION_HEADER Block from an InputStream and populate this CompressionHeader from its contents.
      *
      * @param cramVersion the CRAM version
      * @param blockStream the stream to read from
-     * @return a new CompressionHeader
      */
     public CompressionHeader(final CRAMVersion cramVersion, final InputStream blockStream) {
         final Block compressionHeaderBlock = Block.read(cramVersion, blockStream);

--- a/src/main/java/htsjdk/samtools/cram/structure/ContainerHeader.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/ContainerHeader.java
@@ -117,11 +117,11 @@ public class ContainerHeader {
     }
 
     /**
-     * Create a container header from an {@link InputStream}.
+     * Create a container header from an {@link InputStream}. Populates the container header values
+     * but leaves the body empty (no slices and blocks).
      *
      * @param cramVersion the CRAM version to assume
      * @param inputStream the input stream from which to read
-     * @return a new {@link ContainerHeader} object with container header values filled out but empty body (no slices and blocks).
      */
     public ContainerHeader(final CRAMVersion cramVersion, final InputStream inputStream) {
         this.containerBlocksByteSize = CramInt.readInt32(inputStream);

--- a/src/main/java/htsjdk/samtools/cram/structure/Slice.java
+++ b/src/main/java/htsjdk/samtools/cram/structure/Slice.java
@@ -170,7 +170,6 @@ public class Slice {
      * @param compressionHeader the enclosing {@link Container}'s Compression Header
      * @param containerByteOffset
      * @param globalRecordCounter
-     * @return a Slice corresponding to the given records
      *
      * Determines whether the slice is single ref, unmapped or multi reference, and derives alignment
      * boundaries for the slice if single ref.

--- a/src/main/java/htsjdk/samtools/filter/IntervalFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/IntervalFilter.java
@@ -50,7 +50,7 @@ public class IntervalFilter implements SamRecordFilter {
 
     /**
      * Prepare to filter out SAMRecords that do not overlap the given list of intervals
-     * @param intervals -- must be locus-ordered & non-overlapping
+     * @param intervals -- must be locus-ordered and non-overlapping
      */
     public IntervalFilter(final List<Interval> intervals, final SAMFileHeader samHeader) {
         this.samHeader = samHeader;

--- a/src/main/java/htsjdk/samtools/reference/FastaReferenceWriter.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaReferenceWriter.java
@@ -52,7 +52,7 @@ import org.apache.commons.compress.utils.CountingOutputStream;
  * byte[][] seqBases = ...;
  * ...
  * try (final FastaReferenceWriter writer = new FastaReferenceFileWriter(outputFile)) {
- *      for (int i = 0; i < seqNames.length; i++) {
+ *      for (int i = 0; i &lt; seqNames.length; i++) {
  *          writer.startSequence(seqNames[i]).appendBases(seqBases[i]);
  *      }
  * }

--- a/src/main/java/htsjdk/samtools/util/AbstractLocusIterator.java
+++ b/src/main/java/htsjdk/samtools/util/AbstractLocusIterator.java
@@ -211,7 +211,7 @@ public abstract class AbstractLocusIterator<T extends AbstractRecordAndOffset, K
     }
 
     /**
-     * Closes inner <code>SamIterator</>.
+     * Closes inner {@code SamIterator}.
      */
     @Override
     public void close() {

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -57,7 +57,7 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
     /**
      * Sets the GZip compression level for subsequent BlockCompressedOutputStream object creation
      * that do not specify the compression level.
-     * @param compressionLevel 1 <= compressionLevel <= 9
+     * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      */
     public static void setDefaultCompressionLevel(final int compressionLevel) {
         if (compressionLevel < Deflater.NO_COMPRESSION || compressionLevel > Deflater.BEST_COMPRESSION) {
@@ -133,7 +133,7 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
     /**
      * Prepare to compress at the given compression level
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * @param compressionLevel 1 <= compressionLevel <= 9
+     * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      */
     public BlockCompressedOutputStream(final String filename, final int compressionLevel) {
         this(new File(filename), compressionLevel);
@@ -141,7 +141,7 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
 
     /**
      * Prepare to compress at the given compression level
-     * @param compressionLevel 1 <= compressionLevel <= 9
+     * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
      * Use {@link #BlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
      */
@@ -151,7 +151,7 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
 
     /**
      * Prepare to compress at the given compression level
-     * @param compressionLevel 1 <= compressionLevel <= 9
+     * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      * @param deflaterFactory custom factory to create deflaters (overrides the default)
      */
     public BlockCompressedOutputStream(
@@ -161,7 +161,7 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
 
     /**
      * Prepare to compress at the given compression level
-     * @param compressionLevel 1 <= compressionLevel <= 9
+     * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      * @param deflaterFactory custom factory to create deflaters (overrides the default)
      */
     public BlockCompressedOutputStream(

--- a/src/main/java/htsjdk/samtools/util/BlockGunzipper.java
+++ b/src/main/java/htsjdk/samtools/util/BlockGunzipper.java
@@ -100,7 +100,7 @@ public class BlockGunzipper {
      * @param uncompressedBlock must be big enough to hold decompressed output.
      * @param uncompressedBlockOffset the offset into uncompressedBlock.
      * @param compressedBlock compressed data starting at offset 0.
-     * @param compressedBlock  the offset into the compressed data.
+     * @param compressedBlockOffset  the offset into the compressed data.
      * @param compressedLength size of compressed data, possibly less than the size of the buffer.
      * @return the uncompressed data size.
      */

--- a/src/main/java/htsjdk/samtools/util/CloserUtil.java
+++ b/src/main/java/htsjdk/samtools/util/CloserUtil.java
@@ -54,8 +54,8 @@ public class CloserUtil {
      *
      * @param objs   A list of potentially closeable objects
      *
-     * NOTE: This method must take a List<? extends Object>, not List<Object>, otherwise the overload above will be selected
-     * if the argument is not exactly List<Object>.
+     * NOTE: This method must take a {@code List<? extends Object>}, not {@code List<Object>}, otherwise the overload above will be selected
+     * if the argument is not exactly {@code List<Object>}.
      */
     public static void close(List<? extends Object> objs) {
         for (Object o : objs) {

--- a/src/main/java/htsjdk/samtools/util/FormatUtil.java
+++ b/src/main/java/htsjdk/samtools/util/FormatUtil.java
@@ -109,7 +109,7 @@ public class FormatUtil {
         return this.dateFormat.format(value);
     }
 
-    /** Formats date & time */
+    /** Formats date and time */
     public String format(final Iso8601Date value) {
         return value.toString();
     }

--- a/src/main/java/htsjdk/samtools/util/Histogram.java
+++ b/src/main/java/htsjdk/samtools/util/Histogram.java
@@ -354,7 +354,7 @@ public final class Histogram<K extends Comparable> implements Serializable {
     }
 
     /**
-     * Returns the cumulative probability of observing a value <= v when sampling the
+     * Returns the cumulative probability of observing a value {@code <=} v when sampling the
      * distribution represented by this histogram.
      * @throws UnsupportedOperationException if this histogram does not store instances of Number
      */
@@ -527,7 +527,7 @@ public final class Histogram<K extends Comparable> implements Serializable {
     }
 
     /**
-     * Trims the histogram so that only bins <= width are kept.
+     * Trims the histogram so that only bins {@code <=} width are kept.
      */
     public void trimByWidth(final int width) {
         final Iterator<K> it = map.descendingKeySet().iterator();

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -163,7 +163,7 @@ public class IOUtil {
     private static int compressionLevel = Defaults.COMPRESSION_LEVEL;
     /**
      * Sets the GZip compression level for subsequent GZIPOutputStream object creation.
-     * @param compressionLevel 0 <= compressionLevel <= 9
+     * @param compressionLevel {@code 0 <= compressionLevel <= 9}
      */
     public static void setCompressionLevel(final int compressionLevel) {
         if (compressionLevel < Deflater.NO_COMPRESSION || compressionLevel > Deflater.BEST_COMPRESSION) {

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -239,7 +239,7 @@ public class IntervalList implements Iterable<Interval> {
      * Note: this function modifies the object in-place and is therefore difficult to work with.
      *
      * @return the set of unique intervals condensed from the contained intervals
-     * @deprecated use {@link #uniqued()#getIntervals()} instead.
+     * @deprecated use {@link #uniqued()}.{@link #getIntervals()} instead.
      */
     @Deprecated
     public List<Interval> getUniqueIntervals() {
@@ -306,7 +306,7 @@ public class IntervalList implements Iterable<Interval> {
      * Note: this function modifies the object in-place and is therefore difficult to work with.
      *
      * @param concatenateNames If false, the merged interval has the name of the earlier interval. This keeps name shorter.
-     * @deprecated use {@link #uniqued(boolean)#getIntervals()} or {@link #getUniqueIntervals(IntervalList, boolean)} instead.
+     * @deprecated use {@link #uniqued(boolean)}.{@link #getIntervals()} or {@link #getUniqueIntervals(IntervalList, boolean)} instead.
      */
     @Deprecated
     public List<Interval> getUniqueIntervals(final boolean concatenateNames) {

--- a/src/main/java/htsjdk/samtools/util/StringUtil.java
+++ b/src/main/java/htsjdk/samtools/util/StringUtil.java
@@ -190,7 +190,7 @@ public class StringUtil {
 
     /**
      * Return input string with newlines inserted to ensure that all lines
-     * have length <= maxLineLength.  if a word is too long, it is simply broken
+     * have length {@code <=} maxLineLength.  if a word is too long, it is simply broken
      * at maxLineLength.  Does not handle tabs intelligently (due to implementer laziness).
      */
     public static String wordWrap(final String s, final int maxLineLength) {

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -160,8 +160,8 @@ public class LinearIndex extends AbstractIndex {
      * Note that covered regions are open on the left ( and closed on the right ].
      * <p/>
      * In general, if block i is the ith block (starting from 0), then block i
-     * contains all records that have starting position > (i * binWidth) and
-     * <= ((i + 1) * binWidth))
+     * contains all records that have starting position {@code > (i * binWidth)} and
+     * {@code <= ((i + 1) * binWidth))}
      */
     public static class ChrIndex implements htsjdk.tribble.index.ChrIndex {
         private String name = "";

--- a/src/main/java/htsjdk/tribble/readers/LongLineBufferedReader.java
+++ b/src/main/java/htsjdk/tribble/readers/LongLineBufferedReader.java
@@ -71,7 +71,7 @@ public class LongLineBufferedReader extends Reader {
      *
      * @param in A Reader
      * @param sz Input-buffer size
-     * @throws IllegalArgumentException If sz is <= 0
+     * @throws IllegalArgumentException If sz is {@code <= 0}
      */
     public LongLineBufferedReader(Reader in, int sz) {
         super(in);
@@ -437,7 +437,7 @@ public class LongLineBufferedReader extends Reader {
      *                       buffer will cause a new buffer to be allocated
      *                       whose size is no smaller than limit.
      *                       Therefore large values should be used with care.
-     * @throws IllegalArgumentException If readAheadLimit is < 0
+     * @throws IllegalArgumentException If readAheadLimit is {@code < 0}
      * @throws IOException              If an I/O error occurs
      */
     @Override

--- a/src/main/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
+++ b/src/main/java/htsjdk/variant/variantcontext/GenotypeLikelihoods.java
@@ -435,7 +435,7 @@ public final class GenotypeLikelihoods {
 
     /**
      * This method is no longer necessary and is now a no-op
-     * @throws IllegalArgumentException if altAlleles or ploidy &lt= 0
+     * @throws IllegalArgumentException if altAlleles or ploidy {@code <=} 0
      * @deprecated as of sept 2020, this method is no longer necessary
      */
     @Deprecated
@@ -447,7 +447,7 @@ public final class GenotypeLikelihoods {
      * @param PLindex   the PL index
      * @param ploidy    number of chromosomes
      * @return the ploidy allele indices
-     * @throws IllegalStateException if PLindex < 0 or ploidy < 0
+     * @throws IllegalStateException if {@code PLindex < 0} or {@code ploidy < 0}
      */
     public static synchronized List<Integer> getAlleles(final int PLindex, final int ploidy) {
         if (PLindex < 0) {

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -376,7 +376,6 @@ public class VariantContextWriterBuilder {
      * for all VariantContextWriterBuilders created after this call.
      *
      * @param option the option to unset
-     * @return this <code>VariantContextWriterBuilder</code>
      */
     public static void unsetDefaultOption(final Options option) {
         VariantContextWriterBuilder.DEFAULT_OPTIONS.remove(option);

--- a/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFEncoder.java
@@ -99,7 +99,6 @@ public class VCFEncoder {
      *
      * @param vcfOutput the {@link Appendable} to write to
      * @param context the variant
-     * @return the java.lang.Appendable 'vcfOutput'
      * @throws IOException
      */
     public void write(final Appendable vcfOutput, final VariantContext context) throws IOException {
@@ -408,7 +407,7 @@ public class VCFEncoder {
 
     /**
      * write the encoded GT field for a Genotype
-     * @param alleleMap a mapping of Allele -> GT allele value (from {@link this#buildAlleleStrings(VariantContext)}
+     * @param alleleMap a mapping of Allele to GT allele value (from {@link #buildAlleleStrings(VariantContext)})
      * @param vcfoutput the appendable to write to, to avoid inefficiency due to string copying
      * @param g the genotoype to encode
      * @throws IOException if appending fails with an IOException
@@ -455,7 +454,7 @@ public class VCFEncoder {
 
     /**
      * Easy way to generate the GT field for a Genotype.  This will be less efficient than using
-     * {@link this#writeGtField(Map, Appendable, Genotype)} because of redundant Map initializations
+     * {@link #writeGtField(Map, Appendable, Genotype)} because of redundant Map initializations
      * @param vc a VariantContext which must contain g or the results are likely to be incorrect
      * @param g a Genotype in vc
      * @return a String containing the encoding of the GT field of g


### PR DESCRIPTION
## Summary
- Clears all 100 warnings produced by `./gradlew javadoc`.
- Doc-only edits across ~40 files; no behavioral changes.
- Categories addressed: unescaped `<`/`<=`/`&` in doc text, malformed `@link` references (missing braces, invalid `this#`, double-`#` chains), an unresolved package reference, an unclosed `@code` tag, `@return` tags on void/constructor doc, and a duplicate `@param`.

## Test plan
- [x] `./gradlew javadoc --rerun-tasks` reports 0 warnings
- [x] `./gradlew compileJava` succeeds
- [x] `./gradlew spotlessApply` produces no further changes