### PR TITLE
Migrate from java.io.File to java.nio.file.Path for NIO SPI support (6.0.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,8 +115,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Compile with Gradle
-        run: ./gradlew spotBugsMain spotBugsTest
+      - name: SpotBugs and File->Path migration guard
+        run: ./gradlew spotBugsMain spotBugsTest enforceFilePathMigration
       - name: Upload spotBugs Report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ early infrastructure for a plugin-based codec framework and resource bundles.
 
 ---
 
+## 6.0.0
+
+Major release.
+
+### Headlines
+
+- **htsjdk now uses `java.nio.file.Path` (not `java.io.File`) throughout its public API.**  This makes the whole library work with any NIO `FileSystemProvider` (SPI) — Amazon S3, Google Cloud Storage, HDFS, in-memory filesystems such as [jimfs](https://github.com/google/jimfs), and so on — through the same reader, writer, factory and index APIs you already use, with no File-specific code paths.
+- **String- and URI-based entry points are scheme-aware.**  Where an API takes a path as a `String`, it is resolved with `IOUtil.getPath`, which honours the URI scheme (e.g. `file:`, `gs:`, `s3:`, custom providers) and falls back to the local filesystem for plain paths (including paths containing spaces).  Existing HTTP/HTTPS and FTP behaviour is unchanged — those continue to flow through htsjdk's `SeekableStream` machinery rather than NIO.
+
+### ⚠️ Breaking changes
+
+Consumers should review these before upgrading.
+
+- **`java.io.File`-based public APIs have been removed in favour of `java.nio.file.Path`** across factories, readers, writers, indexes, reference-sequence access and the utility classes (224 methods/constructors).  Update call sites to pass a `Path` (or a `String`/`URI`, which are resolved via `IOUtil.getPath`).  For example:
+
+  ```java
+  // Before (htsjdk 5.x)
+  SamReader r = SamReaderFactory.makeDefault().open(new File("/data/x.bam"));
+  SAMFileWriter w = new SAMFileWriterFactory().makeBAMWriter(header, true, new File("/data/out.bam"));
+  ReferenceSequenceFile ref = ReferenceSequenceFileFactory.getReferenceSequenceFile(new File("/data/ref.fasta"));
+
+  // After (htsjdk 6.0.0)
+  SamReader r = SamReaderFactory.makeDefault().open(Path.of("/data/x.bam"));
+  SAMFileWriter w = new SAMFileWriterFactory().makeBAMWriter(header, true, Path.of("/data/out.bam"));
+  ReferenceSequenceFile ref = ReferenceSequenceFileFactory.getReferenceSequenceFile(Path.of("/data/ref.fasta"));
+
+  // Or open something on a custom filesystem (requires that provider on the classpath)
+  SamReader s3 = SamReaderFactory.makeDefault().open(URI.create("s3://bucket/x.bam"));
+  ```
+
+  To bridge a `File` you already hold, call `file.toPath()` (or `IOUtil.toPath(file)`, which is null-safe).
+
+- **`Defaults.REFERENCE_FASTA` is now a `Path`** (previously a `File`).  It is resolved from the `samjdk.reference_fasta` system property; an unparseable value is logged and treated as unset rather than failing class initialisation.
+
+### Retained `File` APIs
+
+A small, deliberate set of `java.io.File` APIs remains because they are inherently tied to the local filesystem or ease migration; they do not affect NIO-SPI support:
+
+- `IOUtil.newTempFile`, `IOUtil.getDefaultTmpDir`, `IOUtil.createTempDir` — temporary files/directories are always local.
+- `IOUtil.toPath(File)` and `IOUtil.filesToPaths(Collection<File>)` — `File`→`Path` bridge helpers.
+
+### Testing
+
+- The test suite was migrated to `Path`, and a focused `NioSpiCompatibilityTest` exercises the major read/write/index APIs (BAM/CRAM/VCF/FASTQ, reference access and index discovery/creation) against an in-memory jimfs filesystem to validate NIO-SPI compatibility end to end.
+
+---
+
 ## 5.0.0
 
 Major release.  

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ java {
 //
 // To change the planned bump (e.g. after a release lands), update nextVersionBump
 // below and commit.
-final nextVersionBump = "x.x.x"
+final nextVersionBump = "x"
 
 final isRelease = Boolean.getBoolean("release")
 final details = versionDetails()

--- a/build.gradle
+++ b/build.gradle
@@ -302,6 +302,54 @@ spotbugsTest {
     }
 }
 
+// --- File->Path migration guard ---------------------------------------------------------------
+// htsjdk's public API migrated from java.io.File to java.nio.file.Path in 6.0.0. This guard fails
+// the build if java.io.File is referenced in *main* sources outside the small set of files where it
+// is deliberately retained: IOUtil (the inherently-local temp helpers and the File<->Path bridges)
+// and SamInputResource (the package-private File boundary still consumed internally). Javadoc/comment
+// mentions of the old API are ignored. If you are adding a sanctioned File boundary, add the file's
+// package-relative path to the allowlist below; otherwise switch to java.nio.file.Path.
+tasks.register('enforceFilePathMigration') {
+    group = 'verification'
+    description = 'Fail if java.io.File is used in main sources outside approved files (File->Path migration guard).'
+    doLast {
+        final allowlist = [
+            'htsjdk/samtools/util/IOUtil.java',
+            'htsjdk/samtools/SamInputResource.java',
+        ]
+        final filePattern = ~/\bjava\.io\.File\b/
+        final violations = []
+        fileTree('src/main/java') { include '**/*.java' }.each { f ->
+            final normalized = f.path.replace('\\', '/')
+            if (allowlist.any { normalized.endsWith(it) }) {
+                return
+            }
+            int lineNo = 0
+            f.eachLine('UTF-8') { rawLine ->
+                lineNo++
+                final trimmed = rawLine.trim()
+                // Skip javadoc/block-comment lines and trailing line comments so documentation
+                // references to the old API (e.g. {@link java.io.File}) don't trip the guard.
+                if (trimmed.startsWith('*') || trimmed.startsWith('/*') || trimmed.startsWith('//')) {
+                    return
+                }
+                final code = rawLine.replaceFirst(/\/\/.*$/, '')
+                if (filePattern.matcher(code).find()) {
+                    violations << "${normalized.replaceFirst('.*/src/main/java/', '')}:${lineNo}: ${trimmed}"
+                }
+            }
+        }
+        if (!violations.isEmpty()) {
+            throw new GradleException(
+                "java.io.File is no longer allowed in htsjdk main sources (migrated to java.nio.file.Path in 6.0.0).\n" +
+                "Use java.nio.file.Path / IOUtil helpers instead, or — if this is a sanctioned boundary — add the file\n" +
+                "to the allowlist in build.gradle (enforceFilePathMigration). Offending references:\n  " +
+                violations.join('\n  '))
+        }
+    }
+}
+tasks.named('check') { dependsOn 'enforceFilePathMigration' }
+
 // Fat JAR with all dependencies for standalone CLI tools (CramConverter, CramComparison, etc.)
 shadowJar {
     archiveClassifier.set('all')

--- a/src/main/java/htsjdk/beta/codecs/reads/bam/bamV1_0/BAMEncoderV1_0.java
+++ b/src/main/java/htsjdk/beta/codecs/reads/bam/bamV1_0/BAMEncoderV1_0.java
@@ -69,7 +69,7 @@ public class BAMEncoderV1_0 extends BAMEncoder {
         samFileWriterFactory.setDeflaterFactory(bamEncoderOptions.getDeflaterFactory());
         samFileWriterFactory.setCompressionLevel(bamEncoderOptions.getCompressionLevel());
         samFileWriterFactory.setTempDirectory(
-                bamEncoderOptions.getTemporaryDirectory().toPath().toFile());
+                bamEncoderOptions.getTemporaryDirectory().toPath());
         samFileWriterFactory.setBufferSize(bamEncoderOptions.getOutputBufferSize());
         samFileWriterFactory.setUseAsyncIo(bamEncoderOptions.isAsyncIO());
         samFileWriterFactory.setAsyncOutputBufferSize(bamEncoderOptions.getAsyncOutputBufferSize());

--- a/src/main/java/htsjdk/beta/io/IOPathUtils.java
+++ b/src/main/java/htsjdk/beta/io/IOPathUtils.java
@@ -3,6 +3,7 @@ package htsjdk.beta.io;
 import htsjdk.beta.exception.HtsjdkIOException;
 import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
+import htsjdk.samtools.util.IOUtil;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -24,7 +25,7 @@ public class IOPathUtils {
     public static IOPath createTempPath(final String prefix, final String suffix) {
         try {
             final Path tempPath = Files.createTempFile(prefix, suffix);
-            tempPath.toFile().deleteOnExit();
+            IOUtil.deleteOnExit(tempPath);
             return new HtsPath(tempPath.toAbsolutePath().toString());
         } catch (final IOException e) {
             throw new HtsjdkIOException(e);

--- a/src/main/java/htsjdk/beta/io/IOPathUtils.java
+++ b/src/main/java/htsjdk/beta/io/IOPathUtils.java
@@ -4,11 +4,11 @@ import htsjdk.beta.exception.HtsjdkIOException;
 import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -23,9 +23,9 @@ public class IOPathUtils {
      */
     public static IOPath createTempPath(final String prefix, final String suffix) {
         try {
-            final File tempFile = File.createTempFile(prefix, suffix);
-            tempFile.deleteOnExit();
-            return new HtsPath(tempFile.getAbsolutePath());
+            final Path tempPath = Files.createTempFile(prefix, suffix);
+            tempPath.toFile().deleteOnExit();
+            return new HtsPath(tempPath.toAbsolutePath().toString());
         } catch (final IOException e) {
             throw new HtsjdkIOException(e);
         }

--- a/src/main/java/htsjdk/beta/plugin/IOUtils.java
+++ b/src/main/java/htsjdk/beta/plugin/IOUtils.java
@@ -4,6 +4,7 @@ import htsjdk.beta.exception.HtsjdkIOException;
 import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
+import htsjdk.samtools.util.IOUtil;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -27,7 +28,7 @@ public class IOUtils {
     public static IOPath createTempPath(final String prefix, final String suffix) {
         try {
             final Path tempPath = Files.createTempFile(prefix, suffix);
-            tempPath.toFile().deleteOnExit();
+            IOUtil.deleteOnExit(tempPath);
             return new HtsPath(tempPath.toAbsolutePath().toString());
         } catch (final IOException e) {
             throw new HtsjdkIOException(e);

--- a/src/main/java/htsjdk/beta/plugin/IOUtils.java
+++ b/src/main/java/htsjdk/beta/plugin/IOUtils.java
@@ -5,7 +5,6 @@ import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -27,9 +26,9 @@ public class IOUtils {
      */
     public static IOPath createTempPath(final String prefix, final String suffix) {
         try {
-            final File tempFile = File.createTempFile(prefix, suffix);
-            tempFile.deleteOnExit();
-            return new HtsPath(tempFile.getAbsolutePath());
+            final Path tempPath = Files.createTempFile(prefix, suffix);
+            tempPath.toFile().deleteOnExit();
+            return new HtsPath(tempPath.toAbsolutePath().toString());
         } catch (final IOException e) {
             throw new HtsjdkIOException(e);
         }

--- a/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
@@ -23,9 +23,13 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -55,16 +59,30 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
         this(new IndexStreamBuffer(stream), stream.getSource(), dictionary);
     }
 
+    /**
+     * @deprecated since 5.0.0; use {@link #AbstractBAMFileIndex(Path, SAMSequenceDictionary)} instead.
+     */
+    @Deprecated
     protected AbstractBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
-        this(new MemoryMappedFileBuffer(file), file.getName(), dictionary);
+        this(file.toPath(), dictionary);
+    }
+
+    protected AbstractBAMFileIndex(final Path path, final SAMSequenceDictionary dictionary) {
+        this(createBufferForPath(path), path.toString(), dictionary);
+    }
+
+    /**
+     * @deprecated since 5.0.0; use {@link #AbstractBAMFileIndex(Path, SAMSequenceDictionary, boolean)} instead.
+     */
+    @Deprecated
+    protected AbstractBAMFileIndex(
+            final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
+        this(file.toPath(), dictionary, useMemoryMapping);
     }
 
     protected AbstractBAMFileIndex(
-            final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
-        this(
-                (useMemoryMapping ? new MemoryMappedFileBuffer(file) : new RandomAccessFileBuffer(file)),
-                file.getName(),
-                dictionary);
+            final Path path, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
+        this(createBufferForPath(path, useMemoryMapping), path.toString(), dictionary);
     }
 
     protected AbstractBAMFileIndex(
@@ -73,6 +91,46 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
         mBamDictionary = dictionary;
         verifyIndexMagicNumber(source);
         initParameters();
+    }
+
+    /**
+     * Returns true if the given path is not on the default (local) file system.
+     * Non-local paths (e.g., S3, GCS, HDFS, Jimfs) cannot be memory-mapped or
+     * accessed via FileChannel and require a stream-based fallback.
+     */
+    private static boolean isNonLocalPath(final Path path) {
+        return !path.getFileSystem().equals(FileSystems.getDefault());
+    }
+
+    /**
+     * Creates the appropriate IndexFileBuffer for the given path.
+     * Non-local paths use a stream-based buffer; local paths use memory-mapped I/O.
+     */
+    private static IndexFileBuffer createBufferForPath(final Path path) {
+        if (isNonLocalPath(path)) {
+            try {
+                return new IndexStreamBuffer(new SeekablePathStream(path));
+            } catch (final IOException e) {
+                throw new RuntimeIOException("Failed to open index stream for non-local path: " + path, e);
+            }
+        }
+        return new MemoryMappedFileBuffer(path.toFile());
+    }
+
+    /**
+     * Creates the appropriate IndexFileBuffer for the given path, respecting the memory-mapping preference.
+     * Non-local paths always use a stream-based buffer regardless of the useMemoryMapping flag.
+     * Local paths use MemoryMappedFileBuffer when useMemoryMapping is true, RandomAccessFileBuffer otherwise.
+     */
+    private static IndexFileBuffer createBufferForPath(final Path path, final boolean useMemoryMapping) {
+        if (isNonLocalPath(path)) {
+            try {
+                return new IndexStreamBuffer(new SeekablePathStream(path));
+            } catch (final IOException e) {
+                throw new RuntimeIOException("Failed to open index stream for non-local path: " + path, e);
+            }
+        }
+        return useMemoryMapping ? new MemoryMappedFileBuffer(path.toFile()) : new RandomAccessFileBuffer(path.toFile());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/AbstractBAMFileIndex.java
@@ -26,7 +26,6 @@ package htsjdk.samtools;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -59,25 +58,8 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
         this(new IndexStreamBuffer(stream), stream.getSource(), dictionary);
     }
 
-    /**
-     * @deprecated since 5.0.0; use {@link #AbstractBAMFileIndex(Path, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    protected AbstractBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
-        this(file.toPath(), dictionary);
-    }
-
     protected AbstractBAMFileIndex(final Path path, final SAMSequenceDictionary dictionary) {
         this(createBufferForPath(path), path.toString(), dictionary);
-    }
-
-    /**
-     * @deprecated since 5.0.0; use {@link #AbstractBAMFileIndex(Path, SAMSequenceDictionary, boolean)} instead.
-     */
-    @Deprecated
-    protected AbstractBAMFileIndex(
-            final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
-        this(file.toPath(), dictionary, useMemoryMapping);
     }
 
     protected AbstractBAMFileIndex(
@@ -114,7 +96,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
                 throw new RuntimeIOException("Failed to open index stream for non-local path: " + path, e);
             }
         }
-        return new MemoryMappedFileBuffer(path.toFile());
+        return new MemoryMappedFileBuffer(path);
     }
 
     /**
@@ -130,7 +112,7 @@ public abstract class AbstractBAMFileIndex implements BAMIndex {
                 throw new RuntimeIOException("Failed to open index stream for non-local path: " + path, e);
             }
         }
-        return useMemoryMapping ? new MemoryMappedFileBuffer(path.toFile()) : new RandomAccessFileBuffer(path.toFile());
+        return useMemoryMapping ? new MemoryMappedFileBuffer(path) : new RandomAccessFileBuffer(path);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/BAMFileReader.java
@@ -226,9 +226,9 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
         if (!Files.exists(path)) {
             throw new IOException("BAM file not found: " + path.toAbsolutePath());
         }
-        if (!Files.isReadable(path)) {
-            throw new IOException("BAM file is not readable (permission denied): " + path.toAbsolutePath());
-        }
+        // Intentionally no Files.isReadable() check: some NIO filesystem providers (e.g. S3/HDFS
+        // adapters) report paths as non-readable even when they can be opened, which would cause
+        // spurious failures. Let the actual open surface any real permission error.
         return path;
     }
 

--- a/src/main/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/BAMFileReader.java
@@ -28,7 +28,6 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.*;
 import htsjdk.samtools.util.zip.InflaterFactory;
 import java.io.DataInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -116,35 +115,6 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
     /**
      * Prepare to read BAM from a stream (not seekable)
      * @param stream source of bytes.
-     * @param indexFile BAM index file
-     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
-     * @param useAsynchronousIO if true, use asynchronous I/O
-     * @param validationStringency Controls how to handle invalidate reads or header lines.
-     * @param samRecordFactory SAM record factory
-     * @throws IOException
-     * @deprecated since this uses a {@link File} for the index; use the {@link Path}-based constructor instead.
-     */
-    @Deprecated
-    BAMFileReader(
-            final InputStream stream,
-            final File indexFile,
-            final boolean eagerDecode,
-            final boolean useAsynchronousIO,
-            final ValidationStringency validationStringency,
-            final SAMRecordFactory samRecordFactory)
-            throws IOException {
-        this(
-                stream,
-                indexFile == null ? null : indexFile.toPath(),
-                eagerDecode,
-                useAsynchronousIO,
-                validationStringency,
-                samRecordFactory);
-    }
-
-    /**
-     * Prepare to read BAM from a stream (not seekable)
-     * @param stream source of bytes.
      * @param indexPath BAM index file path
      * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
      * @param useAsynchronousIO if true, use asynchronous I/O
@@ -175,38 +145,6 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
     }
 
     /**
-     * Prepare to read BAM from a stream (not seekable)
-     * @param stream source of bytes.
-     * @param indexFile BAM index file
-     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
-     * @param useAsynchronousIO if true, use asynchronous I/O
-     * @param validationStringency Controls how to handle invalidate reads or header lines.
-     * @param samRecordFactory SAM record factory
-     * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
-     * @throws IOException
-     * @deprecated since this uses a {@link File} for the index; use the {@link Path}-based constructor instead.
-     */
-    @Deprecated
-    BAMFileReader(
-            final InputStream stream,
-            final File indexFile,
-            final boolean eagerDecode,
-            final boolean useAsynchronousIO,
-            final ValidationStringency validationStringency,
-            final SAMRecordFactory samRecordFactory,
-            final InflaterFactory inflaterFactory)
-            throws IOException {
-        this(
-                stream,
-                indexFile == null ? null : indexFile.toPath(),
-                eagerDecode,
-                useAsynchronousIO,
-                validationStringency,
-                samRecordFactory,
-                inflaterFactory);
-    }
-
-    /**
      * Prepare to read BAM from a file (seekable)
      * @param path source of bytes.
      * @param indexPath BAM index file path
@@ -232,35 +170,6 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
                 validationStringency,
                 samRecordFactory,
                 BlockGunzipper.getDefaultInflaterFactory());
-    }
-
-    /**
-     * Prepare to read BAM from a file (seekable)
-     * @param file source of bytes.
-     * @param indexFile BAM index file
-     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
-     * @param useAsynchronousIO if true, use asynchronous I/O
-     * @param validationStringency Controls how to handle invalidate reads or header lines.
-     * @param samRecordFactory SAM record factory
-     * @throws IOException
-     * @deprecated since this uses {@link File}s; use the {@link Path}-based constructor instead.
-     */
-    @Deprecated
-    BAMFileReader(
-            final File file,
-            final File indexFile,
-            final boolean eagerDecode,
-            final boolean useAsynchronousIO,
-            final ValidationStringency validationStringency,
-            final SAMRecordFactory samRecordFactory)
-            throws IOException {
-        this(
-                file == null ? null : file.toPath(),
-                indexFile == null ? null : indexFile.toPath(),
-                eagerDecode,
-                useAsynchronousIO,
-                validationStringency,
-                samRecordFactory);
     }
 
     /**
@@ -305,38 +214,6 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
 
         // Provide better error message when there is an error reading.
         mStream.setInputFileName(path.toAbsolutePath().toString());
-    }
-
-    /**
-     * Prepare to read BAM from a file (seekable)
-     * @param file source of bytes.
-     * @param indexFile BAM index file
-     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
-     * @param useAsynchronousIO if true, use asynchronous I/O
-     * @param validationStringency Controls how to handle invalidate reads or header lines.
-     * @param samRecordFactory SAM record factory
-     * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
-     * @throws IOException
-     * @deprecated since this uses {@link File}s; use the {@link Path}-based constructor instead.
-     */
-    @Deprecated
-    BAMFileReader(
-            final File file,
-            final File indexFile,
-            final boolean eagerDecode,
-            final boolean useAsynchronousIO,
-            final ValidationStringency validationStringency,
-            final SAMRecordFactory samRecordFactory,
-            final InflaterFactory inflaterFactory)
-            throws IOException {
-        this(
-                file == null ? null : file.toPath(),
-                indexFile == null ? null : indexFile.toPath(),
-                eagerDecode,
-                useAsynchronousIO,
-                validationStringency,
-                samRecordFactory,
-                inflaterFactory);
     }
 
     /**
@@ -386,35 +263,6 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
     /**
      * Prepare to read BAM from a stream (seekable)
      * @param strm source of bytes
-     * @param indexFile BAM index file
-     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
-     * @param useAsynchronousIO if true, use asynchronous I/O
-     * @param validationStringency Controls how to handle invalidate reads or header lines.
-     * @param samRecordFactory SAM record factory
-     * @throws IOException
-     * @deprecated since this uses a {@link File} for the index; use the {@link Path}-based constructor instead.
-     */
-    @Deprecated
-    BAMFileReader(
-            final SeekableStream strm,
-            final File indexFile,
-            final boolean eagerDecode,
-            final boolean useAsynchronousIO,
-            final ValidationStringency validationStringency,
-            final SAMRecordFactory samRecordFactory)
-            throws IOException {
-        this(
-                strm,
-                indexFile == null ? null : indexFile.toPath(),
-                eagerDecode,
-                useAsynchronousIO,
-                validationStringency,
-                samRecordFactory);
-    }
-
-    /**
-     * Prepare to read BAM from a stream (seekable)
-     * @param strm source of bytes
      * @param indexPath BAM index file path
      * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
      * @param useAsynchronousIO if true, use asynchronous I/O
@@ -442,38 +290,6 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
                 strm.getSource(),
                 validationStringency,
                 samRecordFactory);
-    }
-
-    /**
-     * Prepare to read BAM from a stream (seekable)
-     * @param strm source of bytes
-     * @param indexFile BAM index file
-     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
-     * @param useAsynchronousIO if true, use asynchronous I/O
-     * @param validationStringency Controls how to handle invalidate reads or header lines.
-     * @param samRecordFactory SAM record factory
-     * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
-     * @throws IOException
-     * @deprecated since this uses a {@link File} for the index; use the {@link Path}-based constructor instead.
-     */
-    @Deprecated
-    BAMFileReader(
-            final SeekableStream strm,
-            final File indexFile,
-            final boolean eagerDecode,
-            final boolean useAsynchronousIO,
-            final ValidationStringency validationStringency,
-            final SAMRecordFactory samRecordFactory,
-            final InflaterFactory inflaterFactory)
-            throws IOException {
-        this(
-                strm,
-                indexFile == null ? null : indexFile.toPath(),
-                eagerDecode,
-                useAsynchronousIO,
-                validationStringency,
-                samRecordFactory,
-                inflaterFactory);
     }
 
     /**
@@ -609,15 +425,6 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
 
     /**
      * Reads through the header and sequence records to find the virtual file offset of the first record in the BAM file.
-     * @deprecated use {@link #findVirtualOffsetOfFirstRecord(Path)} instead.
-     */
-    @Deprecated
-    static long findVirtualOffsetOfFirstRecord(final File bam) throws IOException {
-        return findVirtualOffsetOfFirstRecord(bam.toPath());
-    }
-
-    /**
-     * Reads through the header and sequence records to find the virtual file offset of the first record in the BAM file.
      * The caller is responsible for closing the stream.
      */
     static long findVirtualOffsetOfFirstRecord(final SeekableStream seekableStream) throws IOException {
@@ -703,16 +510,12 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
             final SamIndexes samIndexType = getIndexType();
             final SAMSequenceDictionary sequenceDictionary = getFileHeader().getSequenceDictionary();
             if (mIndexPath != null) {
-                // The memory-mapped / random-access index readers below are inherently local-file based
-                // and have not yet been migrated to Path, so convert the index Path to a File here. This
-                // is safe because these readers can only operate on regular files on the default filesystem.
-                final File indexFile = mIndexPath.toFile();
                 if (samIndexType.equals(SamIndexes.BAI)) {
                     mIndex = mEnableIndexCaching
-                            ? new CachingBAMFileIndex(indexFile, sequenceDictionary, mEnableIndexMemoryMapping)
-                            : new DiskBasedBAMFileIndex(indexFile, sequenceDictionary, mEnableIndexMemoryMapping);
+                            ? new CachingBAMFileIndex(mIndexPath, sequenceDictionary, mEnableIndexMemoryMapping)
+                            : new DiskBasedBAMFileIndex(mIndexPath, sequenceDictionary, mEnableIndexMemoryMapping);
                 } else if (samIndexType.equals(SamIndexes.CSI)) {
-                    mIndex = new CSIIndex(indexFile, mEnableIndexMemoryMapping, sequenceDictionary);
+                    mIndex = new CSIIndex(mIndexPath, mEnableIndexMemoryMapping, sequenceDictionary);
                 } else {
                     throw new SAMFormatException("Unsupported BAM index file format: " + mIndexPath.getFileName());
                 }

--- a/src/main/java/htsjdk/samtools/BAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/BAMFileReader.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.samtools;
 
+import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.*;
 import htsjdk.samtools.util.zip.InflaterFactory;
@@ -30,6 +31,8 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,7 +53,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
     private SAMFileHeader mFileHeader = null;
 
     // One of these is populated if the file is seekable and an index exists
-    private File mIndexFile = null;
+    private Path mIndexPath = null;
     private SeekableStream mIndexStream = null;
 
     private BAMIndex mIndex = null;
@@ -85,7 +88,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
     /**
      * Prepare to read BAM from a stream (not seekable)
      * @param stream source of bytes.
-     * @param indexFile BAM index file
+     * @param indexPath BAM index file path
      * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
      * @param useAsynchronousIO if true, use asynchronous I/O
      * @param validationStringency Controls how to handle invalidate reads or header lines.
@@ -94,7 +97,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      */
     BAMFileReader(
             final InputStream stream,
-            final File indexFile,
+            final Path indexPath,
             final boolean eagerDecode,
             final boolean useAsynchronousIO,
             final ValidationStringency validationStringency,
@@ -102,7 +105,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
             throws IOException {
         this(
                 stream,
-                indexFile,
+                indexPath,
                 eagerDecode,
                 useAsynchronousIO,
                 validationStringency,
@@ -118,19 +121,48 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      * @param useAsynchronousIO if true, use asynchronous I/O
      * @param validationStringency Controls how to handle invalidate reads or header lines.
      * @param samRecordFactory SAM record factory
-     * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
      * @throws IOException
+     * @deprecated since this uses a {@link File} for the index; use the {@link Path}-based constructor instead.
      */
+    @Deprecated
     BAMFileReader(
             final InputStream stream,
             final File indexFile,
             final boolean eagerDecode,
             final boolean useAsynchronousIO,
             final ValidationStringency validationStringency,
+            final SAMRecordFactory samRecordFactory)
+            throws IOException {
+        this(
+                stream,
+                indexFile == null ? null : indexFile.toPath(),
+                eagerDecode,
+                useAsynchronousIO,
+                validationStringency,
+                samRecordFactory);
+    }
+
+    /**
+     * Prepare to read BAM from a stream (not seekable)
+     * @param stream source of bytes.
+     * @param indexPath BAM index file path
+     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
+     * @param useAsynchronousIO if true, use asynchronous I/O
+     * @param validationStringency Controls how to handle invalidate reads or header lines.
+     * @param samRecordFactory SAM record factory
+     * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
+     * @throws IOException
+     */
+    BAMFileReader(
+            final InputStream stream,
+            final Path indexPath,
+            final boolean eagerDecode,
+            final boolean useAsynchronousIO,
+            final ValidationStringency validationStringency,
             final SAMRecordFactory samRecordFactory,
             final InflaterFactory inflaterFactory)
             throws IOException {
-        mIndexFile = indexFile;
+        mIndexPath = indexPath;
         mIsSeekable = false;
         mCompressedInputStream = useAsynchronousIO
                 ? new AsyncBlockCompressedInputStream(stream, inflaterFactory)
@@ -143,9 +175,41 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
     }
 
     /**
-     * Prepare to read BAM from a file (seekable)
-     * @param file source of bytes.
+     * Prepare to read BAM from a stream (not seekable)
+     * @param stream source of bytes.
      * @param indexFile BAM index file
+     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
+     * @param useAsynchronousIO if true, use asynchronous I/O
+     * @param validationStringency Controls how to handle invalidate reads or header lines.
+     * @param samRecordFactory SAM record factory
+     * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
+     * @throws IOException
+     * @deprecated since this uses a {@link File} for the index; use the {@link Path}-based constructor instead.
+     */
+    @Deprecated
+    BAMFileReader(
+            final InputStream stream,
+            final File indexFile,
+            final boolean eagerDecode,
+            final boolean useAsynchronousIO,
+            final ValidationStringency validationStringency,
+            final SAMRecordFactory samRecordFactory,
+            final InflaterFactory inflaterFactory)
+            throws IOException {
+        this(
+                stream,
+                indexFile == null ? null : indexFile.toPath(),
+                eagerDecode,
+                useAsynchronousIO,
+                validationStringency,
+                samRecordFactory,
+                inflaterFactory);
+    }
+
+    /**
+     * Prepare to read BAM from a file (seekable)
+     * @param path source of bytes.
+     * @param indexPath BAM index file path
      * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
      * @param useAsynchronousIO if true, use asynchronous I/O
      * @param validationStringency Controls how to handle invalidate reads or header lines.
@@ -153,16 +217,16 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      * @throws IOException
      */
     BAMFileReader(
-            final File file,
-            final File indexFile,
+            final Path path,
+            final Path indexPath,
             final boolean eagerDecode,
             final boolean useAsynchronousIO,
             final ValidationStringency validationStringency,
             final SAMRecordFactory samRecordFactory)
             throws IOException {
         this(
-                file,
-                indexFile,
+                path,
+                indexPath,
                 eagerDecode,
                 useAsynchronousIO,
                 validationStringency,
@@ -178,9 +242,84 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      * @param useAsynchronousIO if true, use asynchronous I/O
      * @param validationStringency Controls how to handle invalidate reads or header lines.
      * @param samRecordFactory SAM record factory
+     * @throws IOException
+     * @deprecated since this uses {@link File}s; use the {@link Path}-based constructor instead.
+     */
+    @Deprecated
+    BAMFileReader(
+            final File file,
+            final File indexFile,
+            final boolean eagerDecode,
+            final boolean useAsynchronousIO,
+            final ValidationStringency validationStringency,
+            final SAMRecordFactory samRecordFactory)
+            throws IOException {
+        this(
+                file == null ? null : file.toPath(),
+                indexFile == null ? null : indexFile.toPath(),
+                eagerDecode,
+                useAsynchronousIO,
+                validationStringency,
+                samRecordFactory);
+    }
+
+    /**
+     * Prepare to read BAM from a file (seekable)
+     * @param path source of bytes.
+     * @param indexPath BAM index file path
+     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
+     * @param useAsynchronousIO if true, use asynchronous I/O
+     * @param validationStringency Controls how to handle invalidate reads or header lines.
+     * @param samRecordFactory SAM record factory
      * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
      * @throws IOException
      */
+    BAMFileReader(
+            final Path path,
+            final Path indexPath,
+            final boolean eagerDecode,
+            final boolean useAsynchronousIO,
+            final ValidationStringency validationStringency,
+            final SAMRecordFactory samRecordFactory,
+            final InflaterFactory inflaterFactory)
+            throws IOException {
+        this(
+                useAsynchronousIO
+                        ? new AsyncBlockCompressedInputStream(
+                                new SeekablePathStream(checkPathExists(path)), inflaterFactory)
+                        : new BlockCompressedInputStream(
+                                new SeekablePathStream(checkPathExists(path)), inflaterFactory),
+                indexPath != null ? indexPath : SamFiles.findIndex(path),
+                eagerDecode,
+                useAsynchronousIO,
+                path.toAbsolutePath().toString(),
+                validationStringency,
+                samRecordFactory);
+
+        if (mIndexPath != null
+                && Files.getLastModifiedTime(mIndexPath).toMillis()
+                        < Files.getLastModifiedTime(path).toMillis() - 5000) {
+            System.err.println("WARNING: BAM index file " + mIndexPath.toAbsolutePath() + " is older than BAM "
+                    + path.toAbsolutePath());
+        }
+
+        // Provide better error message when there is an error reading.
+        mStream.setInputFileName(path.toAbsolutePath().toString());
+    }
+
+    /**
+     * Prepare to read BAM from a file (seekable)
+     * @param file source of bytes.
+     * @param indexFile BAM index file
+     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
+     * @param useAsynchronousIO if true, use asynchronous I/O
+     * @param validationStringency Controls how to handle invalidate reads or header lines.
+     * @param samRecordFactory SAM record factory
+     * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
+     * @throws IOException
+     * @deprecated since this uses {@link File}s; use the {@link Path}-based constructor instead.
+     */
+    @Deprecated
     BAMFileReader(
             final File file,
             final File indexFile,
@@ -191,23 +330,57 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
             final InflaterFactory inflaterFactory)
             throws IOException {
         this(
-                useAsynchronousIO
-                        ? new AsyncBlockCompressedInputStream(file, inflaterFactory)
-                        : new BlockCompressedInputStream(file, inflaterFactory),
-                indexFile != null ? indexFile : SamFiles.findIndex(file),
+                file == null ? null : file.toPath(),
+                indexFile == null ? null : indexFile.toPath(),
                 eagerDecode,
                 useAsynchronousIO,
-                file.getAbsolutePath(),
                 validationStringency,
-                samRecordFactory);
+                samRecordFactory,
+                inflaterFactory);
+    }
 
-        if (mIndexFile != null && mIndexFile.lastModified() < file.lastModified() - 5000) {
-            System.err.println("WARNING: BAM index file " + mIndexFile.getAbsolutePath() + " is older than BAM "
-                    + file.getAbsolutePath());
+    /**
+     * Helper method to check that a path exists and is readable before opening it.
+     * @param path the path to check
+     * @return the same path if it exists and is readable
+     * @throws IOException if the path does not exist or is not readable
+     */
+    private static Path checkPathExists(final Path path) throws IOException {
+        if (!Files.exists(path)) {
+            throw new IOException("BAM file not found: " + path.toAbsolutePath());
         }
+        if (!Files.isReadable(path)) {
+            throw new IOException("BAM file is not readable (permission denied): " + path.toAbsolutePath());
+        }
+        return path;
+    }
 
-        // Provide better error message when there is an error reading.
-        mStream.setInputFileName(file.getAbsolutePath());
+    /**
+     * Prepare to read BAM from a stream (seekable)
+     * @param strm source of bytes
+     * @param indexPath BAM index file path
+     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
+     * @param useAsynchronousIO if true, use asynchronous I/O
+     * @param validationStringency Controls how to handle invalidate reads or header lines.
+     * @param samRecordFactory SAM record factory
+     * @throws IOException
+     */
+    BAMFileReader(
+            final SeekableStream strm,
+            final Path indexPath,
+            final boolean eagerDecode,
+            final boolean useAsynchronousIO,
+            final ValidationStringency validationStringency,
+            final SAMRecordFactory samRecordFactory)
+            throws IOException {
+        this(
+                strm,
+                indexPath,
+                eagerDecode,
+                useAsynchronousIO,
+                validationStringency,
+                samRecordFactory,
+                BlockGunzipper.getDefaultInflaterFactory());
     }
 
     /**
@@ -219,7 +392,9 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      * @param validationStringency Controls how to handle invalidate reads or header lines.
      * @param samRecordFactory SAM record factory
      * @throws IOException
+     * @deprecated since this uses a {@link File} for the index; use the {@link Path}-based constructor instead.
      */
+    @Deprecated
     BAMFileReader(
             final SeekableStream strm,
             final File indexFile,
@@ -230,12 +405,43 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
             throws IOException {
         this(
                 strm,
-                indexFile,
+                indexFile == null ? null : indexFile.toPath(),
                 eagerDecode,
                 useAsynchronousIO,
                 validationStringency,
-                samRecordFactory,
-                BlockGunzipper.getDefaultInflaterFactory());
+                samRecordFactory);
+    }
+
+    /**
+     * Prepare to read BAM from a stream (seekable)
+     * @param strm source of bytes
+     * @param indexPath BAM index file path
+     * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
+     * @param useAsynchronousIO if true, use asynchronous I/O
+     * @param validationStringency Controls how to handle invalidate reads or header lines.
+     * @param samRecordFactory SAM record factory
+     * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
+     * @throws IOException
+     */
+    BAMFileReader(
+            final SeekableStream strm,
+            final Path indexPath,
+            final boolean eagerDecode,
+            final boolean useAsynchronousIO,
+            final ValidationStringency validationStringency,
+            final SAMRecordFactory samRecordFactory,
+            final InflaterFactory inflaterFactory)
+            throws IOException {
+        this(
+                useAsynchronousIO
+                        ? new AsyncBlockCompressedInputStream(strm, inflaterFactory)
+                        : new BlockCompressedInputStream(strm, inflaterFactory),
+                indexPath,
+                eagerDecode,
+                useAsynchronousIO,
+                strm.getSource(),
+                validationStringency,
+                samRecordFactory);
     }
 
     /**
@@ -248,7 +454,9 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      * @param samRecordFactory SAM record factory
      * @param inflaterFactory InflaterFactory used by BlockCompressedInputStream
      * @throws IOException
+     * @deprecated since this uses a {@link File} for the index; use the {@link Path}-based constructor instead.
      */
+    @Deprecated
     BAMFileReader(
             final SeekableStream strm,
             final File indexFile,
@@ -259,15 +467,13 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
             final InflaterFactory inflaterFactory)
             throws IOException {
         this(
-                useAsynchronousIO
-                        ? new AsyncBlockCompressedInputStream(strm, inflaterFactory)
-                        : new BlockCompressedInputStream(strm, inflaterFactory),
-                indexFile,
+                strm,
+                indexFile == null ? null : indexFile.toPath(),
                 eagerDecode,
                 useAsynchronousIO,
-                strm.getSource(),
                 validationStringency,
-                samRecordFactory);
+                samRecordFactory,
+                inflaterFactory);
     }
 
     /**
@@ -333,7 +539,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
     /**
      * Prepare to read BAM from a compressed stream (seekable)
      * @param compressedInputStream source of bytes
-     * @param indexFile BAM index file
+     * @param indexPath BAM index file path
      * @param eagerDecode if true, decode all BAM fields as reading rather than lazily.
      * @param useAsynchronousIO if true, use asynchronous I/O
      * @param source string used when reporting errors
@@ -343,14 +549,14 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      */
     private BAMFileReader(
             final BlockCompressedInputStream compressedInputStream,
-            final File indexFile,
+            final Path indexPath,
             final boolean eagerDecode,
             final boolean useAsynchronousIO,
             final String source,
             final ValidationStringency validationStringency,
             final SAMRecordFactory samRecordFactory)
             throws IOException {
-        mIndexFile = indexFile;
+        mIndexPath = indexPath;
         mIsSeekable = true;
         mCompressedInputStream = compressedInputStream;
         mStream = new BinaryCodec(new DataInputStream(mCompressedInputStream));
@@ -393,12 +599,21 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
     }
 
     /** Reads through the header and sequence records to find the virtual file offset of the first record in the BAM file. */
-    static long findVirtualOffsetOfFirstRecord(final File bam) throws IOException {
-        final BAMFileReader reader =
-                new BAMFileReader(bam, null, false, false, ValidationStringency.SILENT, new DefaultSAMRecordFactory());
+    static long findVirtualOffsetOfFirstRecord(final Path bam) throws IOException {
+        final BAMFileReader reader = new BAMFileReader(
+                bam, (Path) null, false, false, ValidationStringency.SILENT, new DefaultSAMRecordFactory());
         final long offset = reader.mFirstRecordPointer;
         reader.close();
         return offset;
+    }
+
+    /**
+     * Reads through the header and sequence records to find the virtual file offset of the first record in the BAM file.
+     * @deprecated use {@link #findVirtualOffsetOfFirstRecord(Path)} instead.
+     */
+    @Deprecated
+    static long findVirtualOffsetOfFirstRecord(final File bam) throws IOException {
+        return findVirtualOffsetOfFirstRecord(bam.toPath());
     }
 
     /**
@@ -461,7 +676,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
 
     @Override
     public SamReader.Type type() {
-        if (mIndexFile != null && getIndexType().equals(SamIndexes.CSI)) {
+        if (mIndexPath != null && getIndexType().equals(SamIndexes.CSI)) {
             return SamReader.Type.BAM_CSI_TYPE;
         }
         return SamReader.Type.BAM_TYPE;
@@ -472,7 +687,7 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      */
     @Override
     public boolean hasIndex() {
-        return mIsSeekable && ((mIndexFile != null) || (mIndexStream != null));
+        return mIsSeekable && ((mIndexPath != null) || (mIndexStream != null));
     }
 
     /**
@@ -487,15 +702,19 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
         if (mIndex == null) {
             final SamIndexes samIndexType = getIndexType();
             final SAMSequenceDictionary sequenceDictionary = getFileHeader().getSequenceDictionary();
-            if (mIndexFile != null) {
+            if (mIndexPath != null) {
+                // The memory-mapped / random-access index readers below are inherently local-file based
+                // and have not yet been migrated to Path, so convert the index Path to a File here. This
+                // is safe because these readers can only operate on regular files on the default filesystem.
+                final File indexFile = mIndexPath.toFile();
                 if (samIndexType.equals(SamIndexes.BAI)) {
                     mIndex = mEnableIndexCaching
-                            ? new CachingBAMFileIndex(mIndexFile, sequenceDictionary, mEnableIndexMemoryMapping)
-                            : new DiskBasedBAMFileIndex(mIndexFile, sequenceDictionary, mEnableIndexMemoryMapping);
+                            ? new CachingBAMFileIndex(indexFile, sequenceDictionary, mEnableIndexMemoryMapping)
+                            : new DiskBasedBAMFileIndex(indexFile, sequenceDictionary, mEnableIndexMemoryMapping);
                 } else if (samIndexType.equals(SamIndexes.CSI)) {
-                    mIndex = new CSIIndex(mIndexFile, mEnableIndexMemoryMapping, sequenceDictionary);
+                    mIndex = new CSIIndex(indexFile, mEnableIndexMemoryMapping, sequenceDictionary);
                 } else {
-                    throw new SAMFormatException("Unsupported BAM index file format: " + mIndexFile.getName());
+                    throw new SAMFormatException("Unsupported BAM index file format: " + mIndexPath.getFileName());
                 }
             } else if (mIndexStream != null) {
                 if (samIndexType.equals(SamIndexes.BAI)) {
@@ -516,13 +735,14 @@ public class BAMFileReader extends SamReader.ReaderImplementation {
      * @return one of {@link SamIndexes#BAI} or {@link SamIndexes#CSI} or null
      */
     public SamIndexes getIndexType() {
-        if (mIndexFile != null) {
-            if (mIndexFile.getName().toLowerCase().endsWith(FileExtensions.BAI_INDEX)) {
+        if (mIndexPath != null) {
+            final String fileName = mIndexPath.getFileName().toString().toLowerCase();
+            if (fileName.endsWith(FileExtensions.BAI_INDEX)) {
                 return SamIndexes.BAI;
-            } else if (mIndexFile.getName().toLowerCase().endsWith(FileExtensions.CSI)) {
+            } else if (fileName.endsWith(FileExtensions.CSI)) {
                 return SamIndexes.CSI;
             }
-            throw new SAMFormatException("Unknown BAM index file type: " + mIndexFile.getName());
+            throw new SAMFormatException("Unknown BAM index file type: " + mIndexPath.getFileName());
         } else if (mIndexStream != null) {
             final SamIndexes samIndexesType = SamIndexes.getSAMIndexTypeFromStream(mIndexStream);
             if (samIndexesType == SamIndexes.BAI || samIndexesType == SamIndexes.CSI) {

--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -29,7 +29,6 @@ import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
@@ -53,26 +52,10 @@ public class BAMFileWriter extends SAMFileWriterImpl {
         outputBinaryCodec.setOutputFileName(path.toAbsolutePath().toString());
     }
 
-    /**
-     * @deprecated since 5.0.0; use {@link #BAMFileWriter(Path)} instead.
-     */
-    @Deprecated
-    protected BAMFileWriter(final File path) {
-        this(path.toPath());
-    }
-
     protected BAMFileWriter(final Path path, final int compressionLevel) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(path, compressionLevel);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(path.toAbsolutePath().toString());
-    }
-
-    /**
-     * @deprecated since 5.0.0; use {@link #BAMFileWriter(Path, int)} instead.
-     */
-    @Deprecated
-    protected BAMFileWriter(final File path, final int compressionLevel) {
-        this(path.toPath(), compressionLevel);
     }
 
     protected BAMFileWriter(final OutputStream os, final Path path) {
@@ -87,28 +70,11 @@ public class BAMFileWriter extends SAMFileWriterImpl {
         outputBinaryCodec.setOutputFileName(getPathString(path));
     }
 
-    /**
-     * @deprecated since 5.0.0; use {@link #BAMFileWriter(OutputStream, Path, int)} instead.
-     */
-    @Deprecated
-    protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel) {
-        this(os, IOUtil.toPath(file), compressionLevel);
-    }
-
     protected BAMFileWriter(
             final OutputStream os, final Path path, final int compressionLevel, final DeflaterFactory deflaterFactory) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(os, path, compressionLevel, deflaterFactory);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
         outputBinaryCodec.setOutputFileName(getPathString(path));
-    }
-
-    /**
-     * @deprecated since 5.0.0; use {@link #BAMFileWriter(OutputStream, Path, int, DeflaterFactory)} instead.
-     */
-    @Deprecated
-    protected BAMFileWriter(
-            final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        this(os, IOUtil.toPath(file), compressionLevel, deflaterFactory);
     }
 
     protected BAMFileWriter(

--- a/src/main/java/htsjdk/samtools/BAMFileWriter.java
+++ b/src/main/java/htsjdk/samtools/BAMFileWriter.java
@@ -47,35 +47,68 @@ public class BAMFileWriter extends SAMFileWriterImpl {
     private final BlockCompressedOutputStream blockCompressedOutputStream;
     private BAMIndexer bamIndexer = null;
 
-    protected BAMFileWriter(final File path) {
+    protected BAMFileWriter(final Path path) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(path);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
-        outputBinaryCodec.setOutputFileName(path.getAbsolutePath());
+        outputBinaryCodec.setOutputFileName(path.toAbsolutePath().toString());
     }
 
-    protected BAMFileWriter(final File path, final int compressionLevel) {
+    /**
+     * @deprecated since 5.0.0; use {@link #BAMFileWriter(Path)} instead.
+     */
+    @Deprecated
+    protected BAMFileWriter(final File path) {
+        this(path.toPath());
+    }
+
+    protected BAMFileWriter(final Path path, final int compressionLevel) {
         blockCompressedOutputStream = new BlockCompressedOutputStream(path, compressionLevel);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
-        outputBinaryCodec.setOutputFileName(path.getAbsolutePath());
+        outputBinaryCodec.setOutputFileName(path.toAbsolutePath().toString());
     }
 
-    protected BAMFileWriter(final OutputStream os, final File file) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file);
+    /**
+     * @deprecated since 5.0.0; use {@link #BAMFileWriter(Path, int)} instead.
+     */
+    @Deprecated
+    protected BAMFileWriter(final File path, final int compressionLevel) {
+        this(path.toPath(), compressionLevel);
+    }
+
+    protected BAMFileWriter(final OutputStream os, final Path path) {
+        blockCompressedOutputStream = new BlockCompressedOutputStream(os, path);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
-        outputBinaryCodec.setOutputFileName(getPathString(file));
+        outputBinaryCodec.setOutputFileName(getPathString(path));
     }
 
+    protected BAMFileWriter(final OutputStream os, final Path path, final int compressionLevel) {
+        blockCompressedOutputStream = new BlockCompressedOutputStream(os, path, compressionLevel);
+        outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
+        outputBinaryCodec.setOutputFileName(getPathString(path));
+    }
+
+    /**
+     * @deprecated since 5.0.0; use {@link #BAMFileWriter(OutputStream, Path, int)} instead.
+     */
+    @Deprecated
     protected BAMFileWriter(final OutputStream os, final File file, final int compressionLevel) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file, compressionLevel);
-        outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
-        outputBinaryCodec.setOutputFileName(getPathString(file));
+        this(os, IOUtil.toPath(file), compressionLevel);
     }
 
     protected BAMFileWriter(
-            final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        blockCompressedOutputStream = new BlockCompressedOutputStream(os, file, compressionLevel, deflaterFactory);
+            final OutputStream os, final Path path, final int compressionLevel, final DeflaterFactory deflaterFactory) {
+        blockCompressedOutputStream = new BlockCompressedOutputStream(os, path, compressionLevel, deflaterFactory);
         outputBinaryCodec = new BinaryCodec(blockCompressedOutputStream);
-        outputBinaryCodec.setOutputFileName(getPathString(file));
+        outputBinaryCodec.setOutputFileName(getPathString(path));
+    }
+
+    /**
+     * @deprecated since 5.0.0; use {@link #BAMFileWriter(OutputStream, Path, int, DeflaterFactory)} instead.
+     */
+    @Deprecated
+    protected BAMFileWriter(
+            final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
+        this(os, IOUtil.toPath(file), compressionLevel, deflaterFactory);
     }
 
     protected BAMFileWriter(
@@ -97,8 +130,8 @@ public class BAMFileWriter extends SAMFileWriterImpl {
     }
 
     /** @return absolute path, or null if arg is null.  */
-    private String getPathString(final File path) {
-        return (path != null) ? path.getAbsolutePath() : null;
+    private String getPathString(final Path path) {
+        return (path != null) ? path.toAbsolutePath().toString() : null;
     }
 
     // Allow enabling the bam index construction

--- a/src/main/java/htsjdk/samtools/BAMIndexMetaData.java
+++ b/src/main/java/htsjdk/samtools/BAMIndexMetaData.java
@@ -27,6 +27,7 @@ import htsjdk.samtools.cram.BAIEntry;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -227,13 +228,25 @@ public class BAMIndexMetaData {
      * Prints meta-data statistics from BAM index (.bai or .csi) file
      * Statistics include count of aligned and unaligned reads for each reference sequence
      * and a count of all records with no start coordinate
+     *
+     * @deprecated since this uses a {@link File}; use {@link #printIndexStats(Path)} instead.
      */
+    @Deprecated
     public static void printIndexStats(final File inputBamFile) {
+        printIndexStats(inputBamFile == null ? null : inputBamFile.toPath());
+    }
+
+    /**
+     * Prints meta-data statistics from BAM index (.bai or .csi) file
+     * Statistics include count of aligned and unaligned reads for each reference sequence
+     * and a count of all records with no start coordinate
+     */
+    public static void printIndexStats(final Path inputBamPath) {
         try {
             final BAMFileReader bam = new BAMFileReader(
-                    inputBamFile, null, false, false, ValidationStringency.SILENT, new DefaultSAMRecordFactory());
+                    inputBamPath, null, false, false, ValidationStringency.SILENT, new DefaultSAMRecordFactory());
             if (!bam.hasIndex() || bam.getIndexType() == null) {
-                throw new SAMException("No index for bam file " + inputBamFile);
+                throw new SAMException("No index for bam file " + inputBamPath);
             }
 
             BAMIndexMetaData[] data = getIndexStats(bam);

--- a/src/main/java/htsjdk/samtools/BAMIndexMetaData.java
+++ b/src/main/java/htsjdk/samtools/BAMIndexMetaData.java
@@ -25,7 +25,6 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.cram.BAIEntry;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
@@ -222,18 +221,6 @@ public class BAMIndexMetaData {
         final long newLastOffset =
                 lastOffset == 0 ? lastOffset : BlockCompressedFilePointerUtil.shift(lastOffset, offset); // 0 is unset
         return new BAMIndexMetaData(newFirstOffset, newLastOffset, alignedRecords, unAlignedRecords);
-    }
-
-    /**
-     * Prints meta-data statistics from BAM index (.bai or .csi) file
-     * Statistics include count of aligned and unaligned reads for each reference sequence
-     * and a count of all records with no start coordinate
-     *
-     * @deprecated since this uses a {@link File}; use {@link #printIndexStats(Path)} instead.
-     */
-    @Deprecated
-    public static void printIndexStats(final File inputBamFile) {
-        printIndexStats(inputBamFile == null ? null : inputBamFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/BAMIndexer.java
+++ b/src/main/java/htsjdk/samtools/BAMIndexer.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.Log;
-import java.io.File;
 import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.function.Function;
@@ -60,16 +59,6 @@ public class BAMIndexer {
      */
     public BAMIndexer(final Path output, final SAMFileHeader fileHeader) {
         this(fileHeader, numRefs -> new BinaryBAMIndexWriter(numRefs, output), true);
-    }
-
-    /**
-     * @param output     binary BAM Index (.bai) file
-     * @param fileHeader header for the corresponding bam file
-     * @deprecated since 06/2026 use {@link #BAMIndexer(Path, SAMFileHeader)} instead.
-     */
-    @Deprecated
-    public BAMIndexer(final File output, final SAMFileHeader fileHeader) {
-        this(output.toPath(), fileHeader);
     }
 
     /**
@@ -179,8 +168,7 @@ public class BAMIndexer {
         final int n_ref = existingIndex.getNumberOfReferences();
         final BAMIndexWriter outputWriter;
         if (textOutput) {
-            // TextualBAMIndexWriter is local, test-only output; it currently only accepts a File.
-            outputWriter = new TextualBAMIndexWriter(n_ref, output.toFile());
+            outputWriter = new TextualBAMIndexWriter(n_ref, output);
         } else {
             outputWriter = new BinaryBAMIndexWriter(n_ref, output);
         }
@@ -196,20 +184,6 @@ public class BAMIndexer {
         } catch (final Exception e) {
             throw new SAMException("Exception creating BAM index", e);
         }
-    }
-
-    /**
-     * Generates a BAM index file, either textual or binary, from an input BAI file.
-     * Only used for testing, but located here for visibility into CachingBAMFileIndex.
-     *
-     * @param input      Input BAM Index (.bai) file
-     * @param output     Output BAM Index (.bai) file (or bai.txt file when text)
-     * @param textOutput Whether to create text output or binary
-     * @deprecated since 06/2026 use {@link #createAndWriteIndex(Path, Path, boolean)} instead.
-     */
-    @Deprecated
-    public static void createAndWriteIndex(final File input, final File output, final boolean textOutput) {
-        createAndWriteIndex(input.toPath(), output.toPath(), textOutput);
     }
 
     /**
@@ -344,18 +318,6 @@ public class BAMIndexer {
      * Generates a BAM index file from an input BAM file
      *
      * @param reader SamReader for input BAM file
-     * @param output File for output index file
-     * @deprecated since 06/2026 use {@link #createIndex(SamReader, Path)} instead.
-     */
-    @Deprecated
-    public static void createIndex(SamReader reader, File output) {
-        createIndex(reader, output.toPath(), null);
-    }
-
-    /**
-     * Generates a BAM index file from an input BAM file
-     *
-     * @param reader SamReader for input BAM file
      * @param output Path for output index file
      * @param log    Optional logger for progress messages
      */
@@ -373,18 +335,5 @@ public class BAMIndexer {
             indexer.processAlignment(rec);
         }
         indexer.finish();
-    }
-
-    /**
-     * Generates a BAM index file from an input BAM file
-     *
-     * @param reader SamReader for input BAM file
-     * @param output File for output index file
-     * @param log    Optional logger for progress messages
-     * @deprecated since 06/2026 use {@link #createIndex(SamReader, Path, Log)} instead.
-     */
-    @Deprecated
-    public static void createIndex(SamReader reader, File output, Log log) {
-        createIndex(reader, output.toPath(), log);
     }
 }

--- a/src/main/java/htsjdk/samtools/BAMIndexer.java
+++ b/src/main/java/htsjdk/samtools/BAMIndexer.java
@@ -53,7 +53,9 @@ public class BAMIndexer {
     private static final Log log = Log.getInstance(BAMIndexer.class);
 
     /**
-     * @param output     binary BAM Index (.bai) file
+     * Prepare to index a BAM.
+     *
+     * @param output     binary BAM Index (.bai) file path
      * @param fileHeader header for the corresponding bam file
      */
     public BAMIndexer(final Path output, final SAMFileHeader fileHeader) {
@@ -63,7 +65,9 @@ public class BAMIndexer {
     /**
      * @param output     binary BAM Index (.bai) file
      * @param fileHeader header for the corresponding bam file
+     * @deprecated since 06/2026 use {@link #BAMIndexer(Path, SAMFileHeader)} instead.
      */
+    @Deprecated
     public BAMIndexer(final File output, final SAMFileHeader fileHeader) {
         this(output.toPath(), fileHeader);
     }
@@ -163,10 +167,11 @@ public class BAMIndexer {
      * Generates a BAM index file, either textual or binary, from an input BAI file.
      * Only used for testing, but located here for visibility into CachingBAMFileIndex.
      *
-     * @param output     BAM Index (.bai) file (or bai.txt file when text)
+     * @param input      Input BAM Index (.bai) file path
+     * @param output     Output BAM Index (.bai) file path (or bai.txt file when text)
      * @param textOutput Whether to create text output or binary
      */
-    public static void createAndWriteIndex(final File input, final File output, final boolean textOutput) {
+    public static void createAndWriteIndex(final Path input, final Path output, final boolean textOutput) {
 
         // content is from an existing bai file.
 
@@ -174,7 +179,8 @@ public class BAMIndexer {
         final int n_ref = existingIndex.getNumberOfReferences();
         final BAMIndexWriter outputWriter;
         if (textOutput) {
-            outputWriter = new TextualBAMIndexWriter(n_ref, output);
+            // TextualBAMIndexWriter is local, test-only output; it currently only accepts a File.
+            outputWriter = new TextualBAMIndexWriter(n_ref, output.toFile());
         } else {
             outputWriter = new BinaryBAMIndexWriter(n_ref, output);
         }
@@ -190,6 +196,20 @@ public class BAMIndexer {
         } catch (final Exception e) {
             throw new SAMException("Exception creating BAM index", e);
         }
+    }
+
+    /**
+     * Generates a BAM index file, either textual or binary, from an input BAI file.
+     * Only used for testing, but located here for visibility into CachingBAMFileIndex.
+     *
+     * @param input      Input BAM Index (.bai) file
+     * @param output     Output BAM Index (.bai) file (or bai.txt file when text)
+     * @param textOutput Whether to create text output or binary
+     * @deprecated since 06/2026 use {@link #createAndWriteIndex(Path, Path, boolean)} instead.
+     */
+    @Deprecated
+    public static void createAndWriteIndex(final File input, final File output, final boolean textOutput) {
+        createAndWriteIndex(input.toPath(), output.toPath(), textOutput);
     }
 
     /**
@@ -325,7 +345,9 @@ public class BAMIndexer {
      *
      * @param reader SamReader for input BAM file
      * @param output File for output index file
+     * @deprecated since 06/2026 use {@link #createIndex(SamReader, Path)} instead.
      */
+    @Deprecated
     public static void createIndex(SamReader reader, File output) {
         createIndex(reader, output.toPath(), null);
     }
@@ -335,6 +357,7 @@ public class BAMIndexer {
      *
      * @param reader SamReader for input BAM file
      * @param output Path for output index file
+     * @param log    Optional logger for progress messages
      */
     public static void createIndex(SamReader reader, Path output, Log log) {
 
@@ -357,7 +380,10 @@ public class BAMIndexer {
      *
      * @param reader SamReader for input BAM file
      * @param output File for output index file
+     * @param log    Optional logger for progress messages
+     * @deprecated since 06/2026 use {@link #createIndex(SamReader, Path, Log)} instead.
      */
+    @Deprecated
     public static void createIndex(SamReader reader, File output, Log log) {
         createIndex(reader, output.toPath(), log);
     }

--- a/src/main/java/htsjdk/samtools/BamConverter.java
+++ b/src/main/java/htsjdk/samtools/BamConverter.java
@@ -1,6 +1,9 @@
 package htsjdk.samtools;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Simple command-line tool for reading and optionally converting BAM files, primarily
@@ -50,6 +53,8 @@ public class BamConverter {
         }
         final String inputPath = positional[0];
         final String outputPath = positional.length > 1 ? positional[1] : null;
+        final Path input = Paths.get(inputPath);
+        final Path output = outputPath != null ? Paths.get(outputPath) : null;
 
         if (outputPath != null) {
             System.err.printf("Converting %s -> %s%s%n", inputPath, outputPath, eager ? " (eager decode)" : "");
@@ -63,13 +68,12 @@ public class BamConverter {
         long count = 0;
         final long startTime = System.currentTimeMillis();
 
-        try (final SamReader reader = readerFactory.open(new File(inputPath))) {
+        try (final SamReader reader = readerFactory.open(input)) {
             final SAMFileHeader header = reader.getFileHeader();
 
-            if (outputPath != null) {
+            if (output != null) {
                 final SAMFileWriterFactory writerFactory = new SAMFileWriterFactory();
-                try (final SAMFileWriter writer =
-                        writerFactory.makeBAMWriter(header, true, new File(outputPath).toPath())) {
+                try (final SAMFileWriter writer = writerFactory.makeBAMWriter(header, true, output)) {
                     for (final SAMRecord record : reader) {
                         if (eager) record.eagerDecode();
                         writer.addAlignment(record);
@@ -93,10 +97,10 @@ public class BamConverter {
         }
 
         final long elapsed = System.currentTimeMillis() - startTime;
-        final long inputSize = new File(inputPath).length();
+        final long inputSize = fileSize(input);
 
-        if (outputPath != null) {
-            final long outputSize = new File(outputPath).length();
+        if (output != null) {
+            final long outputSize = fileSize(output);
             System.err.printf(
                     "Done. %,d records in %.1fs. Input: %,d bytes, Output: %,d bytes (%.1f%%)%n",
                     count,
@@ -114,6 +118,21 @@ public class BamConverter {
             if (flag.equals(arg)) return true;
         }
         return false;
+    }
+
+    /**
+     * Returns the size of the file at the given path in bytes, or 0 if it cannot be determined.
+     * Mirrors the lenient behavior of the previous {@code java.io.File#length()} usage.
+     *
+     * @param path the file to size
+     * @return the size in bytes, or 0 if the file is missing or cannot be read
+     */
+    private static long fileSize(final Path path) {
+        try {
+            return Files.size(path);
+        } catch (final IOException e) {
+            return 0;
+        }
     }
 
     private static void die(final String message) {

--- a/src/main/java/htsjdk/samtools/BamFileIoUtils.java
+++ b/src/main/java/htsjdk/samtools/BamFileIoUtils.java
@@ -13,14 +13,12 @@ import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.Md5CalculatingOutputStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.utils.ValidationUtils;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class BamFileIoUtils {
     private static final Log LOG = Log.getInstance(BamFileIoUtils.class);
@@ -30,14 +28,6 @@ public class BamFileIoUtils {
      */
     @Deprecated
     public static final String BAM_FILE_EXTENSION = FileExtensions.BAM;
-
-    /**
-     * @deprecated since June 2024 Use {@link #isBamFile(Path)} instead.
-     */
-    @Deprecated
-    public static boolean isBamFile(final File file) {
-        return (file != null) && isBamFile(file.toPath());
-    }
 
     /**
      * Checks whether the given path points to a file with a valid BAM extension.
@@ -53,22 +43,6 @@ public class BamFileIoUtils {
 
     public static void reheaderBamFile(final SAMFileHeader samFileHeader, final Path inputFile, final Path outputFile) {
         reheaderBamFile(samFileHeader, inputFile, outputFile, true, true);
-    }
-
-    /**
-     * Support File input types for backward compatibility. Use {@link #reheaderBamFile(SAMFileHeader, Path, Path,
-     * boolean, boolean)} with Path inputs instead.
-     *
-     * @deprecated since June 2024 Use the {@link Path}-based overload instead.
-     */
-    @Deprecated
-    public static void reheaderBamFile(
-            final SAMFileHeader samFileHeader,
-            final File inputFile,
-            final File outputFile,
-            final boolean createMd5,
-            final boolean createIndex) {
-        reheaderBamFile(samFileHeader, IOUtil.toPath(inputFile), IOUtil.toPath(outputFile), createMd5, createIndex);
     }
 
     /**
@@ -105,18 +79,6 @@ public class BamFileIoUtils {
         } catch (final IOException ioe) {
             throw new RuntimeIOException(ioe);
         }
-    }
-
-    /**
-     * @deprecated since June 2024 Use {@link #blockCopyBamFile(Path, OutputStream, boolean, boolean)} instead.
-     */
-    @Deprecated
-    public static void blockCopyBamFile(
-            final File inputFile,
-            final OutputStream outputStream,
-            final boolean skipHeader,
-            final boolean skipTerminator) {
-        blockCopyBamFile(IOUtil.toPath(inputFile), outputStream, skipHeader, skipTerminator);
     }
 
     /**
@@ -180,22 +142,6 @@ public class BamFileIoUtils {
         } catch (final IOException ioe) {
             throw new RuntimeIOException(ioe);
         }
-    }
-
-    /**
-     * Support File input types for backward compatibility. Use {@link #gatherWithBlockCopying(List, Path, boolean,
-     * boolean)} with Path inputs instead.
-     *
-     * @deprecated since June 2024 Use the {@link Path}-based overload instead.
-     */
-    @Deprecated
-    public static void gatherWithBlockCopying(
-            final List<File> bams, final File output, final boolean createIndex, final boolean createMd5) {
-        gatherWithBlockCopying(
-                bams.stream().map(File::toPath).collect(Collectors.toList()),
-                IOUtil.toPath(output),
-                createIndex,
-                createMd5);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/BamFileIoUtils.java
+++ b/src/main/java/htsjdk/samtools/BamFileIoUtils.java
@@ -14,12 +14,13 @@ import htsjdk.samtools.util.Md5CalculatingOutputStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.utils.ValidationUtils;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class BamFileIoUtils {
     private static final Log LOG = Log.getInstance(BamFileIoUtils.class);
@@ -30,8 +31,24 @@ public class BamFileIoUtils {
     @Deprecated
     public static final String BAM_FILE_EXTENSION = FileExtensions.BAM;
 
+    /**
+     * @deprecated since June 2024 Use {@link #isBamFile(Path)} instead.
+     */
+    @Deprecated
     public static boolean isBamFile(final File file) {
-        return ((file != null) && SamReader.Type.BAM_TYPE.hasValidFileExtension(file.getName()));
+        return (file != null) && isBamFile(file.toPath());
+    }
+
+    /**
+     * Checks whether the given path points to a file with a valid BAM extension.
+     *
+     * @param path the path to check; may be {@code null}
+     * @return true if the path is non-null and has a valid BAM file extension
+     */
+    public static boolean isBamFile(final Path path) {
+        return (path != null)
+                && SamReader.Type.BAM_TYPE.hasValidFileExtension(
+                        path.getFileName().toString());
     }
 
     public static void reheaderBamFile(final SAMFileHeader samFileHeader, final Path inputFile, final Path outputFile) {
@@ -39,8 +56,12 @@ public class BamFileIoUtils {
     }
 
     /**
-     * Support File input types for backward compatibility. Use the same method with Path inputs below.
+     * Support File input types for backward compatibility. Use {@link #reheaderBamFile(SAMFileHeader, Path, Path,
+     * boolean, boolean)} with Path inputs instead.
+     *
+     * @deprecated since June 2024 Use the {@link Path}-based overload instead.
      */
+    @Deprecated
     public static void reheaderBamFile(
             final SAMFileHeader samFileHeader,
             final File inputFile,
@@ -86,6 +107,10 @@ public class BamFileIoUtils {
         }
     }
 
+    /**
+     * @deprecated since June 2024 Use {@link #blockCopyBamFile(Path, OutputStream, boolean, boolean)} instead.
+     */
+    @Deprecated
     public static void blockCopyBamFile(
             final File inputFile,
             final OutputStream outputStream,
@@ -158,27 +183,50 @@ public class BamFileIoUtils {
     }
 
     /**
-     * Assumes that all inputs and outputs are block compressed VCF files and copies them without decompressing and parsing
-     * most of the gzip blocks. Will decompress and parse blocks up to the one containing the end of the header in each file
-     * (often the first block) and re-compress any data remaining in that block into a new block in the output file. Subsequent
-     * blocks (excluding a terminator block if present) are copied directly from input to output.
+     * Support File input types for backward compatibility. Use {@link #gatherWithBlockCopying(List, Path, boolean,
+     * boolean)} with Path inputs instead.
+     *
+     * @deprecated since June 2024 Use the {@link Path}-based overload instead.
      */
+    @Deprecated
     public static void gatherWithBlockCopying(
             final List<File> bams, final File output, final boolean createIndex, final boolean createMd5) {
+        gatherWithBlockCopying(
+                bams.stream().map(File::toPath).collect(Collectors.toList()),
+                IOUtil.toPath(output),
+                createIndex,
+                createMd5);
+    }
+
+    /**
+     * Assumes that all inputs and outputs are block compressed BAM files and copies them without decompressing and
+     * parsing most of the gzip blocks. Will decompress and parse blocks up to the one containing the end of the header
+     * in each file (often the first block) and re-compress any data remaining in that block into a new block in the
+     * output file. Subsequent blocks (excluding a terminator block if present) are copied directly from input to output.
+     *
+     * @param bams        the BAM files to gather, in order
+     * @param output      the output BAM file to create
+     * @param createIndex whether to create an index file for the output
+     * @param createMd5   whether to create an MD5 file for the output
+     */
+    public static void gatherWithBlockCopying(
+            final List<Path> bams, final Path output, final boolean createIndex, final boolean createMd5) {
         try {
-            OutputStream out = new FileOutputStream(output);
-            if (createMd5) out = new Md5CalculatingOutputStream(out, new File(output.getAbsolutePath() + ".md5"));
-            File indexFile = null;
+            OutputStream out = Files.newOutputStream(output);
+            if (createMd5) {
+                out = new Md5CalculatingOutputStream(out, IOUtil.addExtension(output, FileExtensions.MD5));
+            }
+            Path indexFile = null;
             if (createIndex) {
-                indexFile = new File(output.getParentFile(), IOUtil.basename(output) + FileExtensions.BAI_INDEX);
+                indexFile = output.resolveSibling(IOUtil.basename(output) + FileExtensions.BAI_INDEX);
                 out = new StreamInflatingIndexingOutputStream(out, indexFile);
             }
 
             boolean isFirstFile = true;
 
-            for (final File f : bams) {
-                LOG.info(String.format("Block copying %s ...", f.getAbsolutePath()));
-                blockCopyBamFile(IOUtil.toPath(f), out, !isFirstFile, true);
+            for (final Path f : bams) {
+                LOG.info(String.format("Block copying %s ...", f.toUri()));
+                blockCopyBamFile(f, out, !isFirstFile, true);
                 isFirstFile = false;
             }
 
@@ -189,22 +237,23 @@ public class BamFileIoUtils {
             // It is possible that the modified time on the index file is ever so slightly older than the original BAM
             // file
             // and this makes ValidateSamFile unhappy.
-            if (createIndex && (output.lastModified() > indexFile.lastModified())) {
-                final boolean success = indexFile.setLastModified(System.currentTimeMillis());
-                if (!success) {
+            if (createIndex && indexFile != null) {
+                try {
+                    final long outputModified =
+                            Files.getLastModifiedTime(output).toMillis();
+                    final long indexModified =
+                            Files.getLastModifiedTime(indexFile).toMillis();
+                    if (outputModified > indexModified) {
+                        Files.setLastModifiedTime(indexFile, FileTime.fromMillis(System.currentTimeMillis()));
+                    }
+                } catch (final IOException e) {
                     System.err.print(String.format(
-                            "Index file is older than BAM file for %s and unable to resolve this",
-                            output.getAbsolutePath()));
+                            "Index file is older than BAM file for %s and unable to resolve this", output.toUri()));
                 }
             }
         } catch (final IOException ioe) {
             throw new RuntimeIOException(ioe);
         }
-    }
-
-    private static OutputStream buildOutputStream(
-            final File outputFile, final boolean createMd5, final boolean createIndex) throws IOException {
-        return buildOutputStream(IOUtil.toPath(outputFile), createMd5, createIndex);
     }
 
     private static OutputStream buildOutputStream(
@@ -219,12 +268,6 @@ public class BamFileIoUtils {
                     outputStream, outputFile.resolveSibling(outputFile.getFileName() + FileExtensions.BAI_INDEX));
         }
         return outputStream;
-    }
-
-    @Deprecated
-    private static void assertSortOrdersAreEqual(final SAMFileHeader newHeader, final File inputFile)
-            throws IOException {
-        assertSortOrdersAreEqual(newHeader, IOUtil.toPath(inputFile));
     }
 
     private static void assertSortOrdersAreEqual(final SAMFileHeader newHeader, final Path inputFile)

--- a/src/main/java/htsjdk/samtools/BinaryBAMIndexWriter.java
+++ b/src/main/java/htsjdk/samtools/BinaryBAMIndexWriter.java
@@ -42,18 +42,22 @@ class BinaryBAMIndexWriter implements BAMIndexWriter {
     private int count = 0;
 
     /**
+     * Constructs a binary BAM index writer.
      *
      * @param nRef    Number of reference sequences
      * @param output  BAM Index output file
+     * @deprecated since 5.0, use {@link #BinaryBAMIndexWriter(int, Path)} instead.
      */
+    @Deprecated
     public BinaryBAMIndexWriter(final int nRef, final File output) {
         this(nRef, IOUtil.toPath(output));
     }
 
     /**
+     * Constructs a binary BAM index writer.
      *
      * @param nRef    Number of reference sequences
-     * @param output  BAM Index output file
+     * @param output  BAM Index output file path
      */
     public BinaryBAMIndexWriter(final int nRef, final Path output) {
 
@@ -68,6 +72,7 @@ class BinaryBAMIndexWriter implements BAMIndexWriter {
     }
 
     /**
+     * Constructs a binary BAM index writer.
      *
      * @param nRef Number of reference sequences.
      * @param output BAM index output stream.  This stream will be closed when BinaryBAMIndexWriter.close() is called.

--- a/src/main/java/htsjdk/samtools/BinaryBAMIndexWriter.java
+++ b/src/main/java/htsjdk/samtools/BinaryBAMIndexWriter.java
@@ -25,8 +25,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.BinaryCodec;
-import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Path;
@@ -40,18 +38,6 @@ class BinaryBAMIndexWriter implements BAMIndexWriter {
     protected final int nRef;
     private final BinaryCodec codec;
     private int count = 0;
-
-    /**
-     * Constructs a binary BAM index writer.
-     *
-     * @param nRef    Number of reference sequences
-     * @param output  BAM Index output file
-     * @deprecated since 5.0, use {@link #BinaryBAMIndexWriter(int, Path)} instead.
-     */
-    @Deprecated
-    public BinaryBAMIndexWriter(final int nRef, final File output) {
-        this(nRef, IOUtil.toPath(output));
-    }
 
     /**
      * Constructs a binary BAM index writer.

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -46,11 +46,9 @@ import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.*;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -184,24 +182,6 @@ public class CRAMBAIIndexer implements CRAMIndexer {
             currentReference++;
             indexBuilder.startNewReference();
         }
-    }
-
-    /**
-     * Generates a BAI index file from an input CRAM stream
-     *
-     * @param stream CRAM stream to index
-     * @param output File for output index file
-     * @param log    optional {@link htsjdk.samtools.util.Log} to output progress
-     * @param validationStringency validation stringency for processing
-     * @deprecated since 5.0, use {@link #createIndex(SeekableStream, Path, Log, ValidationStringency)} instead.
-     */
-    @Deprecated
-    public static void createIndex(
-            final SeekableStream stream,
-            final File output,
-            final Log log,
-            final ValidationStringency validationStringency) {
-        createIndex(stream, IOUtil.toPath(output), log, validationStringency);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
+++ b/src/main/java/htsjdk/samtools/CRAMBAIIndexer.java
@@ -46,6 +46,7 @@ import htsjdk.samtools.cram.ref.ReferenceContext;
 import htsjdk.samtools.cram.structure.*;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.RuntimeIOException;
@@ -53,6 +54,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -72,7 +74,7 @@ import java.util.*;
  * is called on each {@link CRAIEntry} and {@link CRAMBAIIndexer#finish()} is called at the end.
  *
  * NOTE: a third pattern of building a BAI from a CRAM file is also supported by this class,
- * but it is unused.  This would be accomplished via {@link #createIndex(SeekableStream, File, Log, ValidationStringency)}.
+ * but it is unused.  This would be accomplished via {@link #createIndex(SeekableStream, Path, Log, ValidationStringency)}.
  */
 public class CRAMBAIIndexer implements CRAMIndexer {
 
@@ -91,10 +93,10 @@ public class CRAMBAIIndexer implements CRAMIndexer {
     /**
      * Create a CRAM indexer that writes BAI to a file.
      *
-     * @param output     binary BAM Index (.bai) file
+     * @param output     binary BAM Index (.bai) file path
      * @param fileHeader header for the corresponding bam file
      */
-    private CRAMBAIIndexer(final File output, final SAMFileHeader fileHeader) {
+    private CRAMBAIIndexer(final Path output, final SAMFileHeader fileHeader) {
         if (fileHeader.getSortOrder() != SAMFileHeader.SortOrder.coordinate) {
             throw new SAMException("CRAM file must be coordinate-sorted for indexing.");
         }
@@ -190,10 +192,29 @@ public class CRAMBAIIndexer implements CRAMIndexer {
      * @param stream CRAM stream to index
      * @param output File for output index file
      * @param log    optional {@link htsjdk.samtools.util.Log} to output progress
+     * @param validationStringency validation stringency for processing
+     * @deprecated since 5.0, use {@link #createIndex(SeekableStream, Path, Log, ValidationStringency)} instead.
      */
+    @Deprecated
     public static void createIndex(
             final SeekableStream stream,
             final File output,
+            final Log log,
+            final ValidationStringency validationStringency) {
+        createIndex(stream, IOUtil.toPath(output), log, validationStringency);
+    }
+
+    /**
+     * Generates a BAI index file from an input CRAM stream
+     *
+     * @param stream CRAM stream to index
+     * @param output Path for output index file
+     * @param log    optional {@link htsjdk.samtools.util.Log} to output progress
+     * @param validationStringency validation stringency for processing
+     */
+    public static void createIndex(
+            final SeekableStream stream,
+            final Path output,
             final Log log,
             final ValidationStringency validationStringency) {
 

--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -162,7 +162,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
     @Deprecated
     public CRAMFileReader(final File cramFile, final File indexFile, final CRAMReferenceSource referenceSource) {
         this(
-                cramFile == null ? null : cramFile.toPath(),
+                ValidationUtils.nonNull(cramFile, "cramFile").toPath(),
                 indexFile == null ? null : indexFile.toPath(),
                 referenceSource);
     }
@@ -196,7 +196,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
      */
     @Deprecated
     public CRAMFileReader(final File cramFile, final CRAMReferenceSource referenceSource) {
-        this(cramFile == null ? null : cramFile.toPath(), referenceSource);
+        this(ValidationUtils.nonNull(cramFile, "cramFile").toPath(), referenceSource);
     }
 
     /**
@@ -318,7 +318,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
             final ValidationStringency validationStringency)
             throws IOException {
         this(
-                cramFile == null ? null : cramFile.toPath(),
+                ValidationUtils.nonNull(cramFile, "cramFile").toPath(),
                 indexFile == null ? null : indexFile.toPath(),
                 referenceSource,
                 validationStringency);

--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -100,7 +100,9 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
                 cramPath != null || inputStream != null, "Either path or input stream is required.");
 
         this.cramPath = cramPath;
-        this.inputStream = new BufferedInputStream(inputStream);
+        // inputStream may legitimately be null when a path is supplied (reads then go through the path);
+        // only wrap a non-null stream to avoid a NullPointerException from BufferedInputStream.
+        this.inputStream = inputStream == null ? null : new BufferedInputStream(inputStream);
         this.referenceSource = referenceSource;
         if (cramPath != null) {
             mIndexPath = findIndexForPath(null, cramPath);

--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -392,13 +392,9 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
             final SAMSequenceDictionary dictionary = getFileHeader().getSequenceDictionary();
             final String indexFileName = mIndexPath.getFileName().toString();
             if (indexFileName.endsWith(FileExtensions.BAI_INDEX)) {
-                // The BAI index readers are backed by memory-mapped or random-access local files, so
-                // the index path must be resolvable to a java.io.File. Migrating these index readers to
-                // Path is tracked separately (see issue #1783, index reader phase).
-                final File indexFile = mIndexPath.toFile();
                 mIndex = mEnableIndexCaching
-                        ? new CachingBAMFileIndex(indexFile, dictionary, mEnableIndexMemoryMapping)
-                        : new DiskBasedBAMFileIndex(indexFile, dictionary, mEnableIndexMemoryMapping);
+                        ? new CachingBAMFileIndex(mIndexPath, dictionary, mEnableIndexMemoryMapping)
+                        : new DiskBasedBAMFileIndex(mIndexPath, dictionary, mEnableIndexMemoryMapping);
                 return mIndex;
             }
 

--- a/src/main/java/htsjdk/samtools/CRAMFileReader.java
+++ b/src/main/java/htsjdk/samtools/CRAMFileReader.java
@@ -19,11 +19,13 @@ import htsjdk.samtools.SAMFileHeader.SortOrder;
 import htsjdk.samtools.SamReader.Type;
 import htsjdk.samtools.cram.ref.CRAMReferenceSource;
 import htsjdk.samtools.cram.ref.ReferenceSource;
-import htsjdk.samtools.seekablestream.SeekableFileStream;
+import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.*;
 import htsjdk.utils.ValidationUtils;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
@@ -35,19 +37,34 @@ import java.util.NoSuchElementException;
  * @author vadim
  */
 public class CRAMFileReader extends SamReader.ReaderImplementation implements SamReader.Indexing, AutoCloseable {
-    private File cramFile;
+    private Path cramPath;
     private final CRAMReferenceSource referenceSource;
     private InputStream inputStream;
     private DeferredCloseSeekableStream deferredCloseSeekableStream;
     private CRAMIterator iterator;
     private BAMIndex mIndex;
-    private File mIndexFile;
+    private Path mIndexPath;
     private boolean mEnableIndexCaching;
     private boolean mEnableIndexMemoryMapping;
 
     private ValidationStringency validationStringency;
 
     private static final Log log = Log.getInstance(CRAMFileReader.class);
+
+    /**
+     * Create a CRAMFileReader from either a path or input stream using the reference source returned by
+     * {@link ReferenceSource#getDefaultCRAMReferenceSource() getDefaultCRAMReferenceSource}.
+     *
+     * @param cramPath CRAM file path to open
+     * @param inputStream CRAM stream to read
+     *
+     * @throws IllegalArgumentException if the {@code cramPath} and the {@code inputStream} are both null
+     * @throws IllegalStateException if a {@link ReferenceSource#getDefaultCRAMReferenceSource() default}
+     * reference source cannot be acquired
+     */
+    public CRAMFileReader(final Path cramPath, final InputStream inputStream) {
+        this(cramPath, inputStream, ReferenceSource.getDefaultCRAMReferenceSource());
+    }
 
     /**
      * Create a CRAMFileReader from either a file or input stream using the reference source returned by
@@ -59,9 +76,36 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
      * @throws IllegalArgumentException if the {@code cramFile} and the {@code inputStream} are both null
      * @throws IllegalStateException if a {@link ReferenceSource#getDefaultCRAMReferenceSource() default}
      * reference source cannot be acquired
+     * @deprecated use {@link #CRAMFileReader(Path, InputStream)} instead.
      */
+    @Deprecated
     public CRAMFileReader(final File cramFile, final InputStream inputStream) {
-        this(cramFile, inputStream, ReferenceSource.getDefaultCRAMReferenceSource());
+        this(cramFile == null ? null : cramFile.toPath(), inputStream);
+    }
+
+    /**
+     * Create a CRAMFileReader from either a path or input stream using the supplied reference source.
+     *
+     * @param cramPath        CRAM file path to read
+     * @param inputStream     CRAM stream to read
+     * @param referenceSource a {@link htsjdk.samtools.cram.ref.ReferenceSource source} of
+     *                        reference sequences. May not be null.
+     *
+     * @throws IllegalArgumentException if the {@code cramPath} and the {@code inputStream} are both null
+     * or if the {@code CRAMReferenceSource} is null
+     */
+    public CRAMFileReader(
+            final Path cramPath, final InputStream inputStream, final CRAMReferenceSource referenceSource) {
+        ValidationUtils.validateArg(
+                cramPath != null || inputStream != null, "Either path or input stream is required.");
+
+        this.cramPath = cramPath;
+        this.inputStream = new BufferedInputStream(inputStream);
+        this.referenceSource = referenceSource;
+        if (cramPath != null) {
+            mIndexPath = findIndexForPath(null, cramPath);
+        }
+        getIterator();
     }
 
     /**
@@ -74,18 +118,31 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
      *
      * @throws IllegalArgumentException if the {@code cramFile} and the {@code inputStream} are both null
      * or if the {@code CRAMReferenceSource} is null
+     * @deprecated use {@link #CRAMFileReader(Path, InputStream, CRAMReferenceSource)} instead.
      */
+    @Deprecated
     public CRAMFileReader(
             final File cramFile, final InputStream inputStream, final CRAMReferenceSource referenceSource) {
-        ValidationUtils.validateArg(
-                cramFile != null || inputStream != null, "Either file or input stream is required.");
+        this(cramFile == null ? null : cramFile.toPath(), inputStream, referenceSource);
+    }
 
-        this.cramFile = cramFile;
-        this.inputStream = new BufferedInputStream(inputStream);
+    /**
+     * Create a CRAMFileReader from a path and optional index path using the supplied reference source. If index path
+     * is supplied then random access will be available.
+     *
+     * @param cramPath        CRAM file path to read. May not be null.
+     * @param indexPath       index file path to be used for random access. May be null.
+     * @param referenceSource a {@link htsjdk.samtools.cram.ref.CRAMReferenceSource source} of
+     *                        reference sequences. May not be null.
+     * @throws IllegalArgumentException if the {@code cramPath} or the {@code CRAMReferenceSource} is null
+     */
+    public CRAMFileReader(final Path cramPath, final Path indexPath, final CRAMReferenceSource referenceSource) {
+        ValidationUtils.nonNull(cramPath, "Path is required.");
+
+        this.cramPath = cramPath;
+        mIndexPath = findIndexForPath(indexPath, cramPath);
         this.referenceSource = referenceSource;
-        if (cramFile != null) {
-            mIndexFile = findIndexForFile(null, cramFile);
-        }
+
         getIterator();
     }
 
@@ -98,13 +155,30 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
      * @param referenceSource a {@link htsjdk.samtools.cram.ref.CRAMReferenceSource source} of
      *                        reference sequences. May not be null.
      * @throws IllegalArgumentException if the {@code cramFile} or the {@code CRAMReferenceSource} is null
+     * @deprecated use {@link #CRAMFileReader(Path, Path, CRAMReferenceSource)} instead.
      */
+    @Deprecated
     public CRAMFileReader(final File cramFile, final File indexFile, final CRAMReferenceSource referenceSource) {
-        ValidationUtils.nonNull(cramFile, "File is required.");
+        this(
+                cramFile == null ? null : cramFile.toPath(),
+                indexFile == null ? null : indexFile.toPath(),
+                referenceSource);
+    }
 
-        this.cramFile = cramFile;
-        mIndexFile = findIndexForFile(indexFile, cramFile);
+    /**
+     * Create a CRAMFileReader from a path using the supplied reference source.
+     *
+     * @param cramPath        CRAM file path to read. Can not be null.
+     * @param referenceSource a {@link htsjdk.samtools.cram.ref.CRAMReferenceSource source} of
+     *                        reference sequences. May not be null.
+     * @throws IllegalArgumentException if the {@code cramPath} or the {@code CRAMReferenceSource} is null
+     */
+    public CRAMFileReader(final Path cramPath, final CRAMReferenceSource referenceSource) {
+        ValidationUtils.nonNull(cramPath, "Path is required.");
+
+        this.cramPath = cramPath;
         this.referenceSource = referenceSource;
+        mIndexPath = findIndexForPath(null, cramPath);
 
         getIterator();
     }
@@ -116,15 +190,11 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
      * @param referenceSource a {@link htsjdk.samtools.cram.ref.CRAMReferenceSource source} of
      *                        reference sequences. May not be null.
      * @throws IllegalArgumentException if the {@code cramFile} or the {@code CRAMReferenceSource} is null
+     * @deprecated use {@link #CRAMFileReader(Path, CRAMReferenceSource)} instead.
      */
+    @Deprecated
     public CRAMFileReader(final File cramFile, final CRAMReferenceSource referenceSource) {
-        ValidationUtils.nonNull(cramFile, "File is required.");
-
-        this.cramFile = cramFile;
-        this.referenceSource = referenceSource;
-        mIndexFile = findIndexForFile(null, cramFile);
-
-        getIterator();
+        this(cramFile == null ? null : cramFile.toPath(), referenceSource);
     }
 
     /**
@@ -151,6 +221,31 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
     }
 
     /**
+     * Create a CRAMFileReader from an input stream and optional index path using the supplied reference
+     * source and validation stringency.
+     *
+     * @param stream            CRAM stream to read. May not be null.
+     * @param indexPath         index file path to be used for random access. May be null.
+     * @param referenceSource a {@link htsjdk.samtools.cram.ref.CRAMReferenceSource source} of
+     *                        reference sequences. May not be null.
+     * @param validationStringency Validation stringency to be used when reading
+     *
+     * @throws IllegalArgumentException if the {@code inputStream} or the {@code CRAMReferenceSource} is null
+     */
+    public CRAMFileReader(
+            final InputStream stream,
+            final Path indexPath,
+            final CRAMReferenceSource referenceSource,
+            final ValidationStringency validationStringency)
+            throws IOException {
+        this(
+                stream,
+                indexPath == null ? null : new SeekablePathStream(indexPath),
+                referenceSource,
+                validationStringency);
+    }
+
+    /**
      * Create a CRAMFileReader from an input stream and optional index file using the supplied reference
      * source and validation stringency.
      *
@@ -161,18 +256,43 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
      * @param validationStringency Validation stringency to be used when reading
      *
      * @throws IllegalArgumentException if the {@code inputStream} or the {@code CRAMReferenceSource} is null
+     * @deprecated use {@link #CRAMFileReader(InputStream, Path, CRAMReferenceSource, ValidationStringency)} instead.
      */
+    @Deprecated
     public CRAMFileReader(
             final InputStream stream,
             final File indexFile,
             final CRAMReferenceSource referenceSource,
             final ValidationStringency validationStringency)
             throws IOException {
-        this(
-                stream,
-                indexFile == null ? null : new SeekableFileStream(indexFile),
-                referenceSource,
-                validationStringency);
+        this(stream, indexFile == null ? null : indexFile.toPath(), referenceSource, validationStringency);
+    }
+
+    /**
+     * Create a CRAMFileReader from a CRAM path and optional index path using the supplied reference
+     * source and validation stringency.
+     *
+     * @param cramPath        CRAM path to read. May not be null.
+     * @param indexPath       index file path to be used for random access. May be null.
+     * @param referenceSource a {@link htsjdk.samtools.cram.ref.CRAMReferenceSource source} of
+     *                        reference sequences. May not be null.
+     * @param validationStringency Validation stringency to be used when reading
+     *
+     * @throws IllegalArgumentException if the {@code cramPath} or the {@code CRAMReferenceSource} is null
+     */
+    public CRAMFileReader(
+            final Path cramPath,
+            final Path indexPath,
+            final CRAMReferenceSource referenceSource,
+            final ValidationStringency validationStringency)
+            throws IOException {
+        ValidationUtils.nonNull(cramPath, "Input path can not be null for CRAM reader");
+
+        this.cramPath = cramPath;
+        this.referenceSource = referenceSource;
+        this.mIndexPath = findIndexForPath(indexPath, cramPath);
+        final SeekablePathStream indexStream = this.mIndexPath == null ? null : new SeekablePathStream(this.mIndexPath);
+        initWithStreams(new BufferedInputStream(Files.newInputStream(cramPath)), indexStream, validationStringency);
     }
 
     /**
@@ -186,20 +306,20 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
      * @param validationStringency Validation stringency to be used when reading
      *
      * @throws IllegalArgumentException if the {@code cramFile} or the {@code CRAMReferenceSource} is null
+     * @deprecated use {@link #CRAMFileReader(Path, Path, CRAMReferenceSource, ValidationStringency)} instead.
      */
+    @Deprecated
     public CRAMFileReader(
             final File cramFile,
             final File indexFile,
             final CRAMReferenceSource referenceSource,
             final ValidationStringency validationStringency)
             throws IOException {
-        ValidationUtils.nonNull(cramFile, "Input file can not be null for CRAM reader");
-
-        this.cramFile = cramFile;
-        this.referenceSource = referenceSource;
-        this.mIndexFile = findIndexForFile(indexFile, cramFile);
-        final SeekableFileStream indexStream = this.mIndexFile == null ? null : new SeekableFileStream(this.mIndexFile);
-        initWithStreams(new BufferedInputStream(new FileInputStream(cramFile)), indexStream, validationStringency);
+        this(
+                cramFile == null ? null : cramFile.toPath(),
+                indexFile == null ? null : indexFile.toPath(),
+                referenceSource,
+                validationStringency);
     }
 
     private void initWithStreams(
@@ -222,13 +342,20 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
         }
     }
 
-    private File findIndexForFile(File indexFile, final File cramFile) {
-        indexFile = indexFile == null ? SamFiles.findIndex(cramFile) : indexFile;
-        if (indexFile != null && indexFile.lastModified() < cramFile.lastModified()) {
-            log.warn("CRAM index file " + indexFile.getAbsolutePath() + " is older than CRAM "
-                    + cramFile.getAbsolutePath());
+    private Path findIndexForPath(Path indexPath, final Path cramPath) {
+        indexPath = indexPath == null ? SamFiles.findIndex(cramPath) : indexPath;
+        if (indexPath != null) {
+            try {
+                if (Files.getLastModifiedTime(indexPath).toMillis()
+                        < Files.getLastModifiedTime(cramPath).toMillis()) {
+                    log.warn("CRAM index file " + indexPath.toAbsolutePath() + " is older than CRAM "
+                            + cramPath.toAbsolutePath());
+                }
+            } catch (final IOException e) {
+                log.warn("Could not check modification times for " + indexPath + " and " + cramPath);
+            }
         }
-        return indexFile;
+        return indexPath;
     }
 
     @Override
@@ -253,7 +380,7 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
 
     @Override
     public boolean hasIndex() {
-        return mIndex != null || mIndexFile != null;
+        return mIndex != null || mIndexPath != null;
     }
 
     @Override
@@ -263,19 +390,24 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
         }
         if (mIndex == null) {
             final SAMSequenceDictionary dictionary = getFileHeader().getSequenceDictionary();
-            if (mIndexFile.getName().endsWith(FileExtensions.BAI_INDEX)) {
+            final String indexFileName = mIndexPath.getFileName().toString();
+            if (indexFileName.endsWith(FileExtensions.BAI_INDEX)) {
+                // The BAI index readers are backed by memory-mapped or random-access local files, so
+                // the index path must be resolvable to a java.io.File. Migrating these index readers to
+                // Path is tracked separately (see issue #1783, index reader phase).
+                final File indexFile = mIndexPath.toFile();
                 mIndex = mEnableIndexCaching
-                        ? new CachingBAMFileIndex(mIndexFile, dictionary, mEnableIndexMemoryMapping)
-                        : new DiskBasedBAMFileIndex(mIndexFile, dictionary, mEnableIndexMemoryMapping);
+                        ? new CachingBAMFileIndex(indexFile, dictionary, mEnableIndexMemoryMapping)
+                        : new DiskBasedBAMFileIndex(indexFile, dictionary, mEnableIndexMemoryMapping);
                 return mIndex;
             }
 
-            if (!mIndexFile.getName().endsWith(FileExtensions.CRAM_INDEX)) return null;
+            if (!indexFileName.endsWith(FileExtensions.CRAM_INDEX)) return null;
             // convert CRAI into BAI:
             final SeekableStream baiStream;
             try {
                 baiStream = SamIndexes.asBaiSeekableStreamOrNull(
-                        new SeekableFileStream(mIndexFile),
+                        new SeekablePathStream(mIndexPath),
                         iterator.getSAMFileHeader().getSequenceDictionary());
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -318,13 +450,13 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
 
     @Override
     public SAMRecordIterator getIterator() {
-        if (iterator != null && cramFile == null) {
+        if (iterator != null && cramPath == null) {
             return iterator;
         }
         try {
-            if (cramFile != null) {
+            if (cramPath != null) {
                 iterator = new CRAMIterator(
-                        new BufferedInputStream(new FileInputStream(cramFile)), referenceSource, validationStringency);
+                        new BufferedInputStream(Files.newInputStream(cramPath)), referenceSource, validationStringency);
             } else {
                 iterator = new CRAMIterator(inputStream, referenceSource, validationStringency);
             }
@@ -410,16 +542,16 @@ public class CRAMFileReader extends SamReader.ReaderImplementation implements Sa
     private SeekableStream getSeekableStreamOrFailWithRTE() {
         SeekableStream seekableStream = null;
 
-        if (cramFile != null) {
+        if (cramPath != null) {
             try {
-                // If this reader was provided with a File, create a SeekableStream directly and
+                // If this reader was provided with a Path, create a SeekableStream directly and
                 // let it be closed by CloseableIterators, and then recreated on demand.
-                seekableStream = new SeekableFileStream(cramFile);
-            } catch (final FileNotFoundException e) {
+                seekableStream = new SeekablePathStream(cramPath);
+            } catch (final IOException e) {
                 throw new RuntimeException(e);
             }
         } else if (inputStream != null && inputStream instanceof SeekableStream) {
-            // For SeekableStreams that were provided to the reader constructor instead of a File, we
+            // For SeekableStreams that were provided to the reader constructor instead of a Path, we
             // need to prevent CloseableIterators from closing the underlying stream since we can't
             // reconstitute a SeekableStream from an InputStream. So wrap the underlying SeekableStream
             // in a DeferredCloseSeekableStream with a no-op close implementation, and defer closing it

--- a/src/main/java/htsjdk/samtools/CSIIndex.java
+++ b/src/main/java/htsjdk/samtools/CSIIndex.java
@@ -3,7 +3,6 @@ package htsjdk.samtools;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
@@ -52,16 +51,7 @@ public class CSIIndex extends AbstractBAMFileIndex implements BrowseableBAMIndex
      * @param dictionary the sequence dictionary associated with the index
      */
     public CSIIndex(final Path path, boolean enableMemoryMapping, final SAMSequenceDictionary dictionary) {
-        this(IndexFileBufferFactory.getBuffer(path.toFile(), enableMemoryMapping), path.toString(), dictionary);
-    }
-
-    /**
-     * @deprecated since the migration to {@link Path}; use
-     *     {@link #CSIIndex(Path, boolean, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public CSIIndex(final File file, boolean enableMemoryMapping, final SAMSequenceDictionary dictionary) {
-        this(file.toPath(), enableMemoryMapping, dictionary);
+        this(IndexFileBufferFactory.getBuffer(path, enableMemoryMapping), path.toString(), dictionary);
     }
 
     private CSIIndex(

--- a/src/main/java/htsjdk/samtools/CSIIndex.java
+++ b/src/main/java/htsjdk/samtools/CSIIndex.java
@@ -41,13 +41,15 @@ public class CSIIndex extends AbstractBAMFileIndex implements BrowseableBAMIndex
     }
 
     /**
-     * Open a CSI index backed by a local file path.
+     * Open a CSI index from the given path.
      *
-     * <p>The index is read from a memory-mapped or random-access buffer, so {@code path} must
-     * refer to a regular file on the default (local) file system.</p>
+     * <p>For paths on the default (local) file system, the index is read via a memory-mapped or
+     * random-access buffer as controlled by {@code enableMemoryMapping}.  For paths on any other
+     * file system, {@code enableMemoryMapping} is ignored and the index is read through a stream
+     * fallback via {@link IndexFileBufferFactory#getBuffer(Path, boolean)}.</p>
      *
-     * @param path the local path to the CSI index file
-     * @param enableMemoryMapping whether to memory-map the index file
+     * @param path the path to the CSI index file; local or non-local file systems are both supported
+     * @param enableMemoryMapping whether to memory-map the index file (ignored for non-local paths)
      * @param dictionary the sequence dictionary associated with the index
      */
     public CSIIndex(final Path path, boolean enableMemoryMapping, final SAMSequenceDictionary dictionary) {

--- a/src/main/java/htsjdk/samtools/CSIIndex.java
+++ b/src/main/java/htsjdk/samtools/CSIIndex.java
@@ -41,8 +41,27 @@ public class CSIIndex extends AbstractBAMFileIndex implements BrowseableBAMIndex
         this(new SeekablePathStream(path), dictionary);
     }
 
+    /**
+     * Open a CSI index backed by a local file path.
+     *
+     * <p>The index is read from a memory-mapped or random-access buffer, so {@code path} must
+     * refer to a regular file on the default (local) file system.</p>
+     *
+     * @param path the local path to the CSI index file
+     * @param enableMemoryMapping whether to memory-map the index file
+     * @param dictionary the sequence dictionary associated with the index
+     */
+    public CSIIndex(final Path path, boolean enableMemoryMapping, final SAMSequenceDictionary dictionary) {
+        this(IndexFileBufferFactory.getBuffer(path.toFile(), enableMemoryMapping), path.toString(), dictionary);
+    }
+
+    /**
+     * @deprecated since the migration to {@link Path}; use
+     *     {@link #CSIIndex(Path, boolean, SAMSequenceDictionary)} instead.
+     */
+    @Deprecated
     public CSIIndex(final File file, boolean enableMemoryMapping, final SAMSequenceDictionary dictionary) {
-        this(IndexFileBufferFactory.getBuffer(file, enableMemoryMapping), file.getName(), dictionary);
+        this(file.toPath(), enableMemoryMapping, dictionary);
     }
 
     private CSIIndex(

--- a/src/main/java/htsjdk/samtools/CachingBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/CachingBAMFileIndex.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.seekablestream.SeekableStream;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -44,15 +43,7 @@ class CachingBAMFileIndex extends AbstractBAMFileIndex implements BrowseableBAMI
     private long cacheMisses = 0;
 
     public CachingBAMFileIndex(final Path path, final SAMSequenceDictionary dictionary) {
-        super(path.toFile(), dictionary);
-    }
-
-    /**
-     * @deprecated since 06/2026 use {@link #CachingBAMFileIndex(Path, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public CachingBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
-        this(file.toPath(), dictionary);
+        super(path, dictionary);
     }
 
     public CachingBAMFileIndex(final SeekableStream stream, final SAMSequenceDictionary dictionary) {
@@ -61,16 +52,7 @@ class CachingBAMFileIndex extends AbstractBAMFileIndex implements BrowseableBAMI
 
     public CachingBAMFileIndex(
             final Path path, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
-        super(path.toFile(), dictionary, useMemoryMapping);
-    }
-
-    /**
-     * @deprecated since 06/2026 use {@link #CachingBAMFileIndex(Path, SAMSequenceDictionary, boolean)} instead.
-     */
-    @Deprecated
-    public CachingBAMFileIndex(
-            final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
-        this(file.toPath(), dictionary, useMemoryMapping);
+        super(path, dictionary, useMemoryMapping);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/CachingBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/CachingBAMFileIndex.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.seekablestream.SeekableStream;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
@@ -42,8 +43,16 @@ class CachingBAMFileIndex extends AbstractBAMFileIndex implements BrowseableBAMI
     private long cacheHits = 0;
     private long cacheMisses = 0;
 
+    public CachingBAMFileIndex(final Path path, final SAMSequenceDictionary dictionary) {
+        super(path.toFile(), dictionary);
+    }
+
+    /**
+     * @deprecated since 06/2026 use {@link #CachingBAMFileIndex(Path, SAMSequenceDictionary)} instead.
+     */
+    @Deprecated
     public CachingBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
-        super(file, dictionary);
+        this(file.toPath(), dictionary);
     }
 
     public CachingBAMFileIndex(final SeekableStream stream, final SAMSequenceDictionary dictionary) {
@@ -51,8 +60,17 @@ class CachingBAMFileIndex extends AbstractBAMFileIndex implements BrowseableBAMI
     }
 
     public CachingBAMFileIndex(
+            final Path path, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
+        super(path.toFile(), dictionary, useMemoryMapping);
+    }
+
+    /**
+     * @deprecated since 06/2026 use {@link #CachingBAMFileIndex(Path, SAMSequenceDictionary, boolean)} instead.
+     */
+    @Deprecated
+    public CachingBAMFileIndex(
             final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
-        super(file, dictionary, useMemoryMapping);
+        this(file.toPath(), dictionary, useMemoryMapping);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/CompressedIndexFileBuffer.java
+++ b/src/main/java/htsjdk/samtools/CompressedIndexFileBuffer.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -16,16 +15,6 @@ class CompressedIndexFileBuffer implements IndexFileBuffer {
 
     private final BlockCompressedInputStream mCompressedStream;
     private final BinaryCodec binaryCodec;
-
-    /**
-     * Constructs a buffer over the given BGZF-compressed CSI index file.
-     *
-     * @deprecated use {@link #CompressedIndexFileBuffer(Path)} instead.
-     */
-    @Deprecated
-    CompressedIndexFileBuffer(File file) {
-        this(file.toPath());
-    }
 
     CompressedIndexFileBuffer(Path path) {
         try {

--- a/src/main/java/htsjdk/samtools/CompressedIndexFileBuffer.java
+++ b/src/main/java/htsjdk/samtools/CompressedIndexFileBuffer.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * CSI index files produced by SAMtools are BGZF compressed by default. This class
@@ -16,9 +17,19 @@ class CompressedIndexFileBuffer implements IndexFileBuffer {
     private final BlockCompressedInputStream mCompressedStream;
     private final BinaryCodec binaryCodec;
 
+    /**
+     * Constructs a buffer over the given BGZF-compressed CSI index file.
+     *
+     * @deprecated use {@link #CompressedIndexFileBuffer(Path)} instead.
+     */
+    @Deprecated
     CompressedIndexFileBuffer(File file) {
+        this(file.toPath());
+    }
+
+    CompressedIndexFileBuffer(Path path) {
         try {
-            mCompressedStream = new BlockCompressedInputStream(file);
+            mCompressedStream = new BlockCompressedInputStream(path);
             binaryCodec = new BinaryCodec(mCompressedStream);
         } catch (IOException ioe) {
             throw (new RuntimeIOException("Construction error of CSI compressed stream: " + ioe));

--- a/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
+++ b/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
@@ -27,11 +27,11 @@ import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.FileAppendStreamLRUCache;
 import htsjdk.samtools.util.IOUtil;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -55,7 +55,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
     /**
      * directory where files will go
      */
-    private final File workDir = IOUtil.createTempDir("CSPI.tmp").toFile();
+    private final Path workDir = IOUtil.createTempDir("CSPI.tmp");
 
     private int sequenceIndexOfMapInRam = INVALID_SEQUENCE_INDEX;
     private Map<KEY, REC> mapInRam = null;
@@ -71,7 +71,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
 
     public CoordinateSortedPairInfoMap(final int maxOpenFiles, final Codec<KEY, REC> elementCodec) {
         this.elementCodec = elementCodec;
-        workDir.deleteOnExit();
+        workDir.toFile().deleteOnExit();
         outputStreams = new FileAppendStreamLRUCache(maxOpenFiles);
     }
 
@@ -95,8 +95,8 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
 
             // Spill map in RAM to disk
             if (mapInRam != null) {
-                final File spillFile = makeFileForSequence(sequenceIndexOfMapInRam);
-                if (spillFile.exists()) throw new IllegalStateException(spillFile + " should not exist.");
+                final Path spillFile = makeFileForSequence(sequenceIndexOfMapInRam);
+                if (Files.exists(spillFile)) throw new IllegalStateException(spillFile + " should not exist.");
                 if (!mapInRam.isEmpty()) {
                     // Do not create file or entry in sizeOfMapOnDisk if there is nothing to write.
                     final OutputStream os = getOutputStreamForSequence(sequenceIndexOfMapInRam);
@@ -114,16 +114,16 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
             sequenceIndexOfMapInRam = sequenceIndex;
 
             // Load map from disk if it existed
-            File mapOnDisk = makeFileForSequence(sequenceIndex);
-            if (outputStreams.containsKey(mapOnDisk)) {
-                outputStreams.remove(mapOnDisk).close();
+            Path mapOnDisk = makeFileForSequence(sequenceIndex);
+            if (outputStreams.containsKey(mapOnDisk.toFile())) {
+                outputStreams.remove(mapOnDisk.toFile()).close();
             }
             final Integer numRecords = sizeOfMapOnDisk.remove(sequenceIndex);
-            if (mapOnDisk.exists()) {
+            if (Files.exists(mapOnDisk)) {
                 if (numRecords == null) throw new IllegalStateException("null numRecords for " + mapOnDisk);
-                FileInputStream is = null;
+                InputStream is = null;
                 try {
-                    is = new FileInputStream(mapOnDisk);
+                    is = Files.newInputStream(mapOnDisk);
                     elementCodec.setInputStream(is);
                     for (int i = 0; i < numRecords; ++i) {
                         final Map.Entry<KEY, REC> keyAndRecord = elementCodec.decode();
@@ -135,7 +135,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
                 } finally {
                     CloserUtil.close(is);
                 }
-                htsjdk.samtools.util.IOUtil.deleteFiles(mapOnDisk);
+                htsjdk.samtools.util.IOUtil.deletePaths(mapOnDisk);
             } else if (numRecords != null && numRecords > 0)
                 throw new IllegalStateException("Non-zero numRecords but " + mapOnDisk + " does not exist");
         } catch (IOException e) {
@@ -169,14 +169,14 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
         }
     }
 
-    private File makeFileForSequence(final int index) {
-        final File file = new File(workDir, index + ".tmp");
-        file.deleteOnExit();
+    private Path makeFileForSequence(final int index) {
+        final Path file = workDir.resolve(index + ".tmp");
+        file.toFile().deleteOnExit();
         return file;
     }
 
     private OutputStream getOutputStreamForSequence(final int mateSequenceIndex) {
-        return outputStreams.get(makeFileForSequence(mateSequenceIndex));
+        return outputStreams.get(makeFileForSequence(mateSequenceIndex).toFile());
     }
 
     public int size() {

--- a/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
+++ b/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
@@ -115,8 +115,8 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
 
             // Load map from disk if it existed
             Path mapOnDisk = makeFileForSequence(sequenceIndex);
-            if (outputStreams.containsKey(mapOnDisk.toFile())) {
-                outputStreams.remove(mapOnDisk.toFile()).close();
+            if (outputStreams.containsKey(mapOnDisk)) {
+                outputStreams.remove(mapOnDisk).close();
             }
             final Integer numRecords = sizeOfMapOnDisk.remove(sequenceIndex);
             if (Files.exists(mapOnDisk)) {
@@ -176,7 +176,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
     }
 
     private OutputStream getOutputStreamForSequence(final int mateSequenceIndex) {
-        return outputStreams.get(makeFileForSequence(mateSequenceIndex).toFile());
+        return outputStreams.get(makeFileForSequence(mateSequenceIndex));
     }
 
     public int size() {

--- a/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
+++ b/src/main/java/htsjdk/samtools/CoordinateSortedPairInfoMap.java
@@ -71,7 +71,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
 
     public CoordinateSortedPairInfoMap(final int maxOpenFiles, final Codec<KEY, REC> elementCodec) {
         this.elementCodec = elementCodec;
-        workDir.toFile().deleteOnExit();
+        IOUtil.deleteOnExit(workDir);
         outputStreams = new FileAppendStreamLRUCache(maxOpenFiles);
     }
 
@@ -171,7 +171,7 @@ public class CoordinateSortedPairInfoMap<KEY, REC> implements Iterable<Map.Entry
 
     private Path makeFileForSequence(final int index) {
         final Path file = workDir.resolve(index + ".tmp");
-        file.toFile().deleteOnExit();
+        IOUtil.deleteOnExit(file);
         return file;
     }
 

--- a/src/main/java/htsjdk/samtools/Defaults.java
+++ b/src/main/java/htsjdk/samtools/Defaults.java
@@ -1,9 +1,9 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.Log;
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -71,7 +71,7 @@ public class Defaults {
      * The reference FASTA file.  If this is not set, the file is null.  This file may be required for reading
      * writing SAM files (ex. CRAM).  Default = null.
      */
-    public static final File REFERENCE_FASTA;
+    public static final Path REFERENCE_FASTA;
 
     /** Custom reader factory able to handle URL based resources like ga4gh.
      *  Expected format: <url prefix>,<fully qualified factory class name>[,<jar file name>]
@@ -131,7 +131,7 @@ public class Defaults {
         } else {
             NON_ZERO_BUFFER_SIZE = BUFFER_SIZE;
         }
-        REFERENCE_FASTA = getFileProperty("reference_fasta", null);
+        REFERENCE_FASTA = getPathProperty("reference_fasta", null);
         USE_CRAM_REF_DOWNLOAD = getBooleanProperty("use_cram_ref_download", false);
         EBI_REFERENCE_SERVICE_URL_MASK = "https://www.ebi.ac.uk/ena/cram/md5/%s";
         CUSTOM_READER_FACTORY = getStringProperty("custom_reader", "");
@@ -206,19 +206,36 @@ public class Defaults {
         return Integer.parseInt(value);
     }
 
-    /** Gets a File system property, prefixed with "samjdk." using the default if the property does not exist. */
-    private static File getFileProperty(final String name, final String def) {
+    /**
+     * Gets a Path system property, prefixed with "samjdk." using the default if the property does not exist.
+     *
+     * <p>This resolves the value with {@link Path#of(String, String...)} rather than the scheme-aware
+     * {@code IOUtil.getPath} on purpose: {@code Defaults} and {@code IOUtil} reference each other during
+     * static initialization, and routing through {@code IOUtil} here would risk a class-initialization
+     * cycle. A value that cannot be parsed into a Path is logged and treated as unset rather than failing
+     * class initialization.
+     */
+    private static Path getPathProperty(final String name, final String def) {
         final String value = getStringProperty(name, def);
-        Optional<File> maybeFile = Optional.ofNullable(value).map(File::new);
-        maybeFile.ifPresent(f -> {
-            if (!f.exists()) {
-                log.warn(String.format(
-                        "File property for %s has value %s. However file %s doesn't exist.",
-                        SAMJDK_PREFIX + name, value, f.getAbsolutePath()));
-            } else {
-                log.info(String.format("Found file for property %s: %s ", SAMJDK_PREFIX + name, f.getAbsolutePath()));
-            }
-        });
-        return maybeFile.orElse(null);
+        if (value == null) {
+            return null;
+        }
+        final Path path;
+        try {
+            path = Path.of(value);
+        } catch (final RuntimeException e) {
+            log.warn(String.format(
+                    "Path property for %s has value %s which could not be parsed as a path: %s",
+                    SAMJDK_PREFIX + name, value, e.getMessage()));
+            return null;
+        }
+        if (!Files.exists(path)) {
+            log.warn(String.format(
+                    "File property for %s has value %s. However file %s doesn't exist.",
+                    SAMJDK_PREFIX + name, value, path.toAbsolutePath()));
+        } else {
+            log.info(String.format("Found file for property %s: %s ", SAMJDK_PREFIX + name, path.toAbsolutePath()));
+        }
+        return path;
     }
 }

--- a/src/main/java/htsjdk/samtools/DiskBasedBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/DiskBasedBAMFileIndex.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.seekablestream.SeekableStream;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,8 +33,16 @@ import java.util.List;
  * A class for reading BAM file indices, hitting the disk once per query.
  */
 public class DiskBasedBAMFileIndex extends AbstractBAMFileIndex {
+    public DiskBasedBAMFileIndex(final Path path, final SAMSequenceDictionary dictionary) {
+        super(path.toFile(), dictionary);
+    }
+
+    /**
+     * @deprecated since 06/2026 use {@link #DiskBasedBAMFileIndex(Path, SAMSequenceDictionary)} instead.
+     */
+    @Deprecated
     public DiskBasedBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
-        super(file, dictionary);
+        this(file.toPath(), dictionary);
     }
 
     public DiskBasedBAMFileIndex(final SeekableStream stream, final SAMSequenceDictionary dictionary) {
@@ -41,8 +50,17 @@ public class DiskBasedBAMFileIndex extends AbstractBAMFileIndex {
     }
 
     public DiskBasedBAMFileIndex(
+            final Path path, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
+        super(path.toFile(), dictionary, useMemoryMapping);
+    }
+
+    /**
+     * @deprecated since 06/2026 use {@link #DiskBasedBAMFileIndex(Path, SAMSequenceDictionary, boolean)} instead.
+     */
+    @Deprecated
+    public DiskBasedBAMFileIndex(
             final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
-        super(file, dictionary, useMemoryMapping);
+        this(file.toPath(), dictionary, useMemoryMapping);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/DiskBasedBAMFileIndex.java
+++ b/src/main/java/htsjdk/samtools/DiskBasedBAMFileIndex.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.seekablestream.SeekableStream;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,15 +33,7 @@ import java.util.List;
  */
 public class DiskBasedBAMFileIndex extends AbstractBAMFileIndex {
     public DiskBasedBAMFileIndex(final Path path, final SAMSequenceDictionary dictionary) {
-        super(path.toFile(), dictionary);
-    }
-
-    /**
-     * @deprecated since 06/2026 use {@link #DiskBasedBAMFileIndex(Path, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public DiskBasedBAMFileIndex(final File file, final SAMSequenceDictionary dictionary) {
-        this(file.toPath(), dictionary);
+        super(path, dictionary);
     }
 
     public DiskBasedBAMFileIndex(final SeekableStream stream, final SAMSequenceDictionary dictionary) {
@@ -51,16 +42,7 @@ public class DiskBasedBAMFileIndex extends AbstractBAMFileIndex {
 
     public DiskBasedBAMFileIndex(
             final Path path, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
-        super(path.toFile(), dictionary, useMemoryMapping);
-    }
-
-    /**
-     * @deprecated since 06/2026 use {@link #DiskBasedBAMFileIndex(Path, SAMSequenceDictionary, boolean)} instead.
-     */
-    @Deprecated
-    public DiskBasedBAMFileIndex(
-            final File file, final SAMSequenceDictionary dictionary, final boolean useMemoryMapping) {
-        this(file.toPath(), dictionary, useMemoryMapping);
+        super(path, dictionary, useMemoryMapping);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/DownsamplingIteratorFactory.java
+++ b/src/main/java/htsjdk/samtools/DownsamplingIteratorFactory.java
@@ -25,6 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.IOUtil;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Iterator;
 
 /**
@@ -112,13 +113,29 @@ public class DownsamplingIteratorFactory {
      * See {@link DownsamplingIteratorFactory#make(Iterator, Strategy, double, double, int)} for detailed parameter information.
      */
     public static DownsamplingIterator make(
-            final File samFile,
+            final Path samFile,
             final Strategy strategy,
             final double proportion,
             final double accuracy,
             final int seed) {
         IOUtil.assertFileIsReadable(samFile);
         return make(SamReaderFactory.makeDefault().open(samFile), strategy, proportion, accuracy, seed);
+    }
+
+    /**
+     * Convenience method that constructs a downsampling iterator for all the reads in a SAM file.
+     * See {@link DownsamplingIteratorFactory#make(Iterator, Strategy, double, double, int)} for detailed parameter information.
+     *
+     * @deprecated since 06/2026 Use {@link #make(Path, Strategy, double, double, int)} instead.
+     */
+    @Deprecated
+    public static DownsamplingIterator make(
+            final File samFile,
+            final Strategy strategy,
+            final double proportion,
+            final double accuracy,
+            final int seed) {
+        return make(samFile.toPath(), strategy, proportion, accuracy, seed);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/DownsamplingIteratorFactory.java
+++ b/src/main/java/htsjdk/samtools/DownsamplingIteratorFactory.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Iterator;
 
@@ -120,22 +119,6 @@ public class DownsamplingIteratorFactory {
             final int seed) {
         IOUtil.assertFileIsReadable(samFile);
         return make(SamReaderFactory.makeDefault().open(samFile), strategy, proportion, accuracy, seed);
-    }
-
-    /**
-     * Convenience method that constructs a downsampling iterator for all the reads in a SAM file.
-     * See {@link DownsamplingIteratorFactory#make(Iterator, Strategy, double, double, int)} for detailed parameter information.
-     *
-     * @deprecated since 06/2026 Use {@link #make(Path, Strategy, double, double, int)} instead.
-     */
-    @Deprecated
-    public static DownsamplingIterator make(
-            final File samFile,
-            final Strategy strategy,
-            final double proportion,
-            final double accuracy,
-            final int seed) {
-        return make(samFile.toPath(), strategy, proportion, accuracy, seed);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/DuplicateSetIterator.java
+++ b/src/main/java/htsjdk/samtools/DuplicateSetIterator.java
@@ -27,7 +27,7 @@ import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.samtools.util.SortingCollection;
-import java.io.File;
+import java.nio.file.Path;
 
 /**
  * An iterator of sets of duplicates.  Duplicates are defined currently by the ordering in
@@ -88,7 +88,7 @@ public class DuplicateSetIterator implements CloseableIterator<DuplicateSet> {
 
             // Sort it!
             final int maxRecordsInRam = SAMFileWriterImpl.getDefaultMaxRecordsInRam();
-            final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+            final Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
             final SortingCollection<SAMRecord> alignmentSorter = SortingCollection.newInstance(
                     SAMRecord.class, new BAMRecordCodec(header), this.comparator, maxRecordsInRam, tmpDir);
 

--- a/src/main/java/htsjdk/samtools/IndexFileBufferFactory.java
+++ b/src/main/java/htsjdk/samtools/IndexFileBufferFactory.java
@@ -4,7 +4,6 @@ import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -18,14 +17,6 @@ class IndexFileBufferFactory {
      */
     static boolean isNonLocalPath(final Path path) {
         return !path.getFileSystem().equals(FileSystems.getDefault());
-    }
-
-    /**
-     * @deprecated use {@link #getBuffer(Path, boolean)} instead.
-     */
-    @Deprecated
-    static IndexFileBuffer getBuffer(File file, boolean enableMemoryMapping) {
-        return getBuffer(file.toPath(), enableMemoryMapping);
     }
 
     static IndexFileBuffer getBuffer(Path path, boolean enableMemoryMapping) {
@@ -44,11 +35,9 @@ class IndexFileBufferFactory {
             throw (new RuntimeIOException(ioe));
         }
 
-        // Local paths back the File-based buffer implementations directly.
-        final File file = path.toFile();
         return isCompressed
-                ? new CompressedIndexFileBuffer(file)
-                : (enableMemoryMapping ? new MemoryMappedFileBuffer(file) : new RandomAccessFileBuffer(file));
+                ? new CompressedIndexFileBuffer(path)
+                : (enableMemoryMapping ? new MemoryMappedFileBuffer(path) : new RandomAccessFileBuffer(path));
     }
 
     static IndexFileBuffer getBuffer(SeekableStream seekableStream) {

--- a/src/main/java/htsjdk/samtools/IndexFileBufferFactory.java
+++ b/src/main/java/htsjdk/samtools/IndexFileBufferFactory.java
@@ -1,21 +1,51 @@
 package htsjdk.samtools;
 
+import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 
 class IndexFileBufferFactory {
 
+    /**
+     * Returns true if the given path is not on the default (local) file system.
+     * Non-local paths (e.g., S3, GCS, HDFS, Jimfs) cannot be memory-mapped or
+     * accessed via {@link java.io.RandomAccessFile} and require a stream-based fallback.
+     */
+    static boolean isNonLocalPath(final Path path) {
+        return !path.getFileSystem().equals(FileSystems.getDefault());
+    }
+
+    /**
+     * @deprecated use {@link #getBuffer(Path, boolean)} instead.
+     */
+    @Deprecated
     static IndexFileBuffer getBuffer(File file, boolean enableMemoryMapping) {
+        return getBuffer(file.toPath(), enableMemoryMapping);
+    }
+
+    static IndexFileBuffer getBuffer(Path path, boolean enableMemoryMapping) {
+        if (isNonLocalPath(path)) {
+            try {
+                return getBuffer(new SeekablePathStream(path));
+            } catch (IOException e) {
+                throw new RuntimeIOException("Failed to open stream for non-local path: " + path, e);
+            }
+        }
+
         boolean isCompressed;
         try {
-            isCompressed = IOUtil.isBlockCompressed(file.toPath());
+            isCompressed = IOUtil.isBlockCompressed(path);
         } catch (IOException ioe) {
             throw (new RuntimeIOException(ioe));
         }
 
+        // Local paths back the File-based buffer implementations directly.
+        final File file = path.toFile();
         return isCompressed
                 ? new CompressedIndexFileBuffer(file)
                 : (enableMemoryMapping ? new MemoryMappedFileBuffer(file) : new RandomAccessFileBuffer(file));

--- a/src/main/java/htsjdk/samtools/MemoryMappedFileBuffer.java
+++ b/src/main/java/htsjdk/samtools/MemoryMappedFileBuffer.java
@@ -1,7 +1,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
@@ -22,14 +21,6 @@ class MemoryMappedFileBuffer implements IndexFileBuffer {
         } catch (final IOException exc) {
             throw new RuntimeIOException(exc.getMessage(), exc);
         }
-    }
-
-    /**
-     * @deprecated since 5.0.0; use {@link #MemoryMappedFileBuffer(Path)} instead.
-     */
-    @Deprecated
-    MemoryMappedFileBuffer(final File file) {
-        this(file.toPath());
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/MemoryMappedFileBuffer.java
+++ b/src/main/java/htsjdk/samtools/MemoryMappedFileBuffer.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
 /**
@@ -14,13 +15,21 @@ import java.nio.file.StandardOpenOption;
 class MemoryMappedFileBuffer implements IndexFileBuffer {
     private MappedByteBuffer mFileBuffer;
 
-    MemoryMappedFileBuffer(final File file) {
-        try (final FileChannel fileChannel = FileChannel.open(file.toPath(), StandardOpenOption.READ); ) {
+    MemoryMappedFileBuffer(final Path path) {
+        try (final FileChannel fileChannel = FileChannel.open(path, StandardOpenOption.READ); ) {
             mFileBuffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, 0L, fileChannel.size());
             mFileBuffer.order(ByteOrder.LITTLE_ENDIAN);
         } catch (final IOException exc) {
             throw new RuntimeIOException(exc.getMessage(), exc);
         }
+    }
+
+    /**
+     * @deprecated since 5.0.0; use {@link #MemoryMappedFileBuffer(Path)} instead.
+     */
+    @Deprecated
+    MemoryMappedFileBuffer(final File file) {
+        this(file.toPath());
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/RandomAccessFileBuffer.java
+++ b/src/main/java/htsjdk/samtools/RandomAccessFileBuffer.java
@@ -1,7 +1,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -44,14 +43,6 @@ class RandomAccessFileBuffer implements IndexFileBuffer {
         } catch (final IOException exc) {
             throw new RuntimeIOException(exc.getMessage(), exc);
         }
-    }
-
-    /**
-     * @deprecated since the migration to {@link Path}; use {@link #RandomAccessFileBuffer(Path)} instead.
-     */
-    @Deprecated
-    RandomAccessFileBuffer(final File file) {
-        this(file.toPath());
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/RandomAccessFileBuffer.java
+++ b/src/main/java/htsjdk/samtools/RandomAccessFileBuffer.java
@@ -3,7 +3,10 @@ package htsjdk.samtools;
 import htsjdk.samtools.util.RuntimeIOException;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 /**
  * Alternative implementation of BAM index file access using regular I/O instead of memory mapping.
@@ -22,20 +25,20 @@ class RandomAccessFileBuffer implements IndexFileBuffer {
     private static final int PAGE_OFFSET_MASK = PAGE_SIZE - 1;
     private static final int PAGE_MASK = ~PAGE_OFFSET_MASK;
     private static final int INVALID_PAGE = 1;
-    private final File mFile;
-    private RandomAccessFile mRandomAccessFile;
+    private final Path mPath;
+    private FileChannel mFileChannel;
     private final int mFileLength;
     private long mFilePointer = 0;
     private int mCurrentPage = INVALID_PAGE;
     private final byte[] mBuffer = new byte[PAGE_SIZE];
 
-    RandomAccessFileBuffer(final File file) {
-        mFile = file;
+    RandomAccessFileBuffer(final Path path) {
+        mPath = path;
         try {
-            mRandomAccessFile = new RandomAccessFile(file, "r");
-            final long fileLength = mRandomAccessFile.length();
+            mFileChannel = FileChannel.open(path, StandardOpenOption.READ);
+            final long fileLength = mFileChannel.size();
             if (fileLength > Integer.MAX_VALUE) {
-                throw new RuntimeIOException("BAM index file " + mFile + " is too large: " + fileLength);
+                throw new RuntimeIOException("BAM index file " + mPath + " is too large: " + fileLength);
             }
             mFileLength = (int) fileLength;
         } catch (final IOException exc) {
@@ -43,12 +46,20 @@ class RandomAccessFileBuffer implements IndexFileBuffer {
         }
     }
 
+    /**
+     * @deprecated since the migration to {@link Path}; use {@link #RandomAccessFileBuffer(Path)} instead.
+     */
+    @Deprecated
+    RandomAccessFileBuffer(final File file) {
+        this(file.toPath());
+    }
+
     @Override
     public void readBytes(final byte[] bytes) {
         int resultOffset = 0;
         int resultLength = bytes.length;
         if (mFilePointer + resultLength > mFileLength) {
-            throw new RuntimeIOException("Attempt to read past end of BAM index file (file is truncated?): " + mFile);
+            throw new RuntimeIOException("Attempt to read past end of BAM index file (file is truncated?): " + mPath);
         }
         while (resultLength > 0) {
             loadPage(mFilePointer);
@@ -101,13 +112,13 @@ class RandomAccessFileBuffer implements IndexFileBuffer {
     public void close() {
         mFilePointer = 0;
         mCurrentPage = INVALID_PAGE;
-        if (mRandomAccessFile != null) {
+        if (mFileChannel != null) {
             try {
-                mRandomAccessFile.close();
+                mFileChannel.close();
             } catch (final IOException exc) {
                 throw new RuntimeIOException(exc.getMessage(), exc);
             }
-            mRandomAccessFile = null;
+            mFileChannel = null;
         }
     }
 
@@ -117,12 +128,19 @@ class RandomAccessFileBuffer implements IndexFileBuffer {
             return;
         }
         try {
-            mRandomAccessFile.seek(page);
+            mFileChannel.position(page);
             final int readLength = Math.min(mFileLength - page, PAGE_SIZE);
-            mRandomAccessFile.readFully(mBuffer, 0, readLength);
+            int totalRead = 0;
+            while (totalRead < readLength) {
+                final int bytesRead = mFileChannel.read(ByteBuffer.wrap(mBuffer, totalRead, readLength - totalRead));
+                if (bytesRead < 0) {
+                    throw new IOException("Unexpected end of file");
+                }
+                totalRead += bytesRead;
+            }
             mCurrentPage = page;
         } catch (final IOException exc) {
-            throw new RuntimeIOException("Exception reading BAM index file " + mFile + ": " + exc.getMessage(), exc);
+            throw new RuntimeIOException("Exception reading BAM index file " + mPath + ": " + exc.getMessage(), exc);
         }
     }
 }

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -35,7 +35,6 @@ import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.Md5CalculatingOutputStream;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -55,7 +54,7 @@ public class SAMFileWriterFactory implements Cloneable {
     private boolean useAsyncIo = Defaults.USE_ASYNC_IO_WRITE_FOR_SAMTOOLS;
     private int asyncOutputBufferSize = AsyncSAMFileWriter.DEFAULT_QUEUE_SIZE;
     private int bufferSize = Defaults.BUFFER_SIZE;
-    private File tmpDir;
+    private Path tmpDir;
     /** compression level 0: min 9:max */
     private int compressionLevel = BlockCompressedOutputStream.getDefaultCompressionLevel();
 
@@ -222,18 +221,6 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param tmpDir Path to the temporary directory
      */
     public SAMFileWriterFactory setTempDirectory(final Path tmpDir) {
-        this.tmpDir = tmpDir == null ? null : tmpDir.toFile();
-        return this;
-    }
-
-    /**
-     * Set the temporary directory to use when sort data.
-     *
-     * @param tmpDir Path to the temporary directory
-     * @deprecated since 6/26, use {@link #setTempDirectory(Path)} instead
-     */
-    @Deprecated
-    public SAMFileWriterFactory setTempDirectory(final File tmpDir) {
         this.tmpDir = tmpDir;
         return this;
     }
@@ -243,7 +230,7 @@ public class SAMFileWriterFactory implements Cloneable {
      * @see #setTempDirectory(Path)
      */
     public Path getTempDirectory() {
-        return tmpDir == null ? null : tmpDir.toPath();
+        return tmpDir;
     }
 
     /**
@@ -285,19 +272,6 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
      * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param outputFile where to write the output.
-     * @deprecated since 6/26, use {@link #makeBAMWriter(SAMFileHeader, boolean, Path)} instead
-     */
-    @Deprecated
-    public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile) {
-        return makeBAMWriter(header, presorted, outputFile.toPath());
-    }
-
-    /**
-     * Create a BAMFileWriter that is ready to receive SAMRecords.  Uses default compression level.
-     *
-     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
      * @param outputPath where to write the output.
      */
     public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final Path outputPath) {
@@ -320,21 +294,6 @@ public class SAMFileWriterFactory implements Cloneable {
     public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final URI outputUri)
             throws IOException {
         return makeBAMWriter(header, presorted, IOUtil.getPath(outputUri));
-    }
-
-    /**
-     * Create a BAMFileWriter that is ready to receive SAMRecords.
-     *
-     * @param header           entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param presorted        if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param outputFile       where to write the output.
-     * @param compressionLevel Override default compression level with the given value, between 0 (fastest) and 9 (smallest).
-     * @deprecated since 6/26, use {@link #makeBAMWriter(SAMFileHeader, boolean, Path, int)} instead
-     */
-    @Deprecated
-    public SAMFileWriter makeBAMWriter(
-            final SAMFileHeader header, final boolean presorted, final File outputFile, final int compressionLevel) {
-        return makeBAMWriter(header, presorted, outputFile.toPath(), compressionLevel);
     }
 
     /**
@@ -385,19 +344,6 @@ public class SAMFileWriterFactory implements Cloneable {
         if (createIndex && writer.getSortOrder().equals(SAMFileHeader.SortOrder.coordinate)) {
             writer.enableBamIndexConstruction();
         }
-    }
-
-    /**
-     * Create a SAMTextWriter that is ready to receive SAMRecords.
-     *
-     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param outputFile where to write the output.
-     * @deprecated since 6/26, use {@link #makeSAMWriter(SAMFileHeader, boolean, Path)} instead
-     */
-    @Deprecated
-    public SAMFileWriter makeSAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile) {
-        return makeSAMWriter(header, presorted, outputFile.toPath());
     }
 
     /**
@@ -503,21 +449,6 @@ public class SAMFileWriterFactory implements Cloneable {
     }
 
     /**
-     * Create either a SAM or a BAM writer based on examination of the outputFile extension, defaults to BAM writer.
-     *
-     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param presorted  presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param outputFile where to write the output.  Must end with .sam or .bam.
-     * @return SAM or BAM writer based on file extension of outputFile.
-     * @deprecated since 6/26, use {@link #makeSAMOrBAMWriter(SAMFileHeader, boolean, Path)} instead
-     */
-    @Deprecated
-    public SAMFileWriter makeSAMOrBAMWriter(
-            final SAMFileHeader header, final boolean presorted, final File outputFile) {
-        return makeSAMOrBAMWriter(header, presorted, outputFile.toPath());
-    }
-
-    /**
      * Create either a SAM or a BAM writer based on examination of the outputPath extension.
      *
      * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
@@ -556,42 +487,6 @@ public class SAMFileWriterFactory implements Cloneable {
     public SAMFileWriter makeSAMOrBAMWriter(final SAMFileHeader header, final boolean presorted, final URI outputUri)
             throws IOException {
         return makeSAMOrBAMWriter(header, presorted, IOUtil.getPath(outputUri));
-    }
-
-    /**
-     *
-     * Create a SAM, BAM or CRAM writer based on examination of the outputFile extension.
-     * The method assumes BAM file format for unknown file extensions.
-     *
-     * @param header header. Sort order is determined by the sortOrder property of this arg.
-     * @param presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param outputFile where to write the output.  Should end with .sam, .bam or .cram.
-     * @param referenceFasta reference sequence file
-     * @return SAMFileWriter appropriate for SAM and CRAM file types specified in outputFile, or a BAM writer for all other types
-     *
-     * @deprecated since 6/26, use {@link #makeWriter(SAMFileHeader, boolean, Path, Path)} instead
-     */
-    @Deprecated
-    public SAMFileWriter makeWriter(
-            final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
-        return makeWriter(header, presorted, IOUtil.toPath(outputFile), IOUtil.toPath(referenceFasta));
-    }
-
-    /**
-     *
-     * Create a SAM, BAM or CRAM writer based on examination of the outputPath extension.
-     *
-     * @param header header. Sort order is determined by the sortOrder property of this arg.
-     * @param presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param outputPath where to write the output.  Must end with .sam, .bam or .cram.
-     * @param referenceFasta reference sequence file
-     * @return SAMFileWriter appropriate for the file type specified in outputPath
-     * @deprecated since 6/18, use {@link #makeWriter(SAMFileHeader, boolean, Path, Path)} instead
-     */
-    @Deprecated
-    public SAMFileWriter makeWriter(
-            final SAMFileHeader header, final boolean presorted, final Path outputPath, final File referenceFasta) {
-        return makeWriter(header, presorted, outputPath, IOUtil.toPath(referenceFasta));
     }
 
     /**
@@ -647,24 +542,6 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param stream where to write the output.
      * @param referenceFasta reference sequence file
      * @return CRAMFileWriter
-     * @deprecated since 6/26, use {@link #makeCRAMWriter(SAMFileHeader, OutputStream, Path)} instead
-     */
-    @Deprecated
-    public CRAMFileWriter makeCRAMWriter(
-            final SAMFileHeader header, final OutputStream stream, final File referenceFasta) {
-        return makeCRAMWriter(header, stream, IOUtil.toPath(referenceFasta));
-    }
-
-    /**
-     * Create a CRAMFileWriter on an output stream. Requires the input to be presorted to match the sort order defined
-     * by the input header.
-     *
-     * Note: does not honor factory settings for CREATE_MD5, CREATE_INDEX, USE_ASYNC_IO.
-     *
-     * @param header entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param stream where to write the output.
-     * @param referenceFasta reference sequence file
-     * @return CRAMFileWriter
      */
     public CRAMFileWriter makeCRAMWriter(
             final SAMFileHeader header, final OutputStream stream, final Path referenceFasta) {
@@ -683,83 +560,6 @@ public class SAMFileWriterFactory implements Cloneable {
      * sort order defined by the input header.
      *
      * Note: does not honor factory settings for USE_ASYNC_IO.
-     *
-     * @param header entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param outputFile where to write the output.  Must end with .sam, .bam or .cram.
-     * @param referenceFasta reference sequence file
-     * @return CRAMFileWriter
-     *
-     * @deprecated since 6/26, use {@link #makeWriter(SAMFileHeader, boolean, Path, Path)} or
-     * {@link #makeCRAMWriter(SAMFileHeader, boolean, Path, Path)} instead
-     */
-    @Deprecated
-    public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final File outputFile, final File referenceFasta) {
-        return createCRAMWriterWithSettings(header, true, outputFile.toPath(), IOUtil.toPath(referenceFasta));
-    }
-
-    /**
-     * Create a CRAMFileWriter on an output file. Requires input record to be presorted to match the
-     * sort order defined by the input header.
-     *
-     * Note: does not honor factory settings for USE_ASYNC_IO.
-     *
-     * @param header entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param outputPath where to write the output.  Must end with .sam, .bam or .cram.
-     * @param referenceFasta reference sequence file
-     * @return CRAMFileWriter
-     *
-     * @deprecated since 6/18, prefer {@link #makeWriter(SAMFileHeader, boolean, Path, Path)} for creating bam/cram writers
-     * however {@link #makeCRAMWriter(SAMFileHeader, boolean, Path, Path)} is the direct replacement for this method
-     */
-    @Deprecated
-    public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final Path outputPath, final File referenceFasta) {
-        return makeCRAMWriter(header, true, outputPath, IOUtil.toPath(referenceFasta));
-    }
-
-    /**
-     * Create a CRAMFileWriter on an output file.
-     *
-     * Note: does not honor factory setting for USE_ASYNC_IO.
-     *
-     * @param header entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param outputFile where to write the output.  Must end with .sam, .bam or .cram.
-     * @param referenceFasta reference sequence file
-     * @return CRAMFileWriter
-     *
-     * @deprecated since 6/26, use {@link #makeCRAMWriter(SAMFileHeader, boolean, Path, Path)} instead
-     */
-    @Deprecated
-    public CRAMFileWriter makeCRAMWriter(
-            final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
-        return makeCRAMWriter(header, presorted, outputFile.toPath(), IOUtil.toPath(referenceFasta));
-    }
-
-    /**
-     * Create a CRAMFileWriter on an output file.
-     *
-     * Note: does not honor factory setting for USE_ASYNC_IO.
-     *
-     * @param header entire header. Sort order is determined by the sortOrder property of this arg.
-     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
-     * @param output where to write the output.  Must end with .sam, .bam or .cram.
-     * @param referenceFasta reference sequence file
-     * @return CRAMFileWriter
-     *
-     * @deprecated since 6/18, prefer {@link #makeWriter(SAMFileHeader, boolean, Path, Path)} for creating bam/cram writers
-     * however {@link #makeCRAMWriter(SAMFileHeader, boolean, Path, Path)} is the direct replacement for this method
-     *
-     */
-    @Deprecated
-    public CRAMFileWriter makeCRAMWriter(
-            final SAMFileHeader header, final boolean presorted, final Path output, final File referenceFasta) {
-        return makeCRAMWriter(header, presorted, output, IOUtil.toPath(referenceFasta));
-    }
-
-    /**
-     * Create a CRAMFileWriter on an output file.
-     *
-     * Note: does not honor factory setting for USE_ASYNC_IO.
      *
      * @param header entire header. Sort order is determined by the sortOrder property of this arg.
      * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.

--- a/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterFactory.java
@@ -38,6 +38,7 @@ import htsjdk.samtools.util.zip.DeflaterFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.Deflater;
@@ -220,6 +221,18 @@ public class SAMFileWriterFactory implements Cloneable {
      *
      * @param tmpDir Path to the temporary directory
      */
+    public SAMFileWriterFactory setTempDirectory(final Path tmpDir) {
+        this.tmpDir = tmpDir == null ? null : tmpDir.toFile();
+        return this;
+    }
+
+    /**
+     * Set the temporary directory to use when sort data.
+     *
+     * @param tmpDir Path to the temporary directory
+     * @deprecated since 6/26, use {@link #setTempDirectory(Path)} instead
+     */
+    @Deprecated
     public SAMFileWriterFactory setTempDirectory(final File tmpDir) {
         this.tmpDir = tmpDir;
         return this;
@@ -227,10 +240,10 @@ public class SAMFileWriterFactory implements Cloneable {
 
     /**
      * Gets the temporary directory that will be used when sorting data.
-     * @see #setTempDirectory(File)
+     * @see #setTempDirectory(Path)
      */
-    public File getTempDirectory() {
-        return tmpDir;
+    public Path getTempDirectory() {
+        return tmpDir == null ? null : tmpDir.toPath();
     }
 
     /**
@@ -273,9 +286,11 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
      * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
      * @param outputFile where to write the output.
+     * @deprecated since 6/26, use {@link #makeBAMWriter(SAMFileHeader, boolean, Path)} instead
      */
+    @Deprecated
     public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile) {
-        return makeBAMWriter(header, presorted, outputFile, this.getCompressionLevel());
+        return makeBAMWriter(header, presorted, outputFile.toPath());
     }
 
     /**
@@ -290,13 +305,33 @@ public class SAMFileWriterFactory implements Cloneable {
     }
 
     /**
+     * Create a BAMFileWriter that is ready to receive SAMRecords from a URI.  Uses default compression level.
+     * <p>
+     * This is a convenience method that delegates to {@link #makeBAMWriter(SAMFileHeader, boolean, Path)} by converting
+     * the URI to a Path via {@link IOUtil#getPath(URI)}. The URI must be supported by an available NIO filesystem provider.
+     * </p>
+     *
+     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputUri  URI where to write the output (e.g., file:///path/to/file.bam)
+     * @return a SAMFileWriter for the specified URI
+     * @throws IOException if the URI cannot be converted to a Path
+     */
+    public SAMFileWriter makeBAMWriter(final SAMFileHeader header, final boolean presorted, final URI outputUri)
+            throws IOException {
+        return makeBAMWriter(header, presorted, IOUtil.getPath(outputUri));
+    }
+
+    /**
      * Create a BAMFileWriter that is ready to receive SAMRecords.
      *
      * @param header           entire header. Sort order is determined by the sortOrder property of this arg.
      * @param presorted        if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
      * @param outputFile       where to write the output.
      * @param compressionLevel Override default compression level with the given value, between 0 (fastest) and 9 (smallest).
+     * @deprecated since 6/26, use {@link #makeBAMWriter(SAMFileHeader, boolean, Path, int)} instead
      */
+    @Deprecated
     public SAMFileWriter makeBAMWriter(
             final SAMFileHeader header, final boolean presorted, final File outputFile, final int compressionLevel) {
         return makeBAMWriter(header, presorted, outputFile.toPath(), compressionLevel);
@@ -358,7 +393,9 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
      * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
      * @param outputFile where to write the output.
+     * @deprecated since 6/26, use {@link #makeSAMWriter(SAMFileHeader, boolean, Path)} instead
      */
+    @Deprecated
     public SAMFileWriter makeSAMWriter(final SAMFileHeader header, final boolean presorted, final File outputFile) {
         return makeSAMWriter(header, presorted, outputFile.toPath());
     }
@@ -390,6 +427,24 @@ public class SAMFileWriterFactory implements Cloneable {
         } catch (final IOException ioe) {
             throw new RuntimeIOException("Error opening file: " + outputPath.toUri(), ioe);
         }
+    }
+
+    /**
+     * Create a SAMTextWriter that is ready to receive SAMRecords from a URI.
+     * <p>
+     * This is a convenience method that delegates to {@link #makeSAMWriter(SAMFileHeader, boolean, Path)} by converting
+     * the URI to a Path via {@link IOUtil#getPath(URI)}. The URI must be supported by an available NIO filesystem provider.
+     * </p>
+     *
+     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputUri  URI where to write the output (e.g., file:///path/to/file.sam)
+     * @return a SAMFileWriter for the specified URI
+     * @throws IOException if the URI cannot be converted to a Path
+     */
+    public SAMFileWriter makeSAMWriter(final SAMFileHeader header, final boolean presorted, final URI outputUri)
+            throws IOException {
+        return makeSAMWriter(header, presorted, IOUtil.getPath(outputUri));
     }
 
     /**
@@ -425,7 +480,7 @@ public class SAMFileWriterFactory implements Cloneable {
         return initWriter(
                 header,
                 presorted,
-                new BAMFileWriter(stream, (File) null, this.getCompressionLevel(), this.deflaterFactory));
+                new BAMFileWriter(stream, (String) null, this.getCompressionLevel(), this.deflaterFactory));
     }
 
     /**
@@ -454,7 +509,9 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param presorted  presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
      * @param outputFile where to write the output.  Must end with .sam or .bam.
      * @return SAM or BAM writer based on file extension of outputFile.
+     * @deprecated since 6/26, use {@link #makeSAMOrBAMWriter(SAMFileHeader, boolean, Path)} instead
      */
+    @Deprecated
     public SAMFileWriter makeSAMOrBAMWriter(
             final SAMFileHeader header, final boolean presorted, final File outputFile) {
         return makeSAMOrBAMWriter(header, presorted, outputFile.toPath());
@@ -483,6 +540,25 @@ public class SAMFileWriterFactory implements Cloneable {
     }
 
     /**
+     * Create either a SAM or a BAM writer based on examination of the URI extension.
+     * <p>
+     * This is a convenience method that delegates to {@link #makeSAMOrBAMWriter(SAMFileHeader, boolean, Path)} by
+     * converting the URI to a Path via {@link IOUtil#getPath(URI)}. The URI must be supported by an available NIO
+     * filesystem provider.
+     * </p>
+     *
+     * @param header     entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted  presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputUri  URI where to write the output (e.g., file:///path/to/file.sam or file:///path/to/file.bam)
+     * @return SAM or BAM writer based on file extension of outputUri
+     * @throws IOException if the URI cannot be converted to a Path
+     */
+    public SAMFileWriter makeSAMOrBAMWriter(final SAMFileHeader header, final boolean presorted, final URI outputUri)
+            throws IOException {
+        return makeSAMOrBAMWriter(header, presorted, IOUtil.getPath(outputUri));
+    }
+
+    /**
      *
      * Create a SAM, BAM or CRAM writer based on examination of the outputFile extension.
      * The method assumes BAM file format for unknown file extensions.
@@ -493,7 +569,9 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param referenceFasta reference sequence file
      * @return SAMFileWriter appropriate for SAM and CRAM file types specified in outputFile, or a BAM writer for all other types
      *
+     * @deprecated since 6/26, use {@link #makeWriter(SAMFileHeader, boolean, Path, Path)} instead
      */
+    @Deprecated
     public SAMFileWriter makeWriter(
             final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
         return makeWriter(header, presorted, IOUtil.toPath(outputFile), IOUtil.toPath(referenceFasta));
@@ -538,6 +616,28 @@ public class SAMFileWriterFactory implements Cloneable {
     }
 
     /**
+     * Create a SAM, BAM or CRAM writer based on examination of the URI extension.
+     * <p>
+     * This is a convenience method that delegates to {@link #makeWriter(SAMFileHeader, boolean, Path, Path)} by
+     * converting the URIs to Paths via {@link IOUtil#getPath(URI)}. The URIs must be supported by an available NIO
+     * filesystem provider.
+     * </p>
+     *
+     * @param header header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputUri URI where to write the output (e.g., file:///path/to/file.sam, file:///path/to/file.bam, or file:///path/to/file.cram)
+     * @param referenceUri URI of the reference sequence file, or null
+     * @return SAMFileWriter appropriate for the file type specified in outputUri
+     * @throws IOException if a URI cannot be converted to a Path
+     */
+    public SAMFileWriter makeWriter(
+            final SAMFileHeader header, final boolean presorted, final URI outputUri, final URI referenceUri)
+            throws IOException {
+        final Path referencePath = referenceUri == null ? null : IOUtil.getPath(referenceUri);
+        return makeWriter(header, presorted, IOUtil.getPath(outputUri), referencePath);
+    }
+
+    /**
      * Create a CRAMFileWriter on an output stream. Requires the input to be presorted to match the sort order defined
      * by the input header.
      *
@@ -547,7 +647,9 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param stream where to write the output.
      * @param referenceFasta reference sequence file
      * @return CRAMFileWriter
+     * @deprecated since 6/26, use {@link #makeCRAMWriter(SAMFileHeader, OutputStream, Path)} instead
      */
+    @Deprecated
     public CRAMFileWriter makeCRAMWriter(
             final SAMFileHeader header, final OutputStream stream, final File referenceFasta) {
         return makeCRAMWriter(header, stream, IOUtil.toPath(referenceFasta));
@@ -587,7 +689,10 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param referenceFasta reference sequence file
      * @return CRAMFileWriter
      *
+     * @deprecated since 6/26, use {@link #makeWriter(SAMFileHeader, boolean, Path, Path)} or
+     * {@link #makeCRAMWriter(SAMFileHeader, boolean, Path, Path)} instead
      */
+    @Deprecated
     public CRAMFileWriter makeCRAMWriter(final SAMFileHeader header, final File outputFile, final File referenceFasta) {
         return createCRAMWriterWithSettings(header, true, outputFile.toPath(), IOUtil.toPath(referenceFasta));
     }
@@ -622,7 +727,9 @@ public class SAMFileWriterFactory implements Cloneable {
      * @param referenceFasta reference sequence file
      * @return CRAMFileWriter
      *
+     * @deprecated since 6/26, use {@link #makeCRAMWriter(SAMFileHeader, boolean, Path, Path)} instead
      */
+    @Deprecated
     public CRAMFileWriter makeCRAMWriter(
             final SAMFileHeader header, final boolean presorted, final File outputFile, final File referenceFasta) {
         return makeCRAMWriter(header, presorted, outputFile.toPath(), IOUtil.toPath(referenceFasta));
@@ -664,6 +771,30 @@ public class SAMFileWriterFactory implements Cloneable {
     public CRAMFileWriter makeCRAMWriter(
             final SAMFileHeader header, final boolean presorted, final Path output, final Path referenceFasta) {
         return createCRAMWriterWithSettings(header, presorted, output, referenceFasta);
+    }
+
+    /**
+     * Create a CRAMFileWriter on an output file from a URI.
+     * <p>
+     * This is a convenience method that delegates to {@link #makeCRAMWriter(SAMFileHeader, boolean, Path, Path)} by
+     * converting the URIs to Paths via {@link IOUtil#getPath(URI)}. The URIs must be supported by an available NIO
+     * filesystem provider.
+     * </p>
+     *
+     * Note: does not honor factory setting for USE_ASYNC_IO.
+     *
+     * @param header entire header. Sort order is determined by the sortOrder property of this arg.
+     * @param presorted  if true, SAMRecords must be added to the SAMFileWriter in order that agrees with header.sortOrder.
+     * @param outputUri URI where to write the output (e.g., file:///path/to/file.cram)
+     * @param referenceUri URI of the reference sequence file, or null
+     * @return CRAMFileWriter
+     * @throws IOException if a URI cannot be converted to a Path
+     */
+    public CRAMFileWriter makeCRAMWriter(
+            final SAMFileHeader header, final boolean presorted, final URI outputUri, final URI referenceUri)
+            throws IOException {
+        final Path referencePath = referenceUri == null ? null : IOUtil.getPath(referenceUri);
+        return makeCRAMWriter(header, presorted, IOUtil.getPath(outputUri), referencePath);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -29,6 +29,7 @@ import htsjdk.samtools.util.ProgressLoggerInterface;
 import htsjdk.samtools.util.SortingCollection;
 import java.io.File;
 import java.io.StringWriter;
+import java.nio.file.Path;
 
 /**
  * Base class for implementing SAM writer with any underlying format.
@@ -42,7 +43,7 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter {
     private SAMFileHeader.SortOrder sortOrder;
     private SAMFileHeader header;
     private SortingCollection<SAMRecord> alignmentSorter;
-    private File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+    private Path tmpDir = Path.of(System.getProperty("java.io.tmpdir"));
     private ProgressLoggerInterface progressLogger = null;
     private boolean isClosed = false;
 
@@ -136,13 +137,24 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter {
      * for spilling to disk.  Must be called before setHeader().
      * @param tmpDir path to the temporary directory
      */
-    protected void setTempDirectory(final File tmpDir) {
+    protected void setTempDirectory(final Path tmpDir) {
         if (tmpDir != null) {
             this.tmpDir = tmpDir;
         }
     }
 
-    protected File getTempDirectory() {
+    /**
+     * When writing records that are not presorted, specify the path of the temporary directory
+     * for spilling to disk.  Must be called before setHeader().
+     * @param tmpDir path to the temporary directory
+     * @deprecated since 06/2025. Use {@link #setTempDirectory(Path)} instead.
+     */
+    @Deprecated
+    protected void setTempDirectory(final File tmpDir) {
+        setTempDirectory(tmpDir == null ? null : tmpDir.toPath());
+    }
+
+    protected Path getTempDirectory() {
         return tmpDir;
     }
 

--- a/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileWriterImpl.java
@@ -27,7 +27,6 @@ import static htsjdk.samtools.SAMFileHeader.SortOrder;
 
 import htsjdk.samtools.util.ProgressLoggerInterface;
 import htsjdk.samtools.util.SortingCollection;
-import java.io.File;
 import java.io.StringWriter;
 import java.nio.file.Path;
 
@@ -141,17 +140,6 @@ public abstract class SAMFileWriterImpl implements SAMFileWriter {
         if (tmpDir != null) {
             this.tmpDir = tmpDir;
         }
-    }
-
-    /**
-     * When writing records that are not presorted, specify the path of the temporary directory
-     * for spilling to disk.  Must be called before setHeader().
-     * @param tmpDir path to the temporary directory
-     * @deprecated since 06/2025. Use {@link #setTempDirectory(Path)} instead.
-     */
-    @Deprecated
-    protected void setTempDirectory(final File tmpDir) {
-        setTempDirectory(tmpDir == null ? null : tmpDir.toPath());
     }
 
     protected Path getTempDirectory() {

--- a/src/main/java/htsjdk/samtools/SAMLineParser.java
+++ b/src/main/java/htsjdk/samtools/SAMLineParser.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.StringUtil;
-import java.io.File;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
@@ -130,20 +129,6 @@ public class SAMLineParser {
     }
 
     /**
-     * Public constructor. Use the default SAMRecordFactory and stringency.
-     *
-     * @param samFileHeader SAM file header
-     * @param samFileReader SAM file reader For passing to SAMRecord.setFileSource, may be null.
-     * @param samFile       SAM file being read (for error message only, may be null)
-     * @deprecated Use {@link #SAMLineParser(SAMFileHeader, SamReader, Path)} instead.
-     */
-    @Deprecated
-    public SAMLineParser(final SAMFileHeader samFileHeader, final SamReader samFileReader, final File samFile) {
-
-        this(samFileHeader, samFileReader, samFile == null ? null : samFile.toPath());
-    }
-
-    /**
      * Public constructor.
      *
      * @param samRecordFactory     SamRecord Factory
@@ -175,33 +160,6 @@ public class SAMLineParser {
 
         // Can be null
         this.mPath = samPath;
-    }
-
-    /**
-     * Public constructor.
-     *
-     * @param samRecordFactory     SamRecord Factory
-     * @param validationStringency validation stringency
-     * @param samFileHeader        SAM file header
-     * @param samFileReader        SAM file reader For passing to SAMRecord.setFileSource, may be null.
-     * @param samFile              SAM file being read (for error message only, may be null)
-     * @deprecated Use {@link #SAMLineParser(SAMRecordFactory, ValidationStringency, SAMFileHeader, SamReader, Path)}
-     *     instead.
-     */
-    @Deprecated
-    public SAMLineParser(
-            final SAMRecordFactory samRecordFactory,
-            final ValidationStringency validationStringency,
-            final SAMFileHeader samFileHeader,
-            final SamReader samFileReader,
-            final File samFile) {
-
-        this(
-                samRecordFactory,
-                validationStringency,
-                samFileHeader,
-                samFileReader,
-                samFile == null ? null : samFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMLineParser.java
+++ b/src/main/java/htsjdk/samtools/SAMLineParser.java
@@ -29,6 +29,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -83,7 +84,7 @@ public class SAMLineParser {
     private final ValidationStringency validationStringency;
     private final SAMFileHeader mFileHeader;
     private final SAMSequenceDictionary mSequenceDictionary;
-    private final File mFile;
+    private final Path mPath;
     /**
      * Optional user-provided format override for the FLAG field. {@code null} means
      * "auto-detect format per record" via {@link SamFlagField#parseDefault}.
@@ -108,7 +109,24 @@ public class SAMLineParser {
      */
     public SAMLineParser(final SAMFileHeader samFileHeader) {
 
-        this(new DefaultSAMRecordFactory(), ValidationStringency.DEFAULT_STRINGENCY, samFileHeader, null, null);
+        this(new DefaultSAMRecordFactory(), ValidationStringency.DEFAULT_STRINGENCY, samFileHeader, null, (Path) null);
+    }
+
+    /**
+     * Public constructor. Use the default SAMRecordFactory and stringency.
+     *
+     * @param samFileHeader SAM file header
+     * @param samFileReader SAM file reader For passing to SAMRecord.setFileSource, may be null.
+     * @param samPath       SAM file path being read (for error message only, may be null)
+     */
+    public SAMLineParser(final SAMFileHeader samFileHeader, final SamReader samFileReader, final Path samPath) {
+
+        this(
+                new DefaultSAMRecordFactory(),
+                ValidationStringency.DEFAULT_STRINGENCY,
+                samFileHeader,
+                samFileReader,
+                samPath);
     }
 
     /**
@@ -117,15 +135,12 @@ public class SAMLineParser {
      * @param samFileHeader SAM file header
      * @param samFileReader SAM file reader For passing to SAMRecord.setFileSource, may be null.
      * @param samFile       SAM file being read (for error message only, may be null)
+     * @deprecated Use {@link #SAMLineParser(SAMFileHeader, SamReader, Path)} instead.
      */
+    @Deprecated
     public SAMLineParser(final SAMFileHeader samFileHeader, final SamReader samFileReader, final File samFile) {
 
-        this(
-                new DefaultSAMRecordFactory(),
-                ValidationStringency.DEFAULT_STRINGENCY,
-                samFileHeader,
-                samFileReader,
-                samFile);
+        this(samFileHeader, samFileReader, samFile == null ? null : samFile.toPath());
     }
 
     /**
@@ -135,14 +150,14 @@ public class SAMLineParser {
      * @param validationStringency validation stringency
      * @param samFileHeader        SAM file header
      * @param samFileReader        SAM file reader For passing to SAMRecord.setFileSource, may be null.
-     * @param samFile              SAM file being read (for error message only, may be null)
+     * @param samPath              SAM file path being read (for error message only, may be null)
      */
     public SAMLineParser(
             final SAMRecordFactory samRecordFactory,
             final ValidationStringency validationStringency,
             final SAMFileHeader samFileHeader,
             final SamReader samFileReader,
-            final File samFile) {
+            final Path samPath) {
 
         if (samRecordFactory == null) throw new NullPointerException("The SamRecordFactory must be set");
 
@@ -159,7 +174,34 @@ public class SAMLineParser {
         this.mParentReader = samFileReader;
 
         // Can be null
-        this.mFile = samFile;
+        this.mPath = samPath;
+    }
+
+    /**
+     * Public constructor.
+     *
+     * @param samRecordFactory     SamRecord Factory
+     * @param validationStringency validation stringency
+     * @param samFileHeader        SAM file header
+     * @param samFileReader        SAM file reader For passing to SAMRecord.setFileSource, may be null.
+     * @param samFile              SAM file being read (for error message only, may be null)
+     * @deprecated Use {@link #SAMLineParser(SAMRecordFactory, ValidationStringency, SAMFileHeader, SamReader, Path)}
+     *     instead.
+     */
+    @Deprecated
+    public SAMLineParser(
+            final SAMRecordFactory samRecordFactory,
+            final ValidationStringency validationStringency,
+            final SAMFileHeader samFileHeader,
+            final SamReader samFileReader,
+            final File samFile) {
+
+        this(
+                samRecordFactory,
+                validationStringency,
+                samFileHeader,
+                samFileReader,
+                samFile == null ? null : samFile.toPath());
     }
 
     /**
@@ -715,8 +757,8 @@ public class SAMLineParser {
 
     private String makeErrorString(final String reason) {
         String fileMessage = "";
-        if (mFile != null) {
-            fileMessage = "File " + mFile + "; ";
+        if (mPath != null) {
+            fileMessage = "File " + mPath + "; ";
         }
         // Materialize the offending line lazily from the byte buffer so we don't pay the String
         // allocation on the (much more common) success path.

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -31,8 +31,8 @@ import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.TestUtil;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
@@ -664,11 +664,11 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
      */
     public SamReader getSamReader() {
 
-        final File tempFile;
+        final Path tempFile;
 
         try {
-            tempFile = File.createTempFile("temp", this.useBamFile ? ".bam" : ".sam");
-            tempFile.deleteOnExit();
+            tempFile = Files.createTempFile("temp", this.useBamFile ? ".bam" : ".sam");
+            tempFile.toFile().deleteOnExit();
         } catch (final IOException e) {
             throw new RuntimeIOException("problems creating tempfile", e);
         }

--- a/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
+++ b/src/main/java/htsjdk/samtools/SAMRecordSetBuilder.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.SAMReadGroupRecord.PlatformValue;
 import htsjdk.samtools.reference.FastaReferenceWriter;
 import htsjdk.samtools.reference.FastaReferenceWriterBuilder;
 import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.TestUtil;
@@ -668,7 +669,7 @@ public class SAMRecordSetBuilder implements Iterable<SAMRecord> {
 
         try {
             tempFile = Files.createTempFile("temp", this.useBamFile ? ".bam" : ".sam");
-            tempFile.toFile().deleteOnExit();
+            IOUtil.deleteOnExit(tempFile);
         } catch (final IOException e) {
             throw new RuntimeIOException("problems creating tempfile", e);
         }

--- a/src/main/java/htsjdk/samtools/SAMTextReader.java
+++ b/src/main/java/htsjdk/samtools/SAMTextReader.java
@@ -27,6 +27,8 @@ import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.SamLineReader;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 
 /**
  * Internal class for reading SAM text files.
@@ -38,7 +40,7 @@ class SAMTextReader extends SamReader.ReaderImplementation {
     private SAMFileHeader mFileHeader = null;
     private boolean mHasCurrentLine = false;
     private RecordIterator mIterator = null;
-    private File mFile = null;
+    private Path mPath = null;
 
     private ValidationStringency validationStringency = ValidationStringency.DEFAULT_STRINGENCY;
 
@@ -64,15 +66,31 @@ class SAMTextReader extends SamReader.ReaderImplementation {
      * Prepare to read a SAM text file.
      *
      * @param stream Need not be buffered, as this class provides buffered reading.
-     * @param file   For error reporting only.
+     * @param path   For error reporting only.
      */
+    public SAMTextReader(
+            final InputStream stream,
+            final Path path,
+            final ValidationStringency validationStringency,
+            final SAMRecordFactory factory) {
+        this(stream, validationStringency, factory);
+        mPath = path;
+    }
+
+    /**
+     * Prepare to read a SAM text file.
+     *
+     * @param stream Need not be buffered, as this class provides buffered reading.
+     * @param file   For error reporting only.
+     * @deprecated since 06/2025 Use {@link #SAMTextReader(InputStream, Path, ValidationStringency, SAMRecordFactory)} instead.
+     */
+    @Deprecated
     public SAMTextReader(
             final InputStream stream,
             final File file,
             final ValidationStringency validationStringency,
             final SAMRecordFactory factory) {
-        this(stream, validationStringency, factory);
-        mFile = file;
+        this(stream, file == null ? null : file.toPath(), validationStringency, factory);
     }
 
     /**
@@ -215,7 +233,7 @@ class SAMTextReader extends SamReader.ReaderImplementation {
     private void readHeader() {
         final SAMTextHeaderCodec headerCodec = new SAMTextHeaderCodec();
         headerCodec.setValidationStringency(validationStringency);
-        mFileHeader = headerCodec.decode(mReader, (mFile != null ? mFile.toString() : null));
+        mFileHeader = headerCodec.decode(mReader, (mPath != null ? mPath.toString() : null));
         advanceLine();
     }
 
@@ -228,8 +246,14 @@ class SAMTextReader extends SamReader.ReaderImplementation {
      */
     private class RecordIterator implements CloseableIterator<SAMRecord> {
 
-        private final SAMLineParser parser =
-                new SAMLineParser(samRecordFactory, validationStringency, mFileHeader, mParentReader, mFile);
+        // SAMLineParser still accepts only a File for error-reporting purposes. The path is converted to a File
+        // when it lives on the default filesystem; otherwise null is passed (the value is only used in messages).
+        private final SAMLineParser parser = new SAMLineParser(
+                samRecordFactory,
+                validationStringency,
+                mFileHeader,
+                mParentReader,
+                (mPath != null && mPath.getFileSystem() == FileSystems.getDefault()) ? mPath.toFile() : null);
 
         private RecordIterator() {
             if (mReader == null) {

--- a/src/main/java/htsjdk/samtools/SAMTextReader.java
+++ b/src/main/java/htsjdk/samtools/SAMTextReader.java
@@ -25,9 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.SamLineReader;
-import java.io.File;
 import java.io.InputStream;
-import java.nio.file.FileSystems;
 import java.nio.file.Path;
 
 /**
@@ -75,22 +73,6 @@ class SAMTextReader extends SamReader.ReaderImplementation {
             final SAMRecordFactory factory) {
         this(stream, validationStringency, factory);
         mPath = path;
-    }
-
-    /**
-     * Prepare to read a SAM text file.
-     *
-     * @param stream Need not be buffered, as this class provides buffered reading.
-     * @param file   For error reporting only.
-     * @deprecated since 06/2025 Use {@link #SAMTextReader(InputStream, Path, ValidationStringency, SAMRecordFactory)} instead.
-     */
-    @Deprecated
-    public SAMTextReader(
-            final InputStream stream,
-            final File file,
-            final ValidationStringency validationStringency,
-            final SAMRecordFactory factory) {
-        this(stream, file == null ? null : file.toPath(), validationStringency, factory);
     }
 
     /**
@@ -246,14 +228,8 @@ class SAMTextReader extends SamReader.ReaderImplementation {
      */
     private class RecordIterator implements CloseableIterator<SAMRecord> {
 
-        // SAMLineParser still accepts only a File for error-reporting purposes. The path is converted to a File
-        // when it lives on the default filesystem; otherwise null is passed (the value is only used in messages).
-        private final SAMLineParser parser = new SAMLineParser(
-                samRecordFactory,
-                validationStringency,
-                mFileHeader,
-                mParentReader,
-                (mPath != null && mPath.getFileSystem() == FileSystems.getDefault()) ? mPath.toFile() : null);
+        private final SAMLineParser parser =
+                new SAMLineParser(samRecordFactory, validationStringency, mFileHeader, mParentReader, mPath);
 
         private RecordIterator() {
             if (mReader == null) {

--- a/src/main/java/htsjdk/samtools/SAMTextWriter.java
+++ b/src/main/java/htsjdk/samtools/SAMTextWriter.java
@@ -26,11 +26,12 @@ package htsjdk.samtools;
 import htsjdk.samtools.util.AsciiWriter;
 import htsjdk.samtools.util.RuntimeIOException;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Writer for text-format SAM files.
@@ -40,7 +41,7 @@ public class SAMTextWriter extends SAMFileWriterImpl {
 
     private final Writer out;
     // For error reporting only.
-    private final File file;
+    private final Path path;
     private final TextTagCodec tagCodec = new TextTagCodec();
 
     private final SamFlagField samFlagFieldOutput;
@@ -54,11 +55,21 @@ public class SAMTextWriter extends SAMFileWriterImpl {
     }
 
     /**
+     * Constructs a SAMTextWriter that writes to a Path.
+     * @param path Where to write the output.
+     */
+    public SAMTextWriter(final Path path) {
+        this(path, SamFlagField.DECIMAL);
+    }
+
+    /**
      * Constructs a SAMTextWriter that writes to a File.
      * @param file Where to write the output.
+     * @deprecated since 06/2025 Use {@link #SAMTextWriter(Path)} instead.
      */
+    @Deprecated
     public SAMTextWriter(final File file) {
-        this(file, SamFlagField.DECIMAL);
+        this(file.toPath());
     }
 
     /**
@@ -84,23 +95,33 @@ public class SAMTextWriter extends SAMFileWriterImpl {
     public SAMTextWriter(final Writer out, final SamFlagField samFlagFieldOutput) {
         if (samFlagFieldOutput == null) throw new IllegalArgumentException("Sam flag field was null");
         this.out = out;
-        this.file = null;
+        this.path = null;
+        this.samFlagFieldOutput = samFlagFieldOutput;
+    }
+
+    /**
+     * Constructs a SAMTextWriter that writes to a Path.
+     * @param path Where to write the output.
+     */
+    public SAMTextWriter(final Path path, final SamFlagField samFlagFieldOutput) {
+        if (samFlagFieldOutput == null) throw new IllegalArgumentException("Sam flag field was null");
+        try {
+            this.path = path;
+            this.out = new AsciiWriter(Files.newOutputStream(path));
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
         this.samFlagFieldOutput = samFlagFieldOutput;
     }
 
     /**
      * Constructs a SAMTextWriter that writes to a File.
      * @param file Where to write the output.
+     * @deprecated since 06/2025 Use {@link #SAMTextWriter(Path, SamFlagField)} instead.
      */
+    @Deprecated
     public SAMTextWriter(final File file, final SamFlagField samFlagFieldOutput) {
-        if (samFlagFieldOutput == null) throw new IllegalArgumentException("Sam flag field was null");
-        try {
-            this.file = file;
-            this.out = new AsciiWriter(new FileOutputStream(file));
-        } catch (final IOException e) {
-            throw new RuntimeIOException(e);
-        }
-        this.samFlagFieldOutput = samFlagFieldOutput;
+        this(file.toPath(), samFlagFieldOutput);
     }
 
     /**
@@ -110,7 +131,7 @@ public class SAMTextWriter extends SAMFileWriterImpl {
      */
     public SAMTextWriter(final OutputStream stream, final SamFlagField samFlagFieldOutput) {
         if (samFlagFieldOutput == null) throw new IllegalArgumentException("Sam flag field was null");
-        this.file = null;
+        this.path = null;
         this.out = new AsciiWriter(stream);
         this.samFlagFieldOutput = samFlagFieldOutput;
     }
@@ -224,9 +245,9 @@ public class SAMTextWriter extends SAMFileWriterImpl {
      */
     @Override
     public String getFilename() {
-        if (file == null) {
+        if (path == null) {
             return null;
         }
-        return file.getAbsolutePath();
+        return path.toAbsolutePath().toString();
     }
 }

--- a/src/main/java/htsjdk/samtools/SAMTextWriter.java
+++ b/src/main/java/htsjdk/samtools/SAMTextWriter.java
@@ -25,7 +25,6 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.AsciiWriter;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
@@ -60,16 +59,6 @@ public class SAMTextWriter extends SAMFileWriterImpl {
      */
     public SAMTextWriter(final Path path) {
         this(path, SamFlagField.DECIMAL);
-    }
-
-    /**
-     * Constructs a SAMTextWriter that writes to a File.
-     * @param file Where to write the output.
-     * @deprecated since 06/2025 Use {@link #SAMTextWriter(Path)} instead.
-     */
-    @Deprecated
-    public SAMTextWriter(final File file) {
-        this(file.toPath());
     }
 
     /**
@@ -112,16 +101,6 @@ public class SAMTextWriter extends SAMFileWriterImpl {
             throw new RuntimeIOException(e);
         }
         this.samFlagFieldOutput = samFlagFieldOutput;
-    }
-
-    /**
-     * Constructs a SAMTextWriter that writes to a File.
-     * @param file Where to write the output.
-     * @deprecated since 06/2025 Use {@link #SAMTextWriter(Path, SamFlagField)} instead.
-     */
-    @Deprecated
-    public SAMTextWriter(final File file, final SamFlagField samFlagFieldOutput) {
-        this(file.toPath(), samFlagFieldOutput);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -544,8 +544,21 @@ public final class SAMUtils {
      * Calculate a hash code from identifying information in the RG (read group) records in a SAM file's
      * header. This hash code changes any time read groups are added or removed. Comparing one file's
      * hash code to another's tells you if the read groups in the BAM files are different.
+     *
+     * @deprecated since 5.0.0; use {@link #calculateReadGroupRecordChecksum(Path, Path)} instead.
      */
+    @Deprecated
     public static String calculateReadGroupRecordChecksum(final File input, final File referenceFasta) {
+        return calculateReadGroupRecordChecksum(
+                input.toPath(), referenceFasta == null ? null : referenceFasta.toPath());
+    }
+
+    /**
+     * Calculate a hash code from identifying information in the RG (read group) records in a SAM file's
+     * header. This hash code changes any time read groups are added or removed. Comparing one file's
+     * hash code to another's tells you if the read groups in the BAM files are different.
+     */
+    public static String calculateReadGroupRecordChecksum(final Path input, final Path referenceFasta) {
         final String ENCODING = "UTF-8";
 
         final MessageDigest digest;
@@ -746,13 +759,12 @@ public final class SAMUtils {
     /**
      * Returns the virtual file offset of the first record in a BAM file - i.e. the virtual file
      * offset after skipping over the text header and the sequence records.
+     *
+     * @deprecated since 5.0.0; use {@link #findVirtualOffsetOfFirstRecordInBam(Path)} instead.
      */
+    @Deprecated
     public static long findVirtualOffsetOfFirstRecordInBam(final File bamFile) {
-        try {
-            return BAMFileReader.findVirtualOffsetOfFirstRecord(bamFile);
-        } catch (final IOException ioe) {
-            throw new RuntimeEOFException(ioe);
-        }
+        return findVirtualOffsetOfFirstRecordInBam(bamFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SAMUtils.java
+++ b/src/main/java/htsjdk/samtools/SAMUtils.java
@@ -32,7 +32,6 @@ import htsjdk.samtools.util.CoordMath;
 import htsjdk.samtools.util.RuntimeEOFException;
 import htsjdk.samtools.util.StringUtil;
 import htsjdk.tribble.annotation.Strand;
-import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
@@ -544,19 +543,6 @@ public final class SAMUtils {
      * Calculate a hash code from identifying information in the RG (read group) records in a SAM file's
      * header. This hash code changes any time read groups are added or removed. Comparing one file's
      * hash code to another's tells you if the read groups in the BAM files are different.
-     *
-     * @deprecated since 5.0.0; use {@link #calculateReadGroupRecordChecksum(Path, Path)} instead.
-     */
-    @Deprecated
-    public static String calculateReadGroupRecordChecksum(final File input, final File referenceFasta) {
-        return calculateReadGroupRecordChecksum(
-                input.toPath(), referenceFasta == null ? null : referenceFasta.toPath());
-    }
-
-    /**
-     * Calculate a hash code from identifying information in the RG (read group) records in a SAM file's
-     * header. This hash code changes any time read groups are added or removed. Comparing one file's
-     * hash code to another's tells you if the read groups in the BAM files are different.
      */
     public static String calculateReadGroupRecordChecksum(final Path input, final Path referenceFasta) {
         final String ENCODING = "UTF-8";
@@ -754,17 +740,6 @@ public final class SAMUtils {
         } catch (final IOException ioe) {
             throw new RuntimeEOFException(ioe);
         }
-    }
-
-    /**
-     * Returns the virtual file offset of the first record in a BAM file - i.e. the virtual file
-     * offset after skipping over the text header and the sequence records.
-     *
-     * @deprecated since 5.0.0; use {@link #findVirtualOffsetOfFirstRecordInBam(Path)} instead.
-     */
-    @Deprecated
-    public static long findVirtualOffsetOfFirstRecordInBam(final File bamFile) {
-        return findVirtualOffsetOfFirstRecordInBam(bamFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -43,7 +43,6 @@ import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -203,14 +202,6 @@ public class SamFileValidator {
         final boolean result = errorsByType.isEmpty();
         cleanup();
         return result;
-    }
-
-    /**
-     * @deprecated use {@link #validateBamFileTermination(Path)} instead
-     */
-    @Deprecated
-    public void validateBamFileTermination(final File inputFile) {
-        validateBamFileTermination(IOUtil.toPath(inputFile));
     }
 
     public void validateBamFileTermination(final Path inputFile) {

--- a/src/main/java/htsjdk/samtools/SamFileValidator.java
+++ b/src/main/java/htsjdk/samtools/SamFileValidator.java
@@ -205,6 +205,10 @@ public class SamFileValidator {
         return result;
     }
 
+    /**
+     * @deprecated use {@link #validateBamFileTermination(Path)} instead
+     */
+    @Deprecated
     public void validateBamFileTermination(final File inputFile) {
         validateBamFileTermination(IOUtil.toPath(inputFile));
     }

--- a/src/main/java/htsjdk/samtools/SamFiles.java
+++ b/src/main/java/htsjdk/samtools/SamFiles.java
@@ -21,7 +21,9 @@ public class SamFiles {
      * If the file is a symlink and the index cannot be found, try to unsymlink the file and look for the bai in the actual file path.
      *
      * @return The index for the provided SAM, or null if one was not found.
+     * @deprecated since 5.0; use {@link #findIndex(Path)} instead.
      */
+    @Deprecated
     public static File findIndex(final File samFile) {
         final Path path = findIndex(IOUtil.toPath(samFile));
         return path == null ? null : path.toFile();
@@ -106,5 +108,41 @@ public class SamFiles {
         }
 
         return null;
+    }
+
+    /**
+     * Determines if the given path represents a BAM file based on its file extension.
+     *
+     * @param path the path to check
+     * @return true if the path has a valid BAM file extension (.bam), false otherwise
+     */
+    public static boolean isBAMFile(final Path path) {
+        return path != null
+                && SamReader.Type.BAM_TYPE.hasValidFileExtension(
+                        path.getFileName().toString());
+    }
+
+    /**
+     * Determines if the given path represents a CRAM file based on its file extension.
+     *
+     * @param path the path to check
+     * @return true if the path has a valid CRAM file extension (.cram), false otherwise
+     */
+    public static boolean isCRAMFile(final Path path) {
+        return path != null
+                && SamReader.Type.CRAM_TYPE.hasValidFileExtension(
+                        path.getFileName().toString());
+    }
+
+    /**
+     * Determines if the given path represents a SAM file based on its file extension.
+     *
+     * @param path the path to check
+     * @return true if the path has a valid SAM file extension (.sam), false otherwise
+     */
+    public static boolean isSAMFile(final Path path) {
+        return path != null
+                && SamReader.Type.SAM_TYPE.hasValidFileExtension(
+                        path.getFileName().toString());
     }
 }

--- a/src/main/java/htsjdk/samtools/SamFiles.java
+++ b/src/main/java/htsjdk/samtools/SamFiles.java
@@ -1,9 +1,7 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.FileExtensions;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,20 +12,6 @@ import java.nio.file.Path;
 public class SamFiles {
 
     private static final Log LOG = Log.getInstance(SamFiles.class);
-
-    /**
-     * Finds the index file associated with the provided SAM file.  The index file must exist and be reachable to be found.
-     *
-     * If the file is a symlink and the index cannot be found, try to unsymlink the file and look for the bai in the actual file path.
-     *
-     * @return The index for the provided SAM, or null if one was not found.
-     * @deprecated since 5.0; use {@link #findIndex(Path)} instead.
-     */
-    @Deprecated
-    public static File findIndex(final File samFile) {
-        final Path path = findIndex(IOUtil.toPath(samFile));
-        return path == null ? null : path.toFile();
-    }
 
     /**
      * Finds the index file associated with the provided SAM file.  The index file must exist and be reachable to be found.

--- a/src/main/java/htsjdk/samtools/SamIndexes.java
+++ b/src/main/java/htsjdk/samtools/SamIndexes.java
@@ -10,6 +10,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.GZIPInputStream;
 
@@ -34,7 +35,19 @@ public enum SamIndexes {
 
     public static InputStream openIndexFileAsBaiOrNull(final Path path, final SAMSequenceDictionary dictionary)
             throws IOException {
-        return openIndexUrlAsBaiOrNull(path.toUri().toURL(), dictionary);
+        // Resolve via the path's own filesystem rather than java.net.URL.openStream(), which is not
+        // NIO-SPI aware and would fail for non-default-filesystem paths (e.g. jimfs, S3, GCS).
+        final String name = path.getFileName().toString().toLowerCase();
+        if (name.endsWith(BAI.fileNameSuffix.toLowerCase())) {
+            return Files.newInputStream(path);
+        }
+        if (name.endsWith(CRAI.fileNameSuffix.toLowerCase())) {
+            return CRAIIndex.openCraiFileAsBaiStream(Files.newInputStream(path), dictionary);
+        }
+        if (name.endsWith(CSI.fileNameSuffix.toLowerCase())) {
+            return Files.newInputStream(path);
+        }
+        return null;
     }
 
     public static InputStream openIndexUrlAsBaiOrNull(final URL url, final SAMSequenceDictionary dictionary)

--- a/src/main/java/htsjdk/samtools/SamIndexes.java
+++ b/src/main/java/htsjdk/samtools/SamIndexes.java
@@ -7,7 +7,6 @@ import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -36,15 +35,6 @@ public enum SamIndexes {
     public static InputStream openIndexFileAsBaiOrNull(final Path path, final SAMSequenceDictionary dictionary)
             throws IOException {
         return openIndexUrlAsBaiOrNull(path.toUri().toURL(), dictionary);
-    }
-
-    /**
-     * @deprecated since 06/2026 use {@link #openIndexFileAsBaiOrNull(Path, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public static InputStream openIndexFileAsBaiOrNull(final File file, final SAMSequenceDictionary dictionary)
-            throws IOException {
-        return openIndexFileAsBaiOrNull(file.toPath(), dictionary);
     }
 
     public static InputStream openIndexUrlAsBaiOrNull(final URL url, final SAMSequenceDictionary dictionary)

--- a/src/main/java/htsjdk/samtools/SamIndexes.java
+++ b/src/main/java/htsjdk/samtools/SamIndexes.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -32,9 +33,18 @@ public enum SamIndexes {
         this.magic = magic;
     }
 
+    public static InputStream openIndexFileAsBaiOrNull(final Path path, final SAMSequenceDictionary dictionary)
+            throws IOException {
+        return openIndexUrlAsBaiOrNull(path.toUri().toURL(), dictionary);
+    }
+
+    /**
+     * @deprecated since 06/2026 use {@link #openIndexFileAsBaiOrNull(Path, SAMSequenceDictionary)} instead.
+     */
+    @Deprecated
     public static InputStream openIndexFileAsBaiOrNull(final File file, final SAMSequenceDictionary dictionary)
             throws IOException {
-        return openIndexUrlAsBaiOrNull(file.toURI().toURL(), dictionary);
+        return openIndexFileAsBaiOrNull(file.toPath(), dictionary);
     }
 
     public static InputStream openIndexUrlAsBaiOrNull(final URL url, final SAMSequenceDictionary dictionary)

--- a/src/main/java/htsjdk/samtools/SamInputResource.java
+++ b/src/main/java/htsjdk/samtools/SamInputResource.java
@@ -86,16 +86,6 @@ public class SamInputResource {
         return String.format("data=%s;index=%s", source, index);
     }
 
-    /**
-     * Creates a {@link SamInputResource} reading from the provided resource, with no index.
-     *
-     * @deprecated since 6.0; use {@link #of(Path)} instead.
-     */
-    @Deprecated
-    public static SamInputResource of(final File file) {
-        return new SamInputResource(new FileInputResource(file.toPath()));
-    }
-
     /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
     public static SamInputResource of(final Path path) {
 
@@ -196,16 +186,6 @@ public class SamInputResource {
         } catch (final IOException e) {
             throw new RuntimeIOException(e);
         }
-    }
-
-    /**
-     * Updates the index to point at the provided resource, then returns itself.
-     *
-     * @deprecated since 6.0; use {@link #index(Path)} instead.
-     */
-    @Deprecated
-    public SamInputResource index(final File file) {
-        return index(file.toPath());
     }
 
     /** Updates the index to point at the provided resource, then returns itself. */
@@ -315,7 +295,7 @@ class FileInputResource extends InputResource {
         @Override
         public SeekableStream get() {
             try {
-                return new SeekableFileStream(pathResource.toFile());
+                return new SeekableFileStream(pathResource);
             } catch (final FileNotFoundException e) {
                 throw new RuntimeIOException(e);
             }

--- a/src/main/java/htsjdk/samtools/SamInputResource.java
+++ b/src/main/java/htsjdk/samtools/SamInputResource.java
@@ -31,7 +31,11 @@ import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Lazy;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -82,9 +86,14 @@ public class SamInputResource {
         return String.format("data=%s;index=%s", source, index);
     }
 
-    /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
+    /**
+     * Creates a {@link SamInputResource} reading from the provided resource, with no index.
+     *
+     * @deprecated since 6.0; use {@link #of(Path)} instead.
+     */
+    @Deprecated
     public static SamInputResource of(final File file) {
-        return new SamInputResource(new FileInputResource(file));
+        return new SamInputResource(new FileInputResource(file.toPath()));
     }
 
     /** Creates a {@link SamInputResource} reading from the provided resource, with no index. */
@@ -103,7 +112,7 @@ public class SamInputResource {
         // To work around this bug, we fall back to using a FileInputResource rather than a PathInputResource
         // when we encounter a non-regular file using the default NIO filesystem (file://)
         if (path.getFileSystem() == FileSystems.getDefault() && !Files.isRegularFile(path)) {
-            return of(path.toFile());
+            return new SamInputResource(new FileInputResource(path));
         } else {
             return new SamInputResource(new PathInputResource(path));
         }
@@ -180,13 +189,23 @@ public class SamInputResource {
         } catch (MalformedURLException e) {
             // ignore
         }
-        return of(new File(string));
+        try {
+            // Use IOUtil.getPath so that scheme-aware NIO providers (gcs, custom SPIs, etc.) are honored;
+            // for a plain local path this resolves against the default file system.
+            return of(IOUtil.getPath(string));
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
     }
 
-    /** Updates the index to point at the provided resource, then returns itself. */
+    /**
+     * Updates the index to point at the provided resource, then returns itself.
+     *
+     * @deprecated since 6.0; use {@link #index(Path)} instead.
+     */
+    @Deprecated
     public SamInputResource index(final File file) {
-        this.index = new FileInputResource(file);
-        return this;
+        return index(file.toPath());
     }
 
     /** Updates the index to point at the provided resource, then returns itself. */
@@ -291,31 +310,39 @@ abstract class InputResource {
 
 class FileInputResource extends InputResource {
 
-    final File fileResource;
+    final Path pathResource;
     final Lazy<SeekableStream> lazySeekableStream = new Lazy<>(new Supplier<SeekableStream>() {
         @Override
         public SeekableStream get() {
             try {
-                return new SeekableFileStream(fileResource);
+                return new SeekableFileStream(pathResource.toFile());
             } catch (final FileNotFoundException e) {
                 throw new RuntimeIOException(e);
             }
         }
     });
 
-    FileInputResource(final File fileResource) {
+    FileInputResource(final Path pathResource) {
         super(Type.FILE);
-        this.fileResource = fileResource;
+        this.pathResource = pathResource;
+    }
+
+    /**
+     * @deprecated since 6.0; use {@link #FileInputResource(Path)} instead.
+     */
+    @Deprecated
+    FileInputResource(final File fileResource) {
+        this(fileResource.toPath());
     }
 
     @Override
     public File asFile() {
-        return fileResource;
+        return pathResource.toFile();
     }
 
     @Override
     public Path asPath() {
-        return IOUtil.toPath(fileResource);
+        return pathResource;
     }
 
     @Override
@@ -331,7 +358,7 @@ class FileInputResource extends InputResource {
     public SeekableStream asUnbufferedSeekableStream() {
         // if the file doesn't exist, the try to open the stream anyway because users might be expecting the exception
         // if it not a regular file than we won't be able to seek on it, so return null
-        if (!fileResource.exists() || fileResource.isFile()) {
+        if (!Files.exists(pathResource) || Files.isRegularFile(pathResource)) {
             return lazySeekableStream.get();
         } else {
             return null;
@@ -344,8 +371,12 @@ class FileInputResource extends InputResource {
         if (seekableStream != null) {
             return seekableStream;
         } else {
+            // Use FileInputStream (rather than Files.newInputStream) for non-regular files such as named
+            // pipes/FIFOs: the channel-based stream returned by Files.newInputStream reports available()==0
+            // and then mis-handles seeking on non-seekable inputs.
+            // See: https://bugs.java.com/view_bug.do?bug_id=7036144
             try {
-                return new FileInputStream(fileResource);
+                return new FileInputStream(pathResource.toFile());
             } catch (FileNotFoundException e) {
                 throw new RuntimeIOException(e);
             }
@@ -441,7 +472,11 @@ class UrlInputResource extends InputResource {
     public Path asPath() {
         try {
             return IOUtil.getPath(urlResource.toExternalForm());
-        } catch (IOException | IllegalArgumentException | FileSystemNotFoundException | SecurityException e) {
+        } catch (IOException
+                | IllegalArgumentException
+                | FileSystemNotFoundException
+                | ProviderNotFoundException
+                | SecurityException e) {
             return null;
         }
     }

--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -29,12 +29,12 @@ import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.*;
 import htsjdk.samtools.util.zip.InflaterFactory;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -45,9 +45,9 @@ import java.util.zip.GZIPInputStream;
  * <p>Describes the functionality for producing {@link SamReader}, and offers a
  * handful of static generators.</p>
  *
- * <p>This factory accepts {@link java.nio.file.Path} and {@link java.net.URI} inputs, as well as
- * legacy {@link java.io.File} inputs (the latter are deprecated). Any NIO-compatible filesystem
- * provider (e.g., jimfs, S3, HDFS) can be used via the standard SPI mechanism.</p>
+ * <p>This factory accepts {@link java.nio.file.Path} and {@link java.net.URI} inputs. Any
+ * NIO-compatible filesystem provider (e.g., jimfs, S3, HDFS) can be used via the standard SPI
+ * mechanism.</p>
  *
  * <pre>
  *     SamReaderFactory.makeDefault().open(Path.of("/my/bam.bam"));
@@ -85,16 +85,6 @@ import java.util.zip.GZIPInputStream;
 public abstract class SamReaderFactory {
 
     private static ValidationStringency defaultValidationStringency = ValidationStringency.DEFAULT_STRINGENCY;
-
-    /**
-     * Open the specified file.
-     *
-     * @deprecated since 5.0.0; use {@link #open(Path)} or {@link #open(URI)} instead.
-     */
-    @Deprecated
-    public SamReader open(final File file) {
-        return open(file.toPath());
-    }
 
     /**
      * Open the specified path (without using any wrappers).
@@ -166,14 +156,6 @@ public abstract class SamReaderFactory {
     /** Sets a specific Option to a boolean value. * */
     public abstract SamReaderFactory setOption(final Option option, boolean value);
 
-    /**
-     * Sets the specified reference sequence.
-     *
-     * @deprecated since 5.0.0; use {@link #referenceSequence(Path)} or {@link #referenceSequence(URI)} instead.
-     */
-    @Deprecated
-    public abstract SamReaderFactory referenceSequence(File referenceSequence);
-
     /** Sets the specified reference sequence. */
     public abstract SamReaderFactory referenceSequence(Path referenceSequence);
 
@@ -192,14 +174,6 @@ public abstract class SamReaderFactory {
 
     /** Sets the specified reference sequence * */
     public abstract SamReaderFactory referenceSource(CRAMReferenceSource referenceSequence);
-
-    /**
-     * Utility method to open the file, get the header, and close the file.
-     *
-     * @deprecated since 5.0.0; use {@link #getFileHeader(Path)} or {@link #getFileHeader(URI)} instead.
-     */
-    @Deprecated
-    public abstract SAMFileHeader getFileHeader(File samFile);
 
     /** Utility method to open the file get the header and close the file */
     public abstract SAMFileHeader getFileHeader(Path samFile);
@@ -285,12 +259,6 @@ public abstract class SamReaderFactory {
         }
 
         @Override
-        @Deprecated
-        public SamReader open(final File file) {
-            return open(file.toPath());
-        }
-
-        @Override
         public ValidationStringency validationStringency() {
             return validationStringency;
         }
@@ -336,12 +304,6 @@ public abstract class SamReaderFactory {
         }
 
         @Override
-        @Deprecated
-        public SamReaderFactory referenceSequence(final File referenceSequence) {
-            return referenceSequence(referenceSequence.toPath());
-        }
-
-        @Override
         public SamReaderFactory referenceSequence(final Path referenceSequence) {
             this.referenceSource = new ReferenceSource(referenceSequence);
             return this;
@@ -356,12 +318,6 @@ public abstract class SamReaderFactory {
         public SamReaderFactory referenceSource(final CRAMReferenceSource referenceSource) {
             this.referenceSource = referenceSource;
             return this;
-        }
-
-        @Override
-        @Deprecated
-        public SAMFileHeader getFileHeader(final File samFile) {
-            return getFileHeader(samFile.toPath());
         }
 
         @Override
@@ -462,12 +418,12 @@ public abstract class SamReaderFactory {
                     InputStream bufferedStream = IOUtil.maybeBufferInputStream(
                             data.asUnbufferedInputStream(),
                             Math.max(Defaults.BUFFER_SIZE, BlockCompressedStreamConstants.MAX_COMPRESSED_BLOCK_SIZE));
-                    File sourceFile = data.asFile();
-                    // calling asFile is safe even if indexMaybe is a Google Cloud Storage bucket
+                    Path sourcePath = data.asPath();
+                    // calling asPath is safe even if indexMaybe is a Google Cloud Storage bucket
                     // (in that case we just get null)
-                    final File indexFile = indexMaybe == null ? null : indexMaybe.asFile();
+                    final Path indexPath = indexMaybe == null ? null : indexMaybe.asPath();
                     if (SamStreams.isBAMFile(bufferedStream)) {
-                        if (sourceFile == null || !sourceFile.isFile()) {
+                        if (sourcePath == null || !Files.isRegularFile(sourcePath)) {
                             // check whether we can seek
                             final SeekableStream indexSeekable =
                                     indexMaybe == null ? null : indexMaybe.asUnbufferedSeekableStream();
@@ -478,7 +434,7 @@ public abstract class SamReaderFactory {
                                 // it's OK that we consumed a bit of the stream already, this ctor expects it.
                                 primitiveSamReader = new BAMFileReader(
                                         bufferedStream,
-                                        indexFile,
+                                        indexPath,
                                         false,
                                         asynchronousIO,
                                         validationStringency,
@@ -501,8 +457,8 @@ public abstract class SamReaderFactory {
                         } else {
                             bufferedStream.close();
                             primitiveSamReader = new BAMFileReader(
-                                    sourceFile,
-                                    indexFile,
+                                    sourcePath,
+                                    indexPath,
                                     false,
                                     asynchronousIO,
                                     validationStringency,
@@ -523,13 +479,13 @@ public abstract class SamReaderFactory {
                         if (referenceSource == null) {
                             referenceSource = ReferenceSource.getDefaultCRAMReferenceSource();
                         }
-                        if (sourceFile == null || !sourceFile.isFile()) {
+                        if (sourcePath == null || !Files.isRegularFile(sourcePath)) {
                             final SeekableStream indexSeekableStream =
                                     indexMaybe == null ? null : indexMaybe.asUnbufferedSeekableStream();
                             final SeekableStream sourceSeekableStream = data.asUnbufferedSeekableStream();
                             if (null == sourceSeekableStream || null == indexSeekableStream) {
                                 primitiveSamReader = new CRAMFileReader(
-                                        bufferedStream, indexFile, referenceSource, validationStringency);
+                                        bufferedStream, indexPath, referenceSource, validationStringency);
                             } else {
                                 sourceSeekableStream.seek(0);
                                 primitiveSamReader = new CRAMFileReader(
@@ -541,7 +497,7 @@ public abstract class SamReaderFactory {
                         } else {
                             bufferedStream.close();
                             primitiveSamReader =
-                                    new CRAMFileReader(sourceFile, indexFile, referenceSource, validationStringency);
+                                    new CRAMFileReader(sourcePath, indexPath, referenceSource, validationStringency);
                         }
                     } else {
                         if (indexDefined) {
@@ -549,7 +505,7 @@ public abstract class SamReaderFactory {
                             throw new RuntimeException("Cannot use index file with textual SAM file");
                         }
                         primitiveSamReader = new SAMTextReader(
-                                bufferedStream, sourceFile, validationStringency, this.samRecordFactory);
+                                bufferedStream, sourcePath, validationStringency, this.samRecordFactory);
                     }
                 }
 

--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -32,6 +32,7 @@ import htsjdk.samtools.util.zip.InflaterFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
@@ -43,8 +44,13 @@ import java.util.zip.GZIPInputStream;
 /**
  * <p>Describes the functionality for producing {@link SamReader}, and offers a
  * handful of static generators.</p>
+ *
+ * <p>This factory accepts {@link java.nio.file.Path} and {@link java.net.URI} inputs, as well as
+ * legacy {@link java.io.File} inputs (the latter are deprecated). Any NIO-compatible filesystem
+ * provider (e.g., jimfs, S3, HDFS) can be used via the standard SPI mechanism.</p>
+ *
  * <pre>
- *     SamReaderFactory.makeDefault().open(new File("/my/bam.bam");
+ *     SamReaderFactory.makeDefault().open(Path.of("/my/bam.bam"));
  * </pre>
  * <p>Example: Configure a factory</p>
  * <pre>
@@ -61,8 +67,11 @@ import java.util.zip.GZIPInputStream;
  *              .enable({@link Option#INCLUDE_SOURCE_IN_RECORDS}, {@link Option#VALIDATE_CRC_CHECKSUMS})
  *              .validationStringency({@link ValidationStringency#SILENT});
  *
- *     // File-based bam
- *     final {@link SamReader} fileReader = factory.open(new File("/my/bam.bam"));
+ *     // Path-based bam
+ *     final {@link SamReader} pathReader = factory.open(Path.of("/my/bam.bam"));
+ *
+ *     // URI-based bam (resolved via the scheme-aware NIO SPI mechanism)
+ *     final {@link SamReader} uriReader = factory.open(URI.create("file:///my/bam.bam"));
  *
  *     // HTTP-hosted BAM with index from an arbitrary stream
  *     final SeekableStream myBamIndexStream = ...
@@ -77,7 +86,15 @@ public abstract class SamReaderFactory {
 
     private static ValidationStringency defaultValidationStringency = ValidationStringency.DEFAULT_STRINGENCY;
 
-    public abstract SamReader open(final File file);
+    /**
+     * Open the specified file.
+     *
+     * @deprecated since 5.0.0; use {@link #open(Path)} or {@link #open(URI)} instead.
+     */
+    @Deprecated
+    public SamReader open(final File file) {
+        return open(file.toPath());
+    }
 
     /**
      * Open the specified path (without using any wrappers).
@@ -86,6 +103,22 @@ public abstract class SamReaderFactory {
      */
     public SamReader open(final Path path) {
         return open(path, null, null);
+    }
+
+    /**
+     * Open the SAM, BAM, or CRAM file identified by the specified URI.
+     *
+     * <p>The URI is resolved to a {@link Path} using the scheme-aware NIO SPI mechanism
+     * (see {@link IOUtil#getPath(URI)}), so any installed NIO filesystem provider
+     * (e.g., file, jimfs, S3, HDFS) may be used. This is a convenience method that
+     * delegates to {@link #open(Path)}.</p>
+     *
+     * @param uri the URI of the SAM, BAM, or CRAM file to open (e.g., {@code file:///path/to/file.bam})
+     * @return a {@link SamReader} for the specified URI
+     * @throws IOException if the URI cannot be resolved to a usable Path
+     */
+    public SamReader open(final URI uri) throws IOException {
+        return open(IOUtil.getPath(uri));
     }
 
     /**
@@ -133,20 +166,56 @@ public abstract class SamReaderFactory {
     /** Sets a specific Option to a boolean value. * */
     public abstract SamReaderFactory setOption(final Option option, boolean value);
 
-    /** Sets the specified reference sequence * */
+    /**
+     * Sets the specified reference sequence.
+     *
+     * @deprecated since 5.0.0; use {@link #referenceSequence(Path)} or {@link #referenceSequence(URI)} instead.
+     */
+    @Deprecated
     public abstract SamReaderFactory referenceSequence(File referenceSequence);
 
     /** Sets the specified reference sequence. */
     public abstract SamReaderFactory referenceSequence(Path referenceSequence);
 
+    /**
+     * Sets the reference sequence identified by the specified URI.
+     *
+     * <p>The URI is resolved to a {@link Path} using the scheme-aware NIO SPI mechanism
+     * (see {@link IOUtil#getPath(URI)}). This is a convenience method that delegates to
+     * {@link #referenceSequence(Path)}.</p>
+     *
+     * @param referenceUri the URI of the reference sequence file
+     * @return this factory
+     * @throws IOException if the URI cannot be resolved to a usable Path
+     */
+    public abstract SamReaderFactory referenceSequence(URI referenceUri) throws IOException;
+
     /** Sets the specified reference sequence * */
     public abstract SamReaderFactory referenceSource(CRAMReferenceSource referenceSequence);
 
-    /** Utility method to open the file get the header and close the file */
+    /**
+     * Utility method to open the file, get the header, and close the file.
+     *
+     * @deprecated since 5.0.0; use {@link #getFileHeader(Path)} or {@link #getFileHeader(URI)} instead.
+     */
+    @Deprecated
     public abstract SAMFileHeader getFileHeader(File samFile);
 
     /** Utility method to open the file get the header and close the file */
     public abstract SAMFileHeader getFileHeader(Path samFile);
+
+    /**
+     * Utility method to open the file identified by the specified URI, get the header, and close the file.
+     *
+     * <p>The URI is resolved to a {@link Path} using the scheme-aware NIO SPI mechanism
+     * (see {@link IOUtil#getPath(URI)}). This is a convenience method that delegates to
+     * {@link #getFileHeader(Path)}.</p>
+     *
+     * @param samUri the URI of the SAM, BAM, or CRAM file
+     * @return the file header
+     * @throws IOException if the URI cannot be resolved to a usable Path
+     */
+    public abstract SAMFileHeader getFileHeader(URI samUri) throws IOException;
 
     /** Reapplies any changed options to the reader * */
     public abstract void reapplyOptions(SamReader reader);
@@ -216,11 +285,9 @@ public abstract class SamReaderFactory {
         }
 
         @Override
+        @Deprecated
         public SamReader open(final File file) {
-            final SamInputResource r = SamInputResource.of(file);
-            final File indexMaybe = SamFiles.findIndex(file);
-            if (indexMaybe != null) r.index(indexMaybe);
-            return open(r);
+            return open(file.toPath());
         }
 
         @Override
@@ -269,9 +336,9 @@ public abstract class SamReaderFactory {
         }
 
         @Override
+        @Deprecated
         public SamReaderFactory referenceSequence(final File referenceSequence) {
-            this.referenceSource = new ReferenceSource(referenceSequence);
-            return this;
+            return referenceSequence(referenceSequence.toPath());
         }
 
         @Override
@@ -281,17 +348,20 @@ public abstract class SamReaderFactory {
         }
 
         @Override
+        public SamReaderFactory referenceSequence(final URI referenceUri) throws IOException {
+            return referenceSequence(IOUtil.getPath(referenceUri));
+        }
+
+        @Override
         public SamReaderFactory referenceSource(final CRAMReferenceSource referenceSource) {
             this.referenceSource = referenceSource;
             return this;
         }
 
         @Override
+        @Deprecated
         public SAMFileHeader getFileHeader(final File samFile) {
-            final SamReader reader = open(samFile);
-            final SAMFileHeader header = reader.getFileHeader();
-            CloserUtil.close(reader);
-            return header;
+            return getFileHeader(samFile.toPath());
         }
 
         @Override
@@ -300,6 +370,11 @@ public abstract class SamReaderFactory {
             final SAMFileHeader header = reader.getFileHeader();
             CloserUtil.close(reader);
             return header;
+        }
+
+        @Override
+        public SAMFileHeader getFileHeader(final URI samUri) throws IOException {
+            return getFileHeader(IOUtil.getPath(samUri));
         }
 
         @Override

--- a/src/main/java/htsjdk/samtools/SamReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/SamReaderFactory.java
@@ -170,7 +170,9 @@ public abstract class SamReaderFactory {
      * @return this factory
      * @throws IOException if the URI cannot be resolved to a usable Path
      */
-    public abstract SamReaderFactory referenceSequence(URI referenceUri) throws IOException;
+    public SamReaderFactory referenceSequence(final URI referenceUri) throws IOException {
+        return referenceSequence(IOUtil.getPath(referenceUri));
+    }
 
     /** Sets the specified reference sequence * */
     public abstract SamReaderFactory referenceSource(CRAMReferenceSource referenceSequence);
@@ -189,7 +191,9 @@ public abstract class SamReaderFactory {
      * @return the file header
      * @throws IOException if the URI cannot be resolved to a usable Path
      */
-    public abstract SAMFileHeader getFileHeader(URI samUri) throws IOException;
+    public SAMFileHeader getFileHeader(final URI samUri) throws IOException {
+        return getFileHeader(IOUtil.getPath(samUri));
+    }
 
     /** Reapplies any changed options to the reader * */
     public abstract void reapplyOptions(SamReader reader);
@@ -310,11 +314,6 @@ public abstract class SamReaderFactory {
         }
 
         @Override
-        public SamReaderFactory referenceSequence(final URI referenceUri) throws IOException {
-            return referenceSequence(IOUtil.getPath(referenceUri));
-        }
-
-        @Override
         public SamReaderFactory referenceSource(final CRAMReferenceSource referenceSource) {
             this.referenceSource = referenceSource;
             return this;
@@ -326,11 +325,6 @@ public abstract class SamReaderFactory {
             final SAMFileHeader header = reader.getFileHeader();
             CloserUtil.close(reader);
             return header;
-        }
-
-        @Override
-        public SAMFileHeader getFileHeader(final URI samUri) throws IOException {
-            return getFileHeader(IOUtil.getPath(samUri));
         }
 
         @Override

--- a/src/main/java/htsjdk/samtools/StreamInflatingIndexingOutputStream.java
+++ b/src/main/java/htsjdk/samtools/StreamInflatingIndexingOutputStream.java
@@ -20,6 +20,11 @@ class StreamInflatingIndexingOutputStream extends OutputStream {
     private final PipedOutputStream s2;
     private final Thread thread;
 
+    /**
+     * @deprecated since File is being phased out in favor of {@link Path}; use
+     *     {@link #StreamInflatingIndexingOutputStream(OutputStream, Path)} instead.
+     */
+    @Deprecated
     public StreamInflatingIndexingOutputStream(final OutputStream s1, final File indexFile) {
         this(s1, indexFile.toPath());
     }

--- a/src/main/java/htsjdk/samtools/StreamInflatingIndexingOutputStream.java
+++ b/src/main/java/htsjdk/samtools/StreamInflatingIndexingOutputStream.java
@@ -2,7 +2,6 @@ package htsjdk.samtools;
 
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -19,15 +18,6 @@ class StreamInflatingIndexingOutputStream extends OutputStream {
     private final OutputStream s1;
     private final PipedOutputStream s2;
     private final Thread thread;
-
-    /**
-     * @deprecated since File is being phased out in favor of {@link Path}; use
-     *     {@link #StreamInflatingIndexingOutputStream(OutputStream, Path)} instead.
-     */
-    @Deprecated
-    public StreamInflatingIndexingOutputStream(final OutputStream s1, final File indexFile) {
-        this(s1, indexFile.toPath());
-    }
 
     public StreamInflatingIndexingOutputStream(final OutputStream s1, final Path indexPath) {
         try {

--- a/src/main/java/htsjdk/samtools/TextualBAMIndexWriter.java
+++ b/src/main/java/htsjdk/samtools/TextualBAMIndexWriter.java
@@ -25,9 +25,12 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
+import htsjdk.samtools.util.IOUtil;
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -38,7 +41,7 @@ import java.util.List;
 class TextualBAMIndexWriter implements BAMIndexWriter {
 
     protected final int nRef;
-    protected final File output;
+    protected final Path output;
     private final PrintWriter pw;
     private int count = 0;
 
@@ -47,14 +50,26 @@ class TextualBAMIndexWriter implements BAMIndexWriter {
      *
      * @param nRef    Number of reference sequences
      * @param output   BAM Index output file
+     * @deprecated since 5.0, use {@link #TextualBAMIndexWriter(int, Path)} instead.
      */
+    @Deprecated
     public TextualBAMIndexWriter(final int nRef, final File output) {
+        this(nRef, IOUtil.toPath(output));
+    }
+
+    /**
+     * constructor
+     *
+     * @param nRef    Number of reference sequences
+     * @param output   BAM Index output file path
+     */
+    public TextualBAMIndexWriter(final int nRef, final Path output) {
         this.output = output;
         this.nRef = nRef;
         try {
-            pw = new PrintWriter(output);
-        } catch (final FileNotFoundException e) {
-            throw new SAMException("Can't find output file " + output, e);
+            pw = new PrintWriter(Files.newBufferedWriter(output));
+        } catch (final IOException e) {
+            throw new SAMException("Can't open output file " + output, e);
         }
         writeHeader();
     }

--- a/src/main/java/htsjdk/samtools/TextualBAMIndexWriter.java
+++ b/src/main/java/htsjdk/samtools/TextualBAMIndexWriter.java
@@ -25,8 +25,6 @@
 package htsjdk.samtools;
 
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
-import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
@@ -44,18 +42,6 @@ class TextualBAMIndexWriter implements BAMIndexWriter {
     protected final Path output;
     private final PrintWriter pw;
     private int count = 0;
-
-    /**
-     * constructor
-     *
-     * @param nRef    Number of reference sequences
-     * @param output   BAM Index output file
-     * @deprecated since 5.0, use {@link #TextualBAMIndexWriter(int, Path)} instead.
-     */
-    @Deprecated
-    public TextualBAMIndexWriter(final int nRef, final File output) {
-        this(nRef, IOUtil.toPath(output));
-    }
 
     /**
      * constructor

--- a/src/main/java/htsjdk/samtools/apps/TimeChannel.java
+++ b/src/main/java/htsjdk/samtools/apps/TimeChannel.java
@@ -22,10 +22,11 @@
  */
 package htsjdk.samtools.apps;
 
-import java.io.File;
+import htsjdk.samtools.util.IOUtil;
 import java.io.FileInputStream;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 
 /**
  * @author alecw@broadinstitute.org
@@ -34,7 +35,9 @@ import java.nio.channels.FileChannel;
 @Deprecated
 public class TimeChannel {
     public static void main(String[] args) throws Exception {
-        long fileSize = new File(args[0]).length();
+        long fileSize = Files.size(IOUtil.getPath(args[0]));
+        // FileInputStream/FileChannel memory-mapping requires a local file, so the channel is opened
+        // from the original path string rather than via NIO.
         FileInputStream in = new FileInputStream(args[0]);
         FileChannel channel = in.getChannel();
         byte[] buf = new byte[64 * 1024];

--- a/src/main/java/htsjdk/samtools/apps/TimeRandomAccessFile.java
+++ b/src/main/java/htsjdk/samtools/apps/TimeRandomAccessFile.java
@@ -22,7 +22,6 @@
  */
 package htsjdk.samtools.apps;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 
@@ -33,7 +32,7 @@ import java.io.RandomAccessFile;
 @Deprecated
 public class TimeRandomAccessFile {
     public static void main(String[] args) throws Exception {
-        RandomAccessFile raf = new RandomAccessFile(new File(args[0]), "r");
+        RandomAccessFile raf = new RandomAccessFile(args[0], "r");
         byte[] buf = new byte[64 * 1024];
         long totalBytesRead = 0;
         int bytesRead;

--- a/src/main/java/htsjdk/samtools/cram/CRAIIndex.java
+++ b/src/main/java/htsjdk/samtools/cram/CRAIIndex.java
@@ -10,6 +10,8 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.RuntimeIOException;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -64,11 +66,30 @@ public class CRAIIndex {
         addEntries(container.getCRAIEntries(compressorCache));
     }
 
+    /**
+     * Open a CRAI index file and convert it to a BAI-style seekable stream.
+     * @param cramIndexFile the CRAI index file
+     * @param dictionary the sequence dictionary
+     * @return a {@link SeekableStream} over the converted BAI index
+     * @deprecated Use {@link #openCraiFileAsBaiStream(Path, SAMSequenceDictionary)} instead.
+     */
+    @Deprecated
     public static SeekableStream openCraiFileAsBaiStream(
             final File cramIndexFile, final SAMSequenceDictionary dictionary) {
+        return openCraiFileAsBaiStream(cramIndexFile.toPath(), dictionary);
+    }
+
+    /**
+     * Open a CRAI index and convert it to a BAI-style seekable stream.
+     * @param cramIndexPath the CRAI index path
+     * @param dictionary the sequence dictionary
+     * @return a {@link SeekableStream} over the converted BAI index
+     */
+    public static SeekableStream openCraiFileAsBaiStream(
+            final Path cramIndexPath, final SAMSequenceDictionary dictionary) {
         try {
-            return openCraiFileAsBaiStream(new FileInputStream(cramIndexFile), dictionary);
-        } catch (final FileNotFoundException e) {
+            return openCraiFileAsBaiStream(Files.newInputStream(cramIndexPath), dictionary);
+        } catch (final IOException e) {
             throw new RuntimeIOException(e);
         }
     }

--- a/src/main/java/htsjdk/samtools/cram/CramComparison.java
+++ b/src/main/java/htsjdk/samtools/cram/CramComparison.java
@@ -2,6 +2,7 @@ package htsjdk.samtools.cram;
 
 import htsjdk.samtools.*;
 import java.io.*;
+import java.nio.file.Paths;
 import java.util.*;
 
 /**
@@ -90,7 +91,7 @@ public class CramComparison {
         final SamReaderFactory factory =
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT);
         if (referencePath != null) {
-            factory.referenceSequence(new File(referencePath));
+            factory.referenceSequence(Paths.get(referencePath));
         }
 
         try (final PrintWriter out =
@@ -116,8 +117,8 @@ public class CramComparison {
         long recordCount = 0;
         int diffCount = 0;
 
-        try (final SamReader reader1 = factory.open(new File(file1));
-                final SamReader reader2 = factory.open(new File(file2))) {
+        try (final SamReader reader1 = factory.open(Paths.get(file1));
+                final SamReader reader2 = factory.open(Paths.get(file2))) {
 
             final Iterator<SAMRecord> it1 = reader1.iterator();
             final Iterator<SAMRecord> it2 = reader2.iterator();

--- a/src/main/java/htsjdk/samtools/cram/CramConverter.java
+++ b/src/main/java/htsjdk/samtools/cram/CramConverter.java
@@ -3,7 +3,7 @@ package htsjdk.samtools.cram;
 import htsjdk.samtools.*;
 import htsjdk.samtools.cram.structure.CRAMCompressionProfile;
 import htsjdk.samtools.cram.structure.CRAMEncodingStrategy;
-import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -110,7 +110,7 @@ public class CramConverter {
             die("--reference is required when reading or writing CRAM files");
         }
 
-        final Path refPath = referencePath != null ? new File(referencePath).toPath() : null;
+        final Path refPath = referencePath != null ? Path.of(referencePath) : null;
         final CRAMEncodingStrategy strategy = profile.toStrategy();
 
         if (outputPath != null) {
@@ -130,17 +130,19 @@ public class CramConverter {
 
         long count = 0;
         final long startTime = System.currentTimeMillis();
+        final Path inputFilePath = Path.of(inputPath);
 
-        try (final SamReader reader = readerFactory.open(new File(inputPath))) {
+        try (final SamReader reader = readerFactory.open(inputFilePath)) {
             final SAMFileHeader header = reader.getFileHeader();
 
             if (outputPath != null) {
                 // Read and write
                 final SAMFileWriterFactory writerFactory = new SAMFileWriterFactory().setCRAMEncodingStrategy(strategy);
 
+                final Path outputFilePath = Path.of(outputPath);
                 try (final SAMFileWriter writer = outputIsCram
-                        ? writerFactory.makeCRAMWriter(header, true, new File(outputPath).toPath(), refPath)
-                        : writerFactory.makeWriter(header, true, new File(outputPath).toPath(), refPath)) {
+                        ? writerFactory.makeCRAMWriter(header, true, outputFilePath, refPath)
+                        : writerFactory.makeWriter(header, true, outputFilePath, refPath)) {
 
                     for (final SAMRecord record : reader) {
                         writer.addAlignment(record);
@@ -165,10 +167,10 @@ public class CramConverter {
         }
 
         final long elapsed = System.currentTimeMillis() - startTime;
-        final long inputSize = new File(inputPath).length();
+        final long inputSize = fileSizeOrZero(inputFilePath);
 
         if (outputPath != null) {
-            final long outputSize = new File(outputPath).length();
+            final long outputSize = fileSizeOrZero(Path.of(outputPath));
             System.err.printf(
                     "Done. %,d records in %.1fs. Input: %,d bytes, Output: %,d bytes (%.1f%%)%n",
                     count,
@@ -186,6 +188,14 @@ public class CramConverter {
             if (flag.equals(arg)) return true;
         }
         return false;
+    }
+
+    private static long fileSizeOrZero(final Path path) {
+        try {
+            return Files.size(path);
+        } catch (final java.io.IOException e) {
+            return 0;
+        }
     }
 
     private static void die(final String message) {

--- a/src/main/java/htsjdk/samtools/cram/CramStats.java
+++ b/src/main/java/htsjdk/samtools/cram/CramStats.java
@@ -5,7 +5,7 @@ import htsjdk.samtools.cram.structure.*;
 import htsjdk.samtools.cram.structure.block.Block;
 import htsjdk.samtools.cram.structure.block.BlockCompressionMethod;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
-import java.io.File;
+import java.nio.file.Paths;
 import java.util.*;
 
 /**
@@ -43,7 +43,7 @@ public class CramStats {
         int sliceCount = 0;
         int recordCount = 0;
 
-        try (final SeekableFileStream stream = new SeekableFileStream(new File(path))) {
+        try (final SeekableFileStream stream = new SeekableFileStream(Paths.get(path))) {
             final CramContainerIterator iter = new CramContainerIterator(stream);
             System.out.printf("CRAM version: %s%n", iter.getCramHeader().getCRAMVersion());
             while (iter.hasNext()) {

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -24,12 +24,10 @@ import htsjdk.samtools.cram.io.InputStreamUtils;
 import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.SequenceUtil;
 import htsjdk.samtools.util.StringUtil;
 import htsjdk.utils.ValidationUtils;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
@@ -65,14 +63,6 @@ public class ReferenceSource implements CRAMReferenceSource {
     // is the weak reference hash map above, resulting in much thrashing.
     private byte[] backingReferenceBases;
     private int backingContigIndex;
-
-    /**
-     * @deprecated since 6.0.0; use {@link #ReferenceSource(Path)} instead.
-     */
-    @Deprecated
-    public ReferenceSource(final File file) {
-        this(IOUtil.toPath(file));
-    }
 
     public ReferenceSource(final Path path) {
         this(path == null ? null : ReferenceSequenceFileFactory.getReferenceSequenceFile(path));

--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -65,6 +66,10 @@ public class ReferenceSource implements CRAMReferenceSource {
     private byte[] backingReferenceBases;
     private int backingContigIndex;
 
+    /**
+     * @deprecated since 6.0.0; use {@link #ReferenceSource(Path)} instead.
+     */
+    @Deprecated
     public ReferenceSource(final File file) {
         this(IOUtil.toPath(file));
     }
@@ -96,14 +101,14 @@ public class ReferenceSource implements CRAMReferenceSource {
      */
     public static CRAMReferenceSource getDefaultCRAMReferenceSource() {
         if (null != Defaults.REFERENCE_FASTA) {
-            if (Defaults.REFERENCE_FASTA.exists()) {
+            if (Files.exists(Defaults.REFERENCE_FASTA)) {
                 log.info(String.format(
                         "Default reference file %s exists, so going to use that.",
-                        Defaults.REFERENCE_FASTA.getAbsolutePath()));
+                        Defaults.REFERENCE_FASTA.toAbsolutePath()));
                 return new ReferenceSource(Defaults.REFERENCE_FASTA);
             } else {
                 throw new IllegalArgumentException("The file specified by the reference_fasta property does not exist: "
-                        + Defaults.REFERENCE_FASTA.getName());
+                        + Defaults.REFERENCE_FASTA.getFileName());
             }
         } else if (Defaults.USE_CRAM_REF_DOWNLOAD) {
             log.info("USE_CRAM_REF_DOWNLOAD=true, so attempting to download reference file as needed.");

--- a/src/main/java/htsjdk/samtools/example/ExampleSamUsage.java
+++ b/src/main/java/htsjdk/samtools/example/ExampleSamUsage.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 
 public class ExampleSamUsage {
     public static SeekableStream myIndexSeekableStream() {
@@ -47,7 +48,7 @@ public class ExampleSamUsage {
         /**
          * Simplest case
          */
-        final SamReader reader = SamReaderFactory.makeDefault().open(new File("/my.bam"));
+        final SamReader reader = SamReaderFactory.makeDefault().open(Path.of("/my.bam"));
 
         /**
          * With different reader options
@@ -56,7 +57,7 @@ public class ExampleSamUsage {
                 .enable(SamReaderFactory.Option.DONT_MEMORY_MAP_INDEX)
                 .validationStringency(ValidationStringency.SILENT)
                 .samRecordFactory(DefaultSAMRecordFactory.getInstance())
-                .open(new File("/my.bam"));
+                .open(Path.of("/my.bam"));
 
         /**
          * With a more complicated source
@@ -73,7 +74,7 @@ public class ExampleSamUsage {
                 .validationStringency(ValidationStringency.LENIENT);
 
         final SamInputResource resource =
-                SamInputResource.of(new File("/my.bam")).index(new URL("http://broadinstitute.org/my.bam.bai"));
+                SamInputResource.of(Path.of("/my.bam")).index(new URL("http://broadinstitute.org/my.bam.bai"));
 
         final SamReader myReader = factory.open(resource);
 
@@ -85,8 +86,20 @@ public class ExampleSamUsage {
     /**
      * Read a SAM or BAM file, convert each read name to upper case, and write a new
      * SAM or BAM file.
+     *
+     * @deprecated since 6/26, use {@link #convertReadNamesToUpperCase(Path, Path)} instead
      */
+    @Deprecated
     public void convertReadNamesToUpperCase(final File inputSamOrBamFile, final File outputSamOrBamFile)
+            throws IOException {
+        convertReadNamesToUpperCase(inputSamOrBamFile.toPath(), outputSamOrBamFile.toPath());
+    }
+
+    /**
+     * Read a SAM or BAM file, convert each read name to upper case, and write a new
+     * SAM or BAM file.
+     */
+    public void convertReadNamesToUpperCase(final Path inputSamOrBamFile, final Path outputSamOrBamFile)
             throws IOException {
 
         final SamReader reader = SamReaderFactory.makeDefault().open(inputSamOrBamFile);

--- a/src/main/java/htsjdk/samtools/example/ExampleSamUsage.java
+++ b/src/main/java/htsjdk/samtools/example/ExampleSamUsage.java
@@ -32,7 +32,6 @@ import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.seekablestream.SeekableStream;
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -81,18 +80,6 @@ public class ExampleSamUsage {
         for (final SAMRecord samRecord : myReader) {
             System.err.print(samRecord);
         }
-    }
-
-    /**
-     * Read a SAM or BAM file, convert each read name to upper case, and write a new
-     * SAM or BAM file.
-     *
-     * @deprecated since 6/26, use {@link #convertReadNamesToUpperCase(Path, Path)} instead
-     */
-    @Deprecated
-    public void convertReadNamesToUpperCase(final File inputSamOrBamFile, final File outputSamOrBamFile)
-            throws IOException {
-        convertReadNamesToUpperCase(inputSamOrBamFile.toPath(), outputSamOrBamFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/example/PrintReadsExample.java
+++ b/src/main/java/htsjdk/samtools/example/PrintReadsExample.java
@@ -23,11 +23,12 @@
 package htsjdk.samtools.example;
 
 import htsjdk.samtools.*;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
-import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,10 +54,10 @@ public final class PrintReadsExample {
                     "Usage: " + PrintReadsExample.class.getCanonicalName() + " inFile eagerDecode [outFile]");
             System.exit(1);
         }
-        final File inputFile = new File(args[0]);
+        final Path inputFile = IOUtil.getPath(args[0]);
         final boolean eagerDecode = Boolean.parseBoolean(
                 args[1]); // useful to test (realistic) scenarios in which every record is always fully decoded.
-        final File outputFile = args.length >= 3 ? new File(args[2]) : null;
+        final Path outputFile = args.length >= 3 ? IOUtil.getPath(args[2]) : null;
 
         final long start = System.currentTimeMillis();
 

--- a/src/main/java/htsjdk/samtools/fastq/BasicFastqWriter.java
+++ b/src/main/java/htsjdk/samtools/fastq/BasicFastqWriter.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.Flushable;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.file.Path;
 
 /**
  * In general FastqWriterFactory should be used so that AsyncFastqWriter can be enabled, but there are some
@@ -38,16 +39,32 @@ public class BasicFastqWriter implements FastqWriter, Flushable {
     private final String path;
     private final PrintStream writer;
 
+    /**
+     * @deprecated since 6/2026, use {@link #BasicFastqWriter(Path)} instead.
+     */
+    @Deprecated
     public BasicFastqWriter(final File file) {
-        this(file, false);
+        this(file == null ? null : file.toPath());
     }
 
+    /**
+     * @deprecated since 6/2026, use {@link #BasicFastqWriter(Path, boolean)} instead.
+     */
+    @Deprecated
     public BasicFastqWriter(final File file, final boolean createMd5) {
-        this(file, new PrintStream(IOUtil.maybeBufferOutputStream(maybeMd5Wrap(file, createMd5))));
+        this(file == null ? null : file.toPath(), createMd5);
     }
 
-    private BasicFastqWriter(final File file, final PrintStream writer) {
-        this.path = (file != null ? file.getAbsolutePath() : "");
+    public BasicFastqWriter(final Path path) {
+        this(path, false);
+    }
+
+    public BasicFastqWriter(final Path path, final boolean createMd5) {
+        this(path, new PrintStream(IOUtil.maybeBufferOutputStream(maybeMd5Wrap(path, createMd5))));
+    }
+
+    private BasicFastqWriter(final Path path, final PrintStream writer) {
+        this.path = (path != null ? path.toAbsolutePath().toString() : "");
         this.writer = writer;
     }
 
@@ -81,11 +98,11 @@ public class BasicFastqWriter implements FastqWriter, Flushable {
         writer.close();
     }
 
-    private static OutputStream maybeMd5Wrap(final File file, final boolean createMd5) {
+    private static OutputStream maybeMd5Wrap(final Path path, final boolean createMd5) {
         if (createMd5) {
-            return IOUtil.openFileForMd5CalculatingWriting(file);
+            return IOUtil.openFileForMd5CalculatingWriting(path);
         } else {
-            return IOUtil.openFileForWriting(file);
+            return IOUtil.openFileForWriting(path);
         }
     }
 }

--- a/src/main/java/htsjdk/samtools/fastq/BasicFastqWriter.java
+++ b/src/main/java/htsjdk/samtools/fastq/BasicFastqWriter.java
@@ -25,7 +25,6 @@ package htsjdk.samtools.fastq;
 
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.io.Flushable;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -38,22 +37,6 @@ import java.nio.file.Path;
 public class BasicFastqWriter implements FastqWriter, Flushable {
     private final String path;
     private final PrintStream writer;
-
-    /**
-     * @deprecated since 6/2026, use {@link #BasicFastqWriter(Path)} instead.
-     */
-    @Deprecated
-    public BasicFastqWriter(final File file) {
-        this(file == null ? null : file.toPath());
-    }
-
-    /**
-     * @deprecated since 6/2026, use {@link #BasicFastqWriter(Path, boolean)} instead.
-     */
-    @Deprecated
-    public BasicFastqWriter(final File file, final boolean createMd5) {
-        this(file == null ? null : file.toPath(), createMd5);
-    }
 
     public BasicFastqWriter(final Path path) {
         this(path, false);

--- a/src/main/java/htsjdk/samtools/fastq/FastqReader.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqReader.java
@@ -30,6 +30,7 @@ import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -59,28 +60,63 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
         }
     }
 
-    private final File fastqFile;
+    private final Path fastqPath;
     private final BufferedReader reader;
     private FastqRecord nextRecord;
     private int line = 1;
 
     private final boolean skipBlankLines;
 
-    public FastqReader(final File file) {
-        this(file, false);
+    public FastqReader(final Path path) {
+        this(path, false);
     }
 
     /**
      * Constructor
      * @param file of FASTQ to read read. Will be opened with htsjdk.samtools.util.IOUtil.openFileForBufferedReading
      * @param skipBlankLines should we skip blank lines ?
+     * @deprecated since 06/2026, use {@link #FastqReader(Path, boolean)} instead.
      */
+    @Deprecated
+    public FastqReader(final File file) {
+        this(file == null ? null : file.toPath(), false);
+    }
+
+    /**
+     * Constructor
+     * @param path of FASTQ to read. Will be opened with htsjdk.samtools.util.IOUtil.openFileForBufferedReading
+     * @param skipBlankLines should we skip blank lines ?
+     */
+    public FastqReader(final Path path, final boolean skipBlankLines) {
+        this(path, IOUtil.openFileForBufferedReading(path), skipBlankLines);
+    }
+
+    /**
+     * Constructor
+     * @param file of FASTQ to read read. Will be opened with htsjdk.samtools.util.IOUtil.openFileForBufferedReading
+     * @param skipBlankLines should we skip blank lines ?
+     * @deprecated since 06/2026, use {@link #FastqReader(Path, boolean)} instead.
+     */
+    @Deprecated
     public FastqReader(final File file, final boolean skipBlankLines) {
-        this(file, IOUtil.openFileForBufferedReading(file), skipBlankLines);
+        this(file == null ? null : file.toPath(), skipBlankLines);
     }
 
     public FastqReader(final BufferedReader reader) {
-        this(null, reader);
+        this((Path) null, reader);
+    }
+
+    /**
+     * Constructor
+     * @param path Name of FASTQ being read, or null if not known.
+     * @param reader input reader . Will be closed by the close method
+     * @param skipBlankLines should we skip blank lines ?
+     */
+    public FastqReader(final Path path, final BufferedReader reader, boolean skipBlankLines) {
+        this.fastqPath = path;
+        this.reader = reader;
+        this.skipBlankLines = skipBlankLines;
+        this.nextRecord = readNextRecord();
     }
 
     /**
@@ -88,16 +124,26 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
      * @param file Name of FASTQ being read, or null if not known.
      * @param reader input reader . Will be closed by the close method
      * @param skipBlankLines should we skip blank lines ?
+     * @deprecated since 06/2026, use {@link #FastqReader(Path, BufferedReader, boolean)} instead.
      */
+    @Deprecated
     public FastqReader(final File file, final BufferedReader reader, boolean skipBlankLines) {
-        this.fastqFile = file;
-        this.reader = reader;
-        this.skipBlankLines = skipBlankLines;
-        this.nextRecord = readNextRecord();
+        this(file == null ? null : file.toPath(), reader, skipBlankLines);
     }
 
+    public FastqReader(final Path path, final BufferedReader reader) {
+        this(path, reader, false);
+    }
+
+    /**
+     * Constructor
+     * @param file Name of FASTQ being read, or null if not known.
+     * @param reader input reader . Will be closed by the close method
+     * @deprecated since 06/2026, use {@link #FastqReader(Path, BufferedReader)} instead.
+     */
+    @Deprecated
     public FastqReader(final File file, final BufferedReader reader) {
-        this(file, reader, false);
+        this(file == null ? null : file.toPath(), reader, false);
     }
 
     private FastqRecord readNextRecord() {
@@ -182,10 +228,20 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
     }
 
     /**
-     * @return Name of FASTQ being read, or null if not known.
+     * @return Path of FASTQ being read, or null if not known.
      */
+    public Path getPath() {
+        return fastqPath;
+    }
+
+    /**
+     * @return Name of FASTQ being read, or null if not known.
+     * @deprecated since 06/2026, use {@link #getPath()} instead. Throws if the underlying path is
+     *     not backed by the default (local) file system.
+     */
+    @Deprecated
     public File getFile() {
-        return fastqFile;
+        return fastqPath == null ? null : fastqPath.toFile();
     }
 
     @Override
@@ -213,8 +269,8 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
     }
 
     private String getAbsolutePath() {
-        if (fastqFile == null) return "";
-        else return fastqFile.getAbsolutePath();
+        if (fastqPath == null) return "";
+        else return fastqPath.toAbsolutePath().toString();
     }
 
     private String readLineConditionallySkippingBlanks() throws IOException {
@@ -228,6 +284,6 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
 
     @Override
     public String toString() {
-        return "FastqReader[" + (this.fastqFile == null ? "" : this.fastqFile) + " Line:" + getLineNumber() + "]";
+        return "FastqReader[" + (this.fastqPath == null ? "" : this.fastqPath) + " Line:" + getLineNumber() + "]";
     }
 }

--- a/src/main/java/htsjdk/samtools/fastq/FastqReader.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqReader.java
@@ -28,7 +28,6 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.StringUtil;
 import java.io.BufferedReader;
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
@@ -73,33 +72,11 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
 
     /**
      * Constructor
-     * @param file of FASTQ to read read. Will be opened with htsjdk.samtools.util.IOUtil.openFileForBufferedReading
-     * @param skipBlankLines should we skip blank lines ?
-     * @deprecated since 06/2026, use {@link #FastqReader(Path, boolean)} instead.
-     */
-    @Deprecated
-    public FastqReader(final File file) {
-        this(file == null ? null : file.toPath(), false);
-    }
-
-    /**
-     * Constructor
      * @param path of FASTQ to read. Will be opened with htsjdk.samtools.util.IOUtil.openFileForBufferedReading
      * @param skipBlankLines should we skip blank lines ?
      */
     public FastqReader(final Path path, final boolean skipBlankLines) {
         this(path, IOUtil.openFileForBufferedReading(path), skipBlankLines);
-    }
-
-    /**
-     * Constructor
-     * @param file of FASTQ to read read. Will be opened with htsjdk.samtools.util.IOUtil.openFileForBufferedReading
-     * @param skipBlankLines should we skip blank lines ?
-     * @deprecated since 06/2026, use {@link #FastqReader(Path, boolean)} instead.
-     */
-    @Deprecated
-    public FastqReader(final File file, final boolean skipBlankLines) {
-        this(file == null ? null : file.toPath(), skipBlankLines);
     }
 
     public FastqReader(final BufferedReader reader) {
@@ -119,31 +96,8 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
         this.nextRecord = readNextRecord();
     }
 
-    /**
-     * Constructor
-     * @param file Name of FASTQ being read, or null if not known.
-     * @param reader input reader . Will be closed by the close method
-     * @param skipBlankLines should we skip blank lines ?
-     * @deprecated since 06/2026, use {@link #FastqReader(Path, BufferedReader, boolean)} instead.
-     */
-    @Deprecated
-    public FastqReader(final File file, final BufferedReader reader, boolean skipBlankLines) {
-        this(file == null ? null : file.toPath(), reader, skipBlankLines);
-    }
-
     public FastqReader(final Path path, final BufferedReader reader) {
         this(path, reader, false);
-    }
-
-    /**
-     * Constructor
-     * @param file Name of FASTQ being read, or null if not known.
-     * @param reader input reader . Will be closed by the close method
-     * @deprecated since 06/2026, use {@link #FastqReader(Path, BufferedReader)} instead.
-     */
-    @Deprecated
-    public FastqReader(final File file, final BufferedReader reader) {
-        this(file == null ? null : file.toPath(), reader, false);
     }
 
     private FastqRecord readNextRecord() {
@@ -232,16 +186,6 @@ public class FastqReader implements Iterator<FastqRecord>, Iterable<FastqRecord>
      */
     public Path getPath() {
         return fastqPath;
-    }
-
-    /**
-     * @return Name of FASTQ being read, or null if not known.
-     * @deprecated since 06/2026, use {@link #getPath()} instead. Throws if the underlying path is
-     *     not backed by the default (local) file system.
-     */
-    @Deprecated
-    public File getFile() {
-        return fastqPath == null ? null : fastqPath.toFile();
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/fastq/FastqWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqWriterFactory.java
@@ -1,7 +1,6 @@
 package htsjdk.samtools.fastq;
 
 import htsjdk.samtools.Defaults;
-import java.io.File;
 import java.nio.file.Path;
 
 /**
@@ -30,22 +29,11 @@ public class FastqWriterFactory {
      * @return a {@link FastqWriter}, wrapped for asynchronous writing if {@link #useAsyncIo} is set
      */
     public FastqWriter newWriter(final Path out) {
-        // BasicFastqWriter is still File-based (migrated separately); convert here to keep the tree compiling.
-        final FastqWriter writer = new BasicFastqWriter(out.toFile(), createMd5);
+        final FastqWriter writer = new BasicFastqWriter(out, createMd5);
         if (useAsyncIo) {
             return new AsyncFastqWriter(writer, AsyncFastqWriter.DEFAULT_QUEUE_SIZE);
         } else {
             return writer;
         }
-    }
-
-    /**
-     * Creates a {@link FastqWriter} that writes to the given file.
-     *
-     * @deprecated since 5.0; use {@link #newWriter(Path)} instead.
-     */
-    @Deprecated
-    public FastqWriter newWriter(final File out) {
-        return newWriter(out.toPath());
     }
 }

--- a/src/main/java/htsjdk/samtools/fastq/FastqWriterFactory.java
+++ b/src/main/java/htsjdk/samtools/fastq/FastqWriterFactory.java
@@ -2,6 +2,7 @@ package htsjdk.samtools.fastq;
 
 import htsjdk.samtools.Defaults;
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Factory class for creating FastqWriter objects.
@@ -22,12 +23,29 @@ public class FastqWriterFactory {
         this.createMd5 = createMd5;
     }
 
-    public FastqWriter newWriter(final File out) {
-        final FastqWriter writer = new BasicFastqWriter(out, createMd5);
+    /**
+     * Creates a {@link FastqWriter} that writes to the given path.
+     *
+     * @param out the path to write the FASTQ data to
+     * @return a {@link FastqWriter}, wrapped for asynchronous writing if {@link #useAsyncIo} is set
+     */
+    public FastqWriter newWriter(final Path out) {
+        // BasicFastqWriter is still File-based (migrated separately); convert here to keep the tree compiling.
+        final FastqWriter writer = new BasicFastqWriter(out.toFile(), createMd5);
         if (useAsyncIo) {
             return new AsyncFastqWriter(writer, AsyncFastqWriter.DEFAULT_QUEUE_SIZE);
         } else {
             return writer;
         }
+    }
+
+    /**
+     * Creates a {@link FastqWriter} that writes to the given file.
+     *
+     * @deprecated since 5.0; use {@link #newWriter(Path)} instead.
+     */
+    @Deprecated
+    public FastqWriter newWriter(final File out) {
+        return newWriter(out.toPath());
     }
 }

--- a/src/main/java/htsjdk/samtools/filter/AbstractJavascriptFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/AbstractJavascriptFilter.java
@@ -26,10 +26,11 @@ package htsjdk.samtools.filter;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.RuntimeScriptException;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import javax.script.Bindings;
 import javax.script.Compilable;
 import javax.script.CompiledScript;
@@ -42,7 +43,7 @@ import javax.script.SimpleBindings;
  * Javascript filter with HEADER type containing TYPE records. contains two
  * static method to get a SAM Read filter or a VariantFilter.
  *
- * warning: tools, like galaxy, using this class are not safe because a script
+ * <p>warning: tools, like galaxy, using this class are not safe because a script
  * can access the filesystem.
  *
  * @author Pierre Lindenbaum PhD
@@ -56,11 +57,26 @@ public abstract class AbstractJavascriptFilter<HEADER, TYPE> {
     protected Bindings bindings;
 
     /**
-     * constructor using a java.io.File script, compiles the script, puts
-     * 'header' in the bindings
+     * Constructor using a Path to a script file, compiles the script, puts
+     * 'header' in the bindings.
+     *
+     * @param scriptPath path to the JavaScript file to be compiled
+     * @param header the header to be injected in the javascript context
+     * @throws IOException if the script file cannot be read
      */
+    protected AbstractJavascriptFilter(final Path scriptPath, final HEADER header) throws IOException {
+        this(Files.newBufferedReader(scriptPath), header);
+    }
+
+    /**
+     * Constructor using a java.io.File script, compiles the script, puts
+     * 'header' in the bindings.
+     *
+     * @deprecated use {@link #AbstractJavascriptFilter(Path, Object)} instead.
+     */
+    @Deprecated
     protected AbstractJavascriptFilter(final File scriptFile, final HEADER header) throws IOException {
-        this(new FileReader(scriptFile), header);
+        this(scriptFile.toPath(), header);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/filter/AbstractJavascriptFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/AbstractJavascriptFilter.java
@@ -25,7 +25,6 @@ package htsjdk.samtools.filter;
 
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.RuntimeScriptException;
-import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -66,17 +65,6 @@ public abstract class AbstractJavascriptFilter<HEADER, TYPE> {
      */
     protected AbstractJavascriptFilter(final Path scriptPath, final HEADER header) throws IOException {
         this(Files.newBufferedReader(scriptPath), header);
-    }
-
-    /**
-     * Constructor using a java.io.File script, compiles the script, puts
-     * 'header' in the bindings.
-     *
-     * @deprecated use {@link #AbstractJavascriptFilter(Path, Object)} instead.
-     */
-    @Deprecated
-    protected AbstractJavascriptFilter(final File scriptFile, final HEADER header) throws IOException {
-        this(scriptFile.toPath(), header);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/filter/JavascriptSamRecordFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/JavascriptSamRecordFilter.java
@@ -25,7 +25,6 @@ package htsjdk.samtools.filter;
 
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
-import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Path;
@@ -68,20 +67,6 @@ public class JavascriptSamRecordFilter extends AbstractJavascriptFilter<SAMFileH
      */
     public JavascriptSamRecordFilter(final Path scriptPath, final SAMFileHeader header) throws IOException {
         super(scriptPath, header);
-    }
-
-    /**
-     * Constructor using a javascript File.
-     *
-     * @param scriptFile
-     *            the javascript file to be compiled
-     * @param header
-     *            the SAMHeader
-     * @deprecated use {@link #JavascriptSamRecordFilter(Path, SAMFileHeader)} instead.
-     */
-    @Deprecated
-    public JavascriptSamRecordFilter(final File scriptFile, final SAMFileHeader header) throws IOException {
-        this(scriptFile.toPath(), header);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/filter/JavascriptSamRecordFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/JavascriptSamRecordFilter.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.SAMRecord;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.file.Path;
 
 /**
  * JavaScript-based {@link SamRecordFilter}.
@@ -56,15 +57,31 @@ import java.io.Reader;
 public class JavascriptSamRecordFilter extends AbstractJavascriptFilter<SAMFileHeader, SAMRecord>
         implements SamRecordFilter {
     /**
-     * constructor using a javascript File
+     * Constructor using a JavaScript file path.
+     *
+     * <p>Using a {@link Path} enables compatibility with the Java NIO Service Provider Interface
+     * (SPI) and custom filesystems.
+     *
+     * @param scriptPath the path to the JavaScript file to be compiled
+     * @param header the SAM file header
+     * @throws IOException if the script file cannot be read
+     */
+    public JavascriptSamRecordFilter(final Path scriptPath, final SAMFileHeader header) throws IOException {
+        super(scriptPath, header);
+    }
+
+    /**
+     * Constructor using a javascript File.
      *
      * @param scriptFile
      *            the javascript file to be compiled
      * @param header
      *            the SAMHeader
+     * @deprecated use {@link #JavascriptSamRecordFilter(Path, SAMFileHeader)} instead.
      */
+    @Deprecated
     public JavascriptSamRecordFilter(final File scriptFile, final SAMFileHeader header) throws IOException {
-        super(scriptFile, header);
+        this(scriptFile.toPath(), header);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/filter/ReadNameFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/ReadNameFilter.java
@@ -29,26 +29,50 @@ import htsjdk.samtools.util.IOUtil;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Filter by a set of specified readnames
- * <p/>
- * $Id$
+ * Filter by a set of specified read names.
+ *
+ * <p>This filter can either include or exclude reads based on whether their names
+ * appear in a provided set or file.
+ *
+ * <p>$Id$
  */
 public class ReadNameFilter implements SamRecordFilter {
 
     private boolean includeReads = false;
     private Set<String> readNameFilterSet = new HashSet<>();
 
+    /**
+     * Constructor that reads read names from a file.
+     *
+     * @param readNameFilterFile a file containing read names (one per line)
+     * @param includeReads if true, include only reads in the file; if false, exclude reads in the file
+     * @throws SAMException if the file cannot be read
+     * @deprecated since 5.0; use {@link #ReadNameFilter(Path, boolean)} instead.
+     */
+    @Deprecated
     public ReadNameFilter(final File readNameFilterFile, final boolean includeReads) {
+        this(readNameFilterFile.toPath(), includeReads);
+    }
 
-        IOUtil.assertFileIsReadable(readNameFilterFile);
-        IOUtil.assertFileSizeNonZero(readNameFilterFile);
+    /**
+     * Constructor that reads read names from a file.
+     *
+     * @param readNameFilterPath path to a file containing read names (one per line)
+     * @param includeReads if true, include only reads in the file; if false, exclude reads in the file
+     * @throws SAMException if the file cannot be read
+     */
+    public ReadNameFilter(final Path readNameFilterPath, final boolean includeReads) {
+
+        IOUtil.assertFileIsReadable(readNameFilterPath);
+        IOUtil.assertFileSizeNonZero(readNameFilterPath);
 
         try {
-            final BufferedReader in = IOUtil.openFileForBufferedReading(readNameFilterFile);
+            final BufferedReader in = IOUtil.openFileForBufferedReading(readNameFilterPath);
 
             String line = null;
 
@@ -66,6 +90,12 @@ public class ReadNameFilter implements SamRecordFilter {
         this.includeReads = includeReads;
     }
 
+    /**
+     * Constructor that uses a provided set of read names.
+     *
+     * @param readNameFilterSet set of read names to filter by
+     * @param includeReads if true, include only reads in the set; if false, exclude reads in the set
+     */
     public ReadNameFilter(final Set<String> readNameFilterSet, final boolean includeReads) {
         this.readNameFilterSet = readNameFilterSet;
         this.includeReads = includeReads;

--- a/src/main/java/htsjdk/samtools/filter/ReadNameFilter.java
+++ b/src/main/java/htsjdk/samtools/filter/ReadNameFilter.java
@@ -27,7 +27,6 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.util.IOUtil;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashSet;
@@ -45,19 +44,6 @@ public class ReadNameFilter implements SamRecordFilter {
 
     private boolean includeReads = false;
     private Set<String> readNameFilterSet = new HashSet<>();
-
-    /**
-     * Constructor that reads read names from a file.
-     *
-     * @param readNameFilterFile a file containing read names (one per line)
-     * @param includeReads if true, include only reads in the file; if false, exclude reads in the file
-     * @throws SAMException if the file cannot be read
-     * @deprecated since 5.0; use {@link #ReadNameFilter(Path, boolean)} instead.
-     */
-    @Deprecated
-    public ReadNameFilter(final File readNameFilterFile, final boolean includeReads) {
-        this(readNameFilterFile.toPath(), includeReads);
-    }
 
     /**
      * Constructor that reads read names from a file.

--- a/src/main/java/htsjdk/samtools/liftover/Chain.java
+++ b/src/main/java/htsjdk/samtools/liftover/Chain.java
@@ -30,6 +30,7 @@ import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.OverlapDetector;
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -334,8 +335,19 @@ class Chain {
      * Read all the chains and load into an OverlapDetector.
      * @param chainFile File in UCSC chain format.
      * @return OverlapDetector with all Chains from reader loaded into it.
+     * @deprecated use {@link #loadChains(Path)} instead.
      */
+    @Deprecated
     static OverlapDetector<Chain> loadChains(final File chainFile) {
+        return loadChains(chainFile.toPath());
+    }
+
+    /**
+     * Read all the chains and load into an OverlapDetector.
+     * @param chainFile Path in UCSC chain format.
+     * @return OverlapDetector with all Chains from reader loaded into it.
+     */
+    static OverlapDetector<Chain> loadChains(final Path chainFile) {
         IOUtil.assertFileIsReadable(chainFile);
         try (final BufferedLineReader reader = new BufferedLineReader(IOUtil.openFileForReading(chainFile))) {
             return loadChains(reader, chainFile.toString());

--- a/src/main/java/htsjdk/samtools/liftover/Chain.java
+++ b/src/main/java/htsjdk/samtools/liftover/Chain.java
@@ -28,7 +28,6 @@ import htsjdk.samtools.util.BufferedLineReader;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.OverlapDetector;
-import java.io.File;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -329,17 +328,6 @@ class Chain {
         result = 31 * result + id;
         result = 31 * result + (blockList != null ? blockList.hashCode() : 0);
         return result;
-    }
-
-    /**
-     * Read all the chains and load into an OverlapDetector.
-     * @param chainFile File in UCSC chain format.
-     * @return OverlapDetector with all Chains from reader loaded into it.
-     * @deprecated use {@link #loadChains(Path)} instead.
-     */
-    @Deprecated
-    static OverlapDetector<Chain> loadChains(final File chainFile) {
-        return loadChains(chainFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/liftover/LiftOver.java
+++ b/src/main/java/htsjdk/samtools/liftover/LiftOver.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.*;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -80,9 +81,29 @@ public class LiftOver {
 
     /**
      * Load UCSC chain file in order to lift over Intervals.
+     *
+     * @deprecated since 6/2024 use {@link #LiftOver(Path)} instead.
      */
+    @Deprecated
     public LiftOver(File chainFile) {
-        this(Chain.loadChains(chainFile));
+        this(chainFile.toPath());
+    }
+
+    /**
+     * Load UCSC chain file in order to lift over Intervals.
+     */
+    public LiftOver(Path chainFile) {
+        this(loadChains(chainFile));
+    }
+
+    /**
+     * Read all the chains from the given UCSC chain format file and load into an OverlapDetector.
+     */
+    private static OverlapDetector<Chain> loadChains(final Path chainFile) {
+        IOUtil.assertFileIsReadable(chainFile);
+        try (final BufferedLineReader reader = new BufferedLineReader(IOUtil.openFileForReading(chainFile))) {
+            return Chain.loadChains(reader, chainFile.toString());
+        }
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/liftover/LiftOver.java
+++ b/src/main/java/htsjdk/samtools/liftover/LiftOver.java
@@ -26,7 +26,6 @@ package htsjdk.samtools.liftover;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.*;
-import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -77,16 +76,6 @@ public class LiftOver {
      */
     public long getFailedIntervalsBelowThreshold() {
         return totalFailedIntervalsBelowThreshold;
-    }
-
-    /**
-     * Load UCSC chain file in order to lift over Intervals.
-     *
-     * @deprecated since 6/2024 use {@link #LiftOver(Path)} instead.
-     */
-    @Deprecated
-    public LiftOver(File chainFile) {
-        this(chainFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
+++ b/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
@@ -32,6 +32,8 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.StringUtil;
 import java.io.*;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -135,17 +137,29 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
     }
 
     /**
+     * Writes out the metrics file to the supplied path. The file is written out
+     * headers first, metrics second and histogram third.
+     *
+     * @param path a Path into which to write the metrics
+     */
+    public void write(final Path path) {
+        try (Writer w = Files.newBufferedWriter(path)) {
+            write(w);
+        } catch (IOException ioe) {
+            throw new SAMException("Could not write metrics to file: " + path.toAbsolutePath(), ioe);
+        }
+    }
+
+    /**
      * Writes out the metrics file to the supplied file. The file is written out
      * headers first, metrics second and histogram third.
      *
      * @param f a File into which to write the metrics
+     * @deprecated use {@link #write(Path)} instead.
      */
+    @Deprecated
     public void write(final File f) {
-        try (FileWriter w = new FileWriter(f)) {
-            write(w);
-        } catch (IOException ioe) {
-            throw new SAMException("Could not write metrics to file: " + f.getAbsolutePath(), ioe);
-        }
+        write(f.toPath());
     }
 
     /**
@@ -541,59 +555,100 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
 
     /**
      * Convenience method to read all the Metric beans from a metrics file.
-     * @param file to be read.
+     * @param path to be read.
      * @return list of beans from the file.
      */
-    public static <T extends MetricBase> List<T> readBeans(final File file) {
+    public static <T extends MetricBase> List<T> readBeans(final Path path) {
         final MetricsFile<T, ?> metricsFile = new MetricsFile<>();
-        final Reader in = IOUtil.openFileForBufferedReading(file);
+        final Reader in = IOUtil.openFileForBufferedReading(path);
         metricsFile.read(in);
         CloserUtil.close(in);
         return metricsFile.getMetrics();
     }
 
     /**
+     * Convenience method to read all the Metric beans from a metrics file.
+     * @param file to be read.
+     * @return list of beans from the file.
+     * @deprecated use {@link #readBeans(Path)} instead.
+     */
+    @Deprecated
+    public static <T extends MetricBase> List<T> readBeans(final File file) {
+        return readBeans(file.toPath());
+    }
+
+    /**
      * Method to read the header from a metrics file.
      */
-    public static List<Header> readHeaders(final File file) {
+    public static List<Header> readHeaders(final Path path) {
         try {
             final MetricsFile<MetricBase, ?> metricsFile = new MetricsFile<>();
-            metricsFile.read(new FileReader(file));
+            metricsFile.read(Files.newBufferedReader(path));
             return metricsFile.getHeaders();
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
+            throw new SAMException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Method to read the header from a metrics file.
+     *
+     * @deprecated use {@link #readHeaders(Path)} instead.
+     */
+    @Deprecated
+    public static List<Header> readHeaders(final File file) {
+        return readHeaders(file.toPath());
+    }
+
+    /**
+     * Compare the metrics in two files, ignoring headers and histograms.
+     */
+    public static boolean areMetricsEqual(final Path path1, final Path path2) {
+        try {
+            final MetricsFile<MetricBase, ?> mf1 = new MetricsFile<>();
+            final MetricsFile<MetricBase, ?> mf2 = new MetricsFile<>();
+            mf1.read(Files.newBufferedReader(path1));
+            mf2.read(Files.newBufferedReader(path2));
+            return mf1.areMetricsEqual(mf2);
+        } catch (IOException e) {
             throw new SAMException(e.getMessage(), e);
         }
     }
 
     /**
      * Compare the metrics in two files, ignoring headers and histograms.
+     *
+     * @deprecated use {@link #areMetricsEqual(Path, Path)} instead.
      */
+    @Deprecated
     public static boolean areMetricsEqual(final File file1, final File file2) {
+        return areMetricsEqual(file1.toPath(), file2.toPath());
+    }
+
+    /**
+     * Compare the metrics and histograms in two files, ignoring headers.
+     */
+    public static boolean areMetricsAndHistogramsEqual(final Path path1, final Path path2) {
         try {
             final MetricsFile<MetricBase, ?> mf1 = new MetricsFile<>();
             final MetricsFile<MetricBase, ?> mf2 = new MetricsFile<>();
-            mf1.read(new FileReader(file1));
-            mf2.read(new FileReader(file2));
-            return mf1.areMetricsEqual(mf2);
-        } catch (FileNotFoundException e) {
+            mf1.read(Files.newBufferedReader(path1));
+            mf2.read(Files.newBufferedReader(path2));
+
+            return mf1.areMetricsEqual(mf2) && mf1.areHistogramsEqual(mf2);
+
+        } catch (IOException e) {
             throw new SAMException(e.getMessage(), e);
         }
     }
 
     /**
      * Compare the metrics and histograms in two files, ignoring headers.
+     *
+     * @deprecated use {@link #areMetricsAndHistogramsEqual(Path, Path)} instead.
      */
+    @Deprecated
     public static boolean areMetricsAndHistogramsEqual(final File file1, final File file2) {
-        try {
-            final MetricsFile<MetricBase, ?> mf1 = new MetricsFile<>();
-            final MetricsFile<MetricBase, ?> mf2 = new MetricsFile<>();
-            mf1.read(new FileReader(file1));
-            mf2.read(new FileReader(file2));
-
-            return mf1.areMetricsEqual(mf2) && mf1.areHistogramsEqual(mf2);
-
-        } catch (FileNotFoundException e) {
-            throw new SAMException(e.getMessage(), e);
-        }
+        return areMetricsAndHistogramsEqual(file1.toPath(), file2.toPath());
     }
 }

--- a/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -51,7 +51,9 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     /**
      * Finds and loads the sequence file dictionary.
      * @param file Fasta file to read.  Also acts as a prefix for supporting files.
+     * @deprecated use {@link #AbstractFastaSequenceFile(Path)} instead.
      */
+    @Deprecated
     AbstractFastaSequenceFile(final File file) {
         this(IOUtil.toPath(file));
     }

--- a/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/AbstractFastaSequenceFile.java
@@ -31,7 +31,6 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Lazy;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -47,16 +46,6 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
     private final Path path;
     private final String source;
     private final Lazy<SAMSequenceDictionary> dictionary;
-
-    /**
-     * Finds and loads the sequence file dictionary.
-     * @param file Fasta file to read.  Also acts as a prefix for supporting files.
-     * @deprecated use {@link #AbstractFastaSequenceFile(Path)} instead.
-     */
-    @Deprecated
-    AbstractFastaSequenceFile(final File file) {
-        this(IOUtil.toPath(file));
-    }
 
     /**
      * Finds and loads the sequence file dictionary.
@@ -107,13 +96,6 @@ abstract class AbstractFastaSequenceFile implements ReferenceSequenceFile {
         } catch (final IOException e) {
             throw new SAMException("Could not open sequence dictionary file: " + dictPath, e);
         }
-    }
-
-    /** @deprecated use findSequenceDictionary(Path) instead. */
-    @Deprecated
-    protected static File findSequenceDictionary(final File file) {
-        final Path dict = findSequenceDictionary(file.toPath());
-        return dict == null ? null : dict.toFile();
     }
 
     /** Attempts to locate the sequence dictionary file adjacent to the reference fasta file. */

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceFile.java
@@ -50,12 +50,21 @@ public class FastaSequenceFile extends AbstractFastaSequenceFile {
     private int sequenceIndex = -1;
     private final byte[] basesBuffer = new byte[Defaults.NON_ZERO_BUFFER_SIZE];
 
-    /** Constructs a FastaSequenceFile that reads from the specified file. */
+    /**
+     * Constructs a FastaSequenceFile that reads from the specified file.
+     *
+     * @deprecated since 06/2026 use {@link #FastaSequenceFile(Path, boolean)} instead.
+     */
+    @Deprecated
     public FastaSequenceFile(final File file, final boolean truncateNamesAtWhitespace) {
         this(IOUtil.toPath(file), truncateNamesAtWhitespace);
     }
 
-    /** Constructs a FastaSequenceFile that reads from the specified file. */
+    /**
+     * Constructs a FastaSequenceFile that reads from the specified file.
+     * @param path Path to the FASTA file
+     * @param truncateNamesAtWhitespace whether to truncate sequence names at whitespace
+     */
     public FastaSequenceFile(final Path path, final boolean truncateNamesAtWhitespace) {
         super(path);
         this.truncateNamesAtWhitespace = truncateNamesAtWhitespace;

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceFile.java
@@ -33,7 +33,6 @@ import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.FastLineReader;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.StringUtil;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -49,16 +48,6 @@ public class FastaSequenceFile extends AbstractFastaSequenceFile {
     private FastLineReader in;
     private int sequenceIndex = -1;
     private final byte[] basesBuffer = new byte[Defaults.NON_ZERO_BUFFER_SIZE];
-
-    /**
-     * Constructs a FastaSequenceFile that reads from the specified file.
-     *
-     * @deprecated since 06/2026 use {@link #FastaSequenceFile(Path, boolean)} instead.
-     */
-    @Deprecated
-    public FastaSequenceFile(final File file, final boolean truncateNamesAtWhitespace) {
-        this(IOUtil.toPath(file), truncateNamesAtWhitespace);
-    }
 
     /**
      * Constructs a FastaSequenceFile that reads from the specified file.

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
@@ -55,7 +55,9 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
      * Build a sequence index from the specified file.
      * @param indexFile File to open.
      * @throws FileNotFoundException if the index file cannot be found.
+     * @deprecated since 5.0; use {@link #FastaSequenceIndex(Path)} instead.
      */
+    @Deprecated
     public FastaSequenceIndex(File indexFile) {
         this(IOUtil.toPath(indexFile));
     }

--- a/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
+++ b/src/main/java/htsjdk/samtools/reference/FastaSequenceIndex.java
@@ -27,7 +27,6 @@ package htsjdk.samtools.reference;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,17 +49,6 @@ public class FastaSequenceIndex implements Iterable<FastaSequenceIndexEntry> {
      */
     private final Map<String, FastaSequenceIndexEntry> sequenceEntries =
             new LinkedHashMap<String, FastaSequenceIndexEntry>();
-
-    /**
-     * Build a sequence index from the specified file.
-     * @param indexFile File to open.
-     * @throws FileNotFoundException if the index file cannot be found.
-     * @deprecated since 5.0; use {@link #FastaSequenceIndex(Path)} instead.
-     */
-    @Deprecated
-    public FastaSequenceIndex(File indexFile) {
-        this(IOUtil.toPath(indexFile));
-    }
 
     /**
      * Build a sequence index from the specified file.

--- a/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
@@ -53,7 +53,9 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
      * Open the given indexed fasta sequence file.  Throw an exception if the file cannot be opened.
      * @param file The file to open.
      * @param index Pre-built FastaSequenceIndex, for the case in which one does not exist on disk.
+     * @deprecated use {@link #IndexedFastaSequenceFile(Path, FastaSequenceIndex)} instead.
      */
+    @Deprecated
     public IndexedFastaSequenceFile(final File file, final FastaSequenceIndex index) {
         this(IOUtil.toPath(file), index);
     }
@@ -62,9 +64,11 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
      * Open the given indexed fasta sequence file.  Throw an exception if the file cannot be opened.
      * @param file The file to open.
      * @throws FileNotFoundException If the fasta or any of its supporting files cannot be found.
+     * @deprecated use {@link #IndexedFastaSequenceFile(Path)} instead.
      */
+    @Deprecated
     public IndexedFastaSequenceFile(final File file) throws FileNotFoundException {
-        this(file, new FastaSequenceIndex((findRequiredFastaIndexFile(IOUtil.toPath(file)))));
+        this(IOUtil.toPath(file), new FastaSequenceIndex(findRequiredFastaIndexFile(IOUtil.toPath(file))));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
+++ b/src/main/java/htsjdk/samtools/reference/IndexedFastaSequenceFile.java
@@ -30,7 +30,6 @@ import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.seekablestream.ReadableSeekableStreamByteChannel;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -48,28 +47,6 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
      * The interface facilitating direct access to the fasta.
      */
     private final SeekableByteChannel channel;
-
-    /**
-     * Open the given indexed fasta sequence file.  Throw an exception if the file cannot be opened.
-     * @param file The file to open.
-     * @param index Pre-built FastaSequenceIndex, for the case in which one does not exist on disk.
-     * @deprecated use {@link #IndexedFastaSequenceFile(Path, FastaSequenceIndex)} instead.
-     */
-    @Deprecated
-    public IndexedFastaSequenceFile(final File file, final FastaSequenceIndex index) {
-        this(IOUtil.toPath(file), index);
-    }
-
-    /**
-     * Open the given indexed fasta sequence file.  Throw an exception if the file cannot be opened.
-     * @param file The file to open.
-     * @throws FileNotFoundException If the fasta or any of its supporting files cannot be found.
-     * @deprecated use {@link #IndexedFastaSequenceFile(Path)} instead.
-     */
-    @Deprecated
-    public IndexedFastaSequenceFile(final File file) throws FileNotFoundException {
-        this(IOUtil.toPath(file), new FastaSequenceIndex(findRequiredFastaIndexFile(IOUtil.toPath(file))));
-    }
 
     /**
      * Open the given indexed fasta sequence file.  Throw an exception if the file cannot be opened.
@@ -129,14 +106,6 @@ public class IndexedFastaSequenceFile extends AbstractIndexedFastaSequenceFile {
             String source, final SeekableStream in, final FastaSequenceIndex index, SAMSequenceDictionary dictionary) {
         super(source, index, dictionary);
         this.channel = new ReadableSeekableStreamByteChannel(in);
-    }
-
-    /**
-     * @deprecated use {@link ReferenceSequenceFileFactory#canCreateIndexedFastaReader(Path)} instead.
-     */
-    @Deprecated
-    public static boolean canCreateIndexedFastaReader(final File fastaFile) {
-        return canCreateIndexedFastaReader(fastaFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
@@ -41,7 +41,6 @@ import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.GZIIndex;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.utils.ValidationUtils;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -70,48 +69,6 @@ public class ReferenceSequenceFileFactory {
      */
     @Deprecated
     public static final String FASTA_INDEX_EXTENSION = FileExtensions.FASTA_INDEX;
-
-    /**
-     * Attempts to determine the type of the reference file and return an instance
-     * of ReferenceSequenceFile that is appropriate to read it.  Sequence names
-     * will be truncated at first whitespace, if any.
-     *
-     * @param file the reference sequence file on disk
-     * @deprecated since June 2024; use {@link #getReferenceSequenceFile(Path)} instead.
-     */
-    @Deprecated
-    public static ReferenceSequenceFile getReferenceSequenceFile(final File file) {
-        return getReferenceSequenceFile(IOUtil.toPath(file));
-    }
-
-    /**
-     * Attempts to determine the type of the reference file and return an instance
-     * of ReferenceSequenceFile that is appropriate to read it.
-     *
-     * @param file the reference sequence file on disk
-     * @param truncateNamesAtWhitespace if true, only include the first word of the sequence name
-     * @deprecated since June 2024; use {@link #getReferenceSequenceFile(Path, boolean)} instead.
-     */
-    @Deprecated
-    public static ReferenceSequenceFile getReferenceSequenceFile(
-            final File file, final boolean truncateNamesAtWhitespace) {
-        return getReferenceSequenceFile(IOUtil.toPath(file), truncateNamesAtWhitespace);
-    }
-
-    /**
-     * Attempts to determine the type of the reference file and return an instance
-     * of ReferenceSequenceFile that is appropriate to read it.
-     *
-     * @param file the reference sequence file on disk
-     * @param truncateNamesAtWhitespace if true, only include the first word of the sequence name
-     * @param preferIndexed if true attempt to return an indexed reader that supports non-linear traversal, else return the non-indexed reader
-     * @deprecated since June 2024; use {@link #getReferenceSequenceFile(Path, boolean, boolean)} instead.
-     */
-    @Deprecated
-    public static ReferenceSequenceFile getReferenceSequenceFile(
-            final File file, final boolean truncateNamesAtWhitespace, final boolean preferIndexed) {
-        return getReferenceSequenceFile(IOUtil.toPath(file), truncateNamesAtWhitespace, preferIndexed);
-    }
 
     /**
      * Attempts to determine the type of the reference file and return an instance
@@ -365,17 +322,6 @@ public class ReferenceSequenceFileFactory {
             return new IndexedFastaSequenceFile(source, in, index, dictionary);
         }
         return new FastaSequenceFile(source, in, dictionary, truncateNamesAtWhitespace);
-    }
-
-    /**
-     * Returns the default dictionary name for a FASTA file.
-     *
-     * @param file the reference sequence file on disk.
-     * @deprecated since June 2024; use {@link #getDefaultDictionaryForReferenceSequence(Path)} instead.
-     */
-    @Deprecated
-    public static File getDefaultDictionaryForReferenceSequence(final File file) {
-        return getDefaultDictionaryForReferenceSequence(IOUtil.toPath(file)).toFile();
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileFactory.java
@@ -44,6 +44,7 @@ import htsjdk.utils.ValidationUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -52,7 +53,7 @@ import java.util.function.Function;
 
 /**
  * Factory class for creating ReferenceSequenceFile instances for reading reference
- * sequences store in various formats.
+ * sequences stored in various formats.
  *
  * @author Tim Fennell
  */
@@ -76,9 +77,11 @@ public class ReferenceSequenceFileFactory {
      * will be truncated at first whitespace, if any.
      *
      * @param file the reference sequence file on disk
+     * @deprecated since June 2024; use {@link #getReferenceSequenceFile(Path)} instead.
      */
+    @Deprecated
     public static ReferenceSequenceFile getReferenceSequenceFile(final File file) {
-        return getReferenceSequenceFile(file, true);
+        return getReferenceSequenceFile(IOUtil.toPath(file));
     }
 
     /**
@@ -87,10 +90,12 @@ public class ReferenceSequenceFileFactory {
      *
      * @param file the reference sequence file on disk
      * @param truncateNamesAtWhitespace if true, only include the first word of the sequence name
+     * @deprecated since June 2024; use {@link #getReferenceSequenceFile(Path, boolean)} instead.
      */
+    @Deprecated
     public static ReferenceSequenceFile getReferenceSequenceFile(
             final File file, final boolean truncateNamesAtWhitespace) {
-        return getReferenceSequenceFile(file, truncateNamesAtWhitespace, true);
+        return getReferenceSequenceFile(IOUtil.toPath(file), truncateNamesAtWhitespace);
     }
 
     /**
@@ -100,10 +105,54 @@ public class ReferenceSequenceFileFactory {
      * @param file the reference sequence file on disk
      * @param truncateNamesAtWhitespace if true, only include the first word of the sequence name
      * @param preferIndexed if true attempt to return an indexed reader that supports non-linear traversal, else return the non-indexed reader
+     * @deprecated since June 2024; use {@link #getReferenceSequenceFile(Path, boolean, boolean)} instead.
      */
+    @Deprecated
     public static ReferenceSequenceFile getReferenceSequenceFile(
             final File file, final boolean truncateNamesAtWhitespace, final boolean preferIndexed) {
-        return getReferenceSequenceFile(IOUtil.toPath(file), HtsPath::new, truncateNamesAtWhitespace, preferIndexed);
+        return getReferenceSequenceFile(IOUtil.toPath(file), truncateNamesAtWhitespace, preferIndexed);
+    }
+
+    /**
+     * Attempts to determine the type of the reference file and return an instance
+     * of ReferenceSequenceFile that is appropriate to read it.  Sequence names
+     * will be truncated at first whitespace, if any.
+     *
+     * @param uri the URI of the reference sequence file
+     * @return a ReferenceSequenceFile instance
+     * @throws IOException if no filesystem provider can be found for the URI, or the file cannot be accessed
+     */
+    public static ReferenceSequenceFile getReferenceSequenceFile(final URI uri) throws IOException {
+        return getReferenceSequenceFile(uri, true);
+    }
+
+    /**
+     * Attempts to determine the type of the reference file and return an instance
+     * of ReferenceSequenceFile that is appropriate to read it.
+     *
+     * @param uri the URI of the reference sequence file
+     * @param truncateNamesAtWhitespace if true, only include the first word of the sequence name
+     * @return a ReferenceSequenceFile instance
+     * @throws IOException if no filesystem provider can be found for the URI, or the file cannot be accessed
+     */
+    public static ReferenceSequenceFile getReferenceSequenceFile(final URI uri, final boolean truncateNamesAtWhitespace)
+            throws IOException {
+        return getReferenceSequenceFile(uri, truncateNamesAtWhitespace, true);
+    }
+
+    /**
+     * Attempts to determine the type of the reference file and return an instance
+     * of ReferenceSequenceFile that is appropriate to read it.
+     *
+     * @param uri the URI of the reference sequence file
+     * @param truncateNamesAtWhitespace if true, only include the first word of the sequence name
+     * @param preferIndexed if true attempt to return an indexed reader that supports non-linear traversal, else return the non-indexed reader
+     * @return a ReferenceSequenceFile instance
+     * @throws IOException if no filesystem provider can be found for the URI, or the file cannot be accessed
+     */
+    public static ReferenceSequenceFile getReferenceSequenceFile(
+            final URI uri, final boolean truncateNamesAtWhitespace, final boolean preferIndexed) throws IOException {
+        return getReferenceSequenceFile(IOUtil.getPath(uri), truncateNamesAtWhitespace, preferIndexed);
     }
 
     /**
@@ -322,7 +371,9 @@ public class ReferenceSequenceFileFactory {
      * Returns the default dictionary name for a FASTA file.
      *
      * @param file the reference sequence file on disk.
+     * @deprecated since June 2024; use {@link #getDefaultDictionaryForReferenceSequence(Path)} instead.
      */
+    @Deprecated
     public static File getDefaultDictionaryForReferenceSequence(final File file) {
         return getDefaultDictionaryForReferenceSequence(IOUtil.toPath(file)).toFile();
     }

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
@@ -50,8 +50,12 @@ public class ReferenceSequenceFileWalker implements Closeable {
         this(ReferenceSequenceFileFactory.getReferenceSequenceFile(path, HtsPath::new, true, false));
     }
 
+    /**
+     * @deprecated since 5/2026 use {@link #ReferenceSequenceFileWalker(Path)} instead.
+     */
+    @Deprecated
     public ReferenceSequenceFileWalker(final File file) {
-        this(ReferenceSequenceFileFactory.getReferenceSequenceFile(file, true, false));
+        this(file.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
+++ b/src/main/java/htsjdk/samtools/reference/ReferenceSequenceFileWalker.java
@@ -28,7 +28,6 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -48,14 +47,6 @@ public class ReferenceSequenceFileWalker implements Closeable {
 
     public ReferenceSequenceFileWalker(final Path path) {
         this(ReferenceSequenceFileFactory.getReferenceSequenceFile(path, HtsPath::new, true, false));
-    }
-
-    /**
-     * @deprecated since 5/2026 use {@link #ReferenceSequenceFileWalker(Path)} instead.
-     */
-    @Deprecated
-    public ReferenceSequenceFileWalker(final File file) {
-        this(file.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableFileStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableFileStream.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -38,18 +39,35 @@ public class SeekableFileStream extends SeekableStream {
     static Collection<SeekableFileStream> allInstances =
             Collections.synchronizedCollection(new HashSet<SeekableFileStream>());
 
-    File file;
+    private final Path path;
     RandomAccessFile fis;
 
-    public SeekableFileStream(final File file) throws FileNotFoundException {
-        this.file = file;
-        fis = new RandomAccessFile(file, "r");
+    /**
+     * Create a {@code SeekableFileStream} over a local file represented by a {@link Path}.
+     *
+     * @param path the path to the local file to open; must be backed by the default (local) filesystem
+     *             because the underlying {@link RandomAccessFile} requires a {@link File}
+     * @throws FileNotFoundException if the file does not exist or cannot be opened for reading
+     */
+    public SeekableFileStream(final Path path) throws FileNotFoundException {
+        this.path = path;
+        fis = new RandomAccessFile(path.toFile(), "r");
         allInstances.add(this);
+    }
+
+    /**
+     * Create a {@code SeekableFileStream} over a local {@link File}.
+     *
+     * @deprecated use {@link #SeekableFileStream(Path)} instead.
+     */
+    @Deprecated
+    public SeekableFileStream(final File file) throws FileNotFoundException {
+        this(file.toPath());
     }
 
     @Override
     public long length() {
-        return file.length();
+        return path.toFile().length();
     }
 
     @Override
@@ -106,7 +124,7 @@ public class SeekableFileStream extends SeekableStream {
 
     @Override
     public String getSource() {
-        return file.getAbsolutePath();
+        return path.toAbsolutePath().toString();
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableFileStream.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableFileStream.java
@@ -17,7 +17,6 @@
  */
 package htsjdk.samtools.seekablestream;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -46,23 +45,13 @@ public class SeekableFileStream extends SeekableStream {
      * Create a {@code SeekableFileStream} over a local file represented by a {@link Path}.
      *
      * @param path the path to the local file to open; must be backed by the default (local) filesystem
-     *             because the underlying {@link RandomAccessFile} requires a {@link File}
+     *             because the underlying {@link RandomAccessFile} requires a local file
      * @throws FileNotFoundException if the file does not exist or cannot be opened for reading
      */
     public SeekableFileStream(final Path path) throws FileNotFoundException {
         this.path = path;
         fis = new RandomAccessFile(path.toFile(), "r");
         allInstances.add(this);
-    }
-
-    /**
-     * Create a {@code SeekableFileStream} over a local {@link File}.
-     *
-     * @deprecated use {@link #SeekableFileStream(Path)} instead.
-     */
-    @Deprecated
-    public SeekableFileStream(final File file) throws FileNotFoundException {
-        this(file.toPath());
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/seekablestream/SeekableStreamFactory.java
+++ b/src/main/java/htsjdk/samtools/seekablestream/SeekableStreamFactory.java
@@ -135,7 +135,7 @@ public class SeekableStreamFactory {
                 final IOPath path, Function<SeekableByteChannel, SeekableByteChannel> wrapper) throws IOException {
             if (path.hasFileSystemProvider()) {
                 return path.getScheme().equals(FILE_SCHEME)
-                        ? new SeekableFileStream(path.toPath().toFile()) // don't apply the wrapper to local files
+                        ? new SeekableFileStream(path.toPath()) // don't apply the wrapper to local files
                         : new SeekablePathStream(path.toPath(), wrapper);
             } else {
                 return switch (path.getScheme()) {

--- a/src/main/java/htsjdk/samtools/util/AsyncBlockCompressedInputStream.java
+++ b/src/main/java/htsjdk/samtools/util/AsyncBlockCompressedInputStream.java
@@ -27,7 +27,6 @@ import htsjdk.samtools.Defaults;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.zip.InflaterFactory;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -85,22 +84,6 @@ public class AsyncBlockCompressedInputStream extends BlockCompressedInputStream 
 
     public AsyncBlockCompressedInputStream(final InputStream stream, InflaterFactory inflaterFactory) {
         super(stream, true, inflaterFactory);
-    }
-
-    /**
-     * @deprecated since 5.0; use {@link #AsyncBlockCompressedInputStream(Path)} instead.
-     */
-    @Deprecated
-    public AsyncBlockCompressedInputStream(final File file) throws IOException {
-        this(file.toPath());
-    }
-
-    /**
-     * @deprecated since 5.0; use {@link #AsyncBlockCompressedInputStream(Path, InflaterFactory)} instead.
-     */
-    @Deprecated
-    public AsyncBlockCompressedInputStream(final File file, InflaterFactory inflaterFactory) throws IOException {
-        this(file.toPath(), inflaterFactory);
     }
 
     public AsyncBlockCompressedInputStream(final Path path) throws IOException {

--- a/src/main/java/htsjdk/samtools/util/AsyncBlockCompressedInputStream.java
+++ b/src/main/java/htsjdk/samtools/util/AsyncBlockCompressedInputStream.java
@@ -24,12 +24,14 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.Defaults;
+import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.zip.InflaterFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
@@ -85,12 +87,28 @@ public class AsyncBlockCompressedInputStream extends BlockCompressedInputStream 
         super(stream, true, inflaterFactory);
     }
 
+    /**
+     * @deprecated since 5.0; use {@link #AsyncBlockCompressedInputStream(Path)} instead.
+     */
+    @Deprecated
     public AsyncBlockCompressedInputStream(final File file) throws IOException {
-        super(file);
+        this(file.toPath());
     }
 
+    /**
+     * @deprecated since 5.0; use {@link #AsyncBlockCompressedInputStream(Path, InflaterFactory)} instead.
+     */
+    @Deprecated
     public AsyncBlockCompressedInputStream(final File file, InflaterFactory inflaterFactory) throws IOException {
-        super(file, inflaterFactory);
+        this(file.toPath(), inflaterFactory);
+    }
+
+    public AsyncBlockCompressedInputStream(final Path path) throws IOException {
+        super(path);
+    }
+
+    public AsyncBlockCompressedInputStream(final Path path, InflaterFactory inflaterFactory) throws IOException {
+        super(new SeekablePathStream(path), inflaterFactory);
     }
 
     public AsyncBlockCompressedInputStream(final URL url) {

--- a/src/main/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/main/java/htsjdk/samtools/util/BinaryCodec.java
@@ -120,19 +120,37 @@ public class BinaryCodec implements Closeable {
      *
      * @param file    file to be written to or read from
      * @param writing whether the file is being written to
+     * @deprecated since 5.0; use {@link #BinaryCodec(Path, boolean)} instead.
      */
+    @Deprecated
     public BinaryCodec(final File file, final boolean writing) {
         this(IOUtil.toPath(file), writing);
     }
 
     /**
-     * Constructs BinaryCodec from a file name and set its mode to writing or not
+     * Constructs BinaryCodec from a file name and set its mode to writing or not.
+     * The name is resolved in a scheme-aware manner via {@link IOUtil#getPath(String)},
+     * so it may refer to a local file or any path supported by an installed NIO file system
+     * provider.
      *
      * @param fileName name of the file to be written to or read from
      * @param writing  writing whether the file is being written to
      */
     public BinaryCodec(final String fileName, final boolean writing) {
-        this(new File(fileName), writing);
+        this(toPath(fileName), writing);
+    }
+
+    /**
+     * Resolves a user-supplied file name into a {@link Path} in a scheme-aware manner,
+     * wrapping the checked {@link IOException} thrown by {@link IOUtil#getPath(String)} so it
+     * can be used from a constructor's delegation expression.
+     */
+    private static Path toPath(final String fileName) {
+        try {
+            return IOUtil.getPath(fileName);
+        } catch (IOException e) {
+            throw new RuntimeIOException("Error resolving path: " + fileName, e);
+        }
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/BinaryCodec.java
+++ b/src/main/java/htsjdk/samtools/util/BinaryCodec.java
@@ -25,7 +25,6 @@ package htsjdk.samtools.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -113,18 +112,6 @@ public class BinaryCodec implements Closeable {
         } catch (IOException e) {
             throw new RuntimeIOException("Error opening: " + path, e);
         }
-    }
-
-    /**
-     * Constructs BinaryCodec from a file and set its mode to writing or not
-     *
-     * @param file    file to be written to or read from
-     * @param writing whether the file is being written to
-     * @deprecated since 5.0; use {@link #BinaryCodec(Path, boolean)} instead.
-     */
-    @Deprecated
-    public BinaryCodec(final File file, final boolean writing) {
-        this(IOUtil.toPath(file), writing);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedInputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedInputStream.java
@@ -26,7 +26,6 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.FileTruncatedException;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.seekablestream.SeekableBufferedStream;
-import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableHTTPStream;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
@@ -117,16 +116,20 @@ public class BlockCompressedInputStream extends InputStream implements LocationA
      * Use this ctor if you wish to call seek()
      * @param file source of bytes
      * @throws IOException
+     * @deprecated since 5.0; use {@link #BlockCompressedInputStream(Path)} instead.
      */
+    @Deprecated
     public BlockCompressedInputStream(final File file) throws IOException {
-        this(file, BlockGunzipper.getDefaultInflaterFactory());
+        this(IOUtil.toPath(file));
     }
 
     /**
-     * Equivalent constructor for Path as the one that takes a File. Supports seeking.
+     * Use this ctor if you wish to call seek()
+     * @param path source of bytes
+     * @throws IOException
      */
-    public BlockCompressedInputStream(final Path file) throws IOException {
-        this(new SeekablePathStream(file));
+    public BlockCompressedInputStream(final Path path) throws IOException {
+        this(path, BlockGunzipper.getDefaultInflaterFactory());
     }
 
     /**
@@ -134,9 +137,21 @@ public class BlockCompressedInputStream extends InputStream implements LocationA
      * @param file source of bytes
      * @param inflaterFactory {@link InflaterFactory} used by {@link BlockGunzipper}
      * @throws IOException
+     * @deprecated since 5.0; use {@link #BlockCompressedInputStream(Path, InflaterFactory)} instead.
      */
+    @Deprecated
     public BlockCompressedInputStream(final File file, final InflaterFactory inflaterFactory) throws IOException {
-        mFile = new SeekableFileStream(file);
+        this(IOUtil.toPath(file), inflaterFactory);
+    }
+
+    /**
+     * Use this ctor if you wish to call seek()
+     * @param path source of bytes
+     * @param inflaterFactory {@link InflaterFactory} used by {@link BlockGunzipper}
+     * @throws IOException
+     */
+    public BlockCompressedInputStream(final Path path, final InflaterFactory inflaterFactory) throws IOException {
+        mFile = new SeekablePathStream(path);
         mStream = null;
         blockGunzipper = new BlockGunzipper(inflaterFactory);
     }
@@ -623,7 +638,9 @@ public class BlockCompressedInputStream extends InputStream implements LocationA
      * @param file the file to check
      * @return status of the last compressed block
      * @throws IOException
+     * @deprecated since 5.0; use {@link #checkTermination(Path)} instead.
      */
+    @Deprecated
     public static FileTermination checkTermination(final File file) throws IOException {
         return checkTermination(IOUtil.toPath(file));
     }

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -115,7 +115,7 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
     /**
      * Uses default compression level, which is 5 unless changed by setCompressionLevel
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
+     * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
      */
     public BlockCompressedOutputStream(final String filename) {
         this(filename, defaultCompressionLevel);
@@ -124,36 +124,65 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
     /**
      * Uses default compression level, which is 5 unless changed by setCompressionLevel
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
+     * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
+     *
+     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(Path)} instead.
      */
+    @Deprecated
     public BlockCompressedOutputStream(final File file) {
-        this(file, defaultCompressionLevel);
+        this(IOUtil.toPath(file));
     }
 
     /**
-     * Prepare to compress at the given compression level
+     * Uses default compression level, which is 5 unless changed by setCompressionLevel
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public BlockCompressedOutputStream(final Path path) {
+        this(path, defaultCompressionLevel);
+    }
+
+    /**
+     * Prepare to compress at the given compression level. The {@code filename} is resolved to a {@link Path} using
+     * {@link IOUtil#getPath(String)}, so scheme-bearing identifiers (e.g. {@code file:}, {@code gs:}) are honored.
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
      * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      */
     public BlockCompressedOutputStream(final String filename, final int compressionLevel) {
-        this(new File(filename), compressionLevel);
+        this(stringToPath(filename), compressionLevel);
     }
 
     /**
      * Prepare to compress at the given compression level
      * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(File, int, DeflaterFactory)} to specify a custom factory.
+     * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
+     *
+     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(Path, int)} instead.
      */
+    @Deprecated
     public BlockCompressedOutputStream(final File file, final int compressionLevel) {
-        this(file, compressionLevel, defaultDeflaterFactory);
+        this(IOUtil.toPath(file), compressionLevel);
+    }
+
+    /**
+     * Prepare to compress at the given compression level
+     * @param compressionLevel {@code 1 <= compressionLevel <= 9}
+     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
+     * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
+     */
+    public BlockCompressedOutputStream(final Path path, final int compressionLevel) {
+        this(path, compressionLevel, defaultDeflaterFactory);
     }
 
     /**
      * Prepare to compress at the given compression level
      * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      * @param deflaterFactory custom factory to create deflaters (overrides the default)
+     *
+     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} instead.
      */
+    @Deprecated
     public BlockCompressedOutputStream(
             final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
         this(IOUtil.toPath(file), compressionLevel, deflaterFactory);
@@ -175,18 +204,20 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
     /**
      * Uses default compression level, which is 5 unless changed by setCompressionLevel
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(OutputStream, File, int, DeflaterFactory)} to specify a custom factory.
+     * Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
      *
      * @param file may be null
+     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(OutputStream, Path)} instead.
      */
+    @Deprecated
     public BlockCompressedOutputStream(final OutputStream os, final File file) {
-        this(os, file, defaultCompressionLevel);
+        this(os, IOUtil.toPath(file));
     }
 
     /**
      * Uses default compression level, which is 5 unless changed by setCompressionLevel
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(OutputStream, File, int, DeflaterFactory)} to specify a custom factory.
+     * Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
      *
      * @param file may be null
      */
@@ -196,15 +227,18 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
 
     /**
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(OutputStream, File, int, DeflaterFactory)} to specify a custom factory.
+     * Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
+     *
+     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(OutputStream, Path, int)} instead.
      */
+    @Deprecated
     public BlockCompressedOutputStream(final OutputStream os, final File file, final int compressionLevel) {
-        this(os, file, compressionLevel, defaultDeflaterFactory);
+        this(os, IOUtil.toPath(file), compressionLevel);
     }
 
     /**
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(OutputStream, File, int, DeflaterFactory)} to specify a custom factory.
+     * Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
      */
     public BlockCompressedOutputStream(final OutputStream os, final Path file, final int compressionLevel) {
         this(os, file, compressionLevel, defaultDeflaterFactory);
@@ -216,7 +250,10 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
      * @param file file to which to write the output or null if not available
      * @param compressionLevel the compression level (0-9)
      * @param deflaterFactory custom factory to create deflaters (overrides the default)
+     *
+     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} instead.
      */
+    @Deprecated
     public BlockCompressedOutputStream(
             final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
         this(os, IOUtil.toPath(file), compressionLevel, deflaterFactory);
@@ -247,11 +284,37 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
      * @return A BlockCompressedOutputStream, either by wrapping the given OutputStream, or by casting if it already
      *         is a BCOS.
      */
-    public static BlockCompressedOutputStream maybeBgzfWrapOutputStream(final File location, OutputStream output) {
+    public static BlockCompressedOutputStream maybeBgzfWrapOutputStream(final Path location, OutputStream output) {
         if (!(output instanceof BlockCompressedOutputStream)) {
             return new BlockCompressedOutputStream(output, location);
         } else {
             return (BlockCompressedOutputStream) output;
+        }
+    }
+
+    /**
+     *
+     * @param location May be null.  Used for error messages, and for checking file termination.
+     * @param output May or not already be a BlockCompressedOutputStream.
+     * @return A BlockCompressedOutputStream, either by wrapping the given OutputStream, or by casting if it already
+     *         is a BCOS.
+     * @deprecated since 5.0.0 Use {@link #maybeBgzfWrapOutputStream(Path, OutputStream)} instead.
+     */
+    @Deprecated
+    public static BlockCompressedOutputStream maybeBgzfWrapOutputStream(final File location, OutputStream output) {
+        return maybeBgzfWrapOutputStream(IOUtil.toPath(location), output);
+    }
+
+    /**
+     * Converts a user-supplied path string to a {@link Path} using the scheme-aware {@link IOUtil#getPath(String)},
+     * so that identifiers carrying a scheme (e.g. {@code file:}, {@code gs:}) are resolved with the correct provider.
+     * Any {@link IOException} raised while resolving the filesystem is rethrown as an unchecked {@link RuntimeIOException}.
+     */
+    private static Path stringToPath(final String filename) {
+        try {
+            return IOUtil.getPath(filename);
+        } catch (final IOException e) {
+            throw new RuntimeIOException("Could not convert to a Path: " + filename, e);
         }
     }
 

--- a/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/BlockCompressedOutputStream.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.util.zip.DeflaterFactory;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -125,18 +124,6 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
      * Uses default compression level, which is 5 unless changed by setCompressionLevel
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
      * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
-     *
-     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(Path)} instead.
-     */
-    @Deprecated
-    public BlockCompressedOutputStream(final File file) {
-        this(IOUtil.toPath(file));
-    }
-
-    /**
-     * Uses default compression level, which is 5 unless changed by setCompressionLevel
-     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
      */
     public BlockCompressedOutputStream(final Path path) {
         this(path, defaultCompressionLevel);
@@ -157,35 +144,9 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
      * @param compressionLevel {@code 1 <= compressionLevel <= 9}
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
      * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
-     *
-     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(Path, int)} instead.
-     */
-    @Deprecated
-    public BlockCompressedOutputStream(final File file, final int compressionLevel) {
-        this(IOUtil.toPath(file), compressionLevel);
-    }
-
-    /**
-     * Prepare to compress at the given compression level
-     * @param compressionLevel {@code 1 <= compressionLevel <= 9}
-     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} to specify a custom factory.
      */
     public BlockCompressedOutputStream(final Path path, final int compressionLevel) {
         this(path, compressionLevel, defaultDeflaterFactory);
-    }
-
-    /**
-     * Prepare to compress at the given compression level
-     * @param compressionLevel {@code 1 <= compressionLevel <= 9}
-     * @param deflaterFactory custom factory to create deflaters (overrides the default)
-     *
-     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(Path, int, DeflaterFactory)} instead.
-     */
-    @Deprecated
-    public BlockCompressedOutputStream(
-            final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        this(IOUtil.toPath(file), compressionLevel, deflaterFactory);
     }
 
     /**
@@ -207,19 +168,6 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
      * Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
      *
      * @param file may be null
-     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(OutputStream, Path)} instead.
-     */
-    @Deprecated
-    public BlockCompressedOutputStream(final OutputStream os, final File file) {
-        this(os, IOUtil.toPath(file));
-    }
-
-    /**
-     * Uses default compression level, which is 5 unless changed by setCompressionLevel
-     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
-     *
-     * @param file may be null
      */
     public BlockCompressedOutputStream(final OutputStream os, final Path file) {
         this(os, file, defaultCompressionLevel);
@@ -228,35 +176,9 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
     /**
      * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
      * Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
-     *
-     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(OutputStream, Path, int)} instead.
-     */
-    @Deprecated
-    public BlockCompressedOutputStream(final OutputStream os, final File file, final int compressionLevel) {
-        this(os, IOUtil.toPath(file), compressionLevel);
-    }
-
-    /**
-     * Note: this constructor uses the default {@link DeflaterFactory}, see {@link #getDefaultDeflaterFactory()}.
-     * Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} to specify a custom factory.
      */
     public BlockCompressedOutputStream(final OutputStream os, final Path file, final int compressionLevel) {
         this(os, file, compressionLevel, defaultDeflaterFactory);
-    }
-
-    /**
-     * Creates the output stream.
-     * @param os output stream to create a BlockCompressedOutputStream from
-     * @param file file to which to write the output or null if not available
-     * @param compressionLevel the compression level (0-9)
-     * @param deflaterFactory custom factory to create deflaters (overrides the default)
-     *
-     * @deprecated since 5.0.0 Use {@link #BlockCompressedOutputStream(OutputStream, Path, int, DeflaterFactory)} instead.
-     */
-    @Deprecated
-    public BlockCompressedOutputStream(
-            final OutputStream os, final File file, final int compressionLevel, final DeflaterFactory deflaterFactory) {
-        this(os, IOUtil.toPath(file), compressionLevel, deflaterFactory);
     }
 
     /**
@@ -290,19 +212,6 @@ public class BlockCompressedOutputStream extends OutputStream implements Locatio
         } else {
             return (BlockCompressedOutputStream) output;
         }
-    }
-
-    /**
-     *
-     * @param location May be null.  Used for error messages, and for checking file termination.
-     * @param output May or not already be a BlockCompressedOutputStream.
-     * @return A BlockCompressedOutputStream, either by wrapping the given OutputStream, or by casting if it already
-     *         is a BCOS.
-     * @deprecated since 5.0.0 Use {@link #maybeBgzfWrapOutputStream(Path, OutputStream)} instead.
-     */
-    @Deprecated
-    public static BlockCompressedOutputStream maybeBgzfWrapOutputStream(final File location, OutputStream output) {
-        return maybeBgzfWrapOutputStream(IOUtil.toPath(location), output);
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
+++ b/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
@@ -104,10 +104,12 @@ public class DiskBackedQueue<E> implements Queue<E> {
      * @param codec For writing records to file and reading them back into RAM
      * @param maxRecordsInRam how many records to accumulate in memory before spilling to disk
      * @param tmpDir Where to write files of records that will not fit in RAM
+     * @deprecated since the File API is being phased out; use {@link #newInstanceFromPaths} instead.
      */
+    @Deprecated
     public static <T> DiskBackedQueue<T> newInstance(
             final SortingCollection.Codec<T> codec, final int maxRecordsInRam, final List<File> tmpDir) {
-        return new DiskBackedQueue<T>(
+        return newInstanceFromPaths(
                 codec, maxRecordsInRam, tmpDir.stream().map(File::toPath).collect(Collectors.toList()));
     }
 

--- a/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
+++ b/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
@@ -26,7 +26,6 @@ package htsjdk.samtools.util;
 
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMException;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -38,7 +37,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
-import java.util.stream.Collectors;
 
 /**
  * A single-ended FIFO queue. Writes elements to temporary files when the queue gets too big.
@@ -96,21 +94,6 @@ public class DiskBackedQueue<E> implements Queue<E> {
                 ? 0
                 : maxRecordsInRam - 1; // the first of our ram records is stored as headRecord
         this.ramRecords = new ArrayDeque<E>(this.maxRecordsInRamQueue);
-    }
-
-    /**
-     * Syntactic sugar around the ctor, to save some typing of type parameters
-     *
-     * @param codec For writing records to file and reading them back into RAM
-     * @param maxRecordsInRam how many records to accumulate in memory before spilling to disk
-     * @param tmpDir Where to write files of records that will not fit in RAM
-     * @deprecated since the File API is being phased out; use {@link #newInstanceFromPaths} instead.
-     */
-    @Deprecated
-    public static <T> DiskBackedQueue<T> newInstance(
-            final SortingCollection.Codec<T> codec, final int maxRecordsInRam, final List<File> tmpDir) {
-        return newInstanceFromPaths(
-                codec, maxRecordsInRam, tmpDir.stream().map(File::toPath).collect(Collectors.toList()));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/FileAppendStreamLRUCache.java
+++ b/src/main/java/htsjdk/samtools/util/FileAppendStreamLRUCache.java
@@ -25,51 +25,84 @@ package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 /**
- * LRU cache of OutputStreams to handle situation in which it is necessary to have more FileOutputStreams
- * than resource limits will allow.  Least-recently-used FileOutputStream is closed when it is pushed out of
+ * LRU cache of OutputStreams to handle situation in which it is necessary to have more open output streams
+ * than resource limits will allow.  The least-recently-used stream is closed when it is pushed out of
  * the cache.  When adding a new element to the cache, the file is opened in append mode.
  *
- * Actual elements in the cache are usually BufferedOutputStreams wrapping the FileOutputStreams, but will
- * be FileOutputStreams if Defaults.BUFFER_SIZE = 0.
+ * Actual elements in the cache are usually BufferedOutputStreams wrapping the underlying file streams, but will
+ * be the unbuffered streams if Defaults.BUFFER_SIZE = 0.
  *
  * @author alecw@broadinstitute.org
  */
-public class FileAppendStreamLRUCache extends ResourceLimitedMap<File, OutputStream> {
+public class FileAppendStreamLRUCache extends ResourceLimitedMap<Path, OutputStream> {
     public FileAppendStreamLRUCache(final int cacheSize) {
         super(cacheSize, new Functor());
     }
 
-    private static class Functor implements ResourceLimitedMapFunctor<File, OutputStream> {
+    /**
+     * Return an existing value, or create a new one if necessary.
+     *
+     * @deprecated use {@link #get(Path)} instead.
+     */
+    @Deprecated
+    public OutputStream get(final File file) {
+        return get(file.toPath());
+    }
+
+    /**
+     * Remove the value associated with the given key.
+     *
+     * @deprecated use {@link #remove(Path)} instead.
+     */
+    @Deprecated
+    public OutputStream remove(final File file) {
+        return remove(file.toPath());
+    }
+
+    /**
+     * Determine if the map contains the given key.
+     *
+     * @deprecated use {@link #containsKey(Path)} instead.
+     */
+    @Deprecated
+    public boolean containsKey(final File file) {
+        return containsKey(file.toPath());
+    }
+
+    private static class Functor implements ResourceLimitedMapFunctor<Path, OutputStream> {
         @Override
-        public OutputStream makeValue(final File file) {
+        public OutputStream makeValue(final Path path) {
             try {
-                return IOUtil.maybeBufferOutputStream(new FileOutputStream(file, true));
-            } catch (final FileNotFoundException e) {
+                return IOUtil.maybeBufferOutputStream(
+                        Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.APPEND));
+            } catch (final IOException e) {
                 // In case the file could not be opened because of too many file handles, try to force
                 // file handles to be closed.
                 System.gc();
                 System.runFinalization();
                 try {
-                    return IOUtil.maybeBufferOutputStream(new FileOutputStream(file, true));
-                } catch (final FileNotFoundException e2) {
-                    throw new SAMException(file + "not found", e2);
+                    return IOUtil.maybeBufferOutputStream(
+                            Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.APPEND));
+                } catch (final IOException e2) {
+                    throw new SAMException(path + " not found", e2);
                 }
             }
         }
 
         @Override
-        public void finalizeValue(final File file, final OutputStream out) {
+        public void finalizeValue(final Path path, final OutputStream out) {
             try {
                 out.flush();
                 out.close();
             } catch (final IOException e) {
-                throw new SAMException("Exception closing FileOutputStream for " + file, e);
+                throw new SAMException("Exception closing OutputStream for " + path, e);
             }
         }
     }

--- a/src/main/java/htsjdk/samtools/util/FileAppendStreamLRUCache.java
+++ b/src/main/java/htsjdk/samtools/util/FileAppendStreamLRUCache.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -44,36 +43,6 @@ import java.nio.file.StandardOpenOption;
 public class FileAppendStreamLRUCache extends ResourceLimitedMap<Path, OutputStream> {
     public FileAppendStreamLRUCache(final int cacheSize) {
         super(cacheSize, new Functor());
-    }
-
-    /**
-     * Return an existing value, or create a new one if necessary.
-     *
-     * @deprecated use {@link #get(Path)} instead.
-     */
-    @Deprecated
-    public OutputStream get(final File file) {
-        return get(file.toPath());
-    }
-
-    /**
-     * Remove the value associated with the given key.
-     *
-     * @deprecated use {@link #remove(Path)} instead.
-     */
-    @Deprecated
-    public OutputStream remove(final File file) {
-        return remove(file.toPath());
-    }
-
-    /**
-     * Determine if the map contains the given key.
-     *
-     * @deprecated use {@link #containsKey(Path)} instead.
-     */
-    @Deprecated
-    public boolean containsKey(final File file) {
-        return containsKey(file.toPath());
     }
 
     private static class Functor implements ResourceLimitedMapFunctor<Path, OutputStream> {

--- a/src/main/java/htsjdk/samtools/util/FormatUtil.java
+++ b/src/main/java/htsjdk/samtools/util/FormatUtil.java
@@ -25,7 +25,6 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
-import java.io.File;
 import java.math.RoundingMode;
 import java.nio.file.Path;
 import java.security.InvalidParameterException;
@@ -225,7 +224,6 @@ public class FormatUtil {
         if (returnType == Iso8601Date.class) return parseIso8601Date(value);
         if (returnType == Date.class) return parseDate(value);
         if (returnType == Path.class) return Path.of(value);
-        if (returnType == File.class) return new File(value);
         if (Enum.class.isAssignableFrom(returnType)) return parseEnum(value, (Class<? extends Enum>) returnType);
         if (returnType == String.class) return value;
 

--- a/src/main/java/htsjdk/samtools/util/FormatUtil.java
+++ b/src/main/java/htsjdk/samtools/util/FormatUtil.java
@@ -27,6 +27,7 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.SAMException;
 import java.io.File;
 import java.math.RoundingMode;
+import java.nio.file.Path;
 import java.security.InvalidParameterException;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
@@ -223,6 +224,7 @@ public class FormatUtil {
         if (returnType == Character.class || returnType == Character.TYPE) return parseChar(value);
         if (returnType == Iso8601Date.class) return parseIso8601Date(value);
         if (returnType == Date.class) return parseDate(value);
+        if (returnType == Path.class) return Path.of(value);
         if (returnType == File.class) return new File(value);
         if (Enum.class.isAssignableFrom(returnType)) return parseEnum(value, (Class<? extends Enum>) returnType);
         if (returnType == String.class) return value;

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -473,7 +473,14 @@ public class IOUtil {
     public static void assertFileIsWritable(final Path path) {
         if (path == null) {
             throw new IllegalArgumentException("Cannot check writability of null path.");
-        } else if (!Files.exists(path)) {
+        }
+        // The file/parent-directory writability checks below assume default-filesystem semantics.
+        // For other providers (S3, GCS, jimfs, ...) those semantics may not apply, so skip the check
+        // rather than risk a spurious failure (matching the historical behavior of this method).
+        if (path.getFileSystem() != FileSystems.getDefault()) {
+            return;
+        }
+        if (!Files.exists(path)) {
             // If the file doesn't exist, check that it's parent directory does and is writable
             final Path parent = path.toAbsolutePath().getParent();
             if (parent == null || !Files.exists(parent)) {
@@ -1133,9 +1140,10 @@ public class IOUtil {
      * Copy input to output, overwriting output if it already exists.
      */
     public static void copyPath(final Path input, final Path output) {
-        // Copy through an output stream opened on the target (rather than Files.copy with
-        // REPLACE_EXISTING, which would delete-then-recreate the target) so that an existing
-        // but non-writable destination causes a failure, matching the historical copyFile behavior.
+        // Copy through an output stream opened on the target so that an existing but non-writable
+        // destination causes a failure, matching the historical File-based copyFile (which wrote via
+        // a FileOutputStream). Files.copy(..., REPLACE_EXISTING) would instead overwrite a
+        // non-writable destination, silently changing that behavior.
         try (final InputStream in = Files.newInputStream(input);
                 final OutputStream out = Files.newOutputStream(output)) {
             in.transferTo(out);

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -26,7 +26,6 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.Defaults;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.seekablestream.SeekableBufferedStream;
-import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableHTTPStream;
 import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
@@ -36,10 +35,7 @@ import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -61,7 +57,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -160,8 +155,6 @@ public class IOUtil {
     /** number of bytes that will be read for the GZIP-header in the function {@link #isGZIPInputStream(InputStream)} */
     public static final int GZIP_HEADER_READ_LENGTH = 8000;
 
-    private static final OpenOption[] EMPTY_OPEN_OPTIONS = new OpenOption[0];
-
     private static int compressionLevel = Defaults.COMPRESSION_LEVEL;
     /**
      * Sets the GZip compression level for subsequent GZIPOutputStream object creation.
@@ -233,14 +226,6 @@ public class IOUtil {
         return maybeBufferedSeekableStream(stream, Defaults.BUFFER_SIZE);
     }
 
-    public static SeekableStream maybeBufferedSeekableStream(final File file) {
-        try {
-            return maybeBufferedSeekableStream(new SeekableFileStream(file));
-        } catch (final FileNotFoundException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
     public static SeekableStream maybeBufferedSeekableStream(final URL url) {
         return maybeBufferedSeekableStream(new SeekableHTTPStream(url));
     }
@@ -278,27 +263,6 @@ public class IOUtil {
         return maybeBufferWriter(writer, Defaults.BUFFER_SIZE);
     }
 
-    /**
-     * Delete a list of files, and write a warning message if one could not be deleted.
-     *
-     * @param files Files to be deleted.
-     */
-    public static void deleteFiles(final File... files) {
-        for (final File f : files) {
-            if (!f.delete()) {
-                System.err.println("Could not delete file " + f);
-            }
-        }
-    }
-
-    public static void deleteFiles(final Iterable<File> files) {
-        for (final File f : files) {
-            if (!f.delete()) {
-                System.err.println("Could not delete file " + f);
-            }
-        }
-    }
-
     public static void deletePaths(final Path... paths) {
         for (Path path : paths) {
             deletePath(path);
@@ -328,15 +292,6 @@ public class IOUtil {
         } catch (IOException e) {
             System.err.println("Could not delete file " + path);
         }
-    }
-
-    /**
-     * @return true if the path is not a device (e.g. /dev/null or /dev/stdin), and is not
-     * an existing directory.  I.e. is is a regular path that may correspond to an existing
-     * file, or a path that could be a regular output file.
-     */
-    public static boolean isRegularPath(final File file) {
-        return !file.exists() || file.isFile();
     }
 
     /**
@@ -433,17 +388,6 @@ public class IOUtil {
         DeleteOnExitPathHook.add(path);
     }
 
-    /** Returns the name of the file minus the extension (i.e. text after the last "." in the filename). */
-    public static String basename(final File f) {
-        final String full = f.getName();
-        final int index = full.lastIndexOf('.');
-        if (index > 0 && index > full.lastIndexOf(File.separator)) {
-            return full.substring(0, index);
-        } else {
-            return full;
-        }
-    }
-
     /**
      * Checks that an input is  is non-null, a URL or a file, exists,
      * and if its a file then it is not a directory and is readable.  If any
@@ -456,7 +400,11 @@ public class IOUtil {
             throw new IllegalArgumentException("Cannot check validity of null input.");
         }
         if (!isUrl(input)) {
-            assertFileIsReadable(new File(input));
+            try {
+                assertFileIsReadable(getPath(input));
+            } catch (final IOException e) {
+                throw new SAMException("Cannot read input: " + input, e);
+            }
         }
     }
 
@@ -471,16 +419,6 @@ public class IOUtil {
         } catch (MalformedURLException e) {
             return false;
         }
-    }
-
-    /**
-     * Checks that a file is non-null, exists, is not a directory and is readable.  If any
-     * condition is false then a runtime exception is thrown.
-     *
-     * @param file the file to check for readability
-     */
-    public static void assertFileIsReadable(final File file) {
-        assertFileIsReadable(toPath(file));
     }
 
     /**
@@ -505,16 +443,6 @@ public class IOUtil {
     }
 
     /**
-     * Checks that each file is non-null, exists, is not a directory and is readable.  If any
-     * condition is false then a runtime exception is thrown.
-     *
-     * @param files the list of files to check for readability
-     */
-    public static void assertFilesAreReadable(final List<File> files) {
-        for (final File file : files) assertFileIsReadable(file);
-    }
-
-    /**
      * Checks that each path is non-null, exists, is not a directory and is readable.  If any
      * condition is false then a runtime exception is thrown.
      *
@@ -536,66 +464,33 @@ public class IOUtil {
     }
 
     /**
-     * Checks that a file is non-null, and is either extent and writable, or non-existent but
+     * Checks that a path is non-null, and is either extent and writable, or non-existent but
      * that the parent directory exists and is writable. If any
      * condition is false then a runtime exception is thrown.
      *
-     * @param file the file to check for writability
+     * @param path the path to check for writability
      */
-    public static void assertFileIsWritable(final File file) {
-        if (file == null) {
-            throw new IllegalArgumentException("Cannot check readability of null file.");
-        } else if (!file.exists()) {
+    public static void assertFileIsWritable(final Path path) {
+        if (path == null) {
+            throw new IllegalArgumentException("Cannot check writability of null path.");
+        } else if (!Files.exists(path)) {
             // If the file doesn't exist, check that it's parent directory does and is writable
-            final File parent = file.getAbsoluteFile().getParentFile();
-            if (!parent.exists()) {
-                throw new SAMException("Cannot write file: " + file.getAbsolutePath() + ". "
+            final Path parent = path.toAbsolutePath().getParent();
+            if (parent == null || !Files.exists(parent)) {
+                throw new SAMException("Cannot write file: " + path.toAbsolutePath() + ". "
                         + "Neither file nor parent directory exist.");
-            } else if (!parent.isDirectory()) {
-                throw new SAMException("Cannot write file: " + file.getAbsolutePath() + ". "
+            } else if (!Files.isDirectory(parent)) {
+                throw new SAMException("Cannot write file: " + path.toAbsolutePath() + ". "
                         + "File does not exist and parent is not a directory.");
-            } else if (!parent.canWrite()) {
-                throw new SAMException("Cannot write file: " + file.getAbsolutePath() + ". "
-                        + "File does not exist and parent directory is not writable..");
+            } else if (!Files.isWritable(parent)) {
+                throw new SAMException("Cannot write file: " + path.toAbsolutePath() + ". "
+                        + "File does not exist and parent directory is not writable.");
             }
-        } else if (file.isDirectory()) {
-            throw new SAMException("Cannot write file because it is a directory: " + file.getAbsolutePath());
-        } else if (!file.canWrite()) {
-            throw new SAMException("File exists but is not writable: " + file.getAbsolutePath());
+        } else if (Files.isDirectory(path)) {
+            throw new SAMException("Cannot write file because it is a directory: " + path.toAbsolutePath());
+        } else if (!Files.isWritable(path)) {
+            throw new SAMException("File exists but is not writable: " + path.toAbsolutePath());
         }
-    }
-
-    /**
-     * Checks that each file is non-null, and is either extent and writable, or non-existent but
-     * that the parent directory exists and is writable. If any
-     * condition is false then a runtime exception is thrown.
-     *
-     * @param files the list of files to check for writability
-     */
-    public static void assertFilesAreWritable(final List<File> files) {
-        for (final File file : files) assertFileIsWritable(file);
-    }
-
-    /**
-     * In some filesystems (e.g. google cloud) it may not make sense to check writability.
-     * This method only checks writability when it's (i.e. for now when the path points to a file
-     * in the local filesystem)
-     */
-    public static void assertFileIsWritable(final Path path) { // tsato: perhaps the input type should be IOPath
-        if (path.toUri().getScheme().equals("file")) {
-            IOUtil.assertFileIsWritable(path.toFile());
-        }
-    }
-
-    /**
-     * Checks that a directory is non-null, extent, writable and a directory
-     * otherwise a runtime exception is thrown.
-     *
-     * @param dir the dir to check for writability
-     */
-    public static void assertDirectoryIsWritable(final File dir) {
-        final Path asPath = IOUtil.toPath(dir);
-        assertDirectoryIsWritable(asPath);
     }
 
     /**
@@ -616,71 +511,6 @@ public class IOUtil {
             throw new SAMException(
                     "Directory exists but is not writable: " + dir.toUri().toString());
         }
-    }
-
-    /**
-     * Checks that a directory is non-null, extent, readable and a directory
-     * otherwise a runtime exception is thrown.
-     *
-     * @param dir the dir to check for writability
-     */
-    public static void assertDirectoryIsReadable(final File dir) {
-        if (dir == null) {
-            throw new IllegalArgumentException("Cannot check readability of null file.");
-        } else if (!dir.exists()) {
-            throw new SAMException("Directory does not exist: " + dir.getAbsolutePath());
-        } else if (!dir.isDirectory()) {
-            throw new SAMException(
-                    "Cannot read from directory because it is not a directory: " + dir.getAbsolutePath());
-        } else if (!dir.canRead()) {
-            throw new SAMException("Directory exists but is not readable: " + dir.getAbsolutePath());
-        }
-    }
-
-    /**
-     * Checks that the two files are the same length, and have the same content, otherwise throws a runtime exception.
-     */
-    public static void assertFilesEqual(final File f1, final File f2) {
-        if (f1.length() != f2.length()) {
-            throw new SAMException(
-                    "File " + f1 + " is " + f1.length() + " bytes but file " + f2 + " is " + f2.length() + " bytes.");
-        }
-        try (final FileInputStream s1 = new FileInputStream(f1);
-                final FileInputStream s2 = new FileInputStream(f2); ) {
-            final byte[] buf1 = new byte[1024 * 1024];
-            final byte[] buf2 = new byte[1024 * 1024];
-            int len1;
-            while ((len1 = s1.read(buf1)) != -1) {
-                final int len2 = s2.read(buf2);
-                if (len1 != len2) {
-                    throw new SAMException("Unexpected EOF comparing files that are supposed to be the same length.");
-                }
-                if (!Arrays.equals(buf1, buf2)) {
-                    throw new SAMException("Files " + f1 + " and " + f2 + " differ.");
-                }
-            }
-        } catch (final IOException e) {
-            throw new SAMException("Exception comparing files " + f1 + " and " + f2, e);
-        }
-    }
-
-    /**
-     * Checks that a file is of non-zero length
-     */
-    public static void assertFileSizeNonZero(final File file) {
-        if (file.length() == 0) {
-            throw new SAMException(file.getAbsolutePath() + " has length 0");
-        }
-    }
-
-    /**
-     * Opens a file for reading, decompressing it if necessary
-     *
-     * @param file  The file to open
-     * @return the input stream to read from
-     */
-    public static InputStream openFileForReading(final File file) {
-        return openFileForReading(toPath(file));
     }
 
     /**
@@ -705,16 +535,6 @@ public class IOUtil {
     /**
      * Opens a GZIP-encoded file for reading, decompressing it if necessary
      *
-     * @param file  The file to open
-     * @return the input stream to read from
-     */
-    public static InputStream openGzipFileForReading(final File file) {
-        return openGzipFileForReading(toPath(file));
-    }
-
-    /**
-     * Opens a GZIP-encoded file for reading, decompressing it if necessary
-     *
      * @param path  The file to open
      * @return the input stream to read from
      */
@@ -725,27 +545,6 @@ public class IOUtil {
         } catch (IOException ioe) {
             throw new SAMException("Error opening file: " + path, ioe);
         }
-    }
-
-    /**
-     * Opens a file for writing, overwriting the file if it already exists
-     *
-     * @param file  the file to write to
-     * @return the output stream to write to
-     */
-    public static OutputStream openFileForWriting(final File file) {
-        return openFileForWriting(toPath(file));
-    }
-
-    /**
-     * Opens a file for writing, gzip it if it ends with ".gz" or "bfq"
-     *
-     * @param file  the file to write to
-     * @param append    whether to append to the file if it already exists (we overwrite it if false)
-     * @return the output stream to write to
-     */
-    public static OutputStream openFileForWriting(final File file, final boolean append) {
-        return openFileForWriting(toPath(file), getAppendOpenOption(append));
     }
 
     /**
@@ -780,31 +579,9 @@ public class IOUtil {
     /**
      * Preferred over PrintStream and PrintWriter because an exception is thrown on I/O error
      */
-    public static BufferedWriter openFileForBufferedWriting(final File file, final boolean append) {
-        return new BufferedWriter(
-                new OutputStreamWriter(openFileForWriting(file, append)), Defaults.NON_ZERO_BUFFER_SIZE);
-    }
-
-    /**
-     * Preferred over PrintStream and PrintWriter because an exception is thrown on I/O error
-     */
     public static BufferedWriter openFileForBufferedWriting(final Path path, final OpenOption... openOptions) {
         return new BufferedWriter(
                 new OutputStreamWriter(openFileForWriting(path, openOptions)), Defaults.NON_ZERO_BUFFER_SIZE);
-    }
-
-    /**
-     * Preferred over PrintStream and PrintWriter because an exception is thrown on I/O error
-     */
-    public static BufferedWriter openFileForBufferedWriting(final File file) {
-        return openFileForBufferedWriting(IOUtil.toPath(file));
-    }
-
-    /**
-     * Preferred over PrintStream and PrintWriter because an exception is thrown on I/O error
-     */
-    public static BufferedWriter openFileForBufferedUtf8Writing(final File file) {
-        return openFileForBufferedUtf8Writing(IOUtil.toPath(file));
     }
 
     /**
@@ -814,34 +591,6 @@ public class IOUtil {
         return new BufferedWriter(
                 new OutputStreamWriter(openFileForWriting(path), Charset.forName("UTF-8")),
                 Defaults.NON_ZERO_BUFFER_SIZE);
-    }
-
-    /**
-     * Opens a file for reading, decompressing it if necessary
-     *
-     * @param file  The file to open
-     * @return the input stream to read from
-     */
-    public static BufferedReader openFileForBufferedUtf8Reading(final File file) {
-        return new BufferedReader(new InputStreamReader(openFileForReading(file), Charset.forName("UTF-8")));
-    }
-
-    /**
-     * Opens a GZIP encoded file for writing
-     *
-     * @param file  the file to write to
-     * @param append    whether to append to the file if it already exists (we overwrite it if false)
-     * @return the output stream to write to
-     */
-    public static OutputStream openGzipFileForWriting(final File file, final boolean append) {
-        return openGzipFileForWriting(IOUtil.toPath(file), getAppendOpenOption(append));
-    }
-
-    /**
-     * converts a boolean into an array containing either the append option or nothing
-     */
-    private static OpenOption[] getAppendOpenOption(boolean append) {
-        return append ? new OpenOption[] {StandardOpenOption.APPEND} : EMPTY_OPEN_OPTIONS;
     }
 
     /**
@@ -865,10 +614,6 @@ public class IOUtil {
         }
     }
 
-    public static OutputStream openFileForMd5CalculatingWriting(final File file) {
-        return openFileForMd5CalculatingWriting(toPath(file));
-    }
-
     public static OutputStream openFileForMd5CalculatingWriting(final Path file) {
         final Path digestFile = file.resolveSibling(file.getFileName() + FileExtensions.MD5);
         return new Md5CalculatingOutputStream(IOUtil.openFileForWriting(file), digestFile);
@@ -890,89 +635,6 @@ public class IOUtil {
             }
         } catch (IOException e) {
             throw new SAMException("Exception copying stream", e);
-        }
-    }
-
-    /**
-     * Copy input to output, overwriting output if it already exists.
-     */
-    public static void copyFile(final File input, final File output) {
-        try {
-            final InputStream is = new FileInputStream(input);
-            final OutputStream os = new FileOutputStream(output);
-            copyStream(is, os);
-            os.close();
-            is.close();
-        } catch (IOException e) {
-            throw new SAMException("Error copying " + input + " to " + output, e);
-        }
-    }
-
-    /**
-     *
-     * @param directory
-     * @param regexp
-     * @return list of files matching regexp.
-     */
-    public static File[] getFilesMatchingRegexp(final File directory, final String regexp) {
-        final Pattern pattern = Pattern.compile(regexp);
-        return getFilesMatchingRegexp(directory, pattern);
-    }
-
-    public static File[] getFilesMatchingRegexp(final File directory, final Pattern regexp) {
-        return directory.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(final File dir, final String name) {
-                return regexp.matcher(name).matches();
-            }
-        });
-    }
-
-    /**
-     * Delete the given file or directory.  If a directory, all enclosing files and subdirs are also deleted.
-     */
-    public static boolean deleteDirectoryTree(final File fileOrDirectory) {
-        boolean success = true;
-
-        if (fileOrDirectory.isDirectory()) {
-            for (final File child : fileOrDirectory.listFiles()) {
-                success = success && deleteDirectoryTree(child);
-            }
-        }
-
-        success = success && fileOrDirectory.delete();
-        return success;
-    }
-
-    /**
-     * Returns the size (in bytes) of the file or directory and all it's children.
-     */
-    public static long sizeOfTree(final File fileOrDirectory) {
-        long total = fileOrDirectory.length();
-        if (fileOrDirectory.isDirectory()) {
-            for (final File f : fileOrDirectory.listFiles()) {
-                total += sizeOfTree(f);
-            }
-        }
-
-        return total;
-    }
-
-    /**
-     *
-     * Copies a directory tree (all subdirectories and files) recursively to a destination
-     */
-    public static void copyDirectoryTree(final File fileOrDirectory, final File destination) {
-        if (fileOrDirectory.isDirectory()) {
-            destination.mkdir();
-            for (final File f : fileOrDirectory.listFiles()) {
-                final File destinationFileOrDirectory = new File(destination.getPath(), f.getName());
-                if (f.isDirectory()) {
-                    copyDirectoryTree(f, destinationFileOrDirectory);
-                } else {
-                    copyFile(f, destinationFileOrDirectory);
-                }
-            }
         }
     }
 
@@ -1010,11 +672,6 @@ public class IOUtil {
         }
     }
 
-    /** Checks that a file exists and is readable, and then returns a buffered reader for it. */
-    public static BufferedReader openFileForBufferedReading(final File file) {
-        return openFileForBufferedReading(toPath(file));
-    }
-
     /** Checks that a path exists and is readable, and then returns a buffered reader for it. */
     public static BufferedReader openFileForBufferedReading(final Path path) {
         return new BufferedReader(new InputStreamReader(openFileForReading(path)), Defaults.NON_ZERO_BUFFER_SIZE);
@@ -1023,34 +680,6 @@ public class IOUtil {
     /** Takes a string and replaces any characters that are not safe for filenames with an underscore */
     public static String makeFileNameSafe(final String str) {
         return str.trim().replaceAll("[\\s!\"#$%&'()*/:;<=>?@\\[\\]\\\\^`{|}~]", "_");
-    }
-
-    /** Returns the name of the file extension (i.e. text after the last "." in the filename) including the . */
-    public static String fileSuffix(final File f) {
-        final String full = f.getName();
-        final int index = full.lastIndexOf('.');
-        if (index > 0 && index > full.lastIndexOf(File.separator)) {
-            return full.substring(index);
-        } else {
-            return null;
-        }
-    }
-
-    /** Returns the full path to the file with all symbolic links resolved **/
-    public static String getFullCanonicalPath(final File file) {
-        try {
-            File f = file.getCanonicalFile();
-            String canonicalPath = "";
-            while (f != null && !f.getName().equals("")) {
-                canonicalPath = "/" + f.getName() + canonicalPath;
-                f = f.getParentFile();
-                if (f != null) f = f.getCanonicalFile();
-            }
-            return canonicalPath;
-        } catch (final IOException ioe) {
-            throw new RuntimeIOException(
-                    "Error getting full canonical path for " + file + ": " + ioe.getMessage(), ioe);
-        }
     }
 
     /**
@@ -1073,63 +702,9 @@ public class IOUtil {
         }
     }
 
-    /**
-     * Returns an iterator over the lines in a text file. The underlying resources are automatically
-     * closed when the iterator hits the end of the input, or manually by calling close().
-     *
-     * @param f a file that is to be read in as text
-     * @return an iterator over the lines in the text file
-     */
-    public static IterableOnceIterator<String> readLines(final File f) {
-        try {
-            final BufferedReader in = IOUtil.openFileForBufferedReading(f);
-
-            return new IterableOnceIterator<String>() {
-                private String next = in.readLine();
-
-                /** Returns true if there is another line to read or false otherwise. */
-                @Override
-                public boolean hasNext() {
-                    return next != null;
-                }
-
-                /** Returns the next line in the file or null if there are no more lines. */
-                @Override
-                public String next() {
-                    try {
-                        final String tmp = next;
-                        next = in.readLine();
-                        if (next == null) in.close();
-                        return tmp;
-                    } catch (final IOException ioe) {
-                        throw new RuntimeIOException(ioe);
-                    }
-                }
-
-                /** Closes the underlying input stream. Not required if end of stream has already been hit. */
-                @Override
-                public void close() throws IOException {
-                    CloserUtil.close(in);
-                }
-            };
-        } catch (final IOException e) {
-            throw new RuntimeIOException(e);
-        }
-    }
-
-    /** Returns all of the untrimmed lines in the provided file. */
-    public static List<String> slurpLines(final File file) throws FileNotFoundException {
-        return slurpLines(new FileInputStream(file));
-    }
-
     public static List<String> slurpLines(final InputStream is) throws FileNotFoundException {
         /** See {@link java.util.Scanner} source for origin of delimiter used here.  */
         return tokenSlurp(is, Charset.defaultCharset(), "\r\n|[\n\r\u2028\u2029\u0085]");
-    }
-
-    /** Convenience overload for {@link #slurp(java.io.InputStream, java.nio.charset.Charset)} using the default charset {@link java.nio.charset.Charset#defaultCharset()}. */
-    public static String slurp(final File file) throws FileNotFoundException {
-        return slurp(new FileInputStream(file));
     }
 
     /** Convenience overload for {@link #slurp(java.io.InputStream, java.nio.charset.Charset)} using the default charset {@link java.nio.charset.Charset#defaultCharset()}. */
@@ -1155,15 +730,6 @@ public class IOUtil {
         } finally {
             CloserUtil.close(is);
         }
-    }
-
-    /**
-     * Go through the files provided and if they have one of the provided file extensions pass the file into the output
-     * otherwise assume that file is a list of filenames and unfold it into the output.
-     */
-    public static List<File> unrollFiles(final Collection<File> inputs, final String... extensions) {
-        Collection<Path> paths = unrollPaths(filesToPaths(inputs), extensions);
-        return paths.stream().map(Path::toFile).collect(Collectors.toList());
     }
 
     /**
@@ -1401,17 +967,6 @@ public class IOUtil {
     /**
      * Checks if a file ends in one of the {@link FileExtensions#BLOCK_COMPRESSED}.
      *
-     * @param file object to extract the name from.
-     *
-     * @return {@code true} if the file has a block-compressed extension; {@code false} otherwise.
-     */
-    public static boolean hasBlockCompressedExtension(final File file) {
-        return hasBlockCompressedExtension(file.getName());
-    }
-
-    /**
-     * Checks if a file ends in one of the {@link FileExtensions#BLOCK_COMPRESSED}.
-     *
      * @param uri file as an URI.
      *
      * @return {@code true} if the file has a block-compressed extension; {@code false} otherwise.
@@ -1468,9 +1023,7 @@ public class IOUtil {
     }
 
     // ------------------------------------------------------------------------------------------
-    // Path-based equivalents of the File-based utility methods above. These are the canonical
-    // entry points going forward; the File-based overloads are retained only as deprecated shims
-    // pending their removal.
+    // Path-based utility methods.
     // ------------------------------------------------------------------------------------------
 
     public static SeekableStream maybeBufferedSeekableStream(final Path path) {

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -28,6 +28,7 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.seekablestream.SeekableBufferedStream;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableHTTPStream;
+import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.nio.DeleteOnExitPathHook;
 import java.io.BufferedInputStream;
@@ -59,6 +60,7 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -1455,6 +1457,334 @@ public class IOUtil {
             Files.walkFileTree(directory, simpleFileVisitor);
         } catch (final IOException e) {
             throw new RuntimeIOException(e);
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Path-based equivalents of the File-based utility methods above. These are the canonical
+    // entry points going forward; the File-based overloads are retained only as deprecated shims
+    // pending their removal.
+    // ------------------------------------------------------------------------------------------
+
+    public static SeekableStream maybeBufferedSeekableStream(final Path path) {
+        try {
+            return maybeBufferedSeekableStream(new SeekablePathStream(path));
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /** Returns the name of the file minus the extension (i.e. text after the last "." in the filename). */
+    public static String basename(final Path path) {
+        final String full = path.getFileName().toString();
+        final int index = full.lastIndexOf('.');
+        if (index > 0 && index > full.lastIndexOf(path.getFileSystem().getSeparator())) {
+            return full.substring(0, index);
+        } else {
+            return full;
+        }
+    }
+
+    /**
+     * Checks that each path is non-null, and is either extent and writable, or non-existent but
+     * that the parent directory exists and is writable. If any
+     * condition is false then a runtime exception is thrown.
+     *
+     * @param paths the list of paths to check for writability
+     */
+    public static void assertPathsAreWritable(final List<Path> paths) {
+        for (final Path path : paths) assertFileIsWritable(path);
+    }
+
+    /**
+     * Checks that a directory is non-null, extent, readable and a directory
+     * otherwise a runtime exception is thrown.
+     *
+     * @param dir the dir to check for readability
+     */
+    public static void assertDirectoryIsReadable(final Path dir) {
+        if (dir == null) {
+            throw new IllegalArgumentException("Cannot check readability of null directory.");
+        } else if (!Files.exists(dir)) {
+            throw new SAMException("Directory does not exist: " + dir.toUri().toString());
+        } else if (!Files.isDirectory(dir)) {
+            throw new SAMException("Cannot read from directory because it is not a directory: "
+                    + dir.toUri().toString());
+        } else if (!Files.isReadable(dir)) {
+            throw new SAMException(
+                    "Directory exists but is not readable: " + dir.toUri().toString());
+        }
+    }
+
+    /**
+     * Checks that the two paths are the same length, and have the same content, otherwise throws a runtime exception.
+     */
+    public static void assertFilesEqual(final Path p1, final Path p2) {
+        try {
+            if (Files.size(p1) != Files.size(p2)) {
+                throw new SAMException("File " + p1 + " is " + Files.size(p1) + " bytes but file " + p2 + " is "
+                        + Files.size(p2) + " bytes.");
+            }
+            try (final InputStream s1 = Files.newInputStream(p1);
+                    final InputStream s2 = Files.newInputStream(p2)) {
+                final byte[] buf1 = new byte[1024 * 1024];
+                final byte[] buf2 = new byte[1024 * 1024];
+                int len1;
+                while ((len1 = s1.read(buf1)) != -1) {
+                    final int len2 = s2.read(buf2);
+                    if (len1 != len2) {
+                        throw new SAMException(
+                                "Unexpected EOF comparing files that are supposed to be the same length.");
+                    }
+                    if (!Arrays.equals(buf1, buf2)) {
+                        throw new SAMException("Files " + p1 + " and " + p2 + " differ.");
+                    }
+                }
+            }
+        } catch (final IOException e) {
+            throw new SAMException("Exception comparing files " + p1 + " and " + p2, e);
+        }
+    }
+
+    /**
+     * Checks that a file is of non-zero length
+     */
+    public static void assertFileSizeNonZero(final Path path) {
+        try {
+            if (Files.size(path) == 0) {
+                throw new SAMException(path.toAbsolutePath() + " has length 0");
+            }
+        } catch (IOException e) {
+            throw new SAMException("Error checking file size: " + path, e);
+        }
+    }
+
+    /**
+     * Opens a file for reading, decompressing it if necessary
+     *
+     * @param path  The file to open
+     * @return the input stream to read from
+     */
+    public static BufferedReader openFileForBufferedUtf8Reading(final Path path) {
+        return new BufferedReader(new InputStreamReader(openFileForReading(path), Charset.forName("UTF-8")));
+    }
+
+    /**
+     * Copy input to output, overwriting output if it already exists.
+     */
+    public static void copyPath(final Path input, final Path output) {
+        try {
+            Files.copy(input, output, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new SAMException("Error copying " + input + " to " + output, e);
+        }
+    }
+
+    /**
+     * Returns paths matching regexp in the given directory.
+     *
+     * @param directory the directory to search
+     * @param regexp the regular expression pattern
+     * @return list of paths matching regexp.
+     */
+    public static List<Path> getPathsMatchingRegexp(final Path directory, final String regexp) {
+        final Pattern pattern = Pattern.compile(regexp);
+        return getPathsMatchingRegexp(directory, pattern);
+    }
+
+    /**
+     * Returns paths matching regexp in the given directory.
+     *
+     * @param directory the directory to search
+     * @param regexp the regular expression pattern
+     * @return list of paths matching regexp.
+     */
+    public static List<Path> getPathsMatchingRegexp(final Path directory, final Pattern regexp) {
+        try {
+            return Files.list(directory)
+                    .filter(path ->
+                            regexp.matcher(path.getFileName().toString()).matches())
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeIOException("Error listing directory: " + directory, e);
+        }
+    }
+
+    /**
+     * Delete the given path or directory.  If a directory, all enclosing files and subdirs are also deleted.
+     */
+    public static boolean deleteDirectoryTree(final Path pathOrDirectory) {
+        try {
+            if (Files.isDirectory(pathOrDirectory)) {
+                Files.walk(pathOrDirectory)
+                        .sorted((a, b) -> -a.compareTo(b)) // reverse order to delete children first
+                        .forEach(path -> {
+                            try {
+                                Files.delete(path);
+                            } catch (IOException e) {
+                                throw new RuntimeIOException(e);
+                            }
+                        });
+            } else {
+                Files.delete(pathOrDirectory);
+            }
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the size (in bytes) of the file or directory and all it's children.
+     */
+    public static long sizeOfTree(final Path pathOrDirectory) {
+        try {
+            if (Files.isDirectory(pathOrDirectory)) {
+                return Files.walk(pathOrDirectory)
+                        .mapToLong(path -> {
+                            try {
+                                return Files.size(path);
+                            } catch (IOException e) {
+                                return 0;
+                            }
+                        })
+                        .sum();
+            } else {
+                return Files.size(pathOrDirectory);
+            }
+        } catch (IOException e) {
+            throw new RuntimeIOException("Error calculating size of tree: " + pathOrDirectory, e);
+        }
+    }
+
+    /**
+     * Copies a directory tree (all subdirectories and files) recursively to a destination
+     */
+    public static void copyDirectoryTree(final Path pathOrDirectory, final Path destination) {
+        try {
+            if (Files.isDirectory(pathOrDirectory)) {
+                Files.createDirectories(destination);
+                Files.walk(pathOrDirectory).forEach(source -> {
+                    try {
+                        Path dest = destination.resolve(pathOrDirectory.relativize(source));
+                        if (Files.isDirectory(source)) {
+                            Files.createDirectories(dest);
+                        } else {
+                            Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING);
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeIOException(e);
+                    }
+                });
+            }
+        } catch (IOException e) {
+            throw new RuntimeIOException("Error copying directory tree: " + pathOrDirectory, e);
+        }
+    }
+
+    /** Returns the name of the file extension (i.e. text after the last "." in the filename) including the . */
+    public static String fileSuffix(final Path path) {
+        final String full = path.getFileName().toString();
+        final int index = full.lastIndexOf('.');
+        if (index > 0 && index > full.lastIndexOf(path.getFileSystem().getSeparator())) {
+            return full.substring(index);
+        } else {
+            return null;
+        }
+    }
+
+    /** Returns the full path to the file with all symbolic links resolved **/
+    public static String getFullCanonicalPath(final Path path) {
+        try {
+            Path p = path.toRealPath();
+            return p.toString();
+        } catch (final IOException ioe) {
+            throw new RuntimeIOException(
+                    "Error getting full canonical path for " + path + ": " + ioe.getMessage(), ioe);
+        }
+    }
+
+    /**
+     * Returns an iterator over the lines in a text file. The underlying resources are automatically
+     * closed when the iterator hits the end of the input, or manually by calling close().
+     *
+     * @param path a path that is to be read in as text
+     * @return an iterator over the lines in the text file
+     */
+    public static IterableOnceIterator<String> readLines(final Path path) {
+        try {
+            final BufferedReader in = IOUtil.openFileForBufferedReading(path);
+
+            return new IterableOnceIterator<String>() {
+                private String next = in.readLine();
+
+                /** Returns true if there is another line to read or false otherwise. */
+                @Override
+                public boolean hasNext() {
+                    return next != null;
+                }
+
+                /** Returns the next line in the file or null if there are no more lines. */
+                @Override
+                public String next() {
+                    try {
+                        final String tmp = next;
+                        next = in.readLine();
+                        if (next == null) in.close();
+                        return tmp;
+                    } catch (final IOException ioe) {
+                        throw new RuntimeIOException(ioe);
+                    }
+                }
+
+                /** Closes the underlying input stream. Not required if end of stream has already been hit. */
+                @Override
+                public void close() throws IOException {
+                    CloserUtil.close(in);
+                }
+            };
+        } catch (final IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /** Returns all of the untrimmed lines in the provided path. */
+    public static List<String> slurpLines(final Path path) {
+        try {
+            return slurpLines(Files.newInputStream(path));
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /** Convenience overload for {@link #slurp(java.io.InputStream, java.nio.charset.Charset)} using the default charset {@link java.nio.charset.Charset#defaultCharset()}. */
+    public static String slurp(final Path path) {
+        try {
+            return slurp(Files.newInputStream(path));
+        } catch (IOException e) {
+            throw new RuntimeIOException(e);
+        }
+    }
+
+    /**
+     * Converts the given URI to a {@link Path} object. If the filesystem cannot be found in the usual way, then attempt
+     * to load the filesystem provider using the thread context classloader.
+     *
+     * @param uri the URI to convert
+     * @return the resulting {@code Path}
+     * @throws IOException an I/O error occurs creating the file system
+     */
+    public static Path getPath(URI uri) throws IOException {
+        try {
+            return Paths.get(uri);
+        } catch (FileSystemNotFoundException e) {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            if (cl == null) {
+                throw e;
+            }
+            return FileSystems.newFileSystem(uri, new HashMap<>(), cl)
+                    .provider()
+                    .getPath(uri);
         }
     }
 }

--- a/src/main/java/htsjdk/samtools/util/IOUtil.java
+++ b/src/main/java/htsjdk/samtools/util/IOUtil.java
@@ -1240,7 +1240,14 @@ public class IOUtil {
      * @throws IOException an I/O error occurs creating the file system
      */
     public static Path getPath(String uriString) throws IOException {
-        URI uri = URI.create(uriString);
+        final URI uri;
+        try {
+            uri = URI.create(uriString);
+        } catch (final IllegalArgumentException e) {
+            // Not a valid URI (e.g. it contains spaces or other characters that are illegal in a URI);
+            // treat it as a path on the default filesystem rather than failing.
+            return Paths.get(uriString);
+        }
         try {
             // if the URI has no scheme, then treat as a local file, otherwise use the scheme to determine the
             // filesystem to use
@@ -1573,9 +1580,13 @@ public class IOUtil {
      * Copy input to output, overwriting output if it already exists.
      */
     public static void copyPath(final Path input, final Path output) {
-        try {
-            Files.copy(input, output, StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
+        // Copy through an output stream opened on the target (rather than Files.copy with
+        // REPLACE_EXISTING, which would delete-then-recreate the target) so that an existing
+        // but non-writable destination causes a failure, matching the historical copyFile behavior.
+        try (final InputStream in = Files.newInputStream(input);
+                final OutputStream out = Files.newOutputStream(output)) {
+            in.transferTo(out);
+        } catch (final IOException e) {
             throw new SAMException("Error copying " + input + " to " + output, e);
         }
     }

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -32,7 +32,6 @@ import htsjdk.tribble.IntervalList.IntervalListCodec;
 import htsjdk.tribble.MutableFeature;
 import htsjdk.utils.ValidationUtils;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -449,18 +448,6 @@ public class IntervalList implements Iterable<Interval> {
     }
 
     /**
-     * Parses an interval list from a file.
-     *
-     * @param file the file containing the intervals
-     * @return an IntervalList object that contains the headers and intervals from the file
-     * @deprecated use {@link #fromPath(Path)} instead.
-     */
-    @Deprecated
-    public static IntervalList fromFile(final File file) {
-        return fromPath(IOUtil.toPath(file));
-    }
-
-    /**
      * Parses an interval list from a path.
      *
      * @param path the path containing the intervals
@@ -496,20 +483,6 @@ public class IntervalList implements Iterable<Interval> {
         final Collection<IntervalList> intervalLists = new ArrayList<>();
         for (final Path path : intervalListPaths) {
             intervalLists.add(IntervalList.fromPath(path));
-        }
-        return IntervalList.concatenate(intervalLists);
-    }
-
-    /**
-     * Calls {@link #fromFile(java.io.File)} on the provided files, and returns their {@link #concatenate(Collection)}
-     *
-     * @deprecated use {@link #fromPaths(Collection)} instead.
-     */
-    @Deprecated
-    public static IntervalList fromFiles(final Collection<File> intervalListFiles) {
-        final Collection<IntervalList> intervalLists = new ArrayList<>();
-        for (final File file : intervalListFiles) {
-            intervalLists.add(IntervalList.fromFile(file));
         }
         return IntervalList.concatenate(intervalLists);
     }
@@ -579,17 +552,6 @@ public class IntervalList implements Iterable<Interval> {
         } catch (final IOException ioe) {
             throw new SAMException("Error writing out interval list to file: " + path.toAbsolutePath(), ioe);
         }
-    }
-
-    /**
-     * Writes out the list of intervals to the supplied file.
-     *
-     * @param file a file to write to.  If exists it will be overwritten.
-     * @deprecated use {@link #write(Path)} instead.
-     */
-    @Deprecated
-    public void write(final File file) {
-        this.write(file.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/IntervalList.java
+++ b/src/main/java/htsjdk/samtools/util/IntervalList.java
@@ -453,7 +453,9 @@ public class IntervalList implements Iterable<Interval> {
      *
      * @param file the file containing the intervals
      * @return an IntervalList object that contains the headers and intervals from the file
+     * @deprecated use {@link #fromPath(Path)} instead.
      */
+    @Deprecated
     public static IntervalList fromFile(final File file) {
         return fromPath(IOUtil.toPath(file));
     }
@@ -488,8 +490,22 @@ public class IntervalList implements Iterable<Interval> {
     }
 
     /**
-     * Calls {@link #fromFile(java.io.File)} on the provided files, and returns their {@link #concatenate(Collection)}
+     * Calls {@link #fromPath(Path)} on the provided paths, and returns their {@link #concatenate(Collection)}
      */
+    public static IntervalList fromPaths(final Collection<Path> intervalListPaths) {
+        final Collection<IntervalList> intervalLists = new ArrayList<>();
+        for (final Path path : intervalListPaths) {
+            intervalLists.add(IntervalList.fromPath(path));
+        }
+        return IntervalList.concatenate(intervalLists);
+    }
+
+    /**
+     * Calls {@link #fromFile(java.io.File)} on the provided files, and returns their {@link #concatenate(Collection)}
+     *
+     * @deprecated use {@link #fromPaths(Collection)} instead.
+     */
+    @Deprecated
     public static IntervalList fromFiles(final Collection<File> intervalListFiles) {
         final Collection<IntervalList> intervalLists = new ArrayList<>();
         for (final File file : intervalListFiles) {
@@ -569,7 +585,9 @@ public class IntervalList implements Iterable<Interval> {
      * Writes out the list of intervals to the supplied file.
      *
      * @param file a file to write to.  If exists it will be overwritten.
+     * @deprecated use {@link #write(Path)} instead.
      */
+    @Deprecated
     public void write(final File file) {
         this.write(file.toPath());
     }

--- a/src/main/java/htsjdk/samtools/util/Md5CalculatingInputStream.java
+++ b/src/main/java/htsjdk/samtools/util/Md5CalculatingInputStream.java
@@ -26,10 +26,11 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.SAMException;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -42,17 +43,17 @@ public class Md5CalculatingInputStream extends InputStream {
 
     private final InputStream is;
     private final MessageDigest md5;
-    private final File digestFile;
+    private final Path digestPath;
     private String hash;
 
     /**
      * Constructor that takes in the InputStream that we are wrapping
      * and creates the MD5 MessageDigest
      */
-    public Md5CalculatingInputStream(InputStream is, File digestFile) {
+    public Md5CalculatingInputStream(InputStream is, Path digestPath) {
         super();
         this.is = is;
-        this.digestFile = digestFile;
+        this.digestPath = digestPath;
         this.hash = null;
 
         try {
@@ -61,6 +62,17 @@ public class Md5CalculatingInputStream extends InputStream {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("MD5 algorithm not found", e);
         }
+    }
+
+    /**
+     * Constructor that takes in the InputStream that we are wrapping
+     * and creates the MD5 MessageDigest.
+     *
+     * @deprecated since 06/2026 use {@link #Md5CalculatingInputStream(InputStream, Path)} instead.
+     */
+    @Deprecated
+    public Md5CalculatingInputStream(InputStream is, File digestFile) {
+        this(is, digestFile == null ? null : digestFile.toPath());
     }
 
     @Override
@@ -110,8 +122,8 @@ public class Md5CalculatingInputStream extends InputStream {
         is.close();
         makeHash();
 
-        if (digestFile != null) {
-            BufferedWriter writer = new BufferedWriter(new FileWriter(digestFile));
+        if (digestPath != null) {
+            BufferedWriter writer = Files.newBufferedWriter(digestPath);
             writer.write(hash);
             writer.close();
         }

--- a/src/main/java/htsjdk/samtools/util/Md5CalculatingInputStream.java
+++ b/src/main/java/htsjdk/samtools/util/Md5CalculatingInputStream.java
@@ -25,7 +25,6 @@ package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
@@ -62,17 +61,6 @@ public class Md5CalculatingInputStream extends InputStream {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("MD5 algorithm not found", e);
         }
-    }
-
-    /**
-     * Constructor that takes in the InputStream that we are wrapping
-     * and creates the MD5 MessageDigest.
-     *
-     * @deprecated since 06/2026 use {@link #Md5CalculatingInputStream(InputStream, Path)} instead.
-     */
-    @Deprecated
-    public Md5CalculatingInputStream(InputStream is, File digestFile) {
-        this(is, digestFile == null ? null : digestFile.toPath());
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/util/Md5CalculatingOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/Md5CalculatingOutputStream.java
@@ -64,6 +64,13 @@ public class Md5CalculatingOutputStream extends OutputStream {
         }
     }
 
+    /**
+     * Constructor that takes in the OutputStream that we are wrapping and the digest file to write the MD5 to.
+     *
+     * @deprecated since the File-based API is being migrated to {@link Path}; use
+     *     {@link #Md5CalculatingOutputStream(OutputStream, Path)} instead.
+     */
+    @Deprecated
     public Md5CalculatingOutputStream(OutputStream os, File digestFile) {
         this(os, IOUtil.toPath(digestFile));
     }

--- a/src/main/java/htsjdk/samtools/util/Md5CalculatingOutputStream.java
+++ b/src/main/java/htsjdk/samtools/util/Md5CalculatingOutputStream.java
@@ -25,7 +25,6 @@ package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
@@ -62,17 +61,6 @@ public class Md5CalculatingOutputStream extends OutputStream {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("MD5 algorithm not found", e);
         }
-    }
-
-    /**
-     * Constructor that takes in the OutputStream that we are wrapping and the digest file to write the MD5 to.
-     *
-     * @deprecated since the File-based API is being migrated to {@link Path}; use
-     *     {@link #Md5CalculatingOutputStream(OutputStream, Path)} instead.
-     */
-    @Deprecated
-    public Md5CalculatingOutputStream(OutputStream os, File digestFile) {
-        this(os, IOUtil.toPath(digestFile));
     }
 
     @Override

--- a/src/main/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
+++ b/src/main/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
@@ -28,15 +28,12 @@ import htsjdk.samtools.BAMRecordCodec;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.BitSet;
-import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 
 /**
  * This class stores SAMRecords for return.  The purpose of this class is to buffer records that need to be modified or processed in some
@@ -66,30 +63,6 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
     private final SAMFileHeader header;
 
     private final Class<T> clazz; // the class to create
-
-    /**
-     * @param maxRecordsInRam how many records to buffer before spilling to disk
-     * @param blockSize the number of records in a given block
-     * @param tmpDirs the temporary directories to use when spilling to disk
-     * @param header the header
-     * @param clazz the class that extends SamRecordWithOrdinal
-     * @deprecated since the File API is being phased out; use {@link #SamRecordTrackingBuffer(int, int, List, SAMFileHeader, Class)}
-     *     with a {@code List<Path>} instead.
-     */
-    @Deprecated
-    public SamRecordTrackingBuffer(
-            final int maxRecordsInRam,
-            final int blockSize,
-            final Collection<File> tmpDirs,
-            final SAMFileHeader header,
-            final Class<T> clazz) {
-        this(
-                maxRecordsInRam,
-                blockSize,
-                tmpDirs.stream().map(File::toPath).collect(Collectors.toList()),
-                header,
-                clazz);
-    }
 
     /**
      * @param maxRecordsInRam how many records to buffer before spilling to disk

--- a/src/main/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
+++ b/src/main/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
@@ -29,11 +29,14 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.BitSet;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 /**
  * This class stores SAMRecords for return.  The purpose of this class is to buffer records that need to be modified or processed in some
@@ -56,7 +59,7 @@ import java.util.NoSuchElementException;
 public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
     private int availableRecordsInMemory; // how many more records can we store in memory
     private final int blockSize; // the size of each block
-    private final List<File> tmpDirs; // the list of temporary directories to use
+    private final List<Path> tmpDirs; // the list of temporary directories to use
     private long queueHeadRecordIndex; // the index of the head of the buffer
     private long queueTailRecordIndex; // the index of the tail of the buffer
     private final Deque<BufferBlock> blocks; // the queue of blocks, in which records are contained
@@ -70,11 +73,35 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
      * @param tmpDirs the temporary directories to use when spilling to disk
      * @param header the header
      * @param clazz the class that extends SamRecordWithOrdinal
+     * @deprecated since the File API is being phased out; use {@link #SamRecordTrackingBuffer(int, int, List, SAMFileHeader, Class)}
+     *     with a {@code List<Path>} instead.
+     */
+    @Deprecated
+    public SamRecordTrackingBuffer(
+            final int maxRecordsInRam,
+            final int blockSize,
+            final Collection<File> tmpDirs,
+            final SAMFileHeader header,
+            final Class<T> clazz) {
+        this(
+                maxRecordsInRam,
+                blockSize,
+                tmpDirs.stream().map(File::toPath).collect(Collectors.toList()),
+                header,
+                clazz);
+    }
+
+    /**
+     * @param maxRecordsInRam how many records to buffer before spilling to disk
+     * @param blockSize the number of records in a given block
+     * @param tmpDirs the temporary directories to use when spilling to disk
+     * @param header the header
+     * @param clazz the class that extends SamRecordWithOrdinal
      */
     public SamRecordTrackingBuffer(
             final int maxRecordsInRam,
             final int blockSize,
-            final List<File> tmpDirs,
+            final List<Path> tmpDirs,
             final SAMFileHeader header,
             final Class<T> clazz) {
         this.availableRecordsInMemory = maxRecordsInRam;
@@ -227,11 +254,11 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
         public BufferBlock(
                 final int maxBlockSize,
                 final int maxBlockRecordsInMemory,
-                final List<File> tmpDirs,
+                final List<Path> tmpDirs,
                 final SAMFileHeader header,
                 final long originalStartIndex) {
             this.recordsQueue =
-                    DiskBackedQueue.newInstance(new BAMRecordCodec(header), maxBlockRecordsInMemory, tmpDirs);
+                    DiskBackedQueue.newInstanceFromPaths(new BAMRecordCodec(header), maxBlockRecordsInMemory, tmpDirs);
             this.maxBlockSize = maxBlockSize;
             this.currentStartIndex = 0;
             this.endIndex = -1;

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -36,6 +36,7 @@ import htsjdk.samtools.fastq.FastqConstants;
 import htsjdk.utils.ValidationUtils;
 import java.io.File;
 import java.math.BigInteger;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -354,16 +355,27 @@ public class SequenceUtil {
     }
 
     /**
-     * Throws an exception if both parameters are non-null and unequal, including the filenames.
+     * Throws an exception if both parameters are non-null and unequal, including the paths.
      */
     public static void assertSequenceDictionariesEqual(
-            final SAMSequenceDictionary s1, final SAMSequenceDictionary s2, final File f1, final File f2) {
+            final SAMSequenceDictionary s1, final SAMSequenceDictionary s2, final Path p1, final Path p2) {
         try {
             assertSequenceDictionariesEqual(s1, s2);
         } catch (final SequenceListsDifferException e) {
             throw new SequenceListsDifferException(
-                    "In files " + f1.getAbsolutePath() + " and " + f2.getAbsolutePath(), e);
+                    "In files " + p1.toAbsolutePath() + " and " + p2.toAbsolutePath(), e);
         }
+    }
+
+    /**
+     * Throws an exception if both parameters are non-null and unequal, including the filenames.
+     *
+     * @deprecated use {@link #assertSequenceDictionariesEqual(SAMSequenceDictionary, SAMSequenceDictionary, Path, Path)} instead.
+     */
+    @Deprecated
+    public static void assertSequenceDictionariesEqual(
+            final SAMSequenceDictionary s1, final SAMSequenceDictionary s2, final File f1, final File f2) {
+        assertSequenceDictionariesEqual(s1, s2, f1.toPath(), f2.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/SequenceUtil.java
+++ b/src/main/java/htsjdk/samtools/util/SequenceUtil.java
@@ -34,7 +34,6 @@ import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.SAMTag;
 import htsjdk.samtools.fastq.FastqConstants;
 import htsjdk.utils.ValidationUtils;
-import java.io.File;
 import java.math.BigInteger;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -365,17 +364,6 @@ public class SequenceUtil {
             throw new SequenceListsDifferException(
                     "In files " + p1.toAbsolutePath() + " and " + p2.toAbsolutePath(), e);
         }
-    }
-
-    /**
-     * Throws an exception if both parameters are non-null and unequal, including the filenames.
-     *
-     * @deprecated use {@link #assertSequenceDictionariesEqual(SAMSequenceDictionary, SAMSequenceDictionary, Path, Path)} instead.
-     */
-    @Deprecated
-    public static void assertSequenceDictionariesEqual(
-            final SAMSequenceDictionary s1, final SAMSequenceDictionary s2, final File f1, final File f2) {
-        assertSequenceDictionariesEqual(s1, s2, f1.toPath(), f2.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/SortingCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingCollection.java
@@ -24,7 +24,6 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.Defaults;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -311,58 +310,6 @@ public class SortingCollection<T> implements Iterable<T> {
         this.cleanedUp = true;
 
         IOUtil.deletePaths(this.files);
-    }
-
-    /**
-     * Syntactic sugar around the ctor, to save some typing of type parameters
-     *
-     * @param componentType   Class of the record to be sorted.  Necessary because of Java generic lameness.
-     * @param codec           For writing records to file and reading them back into RAM
-     * @param comparator      Defines output sort order
-     * @param maxRecordsInRAM how many records to accumulate in memory before spilling to disk
-     * @param tmpDir          Where to write files of records that will not fit in RAM
-     * @deprecated since 2017-09. Use {@link #newInstance(Class, Codec, Comparator, int, Path...)} instead
-     */
-    @Deprecated
-    public static <T> SortingCollection<T> newInstance(
-            final Class<T> componentType,
-            final SortingCollection.Codec<T> codec,
-            final Comparator<T> comparator,
-            final int maxRecordsInRAM,
-            final File... tmpDir) {
-        return new SortingCollection<>(
-                componentType,
-                codec,
-                comparator,
-                maxRecordsInRAM,
-                false,
-                Arrays.stream(tmpDir).map(File::toPath).toArray(Path[]::new));
-    }
-
-    /**
-     * Syntactic sugar around the ctor, to save some typing of type parameters
-     *
-     * @param componentType   Class of the record to be sorted.  Necessary because of Java generic lameness.
-     * @param codec           For writing records to file and reading them back into RAM
-     * @param comparator      Defines output sort order
-     * @param maxRecordsInRAM how many records to accumulate in memory before spilling to disk
-     * @param tmpDirs         Where to write files of records that will not fit in RAM
-     * @deprecated since 2017-09. Use {@link #newInstanceFromPaths(Class, Codec, Comparator, int, Collection)} instead
-     */
-    @Deprecated
-    public static <T> SortingCollection<T> newInstance(
-            final Class<T> componentType,
-            final SortingCollection.Codec<T> codec,
-            final Comparator<T> comparator,
-            final int maxRecordsInRAM,
-            final Collection<File> tmpDirs) {
-        return new SortingCollection<>(
-                componentType,
-                codec,
-                comparator,
-                maxRecordsInRAM,
-                false,
-                tmpDirs.stream().map(File::toPath).toArray(Path[]::new));
     }
 
     /**

--- a/src/main/java/htsjdk/samtools/util/SortingLongCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingLongCollection.java
@@ -26,7 +26,6 @@ package htsjdk.samtools.util;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Files;
@@ -94,18 +93,6 @@ public class SortingLongCollection {
 
     // For disk-based iteration
     private PriorityQueue<PeekFileValueIterator> priorityQueue;
-
-    /**
-     * Prepare to accumulate values to be sorted
-     *
-     * @param maxValuesInRam how many values to accumulate before spilling to disk
-     * @param tmpDir         Where to write files of values that will not fit in RAM
-     * @deprecated use {@link #SortingLongCollection(int, Path...)} instead.
-     */
-    @Deprecated
-    public SortingLongCollection(final int maxValuesInRam, final File... tmpDir) {
-        this(maxValuesInRam, Arrays.stream(tmpDir).map(File::toPath).toArray(Path[]::new));
-    }
 
     /**
      * Prepare to accumulate values to be sorted

--- a/src/main/java/htsjdk/samtools/util/SortingLongCollection.java
+++ b/src/main/java/htsjdk/samtools/util/SortingLongCollection.java
@@ -100,7 +100,9 @@ public class SortingLongCollection {
      *
      * @param maxValuesInRam how many values to accumulate before spilling to disk
      * @param tmpDir         Where to write files of values that will not fit in RAM
+     * @deprecated use {@link #SortingLongCollection(int, Path...)} instead.
      */
+    @Deprecated
     public SortingLongCollection(final int maxValuesInRam, final File... tmpDir) {
         this(maxValuesInRam, Arrays.stream(tmpDir).map(File::toPath).toArray(Path[]::new));
     }

--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -52,7 +52,7 @@ public class TestUtil {
     public static Path getTempDirectoryAsPath(final String prefix, final String suffix) {
         try {
             final Path tempDirectory = Files.createTempDirectory(prefix + suffix);
-            tempDirectory.toFile().deleteOnExit();
+            IOUtil.deleteOnExit(tempDirectory);
             return tempDirectory;
         } catch (IOException e) {
             throw new SAMException("Failed to create temporary directory.", e);

--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -24,7 +24,14 @@
 package htsjdk.samtools.util;
 
 import htsjdk.samtools.SAMException;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class TestUtil {
@@ -36,21 +43,33 @@ public class TestUtil {
      */
     public static final String BASE_URL_FOR_HTTP_TESTS = "https://personal.broadinstitute.org/picard/testdata/";
 
-    public static File getTempDirectory(final String prefix, final String suffix) {
-        final File tempDirectory;
+    /**
+     * Creates a new temporary directory that will be deleted on JVM exit.
+     *
+     * @param prefix the prefix for the temporary directory name
+     * @param suffix the suffix appended to the prefix for the temporary directory name
+     * @return the {@link Path} of the newly created temporary directory
+     */
+    public static Path getTempDirectoryAsPath(final String prefix, final String suffix) {
         try {
-            tempDirectory = File.createTempFile(prefix, suffix);
+            final Path tempDirectory = Files.createTempDirectory(prefix + suffix);
+            tempDirectory.toFile().deleteOnExit();
+            return tempDirectory;
         } catch (IOException e) {
-            throw new SAMException("Failed to create temporary file.", e);
+            throw new SAMException("Failed to create temporary directory.", e);
         }
-        if (!tempDirectory.delete()) throw new SAMException("Failed to delete file: " + tempDirectory);
-        if (!tempDirectory.mkdir()) throw new SAMException("Failed to make directory: " + tempDirectory);
-        tempDirectory.deleteOnExit();
-        return tempDirectory;
     }
 
     /**
-     * @deprecated Use properly spelled method. {@link #getTempDirectory}
+     * @deprecated Prefer {@link #getTempDirectoryAsPath(String, String)} which returns a {@link Path}.
+     */
+    @Deprecated
+    public static File getTempDirectory(final String prefix, final String suffix) {
+        return getTempDirectoryAsPath(prefix, suffix).toFile();
+    }
+
+    /**
+     * @deprecated Use properly spelled method. {@link #getTempDirectoryAsPath}
      */
     @Deprecated
     public static File getTempDirecory(final String prefix, final String suffix) {
@@ -87,14 +106,24 @@ public class TestUtil {
      * clean up after themselves.
      *
      * @param directory The directory to be deleted (along with its subdirectories)
+     */
+    public static void recursiveDelete(final Path directory) {
+        try {
+            IOUtil.recursiveDelete(directory);
+        } catch (RuntimeIOException e) {
+            // bury exception
+        }
+    }
+
+    /**
+     * Little test utility to help tests that create multiple levels of subdirectories
+     * clean up after themselves.
+     *
+     * @param directory The directory to be deleted (along with its subdirectories)
      * @deprecated Since 3/19, prefer {@link IOUtil#recursiveDelete(Path)}
      */
     @Deprecated
     public static void recursiveDelete(final File directory) {
-        try {
-            IOUtil.recursiveDelete(directory.toPath());
-        } catch (RuntimeIOException e) {
-            // bury exception
-        }
+        recursiveDelete(directory.toPath());
     }
 }

--- a/src/main/java/htsjdk/samtools/util/TestUtil.java
+++ b/src/main/java/htsjdk/samtools/util/TestUtil.java
@@ -26,7 +26,6 @@ package htsjdk.samtools.util;
 import htsjdk.samtools.SAMException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -58,22 +57,6 @@ public class TestUtil {
         } catch (IOException e) {
             throw new SAMException("Failed to create temporary directory.", e);
         }
-    }
-
-    /**
-     * @deprecated Prefer {@link #getTempDirectoryAsPath(String, String)} which returns a {@link Path}.
-     */
-    @Deprecated
-    public static File getTempDirectory(final String prefix, final String suffix) {
-        return getTempDirectoryAsPath(prefix, suffix).toFile();
-    }
-
-    /**
-     * @deprecated Use properly spelled method. {@link #getTempDirectoryAsPath}
-     */
-    @Deprecated
-    public static File getTempDirecory(final String prefix, final String suffix) {
-        return getTempDirectory(prefix, suffix);
     }
 
     /**
@@ -113,17 +96,5 @@ public class TestUtil {
         } catch (RuntimeIOException e) {
             // bury exception
         }
-    }
-
-    /**
-     * Little test utility to help tests that create multiple levels of subdirectories
-     * clean up after themselves.
-     *
-     * @param directory The directory to be deleted (along with its subdirectories)
-     * @deprecated Since 3/19, prefer {@link IOUtil#recursiveDelete(Path)}
-     */
-    @Deprecated
-    public static void recursiveDelete(final File directory) {
-        recursiveDelete(directory.toPath());
     }
 }

--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Function;
@@ -208,11 +209,19 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
     }
 
     /**
-     * @deprecated use {@link IOUtil#hasBlockCompressedExtension(File)}.
+     * @deprecated use {@link IOUtil#hasBlockCompressedExtension(Path)}.
+     */
+    @Deprecated
+    public static boolean hasBlockCompressedExtension(final Path path) {
+        return IOUtil.hasBlockCompressedExtension(path.getFileName().toString());
+    }
+
+    /**
+     * @deprecated use {@link IOUtil#hasBlockCompressedExtension(Path)}.
      */
     @Deprecated
     public static boolean hasBlockCompressedExtension(final File file) {
-        return IOUtil.hasBlockCompressedExtension(file.getName());
+        return hasBlockCompressedExtension(file.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
+++ b/src/main/java/htsjdk/tribble/AbstractFeatureReader.java
@@ -22,7 +22,6 @@ import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.util.ParsingUtils;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.channels.SeekableByteChannel;
@@ -214,14 +213,6 @@ public abstract class AbstractFeatureReader<T extends Feature, SOURCE> implement
     @Deprecated
     public static boolean hasBlockCompressedExtension(final Path path) {
         return IOUtil.hasBlockCompressedExtension(path.getFileName().toString());
-    }
-
-    /**
-     * @deprecated use {@link IOUtil#hasBlockCompressedExtension(Path)}.
-     */
-    @Deprecated
-    public static boolean hasBlockCompressedExtension(final File file) {
-        return hasBlockCompressedExtension(file.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/Tribble.java
+++ b/src/main/java/htsjdk/tribble/Tribble.java
@@ -55,13 +55,15 @@ public class Tribble {
      * Does not actually create an index
      * @param file  the file
      * @return a non-null File representing the index
+     * @deprecated since June 2025 Use {@link #indexPath(Path)} instead.
      */
+    @Deprecated
     public static File indexFile(final File file) {
-        return indexFile(file.getAbsoluteFile(), FileExtensions.TRIBBLE_INDEX);
+        return indexPath(file.getAbsoluteFile().toPath()).toFile();
     }
 
     /**
-     * Return the name of the index file for the provided {@code path}
+     * Return the Path of the index file for the provided {@code path}
      * Does not actually create an index
      * @param path the path
      * @return Path representing the index filename
@@ -85,13 +87,15 @@ public class Tribble {
      * Does not actually create an index
      * @param file  the file
      * @return a non-null File representing the index
+     * @deprecated since June 2025 Use {@link #tabixIndexPath(Path)} instead.
      */
+    @Deprecated
     public static File tabixIndexFile(final File file) {
-        return indexFile(file.getAbsoluteFile(), FileExtensions.TABIX_INDEX);
+        return tabixIndexPath(file.getAbsoluteFile().toPath()).toFile();
     }
 
     /**
-     * Return the name of the tabix index file for the provided {@code path}
+     * Return the Path of the tabix index file for the provided {@code path}
      * Does not actually create an index
      * @param path the path
      * @return Path representing the index filename
@@ -109,16 +113,5 @@ public class Tribble {
      */
     private static String indexFile(final String filename, final String extension) {
         return ParsingUtils.appendToPath(filename, extension);
-    }
-
-    /**
-     * Return the File of the index file for the provided {@code file} and {@code extension}
-     * Does not actually create an index
-     * @param file  the file
-     * @param extension the extension to use for the index
-     * @return a non-null File representing the index
-     */
-    private static File indexFile(final File file, final String extension) {
-        return new File(file.getAbsoluteFile() + extension);
     }
 }

--- a/src/main/java/htsjdk/tribble/Tribble.java
+++ b/src/main/java/htsjdk/tribble/Tribble.java
@@ -25,7 +25,6 @@ package htsjdk.tribble;
 
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.util.ParsingUtils;
-import java.io.File;
 import java.nio.file.Path;
 
 /**
@@ -51,18 +50,6 @@ public class Tribble {
     }
 
     /**
-     * Return the File of the index file for the provided {@code file}
-     * Does not actually create an index
-     * @param file  the file
-     * @return a non-null File representing the index
-     * @deprecated since June 2025 Use {@link #indexPath(Path)} instead.
-     */
-    @Deprecated
-    public static File indexFile(final File file) {
-        return indexPath(file.getAbsoluteFile().toPath()).toFile();
-    }
-
-    /**
      * Return the Path of the index file for the provided {@code path}
      * Does not actually create an index
      * @param path the path
@@ -80,18 +67,6 @@ public class Tribble {
      */
     public static String tabixIndexFile(final String filename) {
         return indexFile(filename, FileExtensions.TABIX_INDEX);
-    }
-
-    /**
-     * Return the File of the tabix index file for the provided {@code file}
-     * Does not actually create an index
-     * @param file  the file
-     * @return a non-null File representing the index
-     * @deprecated since June 2025 Use {@link #tabixIndexPath(Path)} instead.
-     */
-    @Deprecated
-    public static File tabixIndexFile(final File file) {
-        return tabixIndexPath(file.getAbsoluteFile().toPath()).toFile();
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/example/CountRecords.java
+++ b/src/main/java/htsjdk/tribble/example/CountRecords.java
@@ -35,7 +35,6 @@ import htsjdk.tribble.index.IndexFactory;
 import htsjdk.tribble.index.linear.LinearIndex;
 import htsjdk.tribble.util.LittleEndianOutputStream;
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -79,20 +78,6 @@ public class CountRecords {
         FeatureCodec codec = getFeatureCodec(featureFile);
 
         runWithIndex(featureFile, codec, optimizeIndex);
-    }
-
-    /**
-     *
-     * @see htsjdk.tribble.index.linear.LinearIndex#optimize(double)
-     * @param featureInput  File containing features
-     * @param codec  Codec used to read the features
-     * @param optimizeThreshold Threshold used to optimize the linear index
-     * @return the number of records seen
-     * @deprecated since 6/2025, use {@link #runWithIndex(Path, FeatureCodec, int)} instead.
-     */
-    @Deprecated
-    public static long runWithIndex(File featureInput, FeatureCodec codec, int optimizeThreshold) {
-        return runWithIndex(featureInput.toPath(), codec, optimizeThreshold);
     }
 
     /**
@@ -153,18 +138,6 @@ public class CountRecords {
      * @param featureFile the feature file
      * @param codec the codec to decode features with
      * @return an index instance
-     * @deprecated since 6/2025, use {@link #loadIndex(Path, FeatureCodec)} instead.
-     */
-    @Deprecated
-    public static Index loadIndex(File featureFile, FeatureCodec codec) {
-        return loadIndex(featureFile.toPath(), codec);
-    }
-
-    /**
-     *
-     * @param featureFile the feature file
-     * @param codec the codec to decode features with
-     * @return an index instance
      */
     public static Index loadIndex(Path featureFile, FeatureCodec codec) {
         // lets setup a index file name
@@ -192,19 +165,6 @@ public class CountRecords {
      * @param indexFile the index file; the location we should be writing the index to
      * @param codec the codec to read features with
      * @return an index instance
-     * @deprecated since 6/2025, use {@link #createAndWriteNewIndex(Path, Path, FeatureCodec)} instead.
-     */
-    @Deprecated
-    public static Index createAndWriteNewIndex(File featureFile, File indexFile, FeatureCodec codec) {
-        return createAndWriteNewIndex(featureFile.toPath(), indexFile.toPath(), codec);
-    }
-
-    /**
-     * creates a new index, given the feature file and the codec
-     * @param featureFile the feature file (i.e. .vcf, .bed)
-     * @param indexFile the index file; the location we should be writing the index to
-     * @param codec the codec to read features with
-     * @return an index instance
      */
     public static Index createAndWriteNewIndex(Path featureFile, Path indexFile, FeatureCodec codec) {
         try {
@@ -221,19 +181,6 @@ public class CountRecords {
         } catch (IOException e) {
             throw new RuntimeIOException("Unable to create index from file " + featureFile, e);
         }
-    }
-
-    /**
-     * Return a {@code FeatureCodec} instance appropriate for the given
-     * {@code featureFile}. Codec is generated based on file extension
-     * @param featureFile the feature file to determine a codec for
-     * @return a codec appropriate for the file
-     * @throws IllegalArgumentException If a codec cannot be found
-     * @deprecated since 6/2025, use {@link #getFeatureCodec(Path)} instead.
-     */
-    @Deprecated
-    public static FeatureCodec getFeatureCodec(File featureFile) {
-        return getFeatureCodec(featureFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/example/CountRecords.java
+++ b/src/main/java/htsjdk/tribble/example/CountRecords.java
@@ -23,6 +23,7 @@
  */
 package htsjdk.tribble.example;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.Feature;
@@ -35,8 +36,9 @@ import htsjdk.tribble.index.linear.LinearIndex;
 import htsjdk.tribble.util.LittleEndianOutputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 
 /**
@@ -59,10 +61,15 @@ public class CountRecords {
         // check yourself before you wreck yourself - we require one arg, the input file
         if (args.length > 2) printUsage();
 
-        // our feature file
-        File featureFile = new File(args[0]);
-        if (!featureFile.exists()) {
-            System.err.println("File " + featureFile.getAbsolutePath() + " doesnt' exist");
+        // our feature file; use the scheme-aware resolver so remote inputs keep working
+        final Path featureFile;
+        try {
+            featureFile = IOUtil.getPath(args[0]);
+        } catch (IOException e) {
+            throw new RuntimeIOException("Unable to resolve input path " + args[0], e);
+        }
+        if (!Files.exists(featureFile)) {
+            System.err.println("File " + featureFile.toAbsolutePath() + " doesnt' exist");
             printUsage();
         }
 
@@ -80,9 +87,23 @@ public class CountRecords {
      * @param featureInput  File containing features
      * @param codec  Codec used to read the features
      * @param optimizeThreshold Threshold used to optimize the linear index
-     * @return
+     * @return the number of records seen
+     * @deprecated since 6/2025, use {@link #runWithIndex(Path, FeatureCodec, int)} instead.
      */
+    @Deprecated
     public static long runWithIndex(File featureInput, FeatureCodec codec, int optimizeThreshold) {
+        return runWithIndex(featureInput.toPath(), codec, optimizeThreshold);
+    }
+
+    /**
+     *
+     * @see htsjdk.tribble.index.linear.LinearIndex#optimize(double)
+     * @param featureInput  Path containing features
+     * @param codec  Codec used to read the features
+     * @param optimizeThreshold Threshold used to optimize the linear index
+     * @return the number of records seen
+     */
+    public static long runWithIndex(Path featureInput, FeatureCodec codec, int optimizeThreshold) {
         // get an index
         Index index = loadIndex(featureInput, codec);
         if (optimizeThreshold != -1) ((LinearIndex) index).optimize(optimizeThreshold);
@@ -90,7 +111,8 @@ public class CountRecords {
         // get a reader
         AbstractFeatureReader reader = null;
         try {
-            reader = AbstractFeatureReader.getFeatureReader(featureInput.getAbsolutePath(), codec, index);
+            reader = AbstractFeatureReader.getFeatureReader(
+                    featureInput.toAbsolutePath().toString(), codec, index);
 
             // now read iterate over the file
             long recordCount = 0l;
@@ -131,18 +153,30 @@ public class CountRecords {
      * @param featureFile the feature file
      * @param codec the codec to decode features with
      * @return an index instance
+     * @deprecated since 6/2025, use {@link #loadIndex(Path, FeatureCodec)} instead.
      */
+    @Deprecated
     public static Index loadIndex(File featureFile, FeatureCodec codec) {
+        return loadIndex(featureFile.toPath(), codec);
+    }
+
+    /**
+     *
+     * @param featureFile the feature file
+     * @param codec the codec to decode features with
+     * @return an index instance
+     */
+    public static Index loadIndex(Path featureFile, FeatureCodec codec) {
         // lets setup a index file name
-        File indexFile = Tribble.indexFile(featureFile);
+        Path indexFile = Tribble.indexPath(featureFile);
 
         // our index instance;
         Index index = null;
 
         // can we read the index file
-        if (indexFile.canRead()) {
+        if (Files.isReadable(indexFile)) {
             System.err.println("Loading index from disk for index file -> " + indexFile);
-            index = IndexFactory.loadIndex(indexFile.getAbsolutePath());
+            index = IndexFactory.loadIndex(indexFile.toAbsolutePath().toString());
             // else we want to make the index, and write it to disk if possible
         } else {
             System.err.println("Creating the index and memory, then writing to disk for index file -> " + indexFile);
@@ -158,14 +192,27 @@ public class CountRecords {
      * @param indexFile the index file; the location we should be writing the index to
      * @param codec the codec to read features with
      * @return an index instance
+     * @deprecated since 6/2025, use {@link #createAndWriteNewIndex(Path, Path, FeatureCodec)} instead.
      */
+    @Deprecated
     public static Index createAndWriteNewIndex(File featureFile, File indexFile, FeatureCodec codec) {
+        return createAndWriteNewIndex(featureFile.toPath(), indexFile.toPath(), codec);
+    }
+
+    /**
+     * creates a new index, given the feature file and the codec
+     * @param featureFile the feature file (i.e. .vcf, .bed)
+     * @param indexFile the index file; the location we should be writing the index to
+     * @param codec the codec to read features with
+     * @return an index instance
+     */
+    public static Index createAndWriteNewIndex(Path featureFile, Path indexFile, FeatureCodec codec) {
         try {
             Index index = IndexFactory.createLinearIndex(featureFile, codec);
 
             // try to write it to disk
             LittleEndianOutputStream stream =
-                    new LittleEndianOutputStream(new BufferedOutputStream(new FileOutputStream(indexFile)));
+                    new LittleEndianOutputStream(new BufferedOutputStream(Files.newOutputStream(indexFile)));
 
             index.write(stream);
             stream.close();
@@ -179,13 +226,27 @@ public class CountRecords {
     /**
      * Return a {@code FeatureCodec} instance appropriate for the given
      * {@code featureFile}. Codec is generated based on file extension
-     * @param featureFile
-     * @return
+     * @param featureFile the feature file to determine a codec for
+     * @return a codec appropriate for the file
+     * @throws IllegalArgumentException If a codec cannot be found
+     * @deprecated since 6/2025, use {@link #getFeatureCodec(Path)} instead.
+     */
+    @Deprecated
+    public static FeatureCodec getFeatureCodec(File featureFile) {
+        return getFeatureCodec(featureFile.toPath());
+    }
+
+    /**
+     * Return a {@code FeatureCodec} instance appropriate for the given
+     * {@code featureFile}. Codec is generated based on file extension
+     * @param featureFile the feature file to determine a codec for
+     * @return a codec appropriate for the file
      * @throws IllegalArgumentException If a codec cannot be found
      */
-    public static FeatureCodec getFeatureCodec(File featureFile) {
+    public static FeatureCodec getFeatureCodec(Path featureFile) {
         // quickly determine the codec type
-        if (featureFile.getName().endsWith(".bed") || featureFile.getName().endsWith(".BED")) return new BEDCodec();
+        final String fileName = featureFile.getFileName().toString();
+        if (fileName.endsWith(".bed") || fileName.endsWith(".BED")) return new BEDCodec();
         throw new IllegalArgumentException(
                 "Unable to determine correct file type based on the file name, for file -> " + featureFile);
     }

--- a/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
+++ b/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
@@ -35,7 +35,6 @@ import htsjdk.tribble.readers.LineIterator;
 import htsjdk.tribble.readers.PositionalBufferedStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -108,24 +107,6 @@ public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
                 source.toAbsolutePath().toString(), codec, false); // IndexFactory.loadIndex(idxFile));
         final OutputStream output = Files.newOutputStream(dest);
         ExampleBinaryCodec.convertToBinaryTest(reader, output);
-    }
-
-    /**
-     * Convenience method that creates an ExampleBinaryCodec file from another feature file.
-     *
-     * For testing purposes really
-     *
-     * @param source file containing the features
-     * @param dest the place to write the binary features
-     * @param codec of the source file features
-     * @throws IOException
-     * @deprecated Use {@link #convertToBinaryTest(Path, Path, FeatureCodec)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature> void convertToBinaryTest(
-            final File source, final File dest, final FeatureCodec<FEATURE_TYPE, LineIterator> codec)
-            throws IOException {
-        convertToBinaryTest(source.toPath(), dest.toPath(), codec);
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
+++ b/src/main/java/htsjdk/tribble/example/ExampleBinaryCodec.java
@@ -36,9 +36,10 @@ import htsjdk.tribble.readers.PositionalBufferedStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -95,18 +96,36 @@ public class ExampleBinaryCodec extends BinaryFeatureCodec<Feature> {
      *
      * For testing purposes really
      *
-     * @param source file containing the features
+     * @param source path containing the features
      * @param dest the place to write the binary features
      * @param codec of the source file features
      * @throws IOException
      */
     public static <FEATURE_TYPE extends Feature> void convertToBinaryTest(
-            final File source, final File dest, final FeatureCodec<FEATURE_TYPE, LineIterator> codec)
+            final Path source, final Path dest, final FeatureCodec<FEATURE_TYPE, LineIterator> codec)
             throws IOException {
         final FeatureReader<FEATURE_TYPE> reader = AbstractFeatureReader.getFeatureReader(
-                source.getAbsolutePath(), codec, false); // IndexFactory.loadIndex(idxFile));
-        final OutputStream output = new FileOutputStream(dest);
+                source.toAbsolutePath().toString(), codec, false); // IndexFactory.loadIndex(idxFile));
+        final OutputStream output = Files.newOutputStream(dest);
         ExampleBinaryCodec.convertToBinaryTest(reader, output);
+    }
+
+    /**
+     * Convenience method that creates an ExampleBinaryCodec file from another feature file.
+     *
+     * For testing purposes really
+     *
+     * @param source file containing the features
+     * @param dest the place to write the binary features
+     * @param codec of the source file features
+     * @throws IOException
+     * @deprecated Use {@link #convertToBinaryTest(Path, Path, FeatureCodec)} instead.
+     */
+    @Deprecated
+    public static <FEATURE_TYPE extends Feature> void convertToBinaryTest(
+            final File source, final File dest, final FeatureCodec<FEATURE_TYPE, LineIterator> codec)
+            throws IOException {
+        convertToBinaryTest(source.toPath(), dest.toPath(), codec);
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/example/IndexToTable.java
+++ b/src/main/java/htsjdk/tribble/example/IndexToTable.java
@@ -24,12 +24,14 @@
 
 package htsjdk.tribble.example;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.index.IndexFactory;
 import htsjdk.tribble.index.linear.LinearIndex;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class IndexToTable {
 
@@ -49,11 +51,21 @@ public class IndexToTable {
         // check yourself before you wreck yourself - we require one arg, the input file
         if (args.length != 2) printUsage();
 
-        // LinearIndex.enableAdaptiveIndexing = false;
-        LinearIndex idx = (LinearIndex) IndexFactory.loadIndex(new File(args[0]).getAbsolutePath());
         try {
-            idx.writeTable(new PrintStream(new FileOutputStream(new File(args[1]))));
-        } catch (FileNotFoundException e) {
+            // LinearIndex.enableAdaptiveIndexing = false;
+            // Resolve the input in a scheme-aware way so file/http/https/ftp/gcs/custom NIO SPI
+            // inputs all work; loadIndex(String) does the actual scheme-aware stream opening. Local
+            // (default filesystem) inputs are made absolute to preserve the prior File behavior,
+            // while remote inputs are passed through unchanged.
+            final Path inputPath = IOUtil.getPath(args[0]);
+            final String indexSource = inputPath.getFileSystem() == FileSystems.getDefault()
+                    ? inputPath.toAbsolutePath().toString()
+                    : args[0];
+            LinearIndex idx = (LinearIndex) IndexFactory.loadIndex(indexSource);
+
+            final Path outputPath = IOUtil.getPath(args[1]);
+            idx.writeTable(new PrintStream(Files.newOutputStream(outputPath)));
+        } catch (IOException e) {
             e.printStackTrace();
             System.exit(1);
         }

--- a/src/main/java/htsjdk/tribble/example/IndicesAreEqual.java
+++ b/src/main/java/htsjdk/tribble/example/IndicesAreEqual.java
@@ -23,9 +23,12 @@
  */
 package htsjdk.tribble.example;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Check with two index files are equal
@@ -63,12 +66,15 @@ public class IndicesAreEqual {
      */
     public static Index loadIndex(String filename) {
         // System.err.println("Loading index from disk for index file -> " + filename);
-        File file = new File(filename);
-        if (file.canRead()) {
-            return IndexFactory.loadIndex(file.getAbsolutePath());
-        } else {
-            printUsage();
-            return null;
+        try {
+            final Path path = IOUtil.getPath(filename);
+            if (Files.isReadable(path)) {
+                return IndexFactory.loadIndex(path.toAbsolutePath().toString());
+            }
+        } catch (final IOException e) {
+            // Fall through to the usage message below if the path cannot be resolved.
         }
+        printUsage();
+        return null;
     }
 }

--- a/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
+++ b/src/main/java/htsjdk/tribble/gff/Gff3Writer.java
@@ -33,7 +33,10 @@ public class Gff3Writer implements Closeable {
         }
 
         final OutputStream outputStream = IOUtil.hasGzipFileExtension(path)
-                ? new BlockCompressedOutputStream(path.toFile())
+                ? new BlockCompressedOutputStream(
+                        path,
+                        BlockCompressedOutputStream.getDefaultCompressionLevel(),
+                        BlockCompressedOutputStream.getDefaultDeflaterFactory())
                 : Files.newOutputStream(path);
         out = new BufferedOutputStream(outputStream);
         // start with version directive

--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -170,6 +170,13 @@ public abstract class AbstractIndex implements MutableIndex {
         }
     }
 
+    /**
+     * create an index file from the target feature file
+     *
+     * @param featureFile the feature file to create an index from
+     * @deprecated Use {@link #AbstractIndex(Path)} instead.
+     */
+    @Deprecated
     public AbstractIndex(final File featureFile) {
         this(IOUtil.toPath(featureFile));
     }

--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -26,7 +26,6 @@ import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.util.LittleEndianInputStream;
 import htsjdk.tribble.util.LittleEndianOutputStream;
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -170,17 +169,6 @@ public abstract class AbstractIndex implements MutableIndex {
         }
     }
 
-    /**
-     * create an index file from the target feature file
-     *
-     * @param featureFile the feature file to create an index from
-     * @deprecated Use {@link #AbstractIndex(Path)} instead.
-     */
-    @Deprecated
-    public AbstractIndex(final File featureFile) {
-        this(IOUtil.toPath(featureFile));
-    }
-
     public AbstractIndex(final Path featurePath) {
         this();
         this.indexedPath = featurePath.toAbsolutePath();
@@ -216,16 +204,6 @@ public abstract class AbstractIndex implements MutableIndex {
     @Override
     public boolean isCurrentVersion() {
         return version == VERSION;
-    }
-
-    /**
-     * Gets the indexed file.
-     * @throws UnsupportedOperationException if the path cannot be represented as a file.
-     * @deprecated on 03/2017. Use {@link #getIndexedPath()} instead.
-     */
-    @Deprecated
-    public File getIndexedFile() {
-        return getIndexedPath().toFile();
     }
 
     public Path getIndexedPath() {

--- a/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
@@ -64,6 +64,10 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
         creators = getIndexCreators(inputPath, iba);
     }
 
+    /**
+     * @deprecated since 5.0.0; use {@link #DynamicIndexCreator(Path, IndexFactory.IndexBalanceApproach)} instead.
+     */
+    @Deprecated
     public DynamicIndexCreator(final File inputFile, final IndexFactory.IndexBalanceApproach iba) {
         this(IOUtil.toPath(inputFile), iba);
     }

--- a/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/DynamicIndexCreator.java
@@ -24,13 +24,11 @@
 
 package htsjdk.tribble.index;
 
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.index.interval.IntervalIndexCreator;
 import htsjdk.tribble.index.linear.LinearIndexCreator;
 import htsjdk.tribble.util.MathUtils;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -62,14 +60,6 @@ public class DynamicIndexCreator extends TribbleIndexCreator {
         this.iba = iba;
         // get a list of index creators
         creators = getIndexCreators(inputPath, iba);
-    }
-
-    /**
-     * @deprecated since 5.0.0; use {@link #DynamicIndexCreator(Path, IndexFactory.IndexBalanceApproach)} instead.
-     */
-    @Deprecated
-    public DynamicIndexCreator(final File inputFile, final IndexFactory.IndexBalanceApproach iba) {
-        this(IOUtil.toPath(inputFile), iba);
     }
 
     @Override

--- a/src/main/java/htsjdk/tribble/index/Index.java
+++ b/src/main/java/htsjdk/tribble/index/Index.java
@@ -23,9 +23,7 @@
  */
 package htsjdk.tribble.index;
 
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.util.LittleEndianOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
@@ -71,40 +69,12 @@ public interface Index {
     public void write(LittleEndianOutputStream stream) throws IOException;
 
     /**
-     * Writes the index into a file.
-     *
-     * Default implementation delegates to {@link #write(Path)}
-     *
-     * @param idxFile Where to write the index.
-     * @throws IOException if the index is unable to write to the specified file
-     * @deprecated since 5/2025, use {@link #write(Path)} instead.
-     */
-    @Deprecated
-    public default void write(final File idxFile) throws IOException {
-        write(IOUtil.toPath(idxFile));
-    }
-
-    /**
      * Writes the index into a path.
      *
      * @param indexPath Where to write the index.
      * @throws IOException if the index is unable to write to the specified path.
      */
     public void write(final Path indexPath) throws IOException;
-
-    /**
-     * Write an appropriately named and located Index file based on the name and location of the featureFile.
-     *
-     * Default implementation delegates to {@link #writeBasedOnFeaturePath(Path)}
-     *
-     * @param featureFile
-     * @throws IOException if featureFile is not a normal file.
-     * @deprecated since 5/2025, use {@link #writeBasedOnFeaturePath(Path)} instead.
-     */
-    @Deprecated
-    public default void writeBasedOnFeatureFile(File featureFile) throws IOException {
-        writeBasedOnFeaturePath(IOUtil.toPath(featureFile));
-    }
 
     /**
      * Write an appropriately named and located Index file based on the name and location of the featureFile.

--- a/src/main/java/htsjdk/tribble/index/Index.java
+++ b/src/main/java/htsjdk/tribble/index/Index.java
@@ -77,7 +77,9 @@ public interface Index {
      *
      * @param idxFile Where to write the index.
      * @throws IOException if the index is unable to write to the specified file
+     * @deprecated since 5/2025, use {@link #write(Path)} instead.
      */
+    @Deprecated
     public default void write(final File idxFile) throws IOException {
         write(IOUtil.toPath(idxFile));
     }
@@ -97,7 +99,9 @@ public interface Index {
      *
      * @param featureFile
      * @throws IOException if featureFile is not a normal file.
+     * @deprecated since 5/2025, use {@link #writeBasedOnFeaturePath(Path)} instead.
      */
+    @Deprecated
     public default void writeBasedOnFeatureFile(File featureFile) throws IOException {
         writeBasedOnFeaturePath(IOUtil.toPath(featureFile));
     }

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -243,7 +243,9 @@ public class IndexFactory {
      *
      * @param inputFile the input file to load features from
      * @param codec     the codec to use for decoding records
+     * @deprecated since 6/2025, use {@link #createLinearIndex(Path, FeatureCodec)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> LinearIndex createLinearIndex(
             final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
         return createLinearIndex(IOUtil.toPath(inputFile), codec, LinearIndexCreator.DEFAULT_BIN_WIDTH);
@@ -266,7 +268,9 @@ public class IndexFactory {
      * @param inputFile the input file to load features from
      * @param codec     the codec to use for decoding records
      * @param binSize   the bin size
+     * @deprecated since 6/2025, use {@link #createLinearIndex(Path, FeatureCodec, int)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> LinearIndex createLinearIndex(
             final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final int binSize) {
         return createLinearIndex(IOUtil.toPath(inputFile), codec, binSize);
@@ -291,7 +295,9 @@ public class IndexFactory {
      *
      * @param inputFile the file containing the features
      * @param codec to decode the features
+     * @deprecated since 6/2025, use {@link #createIntervalIndex(Path, FeatureCodec)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> IntervalTreeIndex createIntervalIndex(
             final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
         return createIntervalIndex(IOUtil.toPath(inputFile), codec, IntervalIndexCreator.DEFAULT_FEATURE_COUNT);
@@ -314,7 +320,9 @@ public class IndexFactory {
      * @param inputFile the input file to load features from
      * @param codec     the codec to use for decoding records
      * @param featuresPerInterval
+     * @deprecated since 6/2025, use {@link #createIntervalIndex(Path, FeatureCodec, int)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> IntervalTreeIndex createIntervalIndex(
             final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final int featuresPerInterval) {
         return createIntervalIndex(IOUtil.toPath(inputFile), codec, featuresPerInterval);
@@ -339,7 +347,9 @@ public class IndexFactory {
      *
      * @param inputFile the input file to load features from
      * @param codec     the codec to use for decoding records
+     * @deprecated since 6/2025, use {@link #createDynamicIndex(Path, FeatureCodec)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createDynamicIndex(
             final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
         return createDynamicIndex(IOUtil.toPath(inputFile), codec, IndexBalanceApproach.FOR_SEEK_TIME);
@@ -362,7 +372,9 @@ public class IndexFactory {
      * @param inputFile the input file to load features from
      * @param codec     the codec to use for decoding records
      * @param type      the type of index to create
+     * @deprecated since 6/2025, use {@link #createIndex(Path, FeatureCodec, IndexType)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createIndex(
             final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final IndexType type) {
         return createIndex(IOUtil.toPath(inputFile), codec, type, null);
@@ -371,13 +383,13 @@ public class IndexFactory {
     /**
      * Create a index of the specified type with default binning parameters
      *
-     * @param inputhPath the input file to load features from
+     * @param inputPath the input path to load features from
      * @param codec     the codec to use for decoding records
      * @param type      the type of index to create
      */
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createIndex(
-            final Path inputhPath, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final IndexType type) {
-        return createIndex(inputhPath, codec, type, null);
+            final Path inputPath, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final IndexType type) {
+        return createIndex(inputPath, codec, type, null);
     }
 
     /**
@@ -387,7 +399,9 @@ public class IndexFactory {
      * @param codec     the codec to use for decoding records
      * @param type      the type of index to create
      * @param sequenceDictionary May be null, but if present may reduce memory footprint for tabix index creation
+     * @deprecated since 6/2025, use {@link #createIndex(Path, FeatureCodec, IndexType, SAMSequenceDictionary)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createIndex(
             final File inputFile,
             final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,
@@ -426,11 +440,11 @@ public class IndexFactory {
      * @param idx
      * @param idxFile
      * @throws IOException
-     * @deprecated use {@link Index#write(File)} instead
+     * @deprecated use {@link Index#write(Path)} instead
      */
     @Deprecated
     public static void writeIndex(final Index idx, final File idxFile) throws IOException {
-        idx.write(idxFile);
+        idx.write(IOUtil.toPath(idxFile));
     }
 
     /**
@@ -439,7 +453,9 @@ public class IndexFactory {
      * @param inputFile the input file to load features from
      * @param codec     the codec to use for decoding records
      * @param iba       the index balancing approach
+     * @deprecated since 6/2025, use {@link #createDynamicIndex(Path, FeatureCodec, IndexBalanceApproach)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createDynamicIndex(
             final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final IndexBalanceApproach iba) {
         return createDynamicIndex(IOUtil.toPath(inputFile), codec, iba);
@@ -466,7 +482,9 @@ public class IndexFactory {
      * @param tabixFormat Header fields for TabixIndex to be produced.
      * @param sequenceDictionary May be null, but if present may reduce memory footprint for index creation.  Features
      *                           in inputFile must be in the order defined by sequenceDictionary, if it is present.
+     * @deprecated since 6/2025, use {@link #createTabixIndex(Path, FeatureCodec, TabixFormat, SAMSequenceDictionary)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> TabixIndex createTabixIndex(
             final File inputFile,
             final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,
@@ -497,8 +515,9 @@ public class IndexFactory {
      * @param codec the codec to use for decoding records
      * @param sequenceDictionary May be null, but if present may reduce memory footprint for index creation.  Features
      *                           in inputFile must be in the order defined by sequenceDictionary, if it is present.
-     *
+     * @deprecated since 6/2025, use {@link #createTabixIndex(Path, FeatureCodec, SAMSequenceDictionary)} instead.
      */
+    @Deprecated
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> TabixIndex createTabixIndex(
             final File inputFile,
             final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,
@@ -590,16 +609,19 @@ public class IndexFactory {
         /**
          *
          * @param inputFile The file from which to read. Stream for reading is opened on construction. May not be null.
-         * @param codec
+         * @param codec the codec to use for decoding features
+         * @deprecated since 6/2025, use {@link #FeatureIterator(Path, FeatureCodec)} instead.
          */
+        @Deprecated
         public FeatureIterator(final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE> codec) {
             this(IOUtil.toPath(inputFile), codec);
         }
 
         /**
+         * Constructs a FeatureIterator.
          *
          * @param inputPath The path from which to read. Stream for reading is opened on construction. May not be null.
-         * @param codec
+         * @param codec the codec to use for decoding features
          */
         public FeatureIterator(final Path inputPath, final FeatureCodec<FEATURE_TYPE, SOURCE> codec) {
             ValidationUtils.nonNull(inputPath, "FeatureIterator input path cannot be null");

--- a/src/main/java/htsjdk/tribble/index/IndexFactory.java
+++ b/src/main/java/htsjdk/tribble/index/IndexFactory.java
@@ -49,7 +49,6 @@ import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.utils.ValidationUtils;
 import java.io.BufferedInputStream;
 import java.io.EOFException;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -241,39 +240,12 @@ public class IndexFactory {
     /**
      * a helper method for creating a linear binned index with default bin size
      *
-     * @param inputFile the input file to load features from
-     * @param codec     the codec to use for decoding records
-     * @deprecated since 6/2025, use {@link #createLinearIndex(Path, FeatureCodec)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> LinearIndex createLinearIndex(
-            final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
-        return createLinearIndex(IOUtil.toPath(inputFile), codec, LinearIndexCreator.DEFAULT_BIN_WIDTH);
-    }
-
-    /**
-     * a helper method for creating a linear binned index with default bin size
-     *
      * @param inputPath the input file to load features from
      * @param codec     the codec to use for decoding records
      */
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> LinearIndex createLinearIndex(
             final Path inputPath, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
         return createLinearIndex(inputPath, codec, LinearIndexCreator.DEFAULT_BIN_WIDTH);
-    }
-
-    /**
-     * a helper method for creating a linear binned index
-     *
-     * @param inputFile the input file to load features from
-     * @param codec     the codec to use for decoding records
-     * @param binSize   the bin size
-     * @deprecated since 6/2025, use {@link #createLinearIndex(Path, FeatureCodec, int)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> LinearIndex createLinearIndex(
-            final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final int binSize) {
-        return createLinearIndex(IOUtil.toPath(inputFile), codec, binSize);
     }
 
     /**
@@ -293,39 +265,12 @@ public class IndexFactory {
     /**
      * create an interval-tree index with the default features per bin count
      *
-     * @param inputFile the file containing the features
-     * @param codec to decode the features
-     * @deprecated since 6/2025, use {@link #createIntervalIndex(Path, FeatureCodec)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> IntervalTreeIndex createIntervalIndex(
-            final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
-        return createIntervalIndex(IOUtil.toPath(inputFile), codec, IntervalIndexCreator.DEFAULT_FEATURE_COUNT);
-    }
-
-    /**
-     * create an interval-tree index with the default features per bin count
-     *
      * @param inputPath the file containing the features
      * @param codec to decode the features
      */
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> IntervalTreeIndex createIntervalIndex(
             final Path inputPath, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
         return createIntervalIndex(inputPath, codec, IntervalIndexCreator.DEFAULT_FEATURE_COUNT);
-    }
-
-    /**
-     * a helper method for creating an interval-tree index
-     *
-     * @param inputFile the input file to load features from
-     * @param codec     the codec to use for decoding records
-     * @param featuresPerInterval
-     * @deprecated since 6/2025, use {@link #createIntervalIndex(Path, FeatureCodec, int)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> IntervalTreeIndex createIntervalIndex(
-            final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final int featuresPerInterval) {
-        return createIntervalIndex(IOUtil.toPath(inputFile), codec, featuresPerInterval);
     }
 
     /**
@@ -345,39 +290,12 @@ public class IndexFactory {
     /**
      * Create a dynamic index with the default balancing approach
      *
-     * @param inputFile the input file to load features from
-     * @param codec     the codec to use for decoding records
-     * @deprecated since 6/2025, use {@link #createDynamicIndex(Path, FeatureCodec)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createDynamicIndex(
-            final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
-        return createDynamicIndex(IOUtil.toPath(inputFile), codec, IndexBalanceApproach.FOR_SEEK_TIME);
-    }
-
-    /**
-     * Create a dynamic index with the default balancing approach
-     *
      * @param inputPath the input path to load features from
      * @param codec     the codec to use for decoding records
      */
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createDynamicIndex(
             final Path inputPath, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec) {
         return createDynamicIndex(inputPath, codec, IndexBalanceApproach.FOR_SEEK_TIME);
-    }
-
-    /**
-     * Create a index of the specified type with default binning parameters
-     *
-     * @param inputFile the input file to load features from
-     * @param codec     the codec to use for decoding records
-     * @param type      the type of index to create
-     * @deprecated since 6/2025, use {@link #createIndex(Path, FeatureCodec, IndexType)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createIndex(
-            final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final IndexType type) {
-        return createIndex(IOUtil.toPath(inputFile), codec, type, null);
     }
 
     /**
@@ -390,24 +308,6 @@ public class IndexFactory {
     public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createIndex(
             final Path inputPath, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final IndexType type) {
         return createIndex(inputPath, codec, type, null);
-    }
-
-    /**
-     * Create an index of the specified type with default binning parameters
-     *
-     * @param inputFile the input File to load features from
-     * @param codec     the codec to use for decoding records
-     * @param type      the type of index to create
-     * @param sequenceDictionary May be null, but if present may reduce memory footprint for tabix index creation
-     * @deprecated since 6/2025, use {@link #createIndex(Path, FeatureCodec, IndexType, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createIndex(
-            final File inputFile,
-            final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,
-            final IndexType type,
-            final SAMSequenceDictionary sequenceDictionary) {
-        return createIndex(IOUtil.toPath(inputFile), codec, type, sequenceDictionary);
     }
 
     /**
@@ -436,32 +336,6 @@ public class IndexFactory {
     }
 
     /**
-     * Write the index to a file; little endian.
-     * @param idx
-     * @param idxFile
-     * @throws IOException
-     * @deprecated use {@link Index#write(Path)} instead
-     */
-    @Deprecated
-    public static void writeIndex(final Index idx, final File idxFile) throws IOException {
-        idx.write(IOUtil.toPath(idxFile));
-    }
-
-    /**
-     * create a dynamic index, given an input file, codec, and balance approach
-     *
-     * @param inputFile the input file to load features from
-     * @param codec     the codec to use for decoding records
-     * @param iba       the index balancing approach
-     * @deprecated since 6/2025, use {@link #createDynamicIndex(Path, FeatureCodec, IndexBalanceApproach)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> Index createDynamicIndex(
-            final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec, final IndexBalanceApproach iba) {
-        return createDynamicIndex(IOUtil.toPath(inputFile), codec, iba);
-    }
-
-    /**
      * create a dynamic index, given an input path, codec, and balance approach
      *
      * @param inputPath the input path to load features from
@@ -474,23 +348,6 @@ public class IndexFactory {
         // get a list of index creators
         final DynamicIndexCreator indexCreator = new DynamicIndexCreator(inputPath, iba);
         return createIndex(inputPath, new FeatureIterator<>(inputPath, codec), indexCreator);
-    }
-
-    /**
-     * @param inputFile The file to be indexed.
-     * @param codec Mechanism for reading inputFile.
-     * @param tabixFormat Header fields for TabixIndex to be produced.
-     * @param sequenceDictionary May be null, but if present may reduce memory footprint for index creation.  Features
-     *                           in inputFile must be in the order defined by sequenceDictionary, if it is present.
-     * @deprecated since 6/2025, use {@link #createTabixIndex(Path, FeatureCodec, TabixFormat, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> TabixIndex createTabixIndex(
-            final File inputFile,
-            final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,
-            final TabixFormat tabixFormat,
-            final SAMSequenceDictionary sequenceDictionary) {
-        return createTabixIndex(IOUtil.toPath(inputFile), codec, tabixFormat, sequenceDictionary);
     }
 
     /**
@@ -508,21 +365,6 @@ public class IndexFactory {
         ValidationUtils.nonNull(inputPath, "input path must be non-null");
         final TabixIndexCreator indexCreator = new TabixIndexCreator(sequenceDictionary, tabixFormat);
         return (TabixIndex) createIndex(inputPath, new FeatureIterator<>(inputPath, codec), indexCreator);
-    }
-
-    /**
-     * @param inputFile The file to be indexed.
-     * @param codec the codec to use for decoding records
-     * @param sequenceDictionary May be null, but if present may reduce memory footprint for index creation.  Features
-     *                           in inputFile must be in the order defined by sequenceDictionary, if it is present.
-     * @deprecated since 6/2025, use {@link #createTabixIndex(Path, FeatureCodec, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public static <FEATURE_TYPE extends Feature, SOURCE_TYPE> TabixIndex createTabixIndex(
-            final File inputFile,
-            final FeatureCodec<FEATURE_TYPE, SOURCE_TYPE> codec,
-            final SAMSequenceDictionary sequenceDictionary) {
-        return createTabixIndex(IOUtil.toPath(inputFile), codec, codec.getTabixFormat(), sequenceDictionary);
     }
 
     /**
@@ -605,17 +447,6 @@ public class IndexFactory {
 
         // we also need cache our position
         private long cachedPosition;
-
-        /**
-         *
-         * @param inputFile The file from which to read. Stream for reading is opened on construction. May not be null.
-         * @param codec the codec to use for decoding features
-         * @deprecated since 6/2025, use {@link #FeatureIterator(Path, FeatureCodec)} instead.
-         */
-        @Deprecated
-        public FeatureIterator(final File inputFile, final FeatureCodec<FEATURE_TYPE, SOURCE> codec) {
-            this(IOUtil.toPath(inputFile), codec);
-        }
 
         /**
          * Constructs a FeatureIterator.

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
@@ -18,13 +18,11 @@
 
 package htsjdk.tribble.index.interval;
 
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.TribbleIndexCreator;
 import htsjdk.tribble.index.interval.IntervalTreeIndex.ChrIndex;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -57,22 +55,6 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
     public IntervalIndexCreator(final Path inputPath, final int featuresPerInterval) {
         this.inputPath = inputPath;
         this.featuresPerInterval = featuresPerInterval;
-    }
-
-    /**
-     * @deprecated since the File -&gt; Path migration; use {@link #IntervalIndexCreator(Path, int)} instead.
-     */
-    @Deprecated
-    public IntervalIndexCreator(final File inputFile, final int featuresPerInterval) {
-        this(IOUtil.toPath(inputFile), featuresPerInterval);
-    }
-
-    /**
-     * @deprecated since the File -&gt; Path migration; use {@link #IntervalIndexCreator(Path)} instead.
-     */
-    @Deprecated
-    public IntervalIndexCreator(final File inputFile) {
-        this(IOUtil.toPath(inputFile));
     }
 
     public IntervalIndexCreator(final Path inputPath) {

--- a/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/interval/IntervalIndexCreator.java
@@ -59,10 +59,18 @@ public class IntervalIndexCreator extends TribbleIndexCreator {
         this.featuresPerInterval = featuresPerInterval;
     }
 
+    /**
+     * @deprecated since the File -&gt; Path migration; use {@link #IntervalIndexCreator(Path, int)} instead.
+     */
+    @Deprecated
     public IntervalIndexCreator(final File inputFile, final int featuresPerInterval) {
         this(IOUtil.toPath(inputFile), featuresPerInterval);
     }
 
+    /**
+     * @deprecated since the File -&gt; Path migration; use {@link #IntervalIndexCreator(Path)} instead.
+     */
+    @Deprecated
     public IntervalIndexCreator(final File inputFile) {
         this(IOUtil.toPath(inputFile));
     }

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -18,13 +18,11 @@
 
 package htsjdk.tribble.index.linear;
 
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.index.AbstractIndex;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.util.LittleEndianInputStream;
 import htsjdk.tribble.util.LittleEndianOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -73,17 +71,6 @@ public class LinearIndex extends AbstractIndex {
     public LinearIndex(final List<ChrIndex> indices, final Path featureFile) {
         super(featureFile);
         for (final ChrIndex index : indices) chrIndices.put(index.getName(), index);
-    }
-
-    /**
-     * Initialize using the specified {@code indices}
-     * @param indices
-     * @param featureFile
-     * @deprecated since 5.0; use {@link #LinearIndex(List, Path)} instead.
-     */
-    @Deprecated
-    public LinearIndex(final List<ChrIndex> indices, final File featureFile) {
-        this(indices, IOUtil.toPath(featureFile));
     }
 
     private LinearIndex(final LinearIndex parent, final List<ChrIndex> indices) {

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndex.java
@@ -79,7 +79,9 @@ public class LinearIndex extends AbstractIndex {
      * Initialize using the specified {@code indices}
      * @param indices
      * @param featureFile
+     * @deprecated since 5.0; use {@link #LinearIndex(List, Path)} instead.
      */
+    @Deprecated
     public LinearIndex(final List<ChrIndex> indices, final File featureFile) {
         this(indices, IOUtil.toPath(featureFile));
     }

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
@@ -23,12 +23,10 @@
  */
 package htsjdk.tribble.index.linear;
 
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.TribbleIndexCreator;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -54,22 +52,6 @@ public class LinearIndexCreator extends TribbleIndexCreator {
     public LinearIndexCreator(final Path inputPath, final int binSize) {
         this.inputFile = inputPath;
         binWidth = binSize;
-    }
-
-    /**
-     * @deprecated use {@link #LinearIndexCreator(Path, int)} instead.
-     */
-    @Deprecated
-    public LinearIndexCreator(final File inputFile, final int binSize) {
-        this(IOUtil.toPath(inputFile), binSize);
-    }
-
-    /**
-     * @deprecated use {@link #LinearIndexCreator(Path)} instead.
-     */
-    @Deprecated
-    public LinearIndexCreator(final File inputFile) {
-        this(IOUtil.toPath(inputFile));
     }
 
     public LinearIndexCreator(final Path inputPath) {

--- a/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
+++ b/src/main/java/htsjdk/tribble/index/linear/LinearIndexCreator.java
@@ -56,10 +56,18 @@ public class LinearIndexCreator extends TribbleIndexCreator {
         binWidth = binSize;
     }
 
+    /**
+     * @deprecated use {@link #LinearIndexCreator(Path, int)} instead.
+     */
+    @Deprecated
     public LinearIndexCreator(final File inputFile, final int binSize) {
         this(IOUtil.toPath(inputFile), binSize);
     }
 
+    /**
+     * @deprecated use {@link #LinearIndexCreator(Path)} instead.
+     */
+    @Deprecated
     public LinearIndexCreator(final File inputFile) {
         this(IOUtil.toPath(inputFile));
     }

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -38,7 +38,6 @@ import htsjdk.tribble.index.Index;
 import htsjdk.tribble.util.LittleEndianInputStream;
 import htsjdk.tribble.util.LittleEndianOutputStream;
 import java.io.EOFException;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -88,16 +87,6 @@ public class TabixIndex implements Index {
      */
     public TabixIndex(final InputStream inputStream) throws IOException {
         this(inputStream, false);
-    }
-
-    /**
-     * Convenient ctor that opens the file, wraps with with BGZF reader, and closes after reading index.
-     *
-     * @deprecated since 5/2026 use {@link #TabixIndex(Path)} instead.
-     */
-    @Deprecated
-    public TabixIndex(final File tabixFile) throws IOException {
-        this(tabixFile.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndex.java
@@ -92,16 +92,19 @@ public class TabixIndex implements Index {
 
     /**
      * Convenient ctor that opens the file, wraps with with BGZF reader, and closes after reading index.
+     *
+     * @deprecated since 5/2026 use {@link #TabixIndex(Path)} instead.
      */
+    @Deprecated
     public TabixIndex(final File tabixFile) throws IOException {
-        this(new BlockCompressedInputStream(tabixFile), true);
+        this(tabixFile.toPath());
     }
 
     /**
      * Convenient ctor that opens the path, wraps with with BGZF reader, and closes after reading index.
      */
     public TabixIndex(final Path tabixPath) throws IOException {
-        this(new BlockCompressedInputStream(Files.newInputStream(tabixPath)), true);
+        this(new BlockCompressedInputStream(tabixPath), true);
     }
 
     private TabixIndex(final InputStream inputStream, final boolean closeInputStream) throws IOException {

--- a/src/main/java/htsjdk/tribble/index/tabix/TabixIndexMerger.java
+++ b/src/main/java/htsjdk/tribble/index/tabix/TabixIndexMerger.java
@@ -29,9 +29,9 @@ import htsjdk.samtools.IndexMerger;
 import htsjdk.samtools.LinearIndex;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.tribble.util.LittleEndianOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -111,7 +111,7 @@ public class TabixIndexMerger extends IndexMerger<TabixIndex> {
         final TabixIndex tabixIndex = new TabixIndex(
                 formatSpec, sequenceNames, mergedBinningIndexContentList.toArray(new BinningIndexContent[0]));
         try (LittleEndianOutputStream los =
-                new LittleEndianOutputStream(new BlockCompressedOutputStream(out, (File) null))) {
+                new LittleEndianOutputStream(new BlockCompressedOutputStream(out, (Path) null))) {
             tabixIndex.write(los);
         }
     }

--- a/src/main/java/htsjdk/tribble/readers/PositionalBufferedStream.java
+++ b/src/main/java/htsjdk/tribble/readers/PositionalBufferedStream.java
@@ -17,13 +17,14 @@
  */
 package htsjdk.tribble.readers;
 
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.TribbleException;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * A wrapper around an {@code InputStream} which performs it's own buffering, and keeps track of the position.
@@ -175,7 +176,7 @@ public final class PositionalBufferedStream extends InputStream implements Posit
     }
 
     public static void main(String[] args) throws Exception {
-        final File testFile = new File(args[0]);
+        final Path testFile = IOUtil.getPath(args[0]);
         final int iterations = Integer.parseInt(args[1]);
         final boolean includeInputStream = Boolean.valueOf(args[2]);
         final boolean doReadFileInChunks = Boolean.valueOf(args[3]);
@@ -183,13 +184,13 @@ public final class PositionalBufferedStream extends InputStream implements Posit
         System.out.printf("Testing %s%n", args[0]);
         for (int i = 0; i < iterations; i++) {
             if (includeInputStream) {
-                final InputStream is = new FileInputStream(testFile);
+                final InputStream is = Files.newInputStream(testFile);
                 if (doReadFileInChunks) readFileInChunks("InputStream", is);
                 else readFileByLine("InputStream", is);
                 is.close();
             }
 
-            final PositionalBufferedStream pbs = new PositionalBufferedStream(new FileInputStream(testFile));
+            final PositionalBufferedStream pbs = new PositionalBufferedStream(Files.newInputStream(testFile));
             if (doReadFileInChunks) readFileInChunks("PositionalBufferedStream", pbs);
             else readFileByLine("PositionalBufferedStream", pbs);
             pbs.close();

--- a/src/main/java/htsjdk/tribble/util/ParsingUtils.java
+++ b/src/main/java/htsjdk/tribble/util/ParsingUtils.java
@@ -29,7 +29,6 @@ import htsjdk.samtools.seekablestream.SeekablePathStream;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.util.IOUtil;
 import java.awt.Color;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -403,10 +402,10 @@ public class ParsingUtils {
             }
             URLHelper helper = getURLHelper(url);
             return helper.exists();
-        } else if (IOUtil.hasScheme(resource)) {
-            return Files.exists(IOUtil.getPath(resource));
         } else {
-            return (new File(resource)).exists();
+            // Covers both schemed NIO paths (gcs, custom SPI, file, etc.) and bare local paths;
+            // IOUtil.getPath treats a scheme-less string as a local file path.
+            return Files.exists(IOUtil.getPath(resource));
         }
     }
 

--- a/src/main/java/htsjdk/tribble/util/TabixUtils.java
+++ b/src/main/java/htsjdk/tribble/util/TabixUtils.java
@@ -29,7 +29,6 @@ import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.TabixReader;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -76,19 +75,6 @@ public class TabixUtils {
 
     public static boolean less64(final long u, final long v) { // unsigned 64-bit comparison
         return (u < v) ^ (u < 0) ^ (v < 0);
-    }
-
-    /**
-     * Generates the SAMSequenceDictionary from the given tabix index file
-     *
-     * @param tabixIndex the tabix index file
-     * @return non-null sequence dictionary
-     * @deprecated since June 2025, use {@link #getSequenceDictionary(Path)} instead.
-     */
-    @Deprecated
-    public static SAMSequenceDictionary getSequenceDictionary(final File tabixIndex) {
-        if (tabixIndex == null) throw new IllegalArgumentException();
-        return getSequenceDictionary(tabixIndex.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/tribble/util/TabixUtils.java
+++ b/src/main/java/htsjdk/tribble/util/TabixUtils.java
@@ -30,6 +30,7 @@ import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.TabixReader;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -82,8 +83,21 @@ public class TabixUtils {
      *
      * @param tabixIndex the tabix index file
      * @return non-null sequence dictionary
+     * @deprecated since June 2025, use {@link #getSequenceDictionary(Path)} instead.
      */
+    @Deprecated
     public static SAMSequenceDictionary getSequenceDictionary(final File tabixIndex) {
+        if (tabixIndex == null) throw new IllegalArgumentException();
+        return getSequenceDictionary(tabixIndex.toPath());
+    }
+
+    /**
+     * Generates the SAMSequenceDictionary from the given tabix index file
+     *
+     * @param tabixIndex the path to the tabix index file
+     * @return non-null sequence dictionary
+     */
+    public static SAMSequenceDictionary getSequenceDictionary(final Path tabixIndex) {
         if (tabixIndex == null) throw new IllegalArgumentException();
 
         try {

--- a/src/main/java/htsjdk/utils/ClassFinder.java
+++ b/src/main/java/htsjdk/utils/ClassFinder.java
@@ -32,6 +32,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -62,12 +65,28 @@ public class ClassFinder {
         this.loader = loader;
     }
 
+    /**
+     * Constructs a ClassFinder that will only look for classes within the specified jar file.
+     *
+     * @param jarFile the jar file to scan for classes
+     * @deprecated use {@link #ClassFinder(Path)} instead
+     */
+    @Deprecated
     public ClassFinder(final File jarFile) throws IOException {
+        this(jarFile.toPath());
+    }
+
+    /**
+     * Constructs a ClassFinder that will only look for classes within the specified jar file.
+     *
+     * @param jarFile the jar file to scan for classes
+     */
+    public ClassFinder(final Path jarFile) throws IOException {
         // The class loader must have the context in order to load dependent classes when loading a class,
         // but the jarPath is remembered so that the iteration over the classpath skips anything other than
         // the jarPath.
-        jarPath = jarFile.getCanonicalPath();
-        final URL[] urls = {new File(jarPath).toURI().toURL()};
+        jarPath = jarFile.toRealPath().toString();
+        final URL[] urls = {Path.of(jarPath).toUri().toURL()};
         loader = new URLClassLoader(urls, Thread.currentThread().getContextClassLoader());
     }
 
@@ -116,11 +135,11 @@ public class ClassFinder {
                 }
 
                 // Log.info("Looking for classes in location: " + urlPath);
-                final File file = new File(urlPath);
-                if (file.isDirectory()) {
-                    scanDir(file, packageName);
+                final Path path = Path.of(urlPath);
+                if (Files.isDirectory(path)) {
+                    scanDir(path, packageName);
                 } else {
-                    scanJar(file, packageName);
+                    scanJar(path, packageName);
                 }
             } catch (IOException ioe) {
                 log.warn("could not read entries", ioe);
@@ -132,9 +151,20 @@ public class ClassFinder {
      * Scans the entries in a ZIP/JAR file for classes under the parent package.
      * @param file the jar file to be scanned
      * @param packagePath the top level package to start from
+     * @deprecated use {@link #scanJar(Path, String)} instead
      */
+    @Deprecated
     protected void scanJar(final File file, final String packagePath) throws IOException {
-        final ZipFile zip = new ZipFile(file);
+        scanJar(file.toPath(), packagePath);
+    }
+
+    /**
+     * Scans the entries in a ZIP/JAR file for classes under the parent package.
+     * @param file the jar file to be scanned
+     * @param packagePath the top level package to start from
+     */
+    protected void scanJar(final Path file, final String packagePath) throws IOException {
+        final ZipFile zip = new ZipFile(file.toFile());
         final Enumeration<? extends ZipEntry> entries = zip.entries();
         while (entries.hasMoreElements()) {
             final ZipEntry entry = entries.nextElement();
@@ -149,15 +179,32 @@ public class ClassFinder {
      * Scans a directory on the filesystem for classes.
      * @param file the directory or file to examine
      * @param path the package path acculmulated so far (e.g. edu/mit/broad)
+     * @deprecated use {@link #scanDir(Path, String)} instead
      */
+    @Deprecated
     protected void scanDir(final File file, final String path) {
-        for (final File child : file.listFiles()) {
-            final String newPath = (path == null ? child.getName() : path + '/' + child.getName());
-            if (child.isDirectory()) {
-                scanDir(child, newPath);
-            } else {
-                handleItem(newPath);
+        scanDir(file.toPath(), path);
+    }
+
+    /**
+     * Scans a directory on the filesystem for classes.
+     * @param dir the directory or file to examine
+     * @param path the package path acculmulated so far (e.g. edu/mit/broad)
+     */
+    protected void scanDir(final Path dir, final String path) {
+        try (final DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+            for (final Path child : stream) {
+                final String newPath = (path == null
+                        ? child.getFileName().toString()
+                        : path + '/' + child.getFileName().toString());
+                if (Files.isDirectory(child)) {
+                    scanDir(child, newPath);
+                } else {
+                    handleItem(newPath);
+                }
             }
+        } catch (IOException e) {
+            log.warn("Could not scan directory: " + dir, e);
         }
     }
 

--- a/src/main/java/htsjdk/utils/ClassFinder.java
+++ b/src/main/java/htsjdk/utils/ClassFinder.java
@@ -25,7 +25,6 @@ package htsjdk.utils;
  */
 
 import htsjdk.samtools.util.Log;
-import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.net.URI;
@@ -63,17 +62,6 @@ public class ClassFinder {
 
     public ClassFinder(final ClassLoader loader) {
         this.loader = loader;
-    }
-
-    /**
-     * Constructs a ClassFinder that will only look for classes within the specified jar file.
-     *
-     * @param jarFile the jar file to scan for classes
-     * @deprecated use {@link #ClassFinder(Path)} instead
-     */
-    @Deprecated
-    public ClassFinder(final File jarFile) throws IOException {
-        this(jarFile.toPath());
     }
 
     /**
@@ -151,17 +139,6 @@ public class ClassFinder {
      * Scans the entries in a ZIP/JAR file for classes under the parent package.
      * @param file the jar file to be scanned
      * @param packagePath the top level package to start from
-     * @deprecated use {@link #scanJar(Path, String)} instead
-     */
-    @Deprecated
-    protected void scanJar(final File file, final String packagePath) throws IOException {
-        scanJar(file.toPath(), packagePath);
-    }
-
-    /**
-     * Scans the entries in a ZIP/JAR file for classes under the parent package.
-     * @param file the jar file to be scanned
-     * @param packagePath the top level package to start from
      */
     protected void scanJar(final Path file, final String packagePath) throws IOException {
         final ZipFile zip = new ZipFile(file.toFile());
@@ -173,17 +150,6 @@ public class ClassFinder {
                 handleItem(name);
             }
         }
-    }
-
-    /**
-     * Scans a directory on the filesystem for classes.
-     * @param file the directory or file to examine
-     * @param path the package path acculmulated so far (e.g. edu/mit/broad)
-     * @deprecated use {@link #scanDir(Path, String)} instead
-     */
-    @Deprecated
-    protected void scanDir(final File file, final String path) {
-        scanDir(file.toPath(), path);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/bcf2/BCF2Utils.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2Utils.java
@@ -28,7 +28,6 @@ package htsjdk.variant.bcf2;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.*;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -203,25 +202,6 @@ public final class BCF2Utils {
                 }
             }
         }
-    }
-
-    /**
-     * Returns a good name for a shadow BCF file for vcfFile.
-     *
-     * foo.vcf =&gt; foo.bcf
-     * foo.xxx =&gt; foo.xxx.bcf
-     *
-     * If the resulting BCF file cannot be written, return null.  Happens
-     * when vcfFile = /dev/null for example
-     *
-     * @param vcfFile
-     * @return the BCF
-     * @deprecated use {@link #shadowBCF(Path)} instead
-     */
-    @Deprecated
-    public static final File shadowBCF(final File vcfFile) {
-        final Path bcf = shadowBCF(vcfFile.toPath());
-        return bcf == null ? null : bcf.toFile();
     }
 
     public static BCF2Type determineIntegerType(final int value) {

--- a/src/main/java/htsjdk/variant/bcf2/BCF2Utils.java
+++ b/src/main/java/htsjdk/variant/bcf2/BCF2Utils.java
@@ -29,11 +29,12 @@ import htsjdk.samtools.util.FileExtensions;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.*;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.reflect.Array;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -177,31 +178,50 @@ public final class BCF2Utils {
      * foo.xxx =&gt; foo.xxx.bcf
      *
      * If the resulting BCF file cannot be written, return null.  Happens
-     * when vcfFile = /dev/null for example
+     * when vcfPath = /dev/null for example
      *
-     * @param vcfFile
-     * @return the BCF
+     * @param vcfPath the VCF path for which to build a shadow BCF path
+     * @return the BCF path, or null if a BCF file cannot be written
      */
-    public static final File shadowBCF(final File vcfFile) {
-        final String path = vcfFile.getAbsolutePath();
-        if (path.contains(FileExtensions.VCF)) return new File(path.replace(FileExtensions.VCF, FileExtensions.BCF));
+    public static final Path shadowBCF(final Path vcfPath) {
+        final String path = vcfPath.toAbsolutePath().toString();
+        if (path.contains(FileExtensions.VCF))
+            return vcfPath.resolveSibling(
+                    vcfPath.getFileName().toString().replace(FileExtensions.VCF, FileExtensions.BCF));
         else {
-            final File bcf = new File(path + FileExtensions.BCF);
-            if (bcf.canRead()) return bcf;
+            final Path bcf = vcfPath.resolveSibling(vcfPath.getFileName().toString() + FileExtensions.BCF);
+            if (Files.isReadable(bcf)) return bcf;
             else {
                 try {
                     // this is the only way to robustly decide if we could actually write to BCF
-                    final FileOutputStream o = new FileOutputStream(bcf);
+                    final OutputStream o = Files.newOutputStream(bcf);
                     o.close();
-                    bcf.delete();
+                    Files.delete(bcf);
                     return bcf;
-                } catch (FileNotFoundException e) {
-                    return null;
                 } catch (IOException e) {
                     return null;
                 }
             }
         }
+    }
+
+    /**
+     * Returns a good name for a shadow BCF file for vcfFile.
+     *
+     * foo.vcf =&gt; foo.bcf
+     * foo.xxx =&gt; foo.xxx.bcf
+     *
+     * If the resulting BCF file cannot be written, return null.  Happens
+     * when vcfFile = /dev/null for example
+     *
+     * @param vcfFile
+     * @return the BCF
+     * @deprecated use {@link #shadowBCF(Path)} instead
+     */
+    @Deprecated
+    public static final File shadowBCF(final File vcfFile) {
+        final Path bcf = shadowBCF(vcfFile.toPath());
+        return bcf == null ? null : bcf.toFile();
     }
 
     public static BCF2Type determineIntegerType(final int value) {

--- a/src/main/java/htsjdk/variant/example/PrintVariantsExample.java
+++ b/src/main/java/htsjdk/variant/example/PrintVariantsExample.java
@@ -23,6 +23,7 @@
 package htsjdk.variant.example;
 
 import htsjdk.samtools.Defaults;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Log;
 import htsjdk.samtools.util.ProgressLogger;
 import htsjdk.tribble.AbstractFeatureReader;
@@ -33,9 +34,9 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -59,23 +60,25 @@ public final class PrintVariantsExample {
             System.out.println("Usage: " + PrintVariantsExample.class.getCanonicalName() + " inFile [outFile]");
             System.exit(1);
         }
-        final File inputFile = new File(args[0]);
-        final File outputFile = args.length >= 2 ? new File(args[1]) : null;
+        // Resolve user-supplied arguments through IOUtil.getPath so that scheme-aware inputs
+        // (file/http/https/ftp/gcs and custom NIO SPI providers) are honored, not just local files.
+        final Path inputPath = IOUtil.getPath(args[0]);
+        final Path outputPath = args.length >= 2 ? IOUtil.getPath(args[1]) : null;
 
         final long start = System.currentTimeMillis();
 
         log.info("Start with args:" + Arrays.toString(args));
         printConfigurationInfo();
 
-        try (final VariantContextWriter writer = outputFile == null
+        try (final VariantContextWriter writer = outputPath == null
                         ? null
                         : new VariantContextWriterBuilder()
-                                .setOutputFile(outputFile)
+                                .setOutputPath(outputPath)
                                 .setOutputFileType(VariantContextWriterBuilder.OutputType.VCF)
                                 .unsetOption(Options.INDEX_ON_THE_FLY)
                                 .build();
                 final AbstractFeatureReader<VariantContext, LineIterator> reader =
-                        AbstractFeatureReader.getFeatureReader(inputFile.getAbsolutePath(), new VCFCodec(), false)) {
+                        AbstractFeatureReader.getFeatureReader(inputPath.toUri().toString(), new VCFCodec(), false)) {
 
             log.info(reader.getClass().getSimpleName() + " hasIndex " + reader.hasIndex());
             if (writer != null) {

--- a/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
+++ b/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
@@ -32,7 +32,6 @@ import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
 import htsjdk.samtools.util.*;
 import htsjdk.tribble.util.ParsingUtils;
 import htsjdk.variant.vcf.VCFFileReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -126,23 +125,7 @@ public class SAMSequenceDictionaryExtractor {
             applicableExtensions = extensions;
         }
 
-        /**
-         * @deprecated in favor of {@link #extractDictionary(Path)}
-         */
-        @Deprecated
-        SAMSequenceDictionary extractDictionary(final File file) {
-            return extractDictionary(file.toPath());
-        }
-
         abstract SAMSequenceDictionary extractDictionary(final Path file);
-
-        /**
-         * @deprecated in favor of {@link #forFile(Path)}
-         */
-        @Deprecated
-        static TYPE forFile(final File dictionaryExtractable) {
-            return forFile(dictionaryExtractable.toPath());
-        }
 
         static TYPE forFile(final Path dictionaryExtractable) {
             for (final TYPE type : TYPE.values()) {
@@ -162,14 +145,6 @@ public class SAMSequenceDictionaryExtractor {
         public String toString() {
             return super.toString() + ": " + applicableExtensions.toString();
         }
-    }
-
-    /**
-     * @deprecated in favor of {@link SAMSequenceDictionaryExtractor#extractDictionary(Path) }
-     */
-    @Deprecated
-    public static SAMSequenceDictionary extractDictionary(final File file) {
-        return extractDictionary(file.toPath());
     }
 
     public static SAMSequenceDictionary extractDictionary(final Path path) {

--- a/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
+++ b/src/main/java/htsjdk/variant/utils/SAMSequenceDictionaryExtractor.java
@@ -127,8 +127,8 @@ public class SAMSequenceDictionaryExtractor {
         }
 
         /**
-         * @deprecated in favor of {@link VCFFileReader##extractDictionary(Path) }
-         * */
+         * @deprecated in favor of {@link #extractDictionary(Path)}
+         */
         @Deprecated
         SAMSequenceDictionary extractDictionary(final File file) {
             return extractDictionary(file.toPath());
@@ -137,7 +137,7 @@ public class SAMSequenceDictionaryExtractor {
         abstract SAMSequenceDictionary extractDictionary(final Path file);
 
         /**
-         * @deprecated in favor of {@link SAMSequenceDictionaryExtractor##forFile(Path) }
+         * @deprecated in favor of {@link #forFile(Path)}
          */
         @Deprecated
         static TYPE forFile(final File dictionaryExtractable) {

--- a/src/main/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilter.java
@@ -26,7 +26,6 @@ package htsjdk.variant.variantcontext.filter;
 import htsjdk.samtools.filter.AbstractJavascriptFilter;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Path;
@@ -67,20 +66,6 @@ public class JavascriptVariantFilter extends AbstractJavascriptFilter<VCFHeader,
      */
     public JavascriptVariantFilter(final Path scriptPath, final VCFHeader header) throws IOException {
         super(scriptPath, header);
-    }
-
-    /**
-     * constructor using a javascript File
-     *
-     * @param scriptFile
-     *            the javascript file to be compiled
-     * @param header
-     *            the SAMHeader
-     * @deprecated use {@link #JavascriptVariantFilter(Path, VCFHeader)} instead.
-     */
-    @Deprecated
-    public JavascriptVariantFilter(final File scriptFile, final VCFHeader header) throws IOException {
-        this(scriptFile.toPath(), header);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilter.java
@@ -29,6 +29,7 @@ import htsjdk.variant.vcf.VCFHeader;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.file.Path;
 
 /**
  * JavaScript-based {@link VariantContextFilter}.
@@ -57,15 +58,29 @@ import java.io.Reader;
 public class JavascriptVariantFilter extends AbstractJavascriptFilter<VCFHeader, VariantContext>
         implements VariantContextFilter {
     /**
+     * constructor using a javascript file path
+     *
+     * @param scriptPath
+     *            the path to the javascript file to be compiled
+     * @param header
+     *            the SAMHeader
+     */
+    public JavascriptVariantFilter(final Path scriptPath, final VCFHeader header) throws IOException {
+        super(scriptPath, header);
+    }
+
+    /**
      * constructor using a javascript File
      *
      * @param scriptFile
      *            the javascript file to be compiled
      * @param header
      *            the SAMHeader
+     * @deprecated use {@link #JavascriptVariantFilter(Path, VCFHeader)} instead.
      */
+    @Deprecated
     public JavascriptVariantFilter(final File scriptFile, final VCFHeader header) throws IOException {
-        super(scriptFile, header);
+        this(scriptFile.toPath(), header);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -129,6 +129,11 @@ class BCF2Writer extends IndexingVariantContextWriter {
     // is the header or body written to the output stream?
     private boolean outputHasBeenWritten;
 
+    /**
+     * @deprecated since 06/2024 use the {@link Path}-based constructor
+     *     {@link #BCF2Writer(Path, OutputStream, SAMSequenceDictionary, boolean, boolean)} instead.
+     */
+    @Deprecated
     public BCF2Writer(
             final File location,
             final OutputStream output,
@@ -149,6 +154,11 @@ class BCF2Writer extends IndexingVariantContextWriter {
         this.doNotWriteGenotypes = doNotWriteGenotypes;
     }
 
+    /**
+     * @deprecated since 06/2024 use the {@link Path}-based constructor
+     *     {@link #BCF2Writer(Path, OutputStream, SAMSequenceDictionary, IndexCreator, boolean, boolean)} instead.
+     */
+    @Deprecated
     public BCF2Writer(
             final File location,
             final OutputStream output,

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -26,7 +26,6 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.IndexCreator;
 import htsjdk.variant.bcf2.BCF2Codec;
@@ -45,7 +44,6 @@ import htsjdk.variant.vcf.VCFContigHeaderLine;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFUtils;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -129,20 +127,6 @@ class BCF2Writer extends IndexingVariantContextWriter {
     // is the header or body written to the output stream?
     private boolean outputHasBeenWritten;
 
-    /**
-     * @deprecated since 06/2024 use the {@link Path}-based constructor
-     *     {@link #BCF2Writer(Path, OutputStream, SAMSequenceDictionary, boolean, boolean)} instead.
-     */
-    @Deprecated
-    public BCF2Writer(
-            final File location,
-            final OutputStream output,
-            final SAMSequenceDictionary refDict,
-            final boolean enableOnTheFlyIndexing,
-            final boolean doNotWriteGenotypes) {
-        this(IOUtil.toPath(location), output, refDict, enableOnTheFlyIndexing, doNotWriteGenotypes);
-    }
-
     public BCF2Writer(
             final Path location,
             final OutputStream output,
@@ -152,21 +136,6 @@ class BCF2Writer extends IndexingVariantContextWriter {
         super(writerName(location, output), location, output, refDict, enableOnTheFlyIndexing);
         this.outputStream = getOutputStream();
         this.doNotWriteGenotypes = doNotWriteGenotypes;
-    }
-
-    /**
-     * @deprecated since 06/2024 use the {@link Path}-based constructor
-     *     {@link #BCF2Writer(Path, OutputStream, SAMSequenceDictionary, IndexCreator, boolean, boolean)} instead.
-     */
-    @Deprecated
-    public BCF2Writer(
-            final File location,
-            final OutputStream output,
-            final SAMSequenceDictionary refDict,
-            final IndexCreator indexCreator,
-            final boolean enableOnTheFlyIndexing,
-            final boolean doNotWriteGenotypes) {
-        this(IOUtil.toPath(location), output, refDict, indexCreator, enableOnTheFlyIndexing, doNotWriteGenotypes);
     }
 
     public BCF2Writer(

--- a/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/BCF2Writer.java
@@ -256,7 +256,7 @@ class BCF2Writer extends IndexingVariantContextWriter {
                     System.err.println(
                             "No contig dictionary found in header, falling back to reference sequence dictionary");
                 }
-                createContigDictionary(VCFUtils.makeContigHeaderLines(getRefDict(), null));
+                createContigDictionary(VCFUtils.makeContigHeaderLines(getRefDict(), (Path) null));
             } else {
                 throw new IllegalStateException("Cannot write BCF2 file with missing contig lines");
             }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
@@ -26,7 +26,6 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.LocationAware;
 import htsjdk.samtools.util.PositionalOutputStream;
 import htsjdk.samtools.util.RuntimeIOException;
@@ -36,7 +35,6 @@ import htsjdk.tribble.index.IndexCreator;
 import htsjdk.tribble.index.IndexFactory;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -72,26 +70,6 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
      * @param output    the output stream to write to
      * @param refDict   the reference dictionary
      * @param enableOnTheFlyIndexing    is OTF indexing enabled?
-     * @deprecated since 06/2025 use {@link #IndexingVariantContextWriter(String, Path, OutputStream, SAMSequenceDictionary, boolean)} instead
-     */
-    @Deprecated
-    protected IndexingVariantContextWriter(
-            final String name,
-            final File location,
-            final OutputStream output,
-            final SAMSequenceDictionary refDict,
-            final boolean enableOnTheFlyIndexing) {
-        this(name, IOUtil.toPath(location), output, refDict, enableOnTheFlyIndexing);
-    }
-
-    /**
-     * Create a VariantContextWriter with an associated index using the default index creator
-     *
-     * @param name  the name of this writer (i.e. the file name or stream)
-     * @param location  the path to the output file
-     * @param output    the output stream to write to
-     * @param refDict   the reference dictionary
-     * @param enableOnTheFlyIndexing    is OTF indexing enabled?
      */
     protected IndexingVariantContextWriter(
             final String name,
@@ -104,28 +82,6 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
         if (enableOnTheFlyIndexing) {
             initIndexingWriter(new DynamicIndexCreator(location, IndexFactory.IndexBalanceApproach.FOR_SEEK_TIME));
         }
-    }
-
-    /**
-     * Create a VariantContextWriter with an associated index using a custom index creator
-     *
-     * @param name  the name of this writer (i.e. the file name or stream)
-     * @param location  the path to the output file
-     * @param output    the output stream to write to
-     * @param refDict   the reference dictionary
-     * @param enableOnTheFlyIndexing    is OTF indexing enabled?
-     * @param idxCreator    the custom index creator.  NOTE: must be initialized
-     * @deprecated since 06/2025 use {@link #IndexingVariantContextWriter(String, Path, OutputStream, SAMSequenceDictionary, boolean, IndexCreator)} instead
-     */
-    @Deprecated
-    protected IndexingVariantContextWriter(
-            final String name,
-            final File location,
-            final OutputStream output,
-            final SAMSequenceDictionary refDict,
-            final boolean enableOnTheFlyIndexing,
-            final IndexCreator idxCreator) {
-        this(name, IOUtil.toPath(location), output, refDict, enableOnTheFlyIndexing, idxCreator);
     }
 
     /**
@@ -221,19 +177,6 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
     public void add(final VariantContext vc) {
         // if we are doing on the fly indexing, add the record ***before*** we write any bytes
         if (indexer != null) indexer.addFeature(vc, locationSource.getPosition());
-    }
-
-    /**
-     * Returns a reasonable "name" for this writer, to display to the user if something goes wrong
-     *
-     * @param location
-     * @param stream
-     * @return
-     * @deprecated since 06/2025 use {@link #writerName(Path, OutputStream)} instead
-     */
-    @Deprecated
-    protected static final String writerName(final File location, final OutputStream stream) {
-        return writerName(IOUtil.toPath(location), stream);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/IndexingVariantContextWriter.java
@@ -72,7 +72,9 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
      * @param output    the output stream to write to
      * @param refDict   the reference dictionary
      * @param enableOnTheFlyIndexing    is OTF indexing enabled?
+     * @deprecated since 06/2025 use {@link #IndexingVariantContextWriter(String, Path, OutputStream, SAMSequenceDictionary, boolean)} instead
      */
+    @Deprecated
     protected IndexingVariantContextWriter(
             final String name,
             final File location,
@@ -113,7 +115,9 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
      * @param refDict   the reference dictionary
      * @param enableOnTheFlyIndexing    is OTF indexing enabled?
      * @param idxCreator    the custom index creator.  NOTE: must be initialized
+     * @deprecated since 06/2025 use {@link #IndexingVariantContextWriter(String, Path, OutputStream, SAMSequenceDictionary, boolean, IndexCreator)} instead
      */
+    @Deprecated
     protected IndexingVariantContextWriter(
             final String name,
             final File location,
@@ -225,7 +229,9 @@ abstract class IndexingVariantContextWriter implements VariantContextWriter {
      * @param location
      * @param stream
      * @return
+     * @deprecated since 06/2025 use {@link #writerName(Path, OutputStream)} instead
      */
+    @Deprecated
     protected static final String writerName(final File location, final OutputStream stream) {
         return writerName(IOUtil.toPath(location), stream);
     }

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -26,7 +26,6 @@
 package htsjdk.variant.variantcontext.writer;
 
 import htsjdk.samtools.SAMSequenceDictionary;
-import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.IndexCreator;
 import htsjdk.variant.variantcontext.VariantContext;
@@ -38,7 +37,6 @@ import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFHeaderVersion;
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -83,28 +81,6 @@ class VCFWriter extends IndexingVariantContextWriter {
     /* Wrapping in a {@link BufferedWriter} avoids frequent conversions with individual writes to OutputStreamWriter. */
     private final Writer writer = new BufferedWriter(new OutputStreamWriter(lineBuffer, VCFEncoder.VCF_CHARSET));
 
-    /**
-     * @deprecated since 5.0; use the {@link Path}-based constructor instead.
-     */
-    @Deprecated
-    public VCFWriter(
-            final File location,
-            final OutputStream output,
-            final SAMSequenceDictionary refDict,
-            final boolean enableOnTheFlyIndexing,
-            final boolean doNotWriteGenotypes,
-            final boolean allowMissingFieldsInHeader,
-            final boolean writeFullFormatField) {
-        this(
-                IOUtil.toPath(location),
-                output,
-                refDict,
-                enableOnTheFlyIndexing,
-                doNotWriteGenotypes,
-                allowMissingFieldsInHeader,
-                writeFullFormatField);
-    }
-
     public VCFWriter(
             final Path location,
             final OutputStream output,
@@ -117,30 +93,6 @@ class VCFWriter extends IndexingVariantContextWriter {
         this.doNotWriteGenotypes = doNotWriteGenotypes;
         this.allowMissingFieldsInHeader = allowMissingFieldsInHeader;
         this.writeFullFormatField = writeFullFormatField;
-    }
-
-    /**
-     * @deprecated since 5.0; use the {@link Path}-based constructor instead.
-     */
-    @Deprecated
-    public VCFWriter(
-            final File location,
-            final OutputStream output,
-            final SAMSequenceDictionary refDict,
-            final IndexCreator indexCreator,
-            final boolean enableOnTheFlyIndexing,
-            final boolean doNotWriteGenotypes,
-            final boolean allowMissingFieldsInHeader,
-            final boolean writeFullFormatField) {
-        this(
-                IOUtil.toPath(location),
-                output,
-                refDict,
-                indexCreator,
-                enableOnTheFlyIndexing,
-                doNotWriteGenotypes,
-                allowMissingFieldsInHeader,
-                writeFullFormatField);
     }
 
     public VCFWriter(

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VCFWriter.java
@@ -83,6 +83,10 @@ class VCFWriter extends IndexingVariantContextWriter {
     /* Wrapping in a {@link BufferedWriter} avoids frequent conversions with individual writes to OutputStreamWriter. */
     private final Writer writer = new BufferedWriter(new OutputStreamWriter(lineBuffer, VCFEncoder.VCF_CHARSET));
 
+    /**
+     * @deprecated since 5.0; use the {@link Path}-based constructor instead.
+     */
+    @Deprecated
     public VCFWriter(
             final File location,
             final OutputStream output,
@@ -115,6 +119,10 @@ class VCFWriter extends IndexingVariantContextWriter {
         this.writeFullFormatField = writeFullFormatField;
     }
 
+    /**
+     * @deprecated since 5.0; use the {@link Path}-based constructor instead.
+     */
+    @Deprecated
     public VCFWriter(
             final File location,
             final OutputStream output,

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -36,7 +36,6 @@ import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.tribble.index.IndexCreator;
 import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.index.tabix.TabixIndexCreator;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -150,19 +149,6 @@ public class VariantContextWriterBuilder {
     public VariantContextWriterBuilder setReferenceDictionary(final SAMSequenceDictionary refDict) {
         this.refDict = refDict;
         return this;
-    }
-
-    /**
-     * Set the output file for the next <code>VariantContextWriter</code> created by this builder.
-     * Determines file type implicitly from the filename.
-     *
-     * @param outFile the file the <code>VariantContextWriter</code> will write to
-     * @return this <code>VariantContextWriterBuilder</code>
-     * @deprecated use {@link #setOutputPath(Path)} instead.
-     */
-    @Deprecated
-    public VariantContextWriterBuilder setOutputFile(final File outFile) {
-        return setOutputPath(IOUtil.toPath(outFile));
     }
 
     /**
@@ -529,21 +515,6 @@ public class VariantContextWriterBuilder {
             writer = new AsyncVariantContextWriter(writer, AsyncVariantContextWriter.DEFAULT_QUEUE_SIZE);
 
         return writer;
-    }
-
-    /**
-     * Attempts to determine the type of file/data to write based on the File path being
-     * written to. Will attempt to determine using the logical filename; if that fails it will
-     * attempt to resolve any symlinks and try again.  If that fails, and the output file exists
-     * but is neither a file or directory then VCF_STREAM is returned.
-     *
-     * @param file A file whose {@link OutputType} we want to infer
-     * @return The file's {@link OutputType}. Never {@code null}.
-     * @deprecated use {@link #determineOutputTypeFromFile(Path)} instead.
-     */
-    @Deprecated
-    public static OutputType determineOutputTypeFromFile(final File file) {
-        return determineOutputTypeFromFile(file.toPath());
     }
 
     /**

--- a/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
+++ b/src/main/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilder.java
@@ -74,13 +74,13 @@ import java.util.EnumSet;
  * .setBuffer(8192);
  *
  * VariantContextWriter sample1_writer = builder
- * .setOutputFile("sample1.vcf")
+ * .setOutputPath(Path.of("sample1.vcf"))
  * .build();
  * VariantContextWriter sample2_writer = builder
- * .setOutputFile("sample2.bcf")
+ * .setOutputPath(Path.of("sample2.bcf"))
  * .build();
  * VariantContextWriter sample3_writer = builder
- * .setOutputFile("sample3.vcf.bgzf")
+ * .setOutputPath(Path.of("sample3.vcf.bgzf"))
  * .build();
  * </pre>
  *
@@ -95,11 +95,11 @@ import java.util.EnumSet;
  * .unsetBuffering();
  *
  * VariantContextWriter sample1_writer = builder
- * .setOutputFile("sample1.custom_extension")
+ * .setOutputPath(Path.of("sample1.custom_extension"))
  * .setOutputFileType(OutputType.VCF)
  * .build();
  * VariantContextWriter sample2_writer = builder
- * .setOutputFile("sample2.custom_extension")
+ * .setOutputPath(Path.of("sample2.custom_extension"))
  * .setOutputFileType(OutputType.BLOCK_COMPRESSED_VCF)
  * .build();
  * </pre>
@@ -158,7 +158,9 @@ public class VariantContextWriterBuilder {
      *
      * @param outFile the file the <code>VariantContextWriter</code> will write to
      * @return this <code>VariantContextWriterBuilder</code>
+     * @deprecated use {@link #setOutputPath(Path)} instead.
      */
+    @Deprecated
     public VariantContextWriterBuilder setOutputFile(final File outFile) {
         return setOutputPath(IOUtil.toPath(outFile));
     }
@@ -178,14 +180,45 @@ public class VariantContextWriterBuilder {
     }
 
     /**
-     * Set the output file for the next <code>VariantContextWriter</code> created by this builder.
+     * Set the output for the next <code>VariantContextWriter</code> created by this builder from a URI.
      * Determines file type implicitly from the filename.
+     * <p>
+     * This is a convenience method that delegates to {@link #setOutputPath(Path)} after converting the URI to a
+     * {@link Path} via {@link IOUtil#getPath(java.net.URI)}. The URI's scheme must be supported by an available NIO filesystem
+     * provider (e.g. {@code file}, {@code gs}, etc.).
+     * </p>
      *
-     * @param outFile the file the <code>VariantContextWriter</code> will write to
+     * @param outUri the URI of the output the <code>VariantContextWriter</code> will write to
      * @return this <code>VariantContextWriterBuilder</code>
+     * @throws RuntimeIOException if the URI cannot be converted to a Path
+     */
+    public VariantContextWriterBuilder setOutputURI(final java.net.URI outUri) {
+        try {
+            return setOutputPath(IOUtil.getPath(outUri));
+        } catch (final IOException e) {
+            throw new RuntimeIOException("Could not convert URI to a Path: " + outUri, e);
+        }
+    }
+
+    /**
+     * Set the output for the next <code>VariantContextWriter</code> created by this builder.
+     * Determines file type implicitly from the filename.
+     * <p>
+     * The string is converted to a {@link Path} via {@link IOUtil#getPath(String)}, which is scheme-aware: a value
+     * with no scheme is treated as a local file, while a value with a scheme (e.g. {@code gs://}) is resolved using
+     * the matching NIO filesystem provider. For more control, use {@link #setOutputPath(Path)} directly.
+     * </p>
+     *
+     * @param outFile the output the <code>VariantContextWriter</code> will write to
+     * @return this <code>VariantContextWriterBuilder</code>
+     * @throws RuntimeIOException if the string cannot be converted to a Path
      */
     public VariantContextWriterBuilder setOutputFile(final String outFile) {
-        return setOutputFile(new File(outFile));
+        try {
+            return setOutputPath(IOUtil.getPath(outFile));
+        } catch (final IOException e) {
+            throw new RuntimeIOException("Could not convert to a Path: " + outFile, e);
+        }
     }
 
     /**
@@ -506,7 +539,9 @@ public class VariantContextWriterBuilder {
      *
      * @param file A file whose {@link OutputType} we want to infer
      * @return The file's {@link OutputType}. Never {@code null}.
+     * @deprecated use {@link #determineOutputTypeFromFile(Path)} instead.
      */
+    @Deprecated
     public static OutputType determineOutputTypeFromFile(final File file) {
         return determineOutputTypeFromFile(file.toPath());
     }

--- a/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -35,7 +35,6 @@ import htsjdk.tribble.FeatureReader;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
@@ -49,70 +48,10 @@ public class VCFFileReader implements VCFReader {
     private final FeatureReader<VariantContext> reader;
 
     /**
-     * Returns true if the given file appears to be a BCF file.
-     *
-     * @deprecated since June 2024, use {@link #isBCF(Path)} instead
-     */
-    @Deprecated
-    public static boolean isBCF(final File file) {
-        return isBCF(file.toPath());
-    }
-
-    /**
      * Returns true if the given path appears to be a BCF file.
      */
     public static boolean isBCF(final Path path) {
         return path.toUri().getRawPath().endsWith(FileExtensions.BCF);
-    }
-
-    /**
-     * Returns the SAMSequenceDictionary from the provided VCF file.
-     *
-     * @deprecated since June 2024, use {@link #getSequenceDictionary(Path)} instead
-     */
-    @Deprecated
-    public static SAMSequenceDictionary getSequenceDictionary(final File file) {
-        return getSequenceDictionary(file.toPath());
-    }
-
-    /**
-     * Constructs a VCFFileReader that requires the index to be present.
-     *
-     * @deprecated since June 2024, use {@link #VCFFileReader(Path)} instead
-     */
-    @Deprecated
-    public VCFFileReader(final File file) {
-        this(file.toPath());
-    }
-
-    /**
-     * Constructs a VCFFileReader with a specified index.
-     *
-     * @deprecated since June 2024, use {@link #VCFFileReader(Path, Path)} instead
-     */
-    @Deprecated
-    public VCFFileReader(final File file, final File indexFile) {
-        this(file.toPath(), indexFile.toPath());
-    }
-
-    /**
-     * Allows construction of a VCFFileReader that will or will not assert the presence of an index as desired.
-     *
-     * @deprecated since June 2024, use {@link #VCFFileReader(Path, boolean)} instead
-     */
-    @Deprecated
-    public VCFFileReader(final File file, final boolean requireIndex) {
-        this(file.toPath(), requireIndex);
-    }
-
-    /**
-     * Allows construction of a VCFFileReader with a specified index file.
-     *
-     * @deprecated since June 2024, use {@link #VCFFileReader(Path, Path, boolean)} instead
-     */
-    @Deprecated
-    public VCFFileReader(final File file, final File indexFile, final boolean requireIndex) {
-        this(file.toPath(), indexFile.toPath(), requireIndex);
     }
 
     /**
@@ -180,33 +119,6 @@ public class VCFFileReader implements VCFReader {
         try (final VCFFileReader vcfReader = new VCFFileReader(path, false)) {
             return vcfReader.toIntervalList(includeFiltered);
         }
-    }
-
-    /**
-     * Parse a VCF file and convert to an IntervalList The name field of the IntervalList is taken from the ID field of the variant, if it exists. if not,
-     * creates a name of the format interval-n where n is a running number that increments only on un-named intervals
-     *
-     * @param file a VCF
-     * @return an {@link IntervalList}
-     *
-     * @deprecated since July 2018 use {@link #toIntervalList(Path)} instead
-     */
-    @Deprecated
-    public static IntervalList fromVcf(final File file) {
-        return toIntervalList(file.toPath());
-    }
-
-    /**
-     * Parse a VCF file and convert to an IntervalList The name field of the IntervalList is taken from the ID field of the variant, if it exists. if not,
-     * creates a name of the format interval-n where n is a running number that increments only on un-named intervals
-     *
-     * @param file
-     * @return
-     * @deprecated since July 2018 use {@link #toIntervalList(Path, boolean)} instead
-     */
-    @Deprecated
-    public static IntervalList fromVcf(final File file, final boolean includeFiltered) {
-        return toIntervalList(file.toPath(), includeFiltered);
     }
 
     /**

--- a/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFFileReader.java
@@ -50,7 +50,10 @@ public class VCFFileReader implements VCFReader {
 
     /**
      * Returns true if the given file appears to be a BCF file.
+     *
+     * @deprecated since June 2024, use {@link #isBCF(Path)} instead
      */
+    @Deprecated
     public static boolean isBCF(final File file) {
         return isBCF(file.toPath());
     }
@@ -64,42 +67,51 @@ public class VCFFileReader implements VCFReader {
 
     /**
      * Returns the SAMSequenceDictionary from the provided VCF file.
+     *
+     * @deprecated since June 2024, use {@link #getSequenceDictionary(Path)} instead
      */
+    @Deprecated
     public static SAMSequenceDictionary getSequenceDictionary(final File file) {
-        try (final VCFFileReader vcfFileReader = new VCFFileReader(file, false)) {
-            return vcfFileReader.getFileHeader().getSequenceDictionary();
-        }
+        return getSequenceDictionary(file.toPath());
     }
 
     /**
      * Constructs a VCFFileReader that requires the index to be present.
+     *
+     * @deprecated since June 2024, use {@link #VCFFileReader(Path)} instead
      */
+    @Deprecated
     public VCFFileReader(final File file) {
-        this(file, true);
+        this(file.toPath());
     }
 
     /**
      * Constructs a VCFFileReader with a specified index.
+     *
+     * @deprecated since June 2024, use {@link #VCFFileReader(Path, Path)} instead
      */
+    @Deprecated
     public VCFFileReader(final File file, final File indexFile) {
-        this(file, indexFile, true);
+        this(file.toPath(), indexFile.toPath());
     }
 
     /**
      * Allows construction of a VCFFileReader that will or will not assert the presence of an index as desired.
+     *
+     * @deprecated since June 2024, use {@link #VCFFileReader(Path, boolean)} instead
      */
+    @Deprecated
     public VCFFileReader(final File file, final boolean requireIndex) {
-        // Note how we deal with type safety here, just casting to (FeatureCodec)
-        // in the call to getFeatureReader is not enough for Java 8.
         this(file.toPath(), requireIndex);
     }
 
     /**
      * Allows construction of a VCFFileReader with a specified index file.
+     *
+     * @deprecated since June 2024, use {@link #VCFFileReader(Path, Path, boolean)} instead
      */
+    @Deprecated
     public VCFFileReader(final File file, final File indexFile, final boolean requireIndex) {
-        // Note how we deal with type safety here, just casting to (FeatureCodec)
-        // in the call to getFeatureReader is not enough for Java 8.
         this(file.toPath(), indexFile.toPath(), requireIndex);
     }
 
@@ -115,7 +127,7 @@ public class VCFFileReader implements VCFReader {
     }
 
     /**
-     * Returns the SAMSequenceDictionary from the provided VCF file.
+     * Returns the SAMSequenceDictionary from the provided VCF path.
      */
     public static SAMSequenceDictionary getSequenceDictionary(final Path path) {
         try (final VCFFileReader r = new VCFFileReader(path, false)) {

--- a/src/main/java/htsjdk/variant/vcf/VCFIteratorBuilder.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFIteratorBuilder.java
@@ -34,7 +34,6 @@ import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.bcf2.BCFVersion;
 import htsjdk.variant.variantcontext.VariantContext;
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.SeekableByteChannel;
@@ -145,20 +144,6 @@ public class VCFIteratorBuilder {
     public VCFIterator open(final String path, final Function<SeekableByteChannel, SeekableByteChannel> wrapper)
             throws IOException {
         return open(ParsingUtils.openInputStream(path, wrapper));
-    }
-
-    /**
-     * creates a VCF iterator from a File
-     *
-     * @param file the file (can be bcf, vcf, vcf.gz)
-     * @return the VCFIterator
-     * @throws IOException
-     * @deprecated use {@link #open(Path)} instead.
-     */
-    @Deprecated
-    @SuppressWarnings("static-method")
-    public VCFIterator open(final File file) throws IOException {
-        return this.open(file.toPath());
     }
 
     /** implementation of VCFIterator, reading VCF */

--- a/src/main/java/htsjdk/variant/vcf/VCFIteratorBuilder.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFIteratorBuilder.java
@@ -153,7 +153,9 @@ public class VCFIteratorBuilder {
      * @param file the file (can be bcf, vcf, vcf.gz)
      * @return the VCFIterator
      * @throws IOException
+     * @deprecated use {@link #open(Path)} instead.
      */
+    @Deprecated
     @SuppressWarnings("static-method")
     public VCFIterator open(final File file) throws IOException {
         return this.open(file.toPath());

--- a/src/main/java/htsjdk/variant/vcf/VCFUtils.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFUtils.java
@@ -35,6 +35,8 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -148,24 +150,47 @@ public class VCFUtils {
      * Add / replace the contig header lines in the VCFHeader with the in the reference file and master reference dictionary
      *
      * @param oldHeader     the header to update
-     * @param referenceFile the file path to the reference sequence used to generate this vcf
+     * @param referencePath the path to the reference sequence used to generate this vcf
      * @param refDict       the SAM formatted reference sequence dictionary
      */
     public static VCFHeader withUpdatedContigs(
-            final VCFHeader oldHeader, final File referenceFile, final SAMSequenceDictionary refDict) {
+            final VCFHeader oldHeader, final Path referencePath, final SAMSequenceDictionary refDict) {
         return new VCFHeader(
-                withUpdatedContigsAsLines(oldHeader.getMetaDataInInputOrder(), referenceFile, refDict),
+                withUpdatedContigsAsLines(oldHeader.getMetaDataInInputOrder(), referencePath, refDict),
                 oldHeader.getGenotypeSamples());
     }
 
+    /**
+     * Add / replace the contig header lines in the VCFHeader with the in the reference file and master reference dictionary
+     *
+     * @param oldHeader     the header to update
+     * @param referenceFile the file path to the reference sequence used to generate this vcf
+     * @param refDict       the SAM formatted reference sequence dictionary
+     * @deprecated use {@link #withUpdatedContigs(VCFHeader, Path, SAMSequenceDictionary)} instead.
+     */
+    @Deprecated
+    public static VCFHeader withUpdatedContigs(
+            final VCFHeader oldHeader, final File referenceFile, final SAMSequenceDictionary refDict) {
+        return withUpdatedContigs(oldHeader, referenceFile == null ? null : referenceFile.toPath(), refDict);
+    }
+
+    public static Set<VCFHeaderLine> withUpdatedContigsAsLines(
+            final Set<VCFHeaderLine> oldLines, final Path referencePath, final SAMSequenceDictionary refDict) {
+        return withUpdatedContigsAsLines(oldLines, referencePath, refDict, false);
+    }
+
+    /**
+     * @deprecated use {@link #withUpdatedContigsAsLines(Set, Path, SAMSequenceDictionary)} instead.
+     */
+    @Deprecated
     public static Set<VCFHeaderLine> withUpdatedContigsAsLines(
             final Set<VCFHeaderLine> oldLines, final File referenceFile, final SAMSequenceDictionary refDict) {
-        return withUpdatedContigsAsLines(oldLines, referenceFile, refDict, false);
+        return withUpdatedContigsAsLines(oldLines, referenceFile == null ? null : referenceFile.toPath(), refDict);
     }
 
     public static Set<VCFHeaderLine> withUpdatedContigsAsLines(
             final Set<VCFHeaderLine> oldLines,
-            final File referenceFile,
+            final Path referencePath,
             final SAMSequenceDictionary refDict,
             final boolean referenceNameOnly) {
         final Set<VCFHeaderLine> lines = new LinkedHashSet<>(oldLines.size());
@@ -176,20 +201,49 @@ public class VCFUtils {
             lines.add(line);
         }
 
-        for (final VCFHeaderLine contigLine : makeContigHeaderLines(refDict, referenceFile)) lines.add(contigLine);
+        for (final VCFHeaderLine contigLine : makeContigHeaderLines(refDict, referencePath)) lines.add(contigLine);
 
         final String referenceValue;
-        if (referenceFile != null) {
+        if (referencePath != null) {
             if (referenceNameOnly) {
-                final int extensionStart = referenceFile.getName().lastIndexOf('.');
-                referenceValue = extensionStart == -1
-                        ? referenceFile.getName()
-                        : referenceFile.getName().substring(0, extensionStart);
+                final String fileName = referencePath.getFileName().toString();
+                final int extensionStart = fileName.lastIndexOf('.');
+                referenceValue = extensionStart == -1 ? fileName : fileName.substring(0, extensionStart);
             } else {
-                referenceValue = "file://" + referenceFile.getAbsolutePath();
+                referenceValue = "file://" + referencePath.toAbsolutePath();
             }
             lines.add(new VCFHeaderLine(VCFHeader.REFERENCE_KEY, referenceValue));
         }
+        return lines;
+    }
+
+    /**
+     * @deprecated use {@link #withUpdatedContigsAsLines(Set, Path, SAMSequenceDictionary, boolean)} instead.
+     */
+    @Deprecated
+    public static Set<VCFHeaderLine> withUpdatedContigsAsLines(
+            final Set<VCFHeaderLine> oldLines,
+            final File referenceFile,
+            final SAMSequenceDictionary refDict,
+            final boolean referenceNameOnly) {
+        return withUpdatedContigsAsLines(
+                oldLines, referenceFile == null ? null : referenceFile.toPath(), refDict, referenceNameOnly);
+    }
+
+    /**
+     * Create VCFHeaderLines for each refDict entry, and optionally the assembly if referencePath != null
+     *
+     * @param refDict       reference dictionary
+     * @param referencePath for assembly name.  May be null
+     * @return list of vcf contig header lines
+     */
+    public static List<VCFContigHeaderLine> makeContigHeaderLines(
+            final SAMSequenceDictionary refDict, final Path referencePath) {
+        final List<VCFContigHeaderLine> lines = new ArrayList<>();
+        final String assembly = referencePath != null
+                ? getReferenceAssembly(referencePath.getFileName().toString())
+                : null;
+        for (final SAMSequenceRecord contig : refDict.getSequences()) lines.add(makeContigHeaderLine(contig, assembly));
         return lines;
     }
 
@@ -199,13 +253,12 @@ public class VCFUtils {
      * @param refDict       reference dictionary
      * @param referenceFile for assembly name.  May be null
      * @return list of vcf contig header lines
+     * @deprecated use {@link #makeContigHeaderLines(SAMSequenceDictionary, Path)} instead.
      */
+    @Deprecated
     public static List<VCFContigHeaderLine> makeContigHeaderLines(
             final SAMSequenceDictionary refDict, final File referenceFile) {
-        final List<VCFContigHeaderLine> lines = new ArrayList<>();
-        final String assembly = referenceFile != null ? getReferenceAssembly(referenceFile.getName()) : null;
-        for (final SAMSequenceRecord contig : refDict.getSequences()) lines.add(makeContigHeaderLine(contig, assembly));
-        return lines;
+        return makeContigHeaderLines(refDict, referenceFile == null ? null : referenceFile.toPath());
     }
 
     private static VCFContigHeaderLine makeContigHeaderLine(final SAMSequenceRecord contig, final String assembly) {
@@ -221,12 +274,12 @@ public class VCFUtils {
      *
      * @param prefix - The prefix string to be used in generating the file's name; must be at least three characters long
      * @param suffix - The suffix string to be used in generating the file's name; may be null, in which case the suffix ".tmp" will be used
-     * @return A File object referencing the newly created temporary VCF file
+     * @return A Path object referencing the newly created temporary VCF file
      * @throws IOException - if a file could not be created.
      */
-    public static File createTemporaryIndexedVcfFile(final String prefix, final String suffix) throws IOException {
-        final File out = File.createTempFile(prefix, suffix);
-        out.deleteOnExit();
+    public static Path createTemporaryIndexedVcfPath(final String prefix, final String suffix) throws IOException {
+        final Path out = Files.createTempFile(prefix, suffix);
+        out.toFile().deleteOnExit();
         String indexFileExtension = null;
         if (suffix.endsWith(FileExtensions.COMPRESSED_VCF)) {
             indexFileExtension = FileExtensions.COMPRESSED_VCF_INDEX;
@@ -234,10 +287,60 @@ public class VCFUtils {
             indexFileExtension = FileExtensions.VCF_INDEX;
         }
         if (indexFileExtension != null) {
-            final File indexOut = new File(out.getAbsolutePath() + indexFileExtension);
-            indexOut.deleteOnExit();
+            final Path indexOut = out.resolveSibling(out.getFileName().toString() + indexFileExtension);
+            indexOut.toFile().deleteOnExit();
         }
         return out;
+    }
+
+    /**
+     * This method creates a temporary VCF file and its appropriately named index file, and will delete them on exit.
+     *
+     * @param prefix - The prefix string to be used in generating the file's name; must be at least three characters long
+     * @param suffix - The suffix string to be used in generating the file's name; may be null, in which case the suffix ".tmp" will be used
+     * @return A File object referencing the newly created temporary VCF file
+     * @throws IOException - if a file could not be created.
+     * @deprecated use {@link #createTemporaryIndexedVcfPath(String, String)} instead.
+     */
+    @Deprecated
+    public static File createTemporaryIndexedVcfFile(final String prefix, final String suffix) throws IOException {
+        return createTemporaryIndexedVcfPath(prefix, suffix).toFile();
+    }
+
+    /**
+     * This method makes a copy of the input VCF and creates an index file for it in the same location.
+     * This is done so that we don't need to store the index file in the same repo
+     * The copy of the input is done so that it and its index are in the same directory which is typically required.
+     *
+     * @param vcfPath the vcf file to index
+     * @return Path a vcf file (index file is created in same path).
+     */
+    public static Path createTemporaryIndexedVcfFromInput(final Path vcfPath, final String tempFilePrefix)
+            throws IOException {
+        final String extension;
+
+        if (vcfPath.toAbsolutePath().toString().endsWith(FileExtensions.VCF)) extension = FileExtensions.VCF;
+        else if (vcfPath.toAbsolutePath().toString().endsWith(FileExtensions.COMPRESSED_VCF))
+            extension = FileExtensions.COMPRESSED_VCF;
+        else
+            throw new IllegalArgumentException("couldn't find a " + FileExtensions.VCF + " or "
+                    + FileExtensions.COMPRESSED_VCF + " ending for input file " + vcfPath.toAbsolutePath());
+
+        Path output = createTemporaryIndexedVcfPath(tempFilePrefix, extension);
+
+        try (final VCFFileReader in = new VCFFileReader(vcfPath, false);
+                final VariantContextWriter out = new VariantContextWriterBuilder()
+                        .setReferenceDictionary(in.getFileHeader().getSequenceDictionary())
+                        .setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY))
+                        .setOutputPath(output)
+                        .build()) {
+            out.writeHeader(in.getFileHeader());
+            for (final VariantContext ctx : in) {
+                out.add(ctx);
+            }
+        }
+
+        return output;
     }
 
     /**
@@ -247,33 +350,13 @@ public class VCFUtils {
      *
      * @param vcfFile the vcf file to index
      * @return File a vcf file (index file is created in same path).
+     * @deprecated use {@link #createTemporaryIndexedVcfFromInput(Path, String)} instead.
      */
+    @Deprecated
     public static File createTemporaryIndexedVcfFromInput(final File vcfFile, final String tempFilePrefix)
             throws IOException {
-        final String extension;
-
-        if (vcfFile.getAbsolutePath().endsWith(FileExtensions.VCF)) extension = FileExtensions.VCF;
-        else if (vcfFile.getAbsolutePath().endsWith(FileExtensions.COMPRESSED_VCF))
-            extension = FileExtensions.COMPRESSED_VCF;
-        else
-            throw new IllegalArgumentException("couldn't find a " + FileExtensions.VCF + " or "
-                    + FileExtensions.COMPRESSED_VCF + " ending for input file " + vcfFile.getAbsolutePath());
-
-        File output = createTemporaryIndexedVcfFile(tempFilePrefix, extension);
-
-        try (final VCFFileReader in = new VCFFileReader(vcfFile, false);
-                final VariantContextWriter out = new VariantContextWriterBuilder()
-                        .setReferenceDictionary(in.getFileHeader().getSequenceDictionary())
-                        .setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY))
-                        .setOutputFile(output)
-                        .build()) {
-            out.writeHeader(in.getFileHeader());
-            for (final VariantContext ctx : in) {
-                out.add(ctx);
-            }
-        }
-
-        return output;
+        return createTemporaryIndexedVcfFromInput(vcfFile.toPath(), tempFilePrefix)
+                .toFile();
     }
 
     /**

--- a/src/main/java/htsjdk/variant/vcf/VCFUtils.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFUtils.java
@@ -33,7 +33,6 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -160,32 +159,9 @@ public class VCFUtils {
                 oldHeader.getGenotypeSamples());
     }
 
-    /**
-     * Add / replace the contig header lines in the VCFHeader with the in the reference file and master reference dictionary
-     *
-     * @param oldHeader     the header to update
-     * @param referenceFile the file path to the reference sequence used to generate this vcf
-     * @param refDict       the SAM formatted reference sequence dictionary
-     * @deprecated use {@link #withUpdatedContigs(VCFHeader, Path, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public static VCFHeader withUpdatedContigs(
-            final VCFHeader oldHeader, final File referenceFile, final SAMSequenceDictionary refDict) {
-        return withUpdatedContigs(oldHeader, referenceFile == null ? null : referenceFile.toPath(), refDict);
-    }
-
     public static Set<VCFHeaderLine> withUpdatedContigsAsLines(
             final Set<VCFHeaderLine> oldLines, final Path referencePath, final SAMSequenceDictionary refDict) {
         return withUpdatedContigsAsLines(oldLines, referencePath, refDict, false);
-    }
-
-    /**
-     * @deprecated use {@link #withUpdatedContigsAsLines(Set, Path, SAMSequenceDictionary)} instead.
-     */
-    @Deprecated
-    public static Set<VCFHeaderLine> withUpdatedContigsAsLines(
-            final Set<VCFHeaderLine> oldLines, final File referenceFile, final SAMSequenceDictionary refDict) {
-        return withUpdatedContigsAsLines(oldLines, referenceFile == null ? null : referenceFile.toPath(), refDict);
     }
 
     public static Set<VCFHeaderLine> withUpdatedContigsAsLines(
@@ -218,19 +194,6 @@ public class VCFUtils {
     }
 
     /**
-     * @deprecated use {@link #withUpdatedContigsAsLines(Set, Path, SAMSequenceDictionary, boolean)} instead.
-     */
-    @Deprecated
-    public static Set<VCFHeaderLine> withUpdatedContigsAsLines(
-            final Set<VCFHeaderLine> oldLines,
-            final File referenceFile,
-            final SAMSequenceDictionary refDict,
-            final boolean referenceNameOnly) {
-        return withUpdatedContigsAsLines(
-                oldLines, referenceFile == null ? null : referenceFile.toPath(), refDict, referenceNameOnly);
-    }
-
-    /**
      * Create VCFHeaderLines for each refDict entry, and optionally the assembly if referencePath != null
      *
      * @param refDict       reference dictionary
@@ -245,20 +208,6 @@ public class VCFUtils {
                 : null;
         for (final SAMSequenceRecord contig : refDict.getSequences()) lines.add(makeContigHeaderLine(contig, assembly));
         return lines;
-    }
-
-    /**
-     * Create VCFHeaderLines for each refDict entry, and optionally the assembly if referenceFile != null
-     *
-     * @param refDict       reference dictionary
-     * @param referenceFile for assembly name.  May be null
-     * @return list of vcf contig header lines
-     * @deprecated use {@link #makeContigHeaderLines(SAMSequenceDictionary, Path)} instead.
-     */
-    @Deprecated
-    public static List<VCFContigHeaderLine> makeContigHeaderLines(
-            final SAMSequenceDictionary refDict, final File referenceFile) {
-        return makeContigHeaderLines(refDict, referenceFile == null ? null : referenceFile.toPath());
     }
 
     private static VCFContigHeaderLine makeContigHeaderLine(final SAMSequenceRecord contig, final String assembly) {
@@ -291,20 +240,6 @@ public class VCFUtils {
             indexOut.toFile().deleteOnExit();
         }
         return out;
-    }
-
-    /**
-     * This method creates a temporary VCF file and its appropriately named index file, and will delete them on exit.
-     *
-     * @param prefix - The prefix string to be used in generating the file's name; must be at least three characters long
-     * @param suffix - The suffix string to be used in generating the file's name; may be null, in which case the suffix ".tmp" will be used
-     * @return A File object referencing the newly created temporary VCF file
-     * @throws IOException - if a file could not be created.
-     * @deprecated use {@link #createTemporaryIndexedVcfPath(String, String)} instead.
-     */
-    @Deprecated
-    public static File createTemporaryIndexedVcfFile(final String prefix, final String suffix) throws IOException {
-        return createTemporaryIndexedVcfPath(prefix, suffix).toFile();
     }
 
     /**
@@ -341,22 +276,6 @@ public class VCFUtils {
         }
 
         return output;
-    }
-
-    /**
-     * This method makes a copy of the input VCF and creates an index file for it in the same location.
-     * This is done so that we don't need to store the index file in the same repo
-     * The copy of the input is done so that it and its index are in the same directory which is typically required.
-     *
-     * @param vcfFile the vcf file to index
-     * @return File a vcf file (index file is created in same path).
-     * @deprecated use {@link #createTemporaryIndexedVcfFromInput(Path, String)} instead.
-     */
-    @Deprecated
-    public static File createTemporaryIndexedVcfFromInput(final File vcfFile, final String tempFilePrefix)
-            throws IOException {
-        return createTemporaryIndexedVcfFromInput(vcfFile.toPath(), tempFilePrefix)
-                .toFile();
     }
 
     /**

--- a/src/main/java/htsjdk/variant/vcf/VCFUtils.java
+++ b/src/main/java/htsjdk/variant/vcf/VCFUtils.java
@@ -28,6 +28,7 @@ package htsjdk.variant.vcf;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.FileExtensions;
+import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.utils.GeneralUtils;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.Options;
@@ -228,7 +229,7 @@ public class VCFUtils {
      */
     public static Path createTemporaryIndexedVcfPath(final String prefix, final String suffix) throws IOException {
         final Path out = Files.createTempFile(prefix, suffix);
-        out.toFile().deleteOnExit();
+        IOUtil.deleteOnExit(out);
         String indexFileExtension = null;
         if (suffix.endsWith(FileExtensions.COMPRESSED_VCF)) {
             indexFileExtension = FileExtensions.COMPRESSED_VCF_INDEX;
@@ -237,7 +238,7 @@ public class VCFUtils {
         }
         if (indexFileExtension != null) {
             final Path indexOut = out.resolveSibling(out.getFileName().toString() + indexFileExtension);
-            indexOut.toFile().deleteOnExit();
+            IOUtil.deleteOnExit(indexOut);
         }
         return out;
     }

--- a/src/test/java/htsjdk/beta/codecs/hapref/fasta/HaploidReferenceResolverTest.java
+++ b/src/test/java/htsjdk/beta/codecs/hapref/fasta/HaploidReferenceResolverTest.java
@@ -9,11 +9,11 @@ import htsjdk.beta.io.bundle.BundleResourceType;
 import htsjdk.beta.plugin.registry.HaploidReferenceResolver;
 import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -26,25 +26,49 @@ public class HaploidReferenceResolverTest extends HtsjdkTest {
         final String dataDir = "src/test/resources/htsjdk/samtools/reference";
 
         return new Object[][] {
-            {new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta").getAbsolutePath()), null, null, null
-            },
             {
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.dict").getAbsolutePath()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.fasta")
+                        .toAbsolutePath()
+                        .toString()),
+                null,
                 null,
                 null
             },
             {
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.dict").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.fai").getAbsolutePath()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.fasta")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.dict")
+                        .toAbsolutePath()
+                        .toString()),
+                null,
                 null
             },
             {
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.dict").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz.fai").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz.gzi").getAbsolutePath()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.fasta")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.dict")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.fai")
+                        .toAbsolutePath()
+                        .toString()),
+                null
+            },
+            {
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.dict")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz.fai")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(Paths.get(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz.gzi")
+                        .toAbsolutePath()
+                        .toString()),
             },
         };
     }

--- a/src/test/java/htsjdk/beta/codecs/reads/bam/HtsBAMDecoderQueryTest.java
+++ b/src/test/java/htsjdk/beta/codecs/reads/bam/HtsBAMDecoderQueryTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
 public class HtsBAMDecoderQueryTest extends HtsjdkTest {
     private final IOPath TEST_BAM = new HtsPath("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
     private final IOPath TEST_BAI =
-            new HtsPath(SamFiles.findIndex(TEST_BAM.toPath().toFile()).toString());
+            new HtsPath(SamFiles.findIndex(TEST_BAM.toPath()).toString());
     private final boolean mVerbose = false;
 
     @DataProvider(name = "queryMethodsCases")

--- a/src/test/java/htsjdk/beta/codecs/reads/cram/HtsCRAMCodec30And21QueryTest.java
+++ b/src/test/java/htsjdk/beta/codecs/reads/cram/HtsCRAMCodec30And21QueryTest.java
@@ -20,8 +20,9 @@ import htsjdk.samtools.SamFiles;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloseableIterator;
-import java.io.FileOutputStream;
+import htsjdk.samtools.util.IOUtil;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -65,29 +66,27 @@ public class HtsCRAMCodec30And21QueryTest extends HtsjdkTest {
     public void createLocallyGeneratedCRAIFiles() throws IOException {
         cramQueryWithLocalCRAI = IOPathUtils.createTempPath("cramQueryWithLocalCRAI.", ".cram");
         IOPath tempCRAIOut = new HtsPath(cramQueryWithLocalCRAI.getURIString() + ".crai");
-        tempCRAIOut.toPath().toFile().deleteOnExit();
+        IOUtil.deleteOnExit(tempCRAIOut.toPath());
         createLocalCRAMAndCRAI(cramQueryWithCRAI, cramQueryWithLocalCRAI, tempCRAIOut);
 
         cramQueryReadsWithLocalCRAI = IOPathUtils.createTempPath("cramQueryReadsWithLocalCRAI.", ".cram");
         tempCRAIOut = new HtsPath(cramQueryReadsWithLocalCRAI.getURIString() + ".crai");
-        tempCRAIOut.toPath().toFile().deleteOnExit();
-        cramQueryReadsWithLocalCRAI.toPath().toFile().deleteOnExit();
+        IOUtil.deleteOnExit(tempCRAIOut.toPath());
+        IOUtil.deleteOnExit(cramQueryReadsWithLocalCRAI.toPath());
         createLocalCRAMAndCRAI(cramQueryReadsWithBAI, cramQueryReadsWithLocalCRAI, tempCRAIOut);
 
         cramQueryTestEmptyWithLocalCRAI = IOPathUtils.createTempPath("cramQueryTestEmptyWithLocalCRAI.", ".cram");
         tempCRAIOut = new HtsPath(cramQueryTestEmptyWithLocalCRAI.getURIString() + ".crai");
-        tempCRAIOut.toPath().toFile().deleteOnExit();
-        cramQueryTestEmptyWithLocalCRAI.toPath().toFile().deleteOnExit();
+        IOUtil.deleteOnExit(tempCRAIOut.toPath());
+        IOUtil.deleteOnExit(cramQueryTestEmptyWithLocalCRAI.toPath());
         createLocalCRAMAndCRAI(cramQueryTestEmptyWithBAI, cramQueryTestEmptyWithLocalCRAI, tempCRAIOut);
     }
 
     private void createLocalCRAMAndCRAI(final IOPath inputCRAM, final IOPath outputCRAM, final IOPath outputCRAI)
             throws IOException {
         Files.copy(inputCRAM.toPath(), outputCRAM.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        try (final FileOutputStream bos =
-                        new FileOutputStream(outputCRAI.toPath().toFile());
-                final SeekableFileStream sfs =
-                        new SeekableFileStream(outputCRAM.toPath().toFile())) {
+        try (final OutputStream bos = Files.newOutputStream(outputCRAI.toPath());
+                final SeekableFileStream sfs = new SeekableFileStream(outputCRAM.toPath())) {
             CRAMCRAIIndexer.writeIndex(sfs, bos);
         }
     }

--- a/src/test/java/htsjdk/beta/codecs/reads/htsget/HtsgetBAM/HtsgetBAMCodecTest.java
+++ b/src/test/java/htsjdk/beta/codecs/reads/htsget/HtsgetBAM/HtsgetBAMCodecTest.java
@@ -19,8 +19,8 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.CloseableIterator;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 public class HtsgetBAMCodecTest extends HtsjdkTest {
     private static final IOPath htsgetBAM = new HtsPath(
             HtsgetBAMFileReaderTest.HTSGET_ENDPOINT + HtsgetBAMFileReaderTest.LOCAL_PREFIX + "index_test.bam");
-    private static final File bamFile = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private static final Path bamFile = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testThrowOnGetEncoder() {

--- a/src/test/java/htsjdk/beta/plugin/registry/HtsCodecResolverTest.java
+++ b/src/test/java/htsjdk/beta/plugin/registry/HtsCodecResolverTest.java
@@ -19,10 +19,10 @@ import htsjdk.io.IOPath;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -746,7 +746,7 @@ public class HtsCodecResolverTest extends HtsjdkTest {
 
     static final InputStream getInputStreamOnGzippedContent(final String contents) {
         try (final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            try (final BlockCompressedOutputStream bcs = new BlockCompressedOutputStream(bos, (File) null)) {
+            try (final BlockCompressedOutputStream bcs = new BlockCompressedOutputStream(bos, (Path) null)) {
                 bcs.write(contents.getBytes());
             }
             final byte array[] = bos.toByteArray();

--- a/src/test/java/htsjdk/io/AsyncWriterPoolTest.java
+++ b/src/test/java/htsjdk/io/AsyncWriterPoolTest.java
@@ -3,7 +3,8 @@ package htsjdk.io;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -63,13 +64,13 @@ public class AsyncWriterPoolTest extends HtsjdkTest {
         for (int threads = 1; threads <= 4; threads++) {
             AsyncWriterPool pool = new AsyncWriterPool(threads);
             int fileNum = 8;
-            ArrayList<File> files = new ArrayList<>();
+            ArrayList<Path> files = new ArrayList<>();
             ArrayList<Writer<String>> writers = new ArrayList<>();
             ArrayList<Iterator<Integer>> streams = new ArrayList<>();
             for (int i = 0; i < fileNum; i++) {
-                File file = File.createTempFile(String.format("AsyncPoolWriter_%s_%s", threads, i), ".tmp");
-                file.deleteOnExit();
-                TestWriter writer = new TestWriter(file.toPath());
+                Path file = Files.createTempFile(String.format("AsyncPoolWriter_%s_%s", threads, i), ".tmp");
+                IOUtil.deleteOnExit(file);
+                TestWriter writer = new TestWriter(file);
                 files.add(file);
                 Writer<String> pooledWriter = pool.pool(writer, new LinkedBlockingQueue<>(), 15);
                 writers.add(pooledWriter);
@@ -89,7 +90,7 @@ public class AsyncWriterPoolTest extends HtsjdkTest {
 
             // Verify that values wrote in order and in full
             for (int i = 0; i < fileNum; i++) {
-                File file = files.get(i);
+                Path file = files.get(i);
                 List<Integer> lines =
                         IOUtil.slurpLines(file).stream().map(Integer::parseInt).collect(Collectors.toList());
                 Assert.assertTrue(AsyncWriterPoolTest.isSorted(lines));
@@ -102,9 +103,9 @@ public class AsyncWriterPoolTest extends HtsjdkTest {
     public void testNoSelfSuppression() throws IOException {
 
         AsyncWriterPool pool = new AsyncWriterPool(4);
-        File file = File.createTempFile("AsyncPoolWriterTest", ".tmp");
-        file.deleteOnExit();
-        TestWriter writer = new TestWriter(file.toPath());
+        Path file = Files.createTempFile("AsyncPoolWriterTest", ".tmp");
+        IOUtil.deleteOnExit(file);
+        TestWriter writer = new TestWriter(file);
         Writer<String> pooledWriter =
                 pool.pool(writer, new LinkedBlockingQueue<>(), 1); // NB: buffsize must be 1 to make tests work
         writer.close(); // Close the inner writer so an exception will be thrown when a thread trys to write to it

--- a/src/test/java/htsjdk/io/HtsPathUnitTest.java
+++ b/src/test/java/htsjdk/io/HtsPathUnitTest.java
@@ -5,13 +5,13 @@ import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.ProviderNotFoundException;
@@ -323,12 +323,8 @@ public class HtsPathUnitTest extends HtsjdkTest {
     public Object[][] outputStreamPaths() throws IOException {
         return new Object[][] {
             // output URIs that can be resolved to an actual test file
-            {File.createTempFile("testOutputStream", ".txt").toString()},
-            {
-                "file://"
-                        + getLocalFileAsURIPathString(
-                                File.createTempFile("testOutputStream", ".txt").toPath())
-            },
+            {Files.createTempFile("testOutputStream", ".txt").toString()},
+            {"file://" + getLocalFileAsURIPathString(Files.createTempFile("testOutputStream", ".txt"))},
         };
     }
 
@@ -676,7 +672,7 @@ public class HtsPathUnitTest extends HtsjdkTest {
      * Returns /Users/user/=
      */
     private static String getCWDAsFileReference() {
-        return new File(".").getAbsolutePath();
+        return Paths.get(".").toAbsolutePath().toString();
     }
 
     /**
@@ -699,9 +695,8 @@ public class HtsPathUnitTest extends HtsjdkTest {
     }
 
     /**
-     * Get just the path part of the URI representing a file on the local file system. This
-     * uses java.io.File to get a locally valid file reference, which is then converted to
-     * a URI.
+     * Get just the path part of the URI representing a file on the local file system. The
+     * supplied Path is converted to a normalized URI.
      */
     private String getLocalFileAsURIPathString(final Path localPath) {
         return localPath.toUri().normalize().getPath();

--- a/src/test/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/AbstractBAMFileIndexTest.java
@@ -2,15 +2,15 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.seekablestream.SeekableStream;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class AbstractBAMFileIndexTest extends HtsjdkTest {
 
     private static final AbstractBAMFileIndex afi = new DiskBasedBAMFileIndex(
-            new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai"), null);
+            Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai"), null);
 
     /**
      * @see <a href="https://github.com/samtools/htsjdk/issues/73">https://github.com/samtools/htsjdk/issues/73</a>

--- a/src/test/java/htsjdk/samtools/BAMCigarOverflowTest.java
+++ b/src/test/java/htsjdk/samtools/BAMCigarOverflowTest.java
@@ -4,7 +4,7 @@ import static org.testng.Assert.assertEquals;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloserUtil;
-import java.io.File;
+import java.nio.file.Path;
 import org.testng.annotations.Test;
 
 /**
@@ -12,13 +12,13 @@ import org.testng.annotations.Test;
  * causes an overflow in the CIGAR when reading a BAM file for a read that spans a very large intron.
  */
 public class BAMCigarOverflowTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
 
     @Test
     public void testCigarOverflow() throws Exception {
         final SamReader reader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.LENIENT)
-                .open(new File(TEST_DATA_DIR, "BAMCigarOverflowTest/CigarOverflowTest.bam"));
+                .open(TEST_DATA_DIR.resolve("BAMCigarOverflowTest/CigarOverflowTest.bam"));
 
         // Load the single read from the BAM file.
         final SAMRecord testBAMRecord = reader.iterator().next();

--- a/src/test/java/htsjdk/samtools/BAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileIndexTest.java
@@ -28,7 +28,8 @@ import static org.testng.Assert.*;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.*;
 import java.io.ByteArrayInputStream;
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -44,13 +45,13 @@ import org.testng.annotations.Test;
  * Test BAM file indexing.
  */
 public class BAMFileIndexTest extends HtsjdkTest {
-    private final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private final Path BAM_FILE = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
     private final boolean mVerbose = false;
 
     @Test
     public void testGetSearchBins() throws Exception {
         final DiskBasedBAMFileIndex bfi = new DiskBasedBAMFileIndex(
-                new File(BAM_FILE.getPath() + ".bai"),
+                Path.of(BAM_FILE + ".bai"),
                 null); // todo can null be replaced with a Sequence dictionary for the BAM_FILE?
         final long[] bins = bfi.getSpanOverlapping(1, 0, 0).toCoordinateArray();
         /***
@@ -114,7 +115,7 @@ public class BAMFileIndexTest extends HtsjdkTest {
         final StopWatch linearScan = new StopWatch();
         final StopWatch queryUnmapped = new StopWatch();
         int unmappedCountFromLinearScan = 0;
-        final File bamFile = BAM_FILE;
+        final Path bamFile = BAM_FILE;
         final SamReader reader = SamReaderFactory.makeDefault().open(bamFile);
         linearScan.start();
         CloseableIterator<SAMRecord> it = reader.iterator();
@@ -299,8 +300,8 @@ public class BAMFileIndexTest extends HtsjdkTest {
                 + "one_end_mapped\t73\tchr7\t100\t255\t101M\t*\t0\t0\tCAACAGAAGCNGGNATCTGTGTTTGTGTTTCGGATTTCCTGCTGAANNGNTTNTCGNNTCNNNNNNNNATCCCGATTTCNTTCCGCAGCTNACCTCCCAAN\t)'.*.+2,))&&'&*/)-&*-)&.-)&)&),/-&&..)./.,.).*&&,&.&&-)&&&0*&&&&&&&&/32/,01460&&/6/*0*/2/283//36868/&\tRG:Z:0\n"
                 + "one_end_mapped\t133\tchr7\t100\t0\t*\t=\t100\t0\tNCGCGGCATCNCGATTTCTTTCCGCAGCTAACCTCCCGACAGATCGGCAGCGCGTCGTGTAGGTTATTATGGTACATCTTGTCGTGCGGCNAGAGCATACA\t&/15445666651/566666553+2/14/&/555512+3/)-'/-&-'*+))*''13+3)'//++''/'))/3+&*5++)&'2+&+/*&-&&*)&-./1'1\tRG:Z:0\n";
         final ByteArrayInputStream bis = new ByteArrayInputStream(StringUtil.stringToBytes(samText));
-        final File bamFile = File.createTempFile("BAMFileIndexTest.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path bamFile = Files.createTempFile("BAMFileIndexTest.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
         final SamReader textReader = SamReaderFactory.makeDefault().open(SamInputResource.of(bis));
         SAMFileWriterFactory samFileWriterFactory = new SAMFileWriterFactory();
         samFileWriterFactory.setCreateIndex(true);
@@ -310,7 +311,7 @@ public class BAMFileIndexTest extends HtsjdkTest {
         }
         writer.close();
         final SamReader bamReader = SamReaderFactory.makeDefault().open(bamFile);
-        SamFiles.findIndex(bamFile).deleteOnExit();
+        SamFiles.findIndex(bamFile).toFile().deleteOnExit();
         Assert.assertEquals(countElements(bamReader.queryContained("chr7", 100, 100)), 1);
         Assert.assertEquals(countElements(bamReader.queryOverlapping("chr7", 100, 100)), 2);
         bamReader.close();
@@ -349,7 +350,7 @@ public class BAMFileIndexTest extends HtsjdkTest {
         assertEquals(count, expectedCount);
     }
 
-    private void runRandomTest(final File bamFile, final int count, final Random generator) {
+    private void runRandomTest(final Path bamFile, final int count, final Random generator) {
         final List<String> referenceNames = getReferenceNames(bamFile);
         final QueryInterval[] intervals = generateRandomIntervals(referenceNames.size(), count, generator);
         for (final QueryInterval interval : intervals) {
@@ -383,7 +384,7 @@ public class BAMFileIndexTest extends HtsjdkTest {
         return intervals;
     }
 
-    private List<String> getReferenceNames(final File bamFile) {
+    private List<String> getReferenceNames(final Path bamFile) {
         final SamReader reader = SamReaderFactory.makeDefault().open(bamFile);
         final List<String> result = new ArrayList<String>();
         final List<SAMSequenceRecord> seqRecords =
@@ -398,7 +399,7 @@ public class BAMFileIndexTest extends HtsjdkTest {
     }
 
     private int runQueryTest(
-            final File bamFile, final String sequence, final int startPos, final int endPos, final boolean contained) {
+            final Path bamFile, final String sequence, final int startPos, final int endPos, final boolean contained) {
         verbose("Testing query " + sequence + ":" + startPos + "-" + endPos + " ...");
         final SamReader reader1 = SamReaderFactory.makeDefault().open(bamFile);
         final SamReader reader2 = SamReaderFactory.makeDefault().open(bamFile);

--- a/src/test/java/htsjdk/samtools/BAMFileReaderTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileReaderTest.java
@@ -3,19 +3,18 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CoordMath;
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class BAMFileReaderTest extends HtsjdkTest {
-    private static final File bamFile = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
-    private static final File baiFileIndex = new File(bamFile.getPath() + ".bai");
-    private static final File csiFileIndex = new File(bamFile.getPath() + ".csi");
-    private static final File iiiFileIndex = new File(bamFile.getPath() + ".iii");
+    private static final Path bamFile = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private static final Path baiFileIndex = Path.of(bamFile + ".bai");
+    private static final Path csiFileIndex = Path.of(bamFile + ".csi");
+    private static final Path iiiFileIndex = Path.of(bamFile + ".iii");
     private static final int nofMappedReads = 9721;
     private static final int nofUnmappedReads = 279;
     private static final int noChrMReads = 23;
@@ -52,7 +51,7 @@ public class BAMFileReaderTest extends HtsjdkTest {
                 DefaultSAMRecordFactory.getInstance());
         bamFileReaderNull = new BAMFileReader(
                 bamFile,
-                null,
+                (Path) null,
                 true,
                 false,
                 ValidationStringency.DEFAULT_STRINGENCY,
@@ -62,8 +61,8 @@ public class BAMFileReaderTest extends HtsjdkTest {
     @Test
     public static void testCSIFromURL() throws IOException {
         // https://github.com/samtools/htsjdk/issues/1507
-        final URL bamURL = Paths.get(bamFile.toURI()).toUri().toURL();
-        final URL csiURL = Paths.get(csiFileIndex.toURI()).toUri().toURL();
+        final URL bamURL = bamFile.toUri().toURL();
+        final URL csiURL = csiFileIndex.toUri().toURL();
         final SamInputResource resource = SamInputResource.of(bamURL).index(csiURL);
         final SamReaderFactory factory =
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT);

--- a/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/BAMFileWriterTest.java
@@ -30,7 +30,15 @@ import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.SequenceUtil;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.testng.Assert;
@@ -65,8 +73,8 @@ public class BAMFileWriterTest extends HtsjdkTest {
             final SAMFileHeader.SortOrder sortOrder,
             final boolean presorted)
             throws Exception {
-        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path bamFile = Files.createTempFile("test.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
 
         try (final SamReader samReader = samRecordSetBuilder.getSamReader()) {
             samReader.getFileHeader().setSortOrder(sortOrder);
@@ -82,21 +90,23 @@ public class BAMFileWriterTest extends HtsjdkTest {
             verifyBAMFile(samRecordSetBuilder, bamFile);
         }
 
-        final File tempMetrics = File.createTempFile("CGTagTest", ".validation_metrics");
+        final Path tempMetrics = Files.createTempFile("CGTagTest", ".validation_metrics");
         try (final SamReader samReader = SamReaderFactory.makeDefault().open(bamFile);
-                final OutputStream outputStream = new FileOutputStream(tempMetrics);
+                final OutputStream outputStream = Files.newOutputStream(tempMetrics);
                 final PrintWriter printWriter = new PrintWriter(outputStream)) {
 
             new SamFileValidator(printWriter, 100).validateSamFileSummary(samReader, null);
         }
 
         final MetricsFile<SamFileValidator.ValidationMetrics, String> validationMetrics = new MetricsFile<>();
-        validationMetrics.read(new FileReader(tempMetrics));
+        try (final Reader reader = Files.newBufferedReader(tempMetrics)) {
+            validationMetrics.read(reader);
+        }
 
         Assert.assertNull(validationMetrics.getHistogram().get("ERROR:CG_TAG_FOUND_IN_ATTRIBUTES"));
     }
 
-    private void verifyBAMFile(final SAMRecordSetBuilder samRecordSetBuilder, final File bamFile) throws IOException {
+    private void verifyBAMFile(final SAMRecordSetBuilder samRecordSetBuilder, final Path bamFile) throws IOException {
         try (final SamReader bamReader = SamReaderFactory.makeDefault().open(bamFile);
                 final SamReader samReader = samRecordSetBuilder.getSamReader()) {
             verifySamReadersEqual(samReader, bamReader);
@@ -189,8 +199,8 @@ public class BAMFileWriterTest extends HtsjdkTest {
         }
 
         // make sure the records can actually be written out
-        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path bamFile = Files.createTempFile("test.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
         samHeader.setSortOrder(order);
         try (final SAMFileWriter bamWriter =
                 new SAMFileWriterFactory().makeSAMOrBAMWriter(samHeader, presorted, bamFile)) {
@@ -215,8 +225,8 @@ public class BAMFileWriterTest extends HtsjdkTest {
         // sequence dictionary and unresolvable references
         final SAMFileHeader fakeHeader = new SAMFileHeader();
         fakeHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
-        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path bamFile = Files.createTempFile("test.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
 
         try (final SAMFileWriter bamWriter =
                 new SAMFileWriterFactory().makeSAMOrBAMWriter(fakeHeader, false, bamFile); ) {
@@ -235,8 +245,8 @@ public class BAMFileWriterTest extends HtsjdkTest {
         // sequence dictionary and unresolvable references
         final SAMFileHeader fakeHeader = new SAMFileHeader();
         fakeHeader.setSortOrder(SAMFileHeader.SortOrder.queryname);
-        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path bamFile = Files.createTempFile("test.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
 
         try (final SAMFileWriter bamWriter =
                 new SAMFileWriterFactory().makeSAMOrBAMWriter(fakeHeader, false, bamFile); ) {
@@ -280,7 +290,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
 
         final BAMFileReader reader = new BAMFileReader(
                 new ByteArrayInputStream(baos.toByteArray()),
-                null,
+                (Path) null,
                 true,
                 false,
                 ValidationStringency.SILENT,
@@ -311,7 +321,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
         // read from ByteArray
         final BAMFileReader reader = new BAMFileReader(
                 new ByteArrayInputStream(baos.toByteArray()),
-                null,
+                (Path) null,
                 false,
                 false,
                 ValidationStringency.SILENT,
@@ -385,8 +395,8 @@ public class BAMFileWriterTest extends HtsjdkTest {
 
         builder.addFrag("frag1", 0, 1, false, false, cigar.toString(), null, 30);
 
-        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path bamFile = Files.createTempFile("test.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
 
         try (final SAMFileWriter bamWriter =
                 new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, bamFile)) {
@@ -506,8 +516,8 @@ public class BAMFileWriterTest extends HtsjdkTest {
             rec.setAttribute(SAMTag.CG, cigarEncoding);
         }
 
-        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path bamFile = Files.createTempFile("test.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
 
         try (final SAMFileWriter bamWriter =
                 new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, bamFile)) {
@@ -530,8 +540,8 @@ public class BAMFileWriterTest extends HtsjdkTest {
         builder.addFrag("frag1", 0, 1, false, false, cigar.toString(), null, 30);
         builder.addPair("pair1", 0, 1, 100_000, false, false, cigar.toString(), cigar.toString(), true, false, 30);
 
-        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path bamFile = Files.createTempFile("test.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
 
         try (final SAMFileWriter bamWriter =
                 new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), false, bamFile)) {
@@ -567,9 +577,9 @@ public class BAMFileWriterTest extends HtsjdkTest {
 
     @Test
     public void testRealDataLongCigar() throws Exception {
-        final File samFile = new File("src/test/resources/htsjdk/samtools/BAMCigarOverflowTest/cigar-64k.sam.gz");
-        final File bamFile = File.createTempFile("test.", FileExtensions.BAM);
-        bamFile.deleteOnExit();
+        final Path samFile = Path.of("src/test/resources/htsjdk/samtools/BAMCigarOverflowTest/cigar-64k.sam.gz");
+        final Path bamFile = Files.createTempFile("test.", FileExtensions.BAM);
+        bamFile.toFile().deleteOnExit();
 
         try (final SamReader samReader = SamReaderFactory.make().open(samFile);
                 final SAMFileWriter bamWriter =
@@ -603,7 +613,7 @@ public class BAMFileWriterTest extends HtsjdkTest {
         // read from ByteArray
         final BAMFileReader reader = new BAMFileReader(
                 new ByteArrayInputStream(baos.toByteArray()),
-                null,
+                (Path) null,
                 false,
                 false,
                 ValidationStringency.SILENT,

--- a/src/test/java/htsjdk/samtools/BAMIndexValidatorTest.java
+++ b/src/test/java/htsjdk/samtools/BAMIndexValidatorTest.java
@@ -1,16 +1,16 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class BAMIndexValidatorTest extends HtsjdkTest {
 
-    private static final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
-    private static final File BAI_FILE = new File(BAM_FILE.getPath() + ".bai");
-    private static final File CSI_FILE = new File(BAM_FILE.getPath() + ".csi");
+    private static final Path BAM_FILE = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private static final Path BAI_FILE = Path.of(BAM_FILE + ".bai");
+    private static final Path CSI_FILE = Path.of(BAM_FILE + ".csi");
 
     @Test
     public void exhaustivelyTestIndexTest() throws IOException {

--- a/src/test/java/htsjdk/samtools/BAMIndexWriterTest.java
+++ b/src/test/java/htsjdk/samtools/BAMIndexWriterTest.java
@@ -30,8 +30,10 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.IOUtil;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -42,24 +44,24 @@ public class BAMIndexWriterTest extends HtsjdkTest {
     // Two input files for basic test
     private final String BAM_FILE_LOCATION = "src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam";
     private final String BAI_FILE_LOCATION = "src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai";
-    private final File BAM_FILE = new File(BAM_FILE_LOCATION);
-    private final File BAI_FILE = new File(BAI_FILE_LOCATION);
+    private final Path BAM_FILE = Paths.get(BAM_FILE_LOCATION);
+    private final Path BAI_FILE = Paths.get(BAI_FILE_LOCATION);
 
     private final boolean mVerbose = true;
 
     @Test(enabled = true)
     public void testWriteText() throws Exception {
         // Compare the text form of the c-generated bai file and a java-generated one
-        final File cBaiTxtFile = File.createTempFile("cBai.", ".bai.txt");
+        final Path cBaiTxtFile = Files.createTempFile("cBai.", ".bai.txt");
         BAMIndexer.createAndWriteIndex(BAI_FILE, cBaiTxtFile, true);
         verbose("Wrote textual C BAM Index file " + cBaiTxtFile);
 
-        final File javaBaiFile = File.createTempFile("javaBai.", "java.bai");
-        final File javaBaiTxtFile = new File(javaBaiFile.getAbsolutePath() + ".txt");
+        final Path javaBaiFile = Files.createTempFile("javaBai.", "java.bai");
+        final Path javaBaiTxtFile = javaBaiFile.resolveSibling(javaBaiFile.getFileName() + ".txt");
         final SamReader bam = SamReaderFactory.makeDefault()
                 .enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS)
                 .open(BAM_FILE);
-        BAMIndexer.createIndex(bam, javaBaiFile.toPath());
+        BAMIndexer.createIndex(bam, javaBaiFile);
         verbose("Wrote binary Java BAM Index file " + javaBaiFile);
 
         // now, turn the bai file into text
@@ -67,31 +69,31 @@ public class BAMIndexWriterTest extends HtsjdkTest {
         // and compare them
         verbose("diff " + javaBaiTxtFile + " " + cBaiTxtFile);
         IOUtil.assertFilesEqual(javaBaiTxtFile, cBaiTxtFile);
-        cBaiTxtFile.deleteOnExit();
-        javaBaiFile.deleteOnExit();
-        javaBaiTxtFile.deleteOnExit();
+        cBaiTxtFile.toFile().deleteOnExit();
+        javaBaiFile.toFile().deleteOnExit();
+        javaBaiTxtFile.toFile().deleteOnExit();
         CloserUtil.close(bam);
     }
 
     @Test(enabled = true)
     public void testWriteBinary() throws Exception {
         // Compare java-generated bai file with c-generated and sorted bai file
-        final File javaBaiFile = File.createTempFile("javaBai.", ".bai");
+        final Path javaBaiFile = Files.createTempFile("javaBai.", ".bai");
         final SamReader bam = SamReaderFactory.makeDefault()
                 .enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS)
                 .open(BAM_FILE);
-        BAMIndexer.createIndex(bam, javaBaiFile.toPath());
+        BAMIndexer.createIndex(bam, javaBaiFile);
         verbose("Wrote binary java BAM Index file " + javaBaiFile);
 
-        final File cRegeneratedBaiFile = File.createTempFile("cBai.", ".bai");
+        final Path cRegeneratedBaiFile = Files.createTempFile("cBai.", ".bai");
         BAMIndexer.createAndWriteIndex(BAI_FILE, cRegeneratedBaiFile, false);
         verbose("Wrote sorted C binary BAM Index file " + cRegeneratedBaiFile);
 
         // Binary compare of javaBaiFile and cRegeneratedBaiFile should be the same
         verbose("diff " + javaBaiFile + " " + cRegeneratedBaiFile);
         IOUtil.assertFilesEqual(javaBaiFile, cRegeneratedBaiFile);
-        javaBaiFile.deleteOnExit();
-        cRegeneratedBaiFile.deleteOnExit();
+        javaBaiFile.toFile().deleteOnExit();
+        cRegeneratedBaiFile.toFile().deleteOnExit();
         CloserUtil.close(bam);
     }
 
@@ -104,7 +106,7 @@ public class BAMIndexWriterTest extends HtsjdkTest {
             int problemWindowStart,
             int problemWindowEnd,
             int expectedCount) {
-        final SamReader sfr = SamReaderFactory.makeDefault().open(new File(filepath));
+        final SamReader sfr = SamReaderFactory.makeDefault().open(Paths.get(filepath));
         for (int problemWindow = problemWindowStart; problemWindow <= problemWindowEnd; problemWindow++) {
             int count = countAlignmentsInWindow(problemReference, problemWindow, sfr, expectedCount);
             if (expectedCount != -1) assertEquals(expectedCount, count);
@@ -152,15 +154,15 @@ public class BAMIndexWriterTest extends HtsjdkTest {
         // 3. count bamIndex references comparing counts
 
         // 1. generate bai file
-        File bam = new File(bamFile);
-        assertTrue(bam.exists(), testName + " input bam file doesn't exist: " + bamFile);
+        Path bam = Paths.get(bamFile);
+        assertTrue(Files.exists(bam), testName + " input bam file doesn't exist: " + bamFile);
 
-        File indexFile1 = createIndexFile(bam);
-        assertTrue(indexFile1.exists(), testName + " generated bam file's index doesn't exist: " + indexFile1);
+        Path indexFile1 = createIndexFile(bam);
+        assertTrue(Files.exists(indexFile1), testName + " generated bam file's index doesn't exist: " + indexFile1);
 
         // 2. count its references
-        File indexFile2 = new File(bamIndexFile);
-        assertTrue(indexFile2.exists(), testName + " input index file doesn't exist: " + indexFile2);
+        Path indexFile2 = Paths.get(bamIndexFile);
+        assertTrue(Files.exists(indexFile2), testName + " input index file doesn't exist: " + indexFile2);
 
         final CachingBAMFileIndex existingIndex1 =
                 new CachingBAMFileIndex(indexFile1, null); // todo null sequence dictionary?
@@ -199,7 +201,7 @@ public class BAMIndexWriterTest extends HtsjdkTest {
             }
         }
 
-        indexFile1.deleteOnExit();
+        indexFile1.toFile().deleteOnExit();
     }
 
     @DataProvider(name = "indexComparisonData")
@@ -219,10 +221,10 @@ public class BAMIndexWriterTest extends HtsjdkTest {
     }
 
     /** generates the index file using the latest java index generating code */
-    private File createIndexFile(File bamFile) throws IOException {
-        final File bamIndexFile = File.createTempFile("Bai.", ".bai");
-        final SamReader bam = SamReaderFactory.makeDefault().open(bamFile);
-        BAMIndexer.createIndex(bam, bamIndexFile.toPath());
+    private Path createIndexFile(Path bamPath) throws IOException {
+        final Path bamIndexFile = Files.createTempFile("Bai.", ".bai");
+        final SamReader bam = SamReaderFactory.makeDefault().open(bamPath);
+        BAMIndexer.createIndex(bam, bamIndexFile);
         verbose("Wrote BAM Index file " + bamIndexFile);
         bam.close();
         return bamIndexFile;

--- a/src/test/java/htsjdk/samtools/BAMIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/BAMIteratorTest.java
@@ -26,7 +26,7 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CloserUtil;
-import java.io.File;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -35,11 +35,11 @@ import org.testng.annotations.Test;
  * @author alecw@broadinstitute.org
  */
 public class BAMIteratorTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
 
     @Test(dataProvider = "dataProvider")
     public void testIterateEmptyBam(final String bam) throws Exception {
-        final SamReader reader = SamReaderFactory.makeDefault().open(new File(TEST_DATA_DIR, bam));
+        final SamReader reader = SamReaderFactory.makeDefault().open(TEST_DATA_DIR.resolve(bam));
         int numRecords = 0;
         for (final SAMRecord rec : reader) {
             ++numRecords;
@@ -50,7 +50,7 @@ public class BAMIteratorTest extends HtsjdkTest {
 
     @Test(dataProvider = "dataProvider")
     public void testQueryUnmappedEmptyBam(final String bam) throws Exception {
-        final SamReader reader = SamReaderFactory.makeDefault().open(new File(TEST_DATA_DIR, bam));
+        final SamReader reader = SamReaderFactory.makeDefault().open(TEST_DATA_DIR.resolve(bam));
         final CloseableIterator<SAMRecord> it = reader.queryUnmapped();
         int numRecords = 0;
         while (it.hasNext()) {

--- a/src/test/java/htsjdk/samtools/BAMMergerTest.java
+++ b/src/test/java/htsjdk/samtools/BAMMergerTest.java
@@ -33,12 +33,12 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.ProgressLoggerInterface;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.utils.ValidationUtils;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.testng.Assert;
@@ -47,7 +47,7 @@ import org.testng.annotations.Test;
 public class BAMMergerTest extends HtsjdkTest {
 
     private static final Path BAM_FILE =
-            new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam").toPath();
+            Paths.get("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
 
     /**
      * Writes a <i>partitioned BAM</i>.
@@ -220,7 +220,7 @@ public class BAMMergerTest extends HtsjdkTest {
     // create a human-readable BAI
     private static Path textIndexBai(Path bai) {
         Path textBai = bai.resolveSibling(bai.getFileName().toString() + ".txt");
-        BAMIndexer.createAndWriteIndex(bai.toFile(), textBai.toFile(), true);
+        BAMIndexer.createAndWriteIndex(bai, textBai, true);
         return textBai;
     }
 
@@ -229,8 +229,7 @@ public class BAMMergerTest extends HtsjdkTest {
         final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp");
         IOUtil.deleteOnExit(outputDir);
 
-        final Path outputBam = File.createTempFile(this.getClass().getSimpleName() + ".", ".bam")
-                .toPath();
+        final Path outputBam = Files.createTempFile(this.getClass().getSimpleName() + ".", ".bam");
         IOUtil.deleteOnExit(outputBam);
 
         final Path outputBai = IOUtil.addExtension(outputBam, FileExtensions.BAI_INDEX);
@@ -239,13 +238,11 @@ public class BAMMergerTest extends HtsjdkTest {
         final Path outputSbi = IOUtil.addExtension(outputBam, FileExtensions.SBI);
         IOUtil.deleteOnExit(outputSbi);
 
-        final Path outputBaiMerged = File.createTempFile(
-                        this.getClass().getSimpleName() + ".", FileExtensions.BAI_INDEX)
-                .toPath();
+        final Path outputBaiMerged =
+                Files.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.BAI_INDEX);
         IOUtil.deleteOnExit(outputBaiMerged);
 
-        final Path outputSbiMerged = File.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.SBI)
-                .toPath();
+        final Path outputSbiMerged = Files.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.SBI);
         IOUtil.deleteOnExit(outputBaiMerged);
 
         // 1. Read an input BAM and write it out in partitioned form (header, parts, terminator)
@@ -268,13 +265,9 @@ public class BAMMergerTest extends HtsjdkTest {
         // Check equality on object before comparing file contents to get a better indication
         // of the difference in case they are not equal.
         BaiEqualityChecker.assertEquals(outputBam, outputBai, outputBaiMerged);
-        Assert.assertEquals(
-                com.google.common.io.Files.toByteArray(outputBai.toFile()),
-                com.google.common.io.Files.toByteArray(outputBaiMerged.toFile()));
+        Assert.assertEquals(Files.readAllBytes(outputBai), Files.readAllBytes(outputBaiMerged));
 
         // 5. Assert that the merged SBI index is the same as the SBI index produced from the merged file
-        Assert.assertEquals(
-                com.google.common.io.Files.toByteArray(outputSbi.toFile()),
-                com.google.common.io.Files.toByteArray(outputSbiMerged.toFile()));
+        Assert.assertEquals(Files.readAllBytes(outputSbi), Files.readAllBytes(outputSbiMerged));
     }
 }

--- a/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
+++ b/src/test/java/htsjdk/samtools/BAMRemoteFileTest.java
@@ -28,9 +28,9 @@ import static org.testng.Assert.*;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.TestUtil;
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -41,9 +41,9 @@ import org.testng.annotations.Test;
  * Test BAM file indexing.
  */
 public class BAMRemoteFileTest extends HtsjdkTest {
-    private final File BAM_INDEX_FILE =
-            new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai");
-    private final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private final Path BAM_INDEX_FILE =
+            Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai");
+    private final Path BAM_FILE = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
     private final String BAM_URL_STRING = TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam";
     private final URL bamURL;
 
@@ -146,7 +146,7 @@ public class BAMRemoteFileTest extends HtsjdkTest {
 
     private void runLocalRemoteTest(
             final URL bamURL,
-            final File bamFile,
+            final Path bamFile,
             final String sequence,
             final int startPos,
             final int endPos,

--- a/src/test/java/htsjdk/samtools/BAMSBIIndexerTest.java
+++ b/src/test/java/htsjdk/samtools/BAMSBIIndexerTest.java
@@ -30,24 +30,25 @@ import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.Iterables;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class BAMSBIIndexerTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
-    private static final File CRAM_TEST_DATA_DIR = new File(TEST_DATA_DIR, "cram");
-    private static final File BAM_FILE = new File(TEST_DATA_DIR, "example.bam");
-    private static final File EMPTY_BAM_FILE = new File(TEST_DATA_DIR, "empty.bam");
-    private static final File LARGE_BAM_FILE =
-            new File(CRAM_TEST_DATA_DIR, "CEUTrio.HiSeq.WGS.b37.NA12878.20.first.8000.bam");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
+    private static final Path CRAM_TEST_DATA_DIR = TEST_DATA_DIR.resolve("cram");
+    private static final Path BAM_FILE = TEST_DATA_DIR.resolve("example.bam");
+    private static final Path EMPTY_BAM_FILE = TEST_DATA_DIR.resolve("empty.bam");
+    private static final Path LARGE_BAM_FILE =
+            CRAM_TEST_DATA_DIR.resolve("CEUTrio.HiSeq.WGS.b37.NA12878.20.first.8000.bam");
 
     @Test
     public void testEmptyBam() throws Exception {
-        final long bamFileSize = EMPTY_BAM_FILE.length();
+        final long bamFileSize = Files.size(EMPTY_BAM_FILE);
         final SBIIndex index1 = fromBAMFile(EMPTY_BAM_FILE, SBIIndexWriter.DEFAULT_GRANULARITY);
         final SBIIndex index2 = fromSAMRecords(EMPTY_BAM_FILE, SBIIndexWriter.DEFAULT_GRANULARITY);
         Assert.assertEquals(index1, index2);
@@ -77,7 +78,7 @@ public class BAMSBIIndexerTest extends HtsjdkTest {
 
     @Test
     public void testSplit() throws Exception {
-        final long bamFileSize = LARGE_BAM_FILE.length();
+        final long bamFileSize = Files.size(LARGE_BAM_FILE);
         final SBIIndex index = fromBAMFile(LARGE_BAM_FILE, 100);
         final List<Chunk> chunks = index.split(bamFileSize / 10);
         Assert.assertTrue(chunks.size() > 1);
@@ -98,7 +99,7 @@ public class BAMSBIIndexerTest extends HtsjdkTest {
 
     @Test
     public void testIndexersProduceSameIndexes() throws Exception {
-        final long bamFileSize = BAM_FILE.length();
+        final long bamFileSize = Files.size(BAM_FILE);
         for (final long g : new long[] {1, 2, 10, SBIIndexWriter.DEFAULT_GRANULARITY}) {
             final SBIIndex index1 = fromBAMFile(BAM_FILE, g);
             final SBIIndex index2 = fromSAMRecords(BAM_FILE, g);
@@ -108,13 +109,13 @@ public class BAMSBIIndexerTest extends HtsjdkTest {
         }
     }
 
-    private SBIIndex fromBAMFile(final File bamFile, final long granularity) throws IOException {
+    private SBIIndex fromBAMFile(final Path bamFile, final long granularity) throws IOException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         BAMSBIIndexer.createIndex(new SeekableFileStream(bamFile), out, granularity);
         return SBIIndex.load(new ByteArrayInputStream(out.toByteArray()));
     }
 
-    private SBIIndex fromSAMRecords(final File bamFile, final long granularity) throws IOException {
+    private SBIIndex fromSAMRecords(final Path bamFile, final long granularity) throws IOException {
         final BAMFileReader bamFileReader = bamFileReader(bamFile);
         try (CloseableIterator<SAMRecord> iterator = bamFileReader.getIterator();
                 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
@@ -122,7 +123,7 @@ public class BAMSBIIndexerTest extends HtsjdkTest {
             while (iterator.hasNext()) {
                 processAlignment(indexWriter, iterator.next());
             }
-            indexWriter.finish(bamFileReader.getVirtualFilePointer(), bamFile.length());
+            indexWriter.finish(bamFileReader.getVirtualFilePointer(), Files.size(bamFile));
             return SBIIndex.load(new ByteArrayInputStream(out.toByteArray()));
         }
     }
@@ -136,7 +137,7 @@ public class BAMSBIIndexerTest extends HtsjdkTest {
         indexWriter.processRecord(filePointer.getFirstOffset());
     }
 
-    private BAMFileReader bamFileReader(final File bamFile) {
+    private BAMFileReader bamFileReader(final Path bamFile) {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
                 .enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS)
@@ -144,15 +145,16 @@ public class BAMSBIIndexerTest extends HtsjdkTest {
         return (BAMFileReader) ((SamReader.PrimitiveSamReaderToSamReaderAdapter) samReader).underlyingReader();
     }
 
-    private SAMRecord getReadAtOffset(final File bamFile, final long virtualOffset) {
-        final Chunk chunk = new Chunk(virtualOffset, BlockCompressedFilePointerUtil.makeFilePointer(bamFile.length()));
+    private SAMRecord getReadAtOffset(final Path bamFile, final long virtualOffset) throws IOException {
+        final Chunk chunk =
+                new Chunk(virtualOffset, BlockCompressedFilePointerUtil.makeFilePointer(Files.size(bamFile)));
         try (CloseableIterator<SAMRecord> iterator = bamFileReader(bamFile).getIterator(new BAMFileSpan(chunk))) {
             Assert.assertTrue(iterator.hasNext());
             return iterator.next();
         }
     }
 
-    private List<SAMRecord> getReads(final File bamFile) throws IOException {
+    private List<SAMRecord> getReads(final Path bamFile) throws IOException {
         try (SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
                 .enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS)
@@ -161,7 +163,7 @@ public class BAMSBIIndexerTest extends HtsjdkTest {
         }
     }
 
-    private List<SAMRecord> getReadsInChunk(final File bamFile, final Chunk chunk) {
+    private List<SAMRecord> getReadsInChunk(final Path bamFile, final Chunk chunk) {
         try (CloseableIterator<SAMRecord> iterator = bamFileReader(bamFile).getIterator(new BAMFileSpan(chunk))) {
             return Iterables.slurp(iterator);
         }

--- a/src/test/java/htsjdk/samtools/BaiEqualityChecker.java
+++ b/src/test/java/htsjdk/samtools/BaiEqualityChecker.java
@@ -49,8 +49,8 @@ public class BaiEqualityChecker {
                 .setUseAsyncIo(false);
         SAMFileHeader header = readerFactory.getFileHeader(bamFile);
         SAMSequenceDictionary dict = header.getSequenceDictionary();
-        AbstractBAMFileIndex bai1 = new CachingBAMFileIndex(baiFile1.toFile(), dict);
-        AbstractBAMFileIndex bai2 = new CachingBAMFileIndex(baiFile2.toFile(), dict);
+        AbstractBAMFileIndex bai1 = new CachingBAMFileIndex(baiFile1, dict);
+        AbstractBAMFileIndex bai2 = new CachingBAMFileIndex(baiFile2, dict);
 
         Assert.assertEquals(bai1.getNumberOfReferences(), bai2.getNumberOfReferences(), "Number of references");
         Assert.assertEquals(bai1.getNoCoordinateCount(), bai2.getNoCoordinateCount(), "No coordinate index count");

--- a/src/test/java/htsjdk/samtools/BamFileIoUtilsUnitTest.java
+++ b/src/test/java/htsjdk/samtools/BamFileIoUtilsUnitTest.java
@@ -4,8 +4,6 @@ import htsjdk.HtsjdkTest;
 import htsjdk.beta.exception.HtsjdkException;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.FileExtensions;
-import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -30,20 +28,19 @@ public class BamFileIoUtilsUnitTest extends HtsjdkTest {
 
     @Test(dataProvider = "ReheaderBamFileTestInput")
     public void testReheaderBamFile(final boolean createMd5, final boolean createIndex) throws IOException {
-        final File originalBam = HtsjdkTestUtils.NA12878_500;
-        SAMFileHeader header = SamReaderFactory.make().getFileHeader(HtsjdkTestUtils.NA12878_500);
+        final Path originalBam = HtsjdkTestUtils.NA12878_500;
+        SAMFileHeader header = SamReaderFactory.make().getFileHeader(originalBam);
         header.addComment("This is a new, modified header");
 
         final Path output = Files.createTempFile("output", ".bam");
-        BamFileIoUtils.reheaderBamFile(header, originalBam.toPath(), output, createMd5, createIndex);
+        BamFileIoUtils.reheaderBamFile(header, originalBam, output, createMd5, createIndex);
 
         // Confirm that the header has been replaced
         final SamReader outputReader = SamReaderFactory.make().open(output);
         Assert.assertEquals(outputReader.getFileHeader(), header);
 
         // Check that the reads are the same as the original
-        // tsato: should I be using something similar to IOUtil.toPath for converting Path -> File to propagate null?
-        assertBamRecordsEqual(originalBam, output.toFile());
+        assertBamRecordsEqual(originalBam, output);
 
         if (createMd5) {
             Assert.assertTrue(Files.exists(output.resolveSibling(output.getFileName() + FileExtensions.MD5)));
@@ -57,7 +54,7 @@ public class BamFileIoUtilsUnitTest extends HtsjdkTest {
     /**
      * Compares all the reads in the two bam files are equal (but does not check the headers).
      */
-    private void assertBamRecordsEqual(final File bam1, final File bam2) {
+    private void assertBamRecordsEqual(final Path bam1, final Path bam2) {
         try (SamReader reader1 = SamReaderFactory.make().open(bam1);
                 SamReader reader2 = SamReaderFactory.make().open(bam2)) {
             final Iterator<SAMRecord> originalBamIterator = reader1.iterator();
@@ -65,10 +62,7 @@ public class BamFileIoUtilsUnitTest extends HtsjdkTest {
 
             Assert.assertEquals(originalBamIterator, outputBamIterator);
         } catch (Exception e) {
-            throw new HtsjdkException(
-                    "Encountered an error reading bam files: " + bam1.getAbsolutePath() + " and "
-                            + bam2.getAbsolutePath(),
-                    e);
+            throw new HtsjdkException("Encountered an error reading bam files: " + bam1 + " and " + bam2, e);
         }
     }
 
@@ -84,12 +78,11 @@ public class BamFileIoUtilsUnitTest extends HtsjdkTest {
 
     @Test(dataProvider = "BlockCopyBamFileTestInput")
     public void testBlockCopyBamFile(final boolean skipHeader, final boolean skipTerminator) throws IOException {
-        final File output = File.createTempFile("output", ".bam");
-        try (final OutputStream out = Files.newOutputStream(output.toPath())) {
-            final Path input = IOUtil.toPath(HtsjdkTestUtils.NA12878_500);
+        final Path output = Files.createTempFile("output", ".bam");
+        try (final OutputStream out = Files.newOutputStream(output)) {
+            final Path input = HtsjdkTestUtils.NA12878_500;
 
-            BamFileIoUtils.blockCopyBamFile(
-                    IOUtil.toPath(HtsjdkTestUtils.NA12878_500), out, skipHeader, skipTerminator);
+            BamFileIoUtils.blockCopyBamFile(input, out, skipHeader, skipTerminator);
 
             final SamReader inputReader = SamReaderFactory.make().open(input);
             final SamReader outputReader = SamReaderFactory.make().open(output);
@@ -100,7 +93,7 @@ public class BamFileIoUtilsUnitTest extends HtsjdkTest {
             } else {
                 Assert.assertEquals(outputReader.getFileHeader(), inputReader.getFileHeader());
                 // Reading will fail when the header is absent
-                assertBamRecordsEqual(input.toFile(), output);
+                assertBamRecordsEqual(input, output);
             }
 
             if (skipTerminator) {
@@ -109,8 +102,7 @@ public class BamFileIoUtilsUnitTest extends HtsjdkTest {
                 Assert.assertEquals(termination, BlockCompressedInputStream.FileTermination.HAS_HEALTHY_LAST_BLOCK);
             }
         } catch (IOException e) {
-            throw new HtsjdkException(
-                    "Caught an IO exception block copying a bam file to " + output.getAbsolutePath(), e);
+            throw new HtsjdkException("Caught an IO exception block copying a bam file to " + output, e);
         }
     }
 }

--- a/src/test/java/htsjdk/samtools/CRAMAllEncodingStrategiesTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMAllEncodingStrategiesTest.java
@@ -11,7 +11,9 @@ import htsjdk.samtools.cram.structure.*;
 import htsjdk.samtools.cram.structure.block.BlockCompressionMethod;
 import htsjdk.samtools.util.Tuple;
 import htsjdk.utils.SamtoolsTestUtils;
-import java.io.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import org.testng.Assert;
 import org.testng.SkipException;
@@ -30,7 +32,7 @@ import org.testng.annotations.Test;
  */
 public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
 
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/cram");
     private final CompressorCache compressorCache = new CompressorCache();
 
     @DataProvider(name = "defaultStrategyRoundTripTestFiles")
@@ -38,29 +40,29 @@ public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
         return new Object[][] {
             // a test file with artificially small slices and containers to force multiple slices and containers
             {
-                new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta"),
+                TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta"),
                 false,
                 false
             },
             // the same file without the artificially small container constraints
             {
-                new File(TEST_DATA_DIR, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10m-10m100.cram"),
-                new File("src/test/resources/htsjdk/samtools/reference/human_g1k_v37.20.21.fasta.gz"),
+                TEST_DATA_DIR.resolve("CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10m-10m100.cram"),
+                Path.of("src/test/resources/htsjdk/samtools/reference/human_g1k_v37.20.21.fasta.gz"),
                 false,
                 false
             },
             // a test file with only unmapped reads
             {
-                new File(TEST_DATA_DIR, "NA12878.unmapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta"),
+                TEST_DATA_DIR.resolve("NA12878.unmapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta"),
                 false,
                 false
             },
             // generated with samtools 1.19 from the gatk bam file CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam
             {
-                new File(TEST_DATA_DIR, "CEUTrio.HiSeq.WGS.b37.NA12878.20.21.v3.0.samtools.cram"),
-                new File("src/test/resources/htsjdk/samtools/reference/human_g1k_v37.20.21.fasta.gz"),
+                TEST_DATA_DIR.resolve("CEUTrio.HiSeq.WGS.b37.NA12878.20.21.v3.0.samtools.cram"),
+                Path.of("src/test/resources/htsjdk/samtools/reference/human_g1k_v37.20.21.fasta.gz"),
                 true,
                 false
             },
@@ -71,15 +73,15 @@ public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
             // a user-contributed file with reads aligned only to the mito contig that has been rewritten (long ago)
             // with GATK
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTestGATKGen.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTestGATKGen.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 true,
                 false
             },
             // the original user-contributed file with reads aligned only to the mito contig
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 true,
                 false
             },
@@ -89,14 +91,14 @@ public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
             // 10,000 or 20,000 times, to create a file with 2 or 3 containers, respectively, that have reads aligned to
             // position 1 of the contig
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest_2_containers_aligned_to_pos_1.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest_2_containers_aligned_to_pos_1.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 true,
                 false
             },
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest_3_containers_aligned_to_pos_1.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest_3_containers_aligned_to_pos_1.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 true,
                 false
             }
@@ -105,12 +107,12 @@ public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
 
     @Test(dataProvider = "defaultStrategyRoundTripTestFiles")
     public final void testRoundTripDefaultEncodingStrategy(
-            final File sourceFile, final File referenceFile, final boolean lenientEquality, final boolean emitDetail)
+            final Path sourceFile, final Path referenceFile, final boolean lenientEquality, final boolean emitDetail)
             throws IOException {
         // test the default encoding strategy
         final CRAMEncodingStrategy testStrategy = new CRAMEncodingStrategy();
-        final File tempOutCRAM = File.createTempFile("testRoundTrip", ".cram");
-        tempOutCRAM.deleteOnExit();
+        final Path tempOutCRAM = Files.createTempFile("testRoundTrip", ".cram");
+        tempOutCRAM.toFile().deleteOnExit();
         CRAMTestUtils.writeToCRAMWithEncodingStrategy(testStrategy, sourceFile, tempOutCRAM, referenceFile);
         assertRoundTripFidelity(sourceFile, tempOutCRAM, referenceFile, lenientEquality, emitDetail);
         // test interop with samtools using this encoding
@@ -121,8 +123,8 @@ public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
     public Object[][] encodingStrategiesTestFiles() {
         return new Object[][] {
             {
-                new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta"),
+                TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta"),
                 false,
                 false
             },
@@ -131,14 +133,14 @@ public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
 
     @Test(dataProvider = "encodingStrategiesTestFiles")
     public final void testAllEncodingStrategyCombinations(
-            final File cramSourceFile,
-            final File referenceFile,
+            final Path cramSourceFile,
+            final Path referenceFile,
             final boolean lenientEquality,
             final boolean emitDetail)
             throws IOException {
         for (final Tuple<String, CRAMEncodingStrategy> testStrategy : getAllEncodingStrategies()) {
-            final File tempOutCRAM = File.createTempFile("allEncodingStrategyCombinations", ".cram");
-            tempOutCRAM.deleteOnExit();
+            final Path tempOutCRAM = Files.createTempFile("allEncodingStrategyCombinations", ".cram");
+            tempOutCRAM.toFile().deleteOnExit();
             CRAMTestUtils.writeToCRAMWithEncodingStrategy(testStrategy.b, cramSourceFile, tempOutCRAM, referenceFile);
             assertRoundTripFidelity(cramSourceFile, tempOutCRAM, referenceFile, lenientEquality, emitDetail);
             // test interop with samtools using this encoding
@@ -173,9 +175,9 @@ public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
     }
 
     public void assertRoundTripFidelity(
-            final File sourceFile,
-            final File targetCRAMFile,
-            final File referenceFile,
+            final Path sourceFile,
+            final Path targetCRAMFile,
+            final Path referenceFile,
             final boolean lenientEquality,
             final boolean emitDetail)
             throws IOException {
@@ -214,15 +216,14 @@ public class CRAMAllEncodingStrategiesTest extends HtsjdkTest {
     }
 
     private void assertRoundtripFidelityWithSamtools(
-            final File sourceCRAM, final File referenceFile, final boolean lenientEquality, final boolean emitDetail)
+            final Path sourceCRAM, final Path referenceFile, final boolean lenientEquality, final boolean emitDetail)
             throws IOException {
         if (SamtoolsTestUtils.isSamtoolsAvailable()) {
             final IOPath samtoolsOutFile = SamtoolsTestUtils.convertToCRAM(
-                    new HtsPath(sourceCRAM.getAbsolutePath()),
-                    new HtsPath(referenceFile.getAbsolutePath()),
+                    new HtsPath(sourceCRAM.toAbsolutePath().toString()),
+                    new HtsPath(referenceFile.toAbsolutePath().toString()),
                     "--input-fmt-option decode_md=0 --output-fmt-option store_md=0 --output-fmt-option store_nm=0");
-            assertRoundTripFidelity(
-                    sourceCRAM, samtoolsOutFile.toPath().toFile(), referenceFile, lenientEquality, emitDetail);
+            assertRoundTripFidelity(sourceCRAM, samtoolsOutFile.toPath(), referenceFile, lenientEquality, emitDetail);
         } else {
             throw new SkipException("samtools is not installed, skipping test");
         }

--- a/src/test/java/htsjdk/samtools/CRAMCRAIIndexerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMCRAIIndexerTest.java
@@ -10,6 +10,8 @@ import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import org.testng.Assert;
@@ -32,7 +34,7 @@ public class CRAMCRAIIndexerTest extends HtsjdkTest {
     }
 
     private void testCRAIIndexer(Index index) throws IOException {
-        final File CRAMFile = new File("src/test/resources/htsjdk/samtools/cram/test2.cram");
+        final Path CRAMFile = Path.of("src/test/resources/htsjdk/samtools/cram/test2.cram");
 
         try (final InputStream indexStream = new ByteArrayInputStream(index.getIndex(CRAMFile))) {
             final List<CRAIEntry> craiEntries =
@@ -148,11 +150,11 @@ public class CRAMCRAIIndexerTest extends HtsjdkTest {
     }
 
     private interface Index {
-        byte[] getIndex(final File CRAMFile) throws IOException;
+        byte[] getIndex(final Path CRAMFile) throws IOException;
     }
 
-    private byte[] fromContainer(final File CRAMFile) throws IOException {
-        try (final FileInputStream fis = new FileInputStream(CRAMFile);
+    private byte[] fromContainer(final Path CRAMFile) throws IOException {
+        try (final InputStream fis = Files.newInputStream(CRAMFile);
                 final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
 
             final CRAMCRAIIndexer craiIndexer = new CRAMCRAIIndexer(bos, getSamFileHeader(CRAMFile));
@@ -166,7 +168,7 @@ public class CRAMCRAIIndexerTest extends HtsjdkTest {
         }
     }
 
-    private byte[] fromStream(final File CRAMFile) throws IOException {
+    private byte[] fromStream(final Path CRAMFile) throws IOException {
         try (final ByteArrayOutputStream bos = new ByteArrayOutputStream();
                 final SeekableStream sfs = new SeekableFileStream(CRAMFile)) {
 
@@ -175,9 +177,9 @@ public class CRAMCRAIIndexerTest extends HtsjdkTest {
         }
     }
 
-    private SAMFileHeader getSamFileHeader(final File CRAMFile) throws IOException {
-        final File refFile = new File("src/test/resources/htsjdk/samtools/cram/auxf.fa");
-        final File indexFile = null;
+    private SAMFileHeader getSamFileHeader(final Path CRAMFile) throws IOException {
+        final Path refFile = Path.of("src/test/resources/htsjdk/samtools/cram/auxf.fa");
+        final Path indexFile = null;
         final ReferenceSource refSource = new ReferenceSource(refFile);
         final CRAMFileReader reader = new CRAMFileReader(CRAMFile, indexFile, refSource, ValidationStringency.STRICT);
         final SAMFileHeader samHeader = reader.getFileHeader();

--- a/src/test/java/htsjdk/samtools/CRAMComplianceTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMComplianceTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
  * Created by vadim on 28/04/2015.
  */
 public class CRAMComplianceTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/cram");
 
     @FunctionalInterface
     public interface TriConsumer<T1, T2, T3> {
@@ -98,16 +98,16 @@ public class CRAMComplianceTest extends HtsjdkTest {
     }
 
     private static class TestCase {
-        File bamFile;
-        File refFile;
-        File cramFile_21;
-        File cramFile_30;
+        Path bamFile;
+        Path refFile;
+        Path cramFile_21;
+        Path cramFile_30;
 
-        public TestCase(File root, String name) {
-            bamFile = new File(root, name + ".sam");
-            refFile = new File(root, name.split("#")[0] + ".fa");
-            cramFile_21 = new File(root, name + ".2.1.cram");
-            cramFile_30 = new File(root, name + ".3.0.cram");
+        public TestCase(Path root, String name) {
+            bamFile = root.resolve(name + ".sam");
+            refFile = root.resolve(name.split("#")[0] + ".fa");
+            cramFile_21 = root.resolve(name + ".2.1.cram");
+            cramFile_30 = root.resolve(name + ".3.0.cram");
         }
     }
 
@@ -128,19 +128,20 @@ public class CRAMComplianceTest extends HtsjdkTest {
 
     @Test(dataProvider = "ambiguityCodeVerification")
     public void ambiguityCodeVerificationTest(String name) throws IOException {
-        TestCase t = new TestCase(new File("src/test/resources/htsjdk/samtools/cram/"), name);
+        TestCase t = new TestCase(Path.of("src/test/resources/htsjdk/samtools/cram/"), name);
         /// round trip the bam through cram, but tolerate ambiguity code transforms
         roundTripTolerateAmbiguityCodeConversion(t.bamFile, t.refFile);
         // round trip the original cram (which has already had ambiguity code transform) through bam
         testCRAMThroughBAMRoundTrip(t.cramFile_30, t.refFile);
     }
 
-    private void roundTripTolerateAmbiguityCodeConversion(final File inputFile, final File referenceFile)
+    private void roundTripTolerateAmbiguityCodeConversion(final Path inputFile, final Path referenceFile)
             throws IOException {
         final List<SAMRecord> originalSAMRecords = getSAMRecordsFromFile(inputFile, referenceFile);
         // roundtrip the SAM records through a temporary CRAM
-        final File tempCRAMFile = File.createTempFile("testAmbiguousBasesBAMThroughCRAMRoundTrip", FileExtensions.CRAM);
-        tempCRAMFile.deleteOnExit();
+        final Path tempCRAMFile =
+                Files.createTempFile("testAmbiguousBasesBAMThroughCRAMRoundTrip", FileExtensions.CRAM);
+        tempCRAMFile.toFile().deleteOnExit();
         final SAMFileHeader samHeader = getFileHeader(inputFile, referenceFile);
         writeRecordsToFile(originalSAMRecords, tempCRAMFile, referenceFile, samHeader);
         final List<SAMRecord> roundTripCRAMRecords = getSAMRecordsFromFile(tempCRAMFile, referenceFile);
@@ -165,7 +166,7 @@ public class CRAMComplianceTest extends HtsjdkTest {
 
     private void doComplianceTest(final String name, final TriConsumer<Integer, SAMRecord, SAMRecord> assertFunction)
             throws IOException {
-        final TestCase t = new TestCase(new File("src/test/resources/htsjdk/samtools/cram/"), name);
+        final TestCase t = new TestCase(Path.of("src/test/resources/htsjdk/samtools/cram/"), name);
 
         // 1) Read from SAM/BAM Round Trip through CRAM
         // retrieve all records from the original file
@@ -198,7 +199,7 @@ public class CRAMComplianceTest extends HtsjdkTest {
 
         // Read from v2.1 CRAM round trip through cram
         cramFileReader = new CRAMFileReader(
-                new FileInputStream(t.cramFile_21), (SeekableStream) null, source, ValidationStringency.SILENT);
+                Files.newInputStream(t.cramFile_21), (SeekableStream) null, source, ValidationStringency.SILENT);
         cramFileReaderIterator = cramFileReader.getIterator();
         for (SAMRecord samRecord : samRecords) {
             Assert.assertTrue(cramFileReaderIterator.hasNext());
@@ -210,7 +211,7 @@ public class CRAMComplianceTest extends HtsjdkTest {
 
         // Read from v3.0 CRAM round trip through cram
         cramFileReader = new CRAMFileReader(
-                new FileInputStream(t.cramFile_30), (SeekableStream) null, source, ValidationStringency.SILENT);
+                Files.newInputStream(t.cramFile_30), (SeekableStream) null, source, ValidationStringency.SILENT);
         cramFileReaderIterator = cramFileReader.getIterator();
         for (SAMRecord samRecord : samRecords) {
             Assert.assertTrue(cramFileReaderIterator.hasNext());
@@ -245,34 +246,32 @@ public class CRAMComplianceTest extends HtsjdkTest {
 
     @DataProvider(name = "CRAMSourceFiles")
     public Object[][] getCRAMSources() {
-        final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
-
         return new Object[][] {
             // Test cram file created with samtools using a *reference* that contains ambiguity codes
             // 'R' and 'M', a single no call '.', and some lower case bases.
             {
-                new File(TEST_DATA_DIR, "samtoolsSliceMD5WithAmbiguityCodesTest.cram"),
-                new File(TEST_DATA_DIR, "ambiguityCodes.fasta")
+                TEST_DATA_DIR.resolve("samtoolsSliceMD5WithAmbiguityCodesTest.cram"),
+                TEST_DATA_DIR.resolve("ambiguityCodes.fasta")
             },
             {
-                new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.0-unMapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta")
+                TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.0-unMapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta")
             },
             {
-                new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.1-unMapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta")
+                TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.1-unMapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta")
             },
             {
-                new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta")
+                TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta")
             },
-            {new File(TEST_DATA_DIR, "test.cram"), new File(TEST_DATA_DIR, "auxf.fa")},
-            {new File(TEST_DATA_DIR, "test2.cram"), new File(TEST_DATA_DIR, "auxf.fa")},
+            {TEST_DATA_DIR.resolve("test.cram"), TEST_DATA_DIR.resolve("auxf.fa")},
+            {TEST_DATA_DIR.resolve("test2.cram"), TEST_DATA_DIR.resolve("auxf.fa")},
         };
     }
 
     @Test(dataProvider = "CRAMSourceFiles")
-    public void testCRAMThroughBAMRoundTrip(final File originalCRAMFile, final File referenceFile) throws IOException {
+    public void testCRAMThroughBAMRoundTrip(final Path originalCRAMFile, final Path referenceFile) throws IOException {
 
         // retrieve all records from the cram and make defensive deep copies
         List<SAMRecord> originalCRAMRecords = getSAMRecordsFromFile(originalCRAMFile, referenceFile);
@@ -334,16 +333,14 @@ public class CRAMComplianceTest extends HtsjdkTest {
     @Test(dataProvider = "roundTripTest")
     public void testBAMThroughCRAMRoundTrip(final String testFileName, final String referenceFileName)
             throws IOException {
-        final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
-
-        final File originalBAMInputFile = new File(TEST_DATA_DIR, testFileName);
-        final File referenceFile = new File(TEST_DATA_DIR, referenceFileName);
+        final Path originalBAMInputFile = TEST_DATA_DIR.resolve(testFileName);
+        final Path referenceFile = TEST_DATA_DIR.resolve(referenceFileName);
 
         List<SAMRecord> originalBAMRecords = getSAMRecordsFromFile(originalBAMInputFile, referenceFile);
 
         // write the BAM records to a temporary CRAM
-        final File tempCRAMFile = File.createTempFile("testBAMThroughCRAMRoundTrip", FileExtensions.CRAM);
-        tempCRAMFile.deleteOnExit();
+        final Path tempCRAMFile = Files.createTempFile("testBAMThroughCRAMRoundTrip", FileExtensions.CRAM);
+        tempCRAMFile.toFile().deleteOnExit();
         SAMFileHeader samHeader = getFileHeader(originalBAMInputFile, referenceFile);
         writeRecordsToFile(originalBAMRecords, tempCRAMFile, referenceFile, samHeader);
 
@@ -357,15 +354,13 @@ public class CRAMComplianceTest extends HtsjdkTest {
 
     @Test
     public void testBAMThroughCRAMRoundTripViaPath() throws IOException {
-        final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
-
         // These files are reduced versions of the CEUTrio.HiSeq.WGS.b37.NA12878.20.21.bam and human_g1k_v37.20.21.fasta
         // files used in GATK4 tests. The first 8000 records from chr20 were extracted; from those around 80 placed but
         // unmapped reads that contained cigar elements were removed, along with one read who's mate was on chr21.
         // Finally all read positions were remapped to the subsetted reference file, which contains only the ~9000 bases
         // used by the reduced read set.
-        final File originalBAMInputFile = new File(TEST_DATA_DIR, "CEUTrio.HiSeq.WGS.b37.NA12878.20.first.8000.bam");
-        final File referenceFile = new File(TEST_DATA_DIR, "human_g1k_v37.20.subset.fasta");
+        final Path originalBAMInputFile = TEST_DATA_DIR.resolve("CEUTrio.HiSeq.WGS.b37.NA12878.20.first.8000.bam");
+        final Path referenceFile = TEST_DATA_DIR.resolve("human_g1k_v37.20.subset.fasta");
 
         List<SAMRecord> originalBAMRecords = getSAMRecordsFromFile(originalBAMInputFile, referenceFile);
 
@@ -391,13 +386,13 @@ public class CRAMComplianceTest extends HtsjdkTest {
         // 1301_slice_aux.cram is taken from hts-specs repo. It uses reference files, ce.fa and ce.fa.fai.
         // 1301_slice_aux.cram file:
         // https://github.com/samtools/hts-specs/blob/master/test/cram/3.0/passed/1301_slice_aux.cram
-        final File sourceFile = new File(TEST_DATA_DIR, "1301_slice_aux.cram");
-        final File referenceFile = new File(TEST_DATA_DIR, "ce.fa");
+        final Path sourceFile = TEST_DATA_DIR.resolve("1301_slice_aux.cram");
+        final Path referenceFile = TEST_DATA_DIR.resolve("ce.fa");
         final CRAMEncodingStrategy testStrategy = new CRAMEncodingStrategy();
-        final File tempOutCRAM = File.createTempFile("testRoundTrip", ".cram");
-        tempOutCRAM.deleteOnExit();
+        final Path tempOutCRAM = Files.createTempFile("testRoundTrip", ".cram");
+        tempOutCRAM.toFile().deleteOnExit();
         CRAMTestUtils.writeToCRAMWithEncodingStrategy(testStrategy, sourceFile, tempOutCRAM, referenceFile);
-        try (final InputStream cramInputStream = new BufferedInputStream(new FileInputStream(tempOutCRAM));
+        try (final InputStream cramInputStream = new BufferedInputStream(Files.newInputStream(tempOutCRAM));
                 final CramContainerIterator containerIterator = new CramContainerIterator(cramInputStream)) {
             while (containerIterator.hasNext()) {
 
@@ -418,7 +413,7 @@ public class CRAMComplianceTest extends HtsjdkTest {
         }
     }
 
-    private SAMFileHeader getFileHeader(final File sourceFile, final File referenceFile) throws IOException {
+    private SAMFileHeader getFileHeader(final Path sourceFile, final Path referenceFile) throws IOException {
         try (final SamReader reader = SamReaderFactory.make()
                 .validationStringency(ValidationStringency.SILENT)
                 .referenceSequence(referenceFile)
@@ -427,11 +422,11 @@ public class CRAMComplianceTest extends HtsjdkTest {
         }
     }
 
-    private List<SAMRecord> getSAMRecordsFromFile(final File sourceFile, final File referenceFile) throws IOException {
-        return getSAMRecordsFromPath(sourceFile.toPath(), referenceFile);
+    private List<SAMRecord> getSAMRecordsFromFile(final Path sourceFile, final Path referenceFile) throws IOException {
+        return getSAMRecordsFromPath(sourceFile, referenceFile);
     }
 
-    private List<SAMRecord> getSAMRecordsFromPath(final Path sourcePath, final File referenceFile) throws IOException {
+    private List<SAMRecord> getSAMRecordsFromPath(final Path sourcePath, final Path referenceFile) throws IOException {
         List<SAMRecord> recs = new ArrayList<>();
         try (SamReader reader = SamReaderFactory.make()
                 .validationStringency(ValidationStringency.SILENT)
@@ -446,8 +441,8 @@ public class CRAMComplianceTest extends HtsjdkTest {
 
     private void writeRecordsToFile(
             final List<SAMRecord> recs,
-            final File targetFile,
-            final File referenceFile,
+            final Path targetFile,
+            final Path referenceFile,
             final SAMFileHeader samHeader) {
 
         // NOTE: even when the input is coord-sorted, using assumePresorted=false will cause some
@@ -464,14 +459,14 @@ public class CRAMComplianceTest extends HtsjdkTest {
     private void writeRecordsToPath(
             final List<SAMRecord> recs,
             final Path targetPath,
-            final File referenceFile,
+            final Path referenceFile,
             final SAMFileHeader samHeader) {
 
         // NOTE: even when the input is coord-sorted, using assumePresorted=false will cause some
         // tests to fail since it can change the order of some unmapped reads - this is allowed
         // by the spec since the order is arbitrary for unmapped.
         try (final SAMFileWriter writer =
-                new SAMFileWriterFactory().makeWriter(samHeader, true, targetPath, referenceFile.toPath())) {
+                new SAMFileWriterFactory().makeWriter(samHeader, true, targetPath, referenceFile)) {
             for (SAMRecord rec : recs) {
                 writer.addAlignment(rec);
             }

--- a/src/test/java/htsjdk/samtools/CRAMContainerStreamWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMContainerStreamWriterTest.java
@@ -7,10 +7,10 @@ import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.SequenceUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -109,7 +109,7 @@ public class CRAMContainerStreamWriterTest extends HtsjdkTest {
 
         // read all the records back in
         final CRAMFileReader cReader =
-                new CRAMFileReader(null, new ByteArrayInputStream(outStream.toByteArray()), refSource);
+                new CRAMFileReader((Path) null, new ByteArrayInputStream(outStream.toByteArray()), refSource);
         final SAMRecordIterator iterator = cReader.getIterator();
         int count = 0;
         while (iterator.hasNext()) {
@@ -164,7 +164,7 @@ public class CRAMContainerStreamWriterTest extends HtsjdkTest {
 
         // now iterate through all the records in the aggregate file
         final CRAMFileReader cReader =
-                new CRAMFileReader(null, new ByteArrayInputStream(aggregateStream.toByteArray()), refSource);
+                new CRAMFileReader((Path) null, new ByteArrayInputStream(aggregateStream.toByteArray()), refSource);
         final SAMRecordIterator iterator = cReader.getIterator();
         int count = 0;
         while (iterator.hasNext()) {
@@ -204,18 +204,14 @@ public class CRAMContainerStreamWriterTest extends HtsjdkTest {
             ByteArrayOutputStream outStream, ByteArrayOutputStream indexStream, String indexExtension)
             throws IOException {
         // write the file out
-        final File cramTempFile = File.createTempFile("cramContainerStreamTest", ".cram");
-        cramTempFile.deleteOnExit();
-        final OutputStream cramFileStream = new FileOutputStream(cramTempFile);
-        cramFileStream.write(outStream.toByteArray());
-        cramFileStream.close();
+        final Path cramTempFile = Files.createTempFile("cramContainerStreamTest", ".cram");
+        cramTempFile.toFile().deleteOnExit();
+        Files.write(cramTempFile, outStream.toByteArray());
 
         // write the index out
-        final File indexTempFile = File.createTempFile("cramContainerStreamTest", indexExtension);
-        indexTempFile.deleteOnExit();
-        OutputStream indexFileStream = new FileOutputStream(indexTempFile);
-        indexFileStream.write(indexStream.toByteArray());
-        indexFileStream.close();
+        final Path indexTempFile = Files.createTempFile("cramContainerStreamTest", indexExtension);
+        indexTempFile.toFile().deleteOnExit();
+        Files.write(indexTempFile, indexStream.toByteArray());
 
         final ReferenceSource refSource = createReferenceSource();
         final CRAMFileReader reader =

--- a/src/test/java/htsjdk/samtools/CRAMEdgeCasesTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMEdgeCasesTest.java
@@ -6,9 +6,9 @@ import htsjdk.io.IOPath;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.cram.structure.CRAMEncodingStrategy;
 import htsjdk.utils.SamtoolsTestUtils;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
  */
 public class CRAMEdgeCasesTest extends HtsjdkTest {
 
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/cram");
 
     // NOTE: mateResolutionTest1.sam file has 3 reads, with the first read mated to the third, and the third mated
     // to the second (see with BAM flags and mate alignment start):
@@ -42,37 +42,32 @@ public class CRAMEdgeCasesTest extends HtsjdkTest {
     @DataProvider(name = "mateResolutionTests")
     public Object[][] getMateResolutionTests() throws IOException {
         return new Object[][] {
-            {
-                new File(TEST_DATA_DIR, "mateResolutionTest1.sam"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.subset.fasta")
-            },
-            {
-                new File(TEST_DATA_DIR, "mateResolutionTest2.sam"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.subset.fasta")
-            }
+            {TEST_DATA_DIR.resolve("mateResolutionTest1.sam"), TEST_DATA_DIR.resolve("human_g1k_v37.20.subset.fasta")},
+            {TEST_DATA_DIR.resolve("mateResolutionTest2.sam"), TEST_DATA_DIR.resolve("human_g1k_v37.20.subset.fasta")}
         };
     }
 
     @Test(dataProvider = "mateResolutionTests")
-    public final void testMateResolution(final File testFileWithMates, final File referenceFile) throws IOException {
+    public final void testMateResolution(final Path testFileWithMates, final Path referenceFile) throws IOException {
 
         // convert sam to cram and compare results
         final CRAMEncodingStrategy testStrategy = new CRAMEncodingStrategy();
-        final File htsjdkTempCRAM = File.createTempFile("testMateResolution", ".cram");
+        final Path htsjdkTempCRAM = Files.createTempFile("testMateResolution", ".cram");
+        htsjdkTempCRAM.toFile().deleteOnExit();
         CRAMTestUtils.writeToCRAMWithEncodingStrategy(testStrategy, testFileWithMates, htsjdkTempCRAM, referenceFile);
         assertEqualAlignmentFileContents(testFileWithMates, htsjdkTempCRAM, referenceFile);
 
         // now use samtools to roundtrip the original, and compare results
         if (SamtoolsTestUtils.isSamtoolsAvailable()) {
             final IOPath tempSamtoolsIOPath = SamtoolsTestUtils.convertToCRAM(
-                    new HtsPath(testFileWithMates.getAbsolutePath()),
-                    new HtsPath(referenceFile.getAbsolutePath()),
+                    new HtsPath(testFileWithMates.toAbsolutePath().toString()),
+                    new HtsPath(referenceFile.toAbsolutePath().toString()),
                     null);
-            assertEqualAlignmentFileContents(tempSamtoolsIOPath.toPath().toFile(), htsjdkTempCRAM, referenceFile);
+            assertEqualAlignmentFileContents(tempSamtoolsIOPath.toPath(), htsjdkTempCRAM, referenceFile);
         }
     }
 
-    final void assertEqualAlignmentFileContents(final File testFile1, final File testFile2, final File referenceFile)
+    final void assertEqualAlignmentFileContents(final Path testFile1, final Path testFile2, final Path referenceFile)
             throws IOException {
         final SamReaderFactory readerFactory = SamReaderFactory.makeDefault()
                 .referenceSequence(referenceFile)
@@ -107,11 +102,11 @@ public class CRAMEdgeCasesTest extends HtsjdkTest {
     // testing for a contig found in the reads but not in the reference
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testContigNotFoundInRef() throws IOException {
-        final File CRAMFile = new File("src/test/resources/htsjdk/samtools/cram/CRAMException/testContigNotInRef.cram");
-        final File refFile = new File("src/test/resources/htsjdk/samtools/cram/CRAMException/testContigNotInRef.fa");
+        final Path CRAMFile = Path.of("src/test/resources/htsjdk/samtools/cram/CRAMException/testContigNotInRef.cram");
+        final Path refFile = Path.of("src/test/resources/htsjdk/samtools/cram/CRAMException/testContigNotInRef.fa");
         final ReferenceSource refSource = new ReferenceSource(refFile);
         final CRAMIterator iterator =
-                new CRAMIterator(new FileInputStream(CRAMFile), refSource, ValidationStringency.STRICT);
+                new CRAMIterator(Files.newInputStream(CRAMFile), refSource, ValidationStringency.STRICT);
         while (iterator.hasNext()) {
             iterator.next();
         }

--- a/src/test/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileBAIIndexTest.java
@@ -13,14 +13,11 @@ import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CoordMath;
-import htsjdk.samtools.util.IOUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,7 +33,7 @@ import org.testng.annotations.Test;
  * check that for every records in the BAM file the query returns the same records from the CRAM file.
  */
 public class CRAMFileBAIIndexTest extends HtsjdkTest {
-    private static final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private static final Path BAM_FILE = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
     private static final int NUMBER_OF_UNMAPPED_READS = 279;
     private static final int NUMBER_OF_MAPPED_READS = 9721;
     private static final int NUMBER_OF_READS = 10000;
@@ -45,7 +42,7 @@ public class CRAMFileBAIIndexTest extends HtsjdkTest {
     // Tests are read-only against this data so sharing is safe.
     private static final ConcurrentMap<Integer, byte[]> cramBytesCache = new ConcurrentHashMap<>();
     private static final ConcurrentMap<Integer, byte[]> baiBytesCache = new ConcurrentHashMap<>();
-    private static final ConcurrentMap<Integer, File> cramFileCache = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Integer, Path> cramFileCache = new ConcurrentHashMap<>();
 
     private static final String TEST_QUERY_ALIGNMENT_CONTIG = "chrM";
     private static final int TEST_QUERY_ALIGNMENT_START = 1519;
@@ -84,8 +81,8 @@ public class CRAMFileBAIIndexTest extends HtsjdkTest {
     // Mixes testing queryAlignmentStart with each CRAMFileReaderConstructor
     // Separate into individual tests
     @Test(dataProvider = "filesWithContainerAndSlicePartitioningVariations")
-    public void testConstructors(final File cramFile) throws IOException {
-        final File baiFile = getBAIFileForCRAMFile(cramFile);
+    public void testConstructors(final Path cramFile) throws IOException {
+        final Path baiFile = getBAIFileForCRAMFile(cramFile);
         try (final CRAMFileReader reader =
                 new CRAMFileReader(cramFile, baiFile, referenceSource, ValidationStringency.SILENT)) {
             try (final CloseableIterator<SAMRecord> iterator =
@@ -123,7 +120,7 @@ public class CRAMFileBAIIndexTest extends HtsjdkTest {
         }
 
         try (final CRAMFileReader reader = new CRAMFileReader(
-                new SeekableFileStream(cramFile), (File) null, referenceSource, ValidationStringency.SILENT)) {
+                new SeekableFileStream(cramFile), (Path) null, referenceSource, ValidationStringency.SILENT)) {
             Assert.expectThrows(
                     SAMException.class,
                     () -> reader.queryAlignmentStart(TEST_QUERY_ALIGNMENT_CONTIG, TEST_QUERY_ALIGNMENT_START));
@@ -321,7 +318,7 @@ public class CRAMFileBAIIndexTest extends HtsjdkTest {
         });
     }
 
-    private static File getCachedCRAMFile(final int readsPerSlice) {
+    private static Path getCachedCRAMFile(final int readsPerSlice) {
         return cramFileCache.computeIfAbsent(readsPerSlice, size -> {
             try {
                 return getCRAMFileForBAMFile(
@@ -347,52 +344,52 @@ public class CRAMFileBAIIndexTest extends HtsjdkTest {
     }
 
     private static byte[] getBAIBytesForCRAMBytes(final byte[] cramBytes) throws IOException {
-        final File indexFile = Files.createTempFile("cramBytes", ".bai").toFile();
-        indexFile.deleteOnExit();
+        final Path indexFile = Files.createTempFile("cramBytes", ".bai");
+        indexFile.toFile().deleteOnExit();
         CRAMBAIIndexer.createIndex(
                 new ByteArraySeekableStream(cramBytes), indexFile, null, ValidationStringency.STRICT);
-        return bytesFromFile(indexFile);
+        return bytesFromPath(indexFile);
     }
 
-    private static File getCRAMFileForBAMFile(
-            final File bamFile,
+    private static Path getCRAMFileForBAMFile(
+            final Path bamFile,
             final CRAMReferenceSource referenceSource,
             final CRAMEncodingStrategy cramEncodingStrategy)
             throws IOException {
         final byte[] cramBytes = getCRAMBytesForBAMFile(bamFile, referenceSource, cramEncodingStrategy);
-        final File cramFile = File.createTempFile(bamFile.getName(), ".cram");
-        cramFile.deleteOnExit();
-        try (final FileOutputStream fos = new FileOutputStream(cramFile)) {
-            fos.write(cramBytes);
-        }
+        final Path cramFile = Files.createTempFile(bamFile.getFileName().toString(), ".cram");
+        cramFile.toFile().deleteOnExit();
+        Files.write(cramFile, cramBytes);
         return cramFile;
     }
 
-    private static File getBAIFileForCRAMFile(final File cramFile) throws IOException {
-        final File baiIndexFile = new File(cramFile.getAbsolutePath() + ".bai");
-        baiIndexFile.deleteOnExit();
+    private static Path getBAIFileForCRAMFile(final Path cramFile) throws IOException {
+        final Path baiIndexFile = cramFile.resolveSibling(cramFile.getFileName().toString() + ".bai");
+        baiIndexFile.toFile().deleteOnExit();
         // TODO: its silly to use a stream constructor when we have a cram file...
         CRAMBAIIndexer.createIndex(new SeekableFileStream(cramFile), baiIndexFile, null, ValidationStringency.STRICT);
         return baiIndexFile;
     }
 
     // TODO: these are duplicated in CRAMFileCRAIIndexTest
-    private static byte[] bytesFromFile(final File file) throws IOException {
-        try (final FileInputStream fis = new FileInputStream(file)) {
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            IOUtil.copyStream(fis, baos);
-            return baos.toByteArray();
-        }
+    private static byte[] bytesFromPath(final Path file) throws IOException {
+        return Files.readAllBytes(file);
     }
 
     private static byte[] getCRAMBytesForBAMFile(
-            final File bamFile, final CRAMReferenceSource source, final CRAMEncodingStrategy encodingStrategy)
+            final Path bamFile, final CRAMReferenceSource source, final CRAMEncodingStrategy encodingStrategy)
             throws IOException {
         try (final SamReader samReader = SamReaderFactory.makeDefault().open(bamFile);
                 final SAMRecordIterator samIterator = samReader.iterator();
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             try (final CRAMFileWriter cramWriter = new CRAMFileWriter(
-                    encodingStrategy, baos, null, true, source, samReader.getFileHeader(), bamFile.getName())) {
+                    encodingStrategy,
+                    baos,
+                    null,
+                    true,
+                    source,
+                    samReader.getFileHeader(),
+                    bamFile.getFileName().toString())) {
                 while (samIterator.hasNext()) {
                     SAMRecord record = samIterator.next();
                     cramWriter.addAlignment(record);

--- a/src/test/java/htsjdk/samtools/CRAMFileCRAIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileCRAIIndexTest.java
@@ -12,8 +12,12 @@ import htsjdk.samtools.seekablestream.ByteArraySeekableStream;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.CoordMath;
-import htsjdk.samtools.util.IOUtil;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import org.testng.Assert;
@@ -29,15 +33,15 @@ import org.testng.annotations.Test;
  * CRAM file the query returns the same records from the CRAM file.
  */
 public class CRAMFileCRAIIndexTest extends HtsjdkTest {
-    private static final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private static final Path BAM_FILE = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
 
     private static final int nofReads = 10000;
     private static final int nofReadsPerContainer = 1000;
     private static final int nofUnmappedReads = 279;
     private static final int nofMappedReads = 9721;
 
-    private static File tmpCramFile;
-    private static File tmpCraiFile;
+    private static Path tmpCramFile;
+    private static Path tmpCraiFile;
     private static byte[] cramBytes;
     private static byte[] craiBytes;
     private static ReferenceSource source;
@@ -86,7 +90,7 @@ public class CRAMFileCRAIIndexTest extends HtsjdkTest {
     @Test(expectedExceptions = SAMException.class)
     public void testFileFileConstructorNoIndex() throws IOException {
         try (final CRAMFileReader reader = new CRAMFileReader(
-                new SeekableFileStream(tmpCramFile), (File) null, source, ValidationStringency.STRICT)) {
+                new SeekableFileStream(tmpCramFile), (Path) null, source, ValidationStringency.STRICT)) {
             reader.queryAlignmentStart("chrM", 1519);
         }
     }
@@ -170,11 +174,11 @@ public class CRAMFileCRAIIndexTest extends HtsjdkTest {
 
     @Test
     public void testIteratorConstructor() throws IOException {
-        final File CRAMFile = new File("src/test/resources/htsjdk/samtools/cram/auxf#values.3.0.cram");
-        final File refFile = new File("src/test/resources/htsjdk/samtools/cram/auxf.fa");
+        final Path CRAMFile = Path.of("src/test/resources/htsjdk/samtools/cram/auxf#values.3.0.cram");
+        final Path refFile = Path.of("src/test/resources/htsjdk/samtools/cram/auxf.fa");
         ReferenceSource refSource = new ReferenceSource(refFile);
 
-        long[] boundaries = new long[] {0, (CRAMFile.length() - 1) << 16};
+        long[] boundaries = new long[] {0, (Files.size(CRAMFile) - 1) << 16};
         try (final CRAMIterator iterator = new CRAMIterator(
                 new SeekableFileStream(CRAMFile), refSource, ValidationStringency.STRICT, null, boundaries)) {
             long count = getIteratorCount(iterator);
@@ -303,10 +307,10 @@ public class CRAMFileCRAIIndexTest extends HtsjdkTest {
 
     @BeforeClass
     public static void prepare() throws IOException {
-        tmpCramFile = File.createTempFile(BAM_FILE.getName(), ".cram");
-        tmpCramFile.deleteOnExit();
-        tmpCraiFile = new File(tmpCramFile.getAbsolutePath() + ".crai");
-        tmpCraiFile.deleteOnExit();
+        tmpCramFile = Files.createTempFile(BAM_FILE.getFileName().toString(), ".cram");
+        tmpCramFile.toFile().deleteOnExit();
+        tmpCraiFile = tmpCramFile.resolveSibling(tmpCramFile.getFileName().toString() + ".crai");
+        tmpCraiFile.toFile().deleteOnExit();
 
         source = new ReferenceSource(new FakeReferenceSequenceFile(SamReaderFactory.makeDefault()
                 .getFileHeader(BAM_FILE)
@@ -314,25 +318,19 @@ public class CRAMFileCRAIIndexTest extends HtsjdkTest {
                 .getSequences()));
         cramBytes = cramBytesFromBAMFile(BAM_FILE, source);
 
-        try (final FileOutputStream fios = new FileOutputStream(tmpCraiFile)) {
-            try (final FileOutputStream fos = new FileOutputStream(tmpCramFile)) {
-                fos.write(cramBytes);
-            }
+        try (final OutputStream fios = Files.newOutputStream(tmpCraiFile)) {
+            Files.write(tmpCramFile, cramBytes);
             CRAMCRAIIndexer.writeIndex(new SeekableFileStream(tmpCramFile), fios);
         }
-        craiBytes = bytesFromFile(tmpCraiFile);
+        craiBytes = bytesFromPath(tmpCraiFile);
     }
 
     // TODO: these are duplicated in CRAMFileCRAIIndexTest
-    private static byte[] bytesFromFile(final File file) throws IOException {
-        try (final FileInputStream fis = new FileInputStream(file)) {
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            IOUtil.copyStream(fis, baos);
-            return baos.toByteArray();
-        }
+    private static byte[] bytesFromPath(final Path file) throws IOException {
+        return Files.readAllBytes(file);
     }
 
-    private static byte[] cramBytesFromBAMFile(final File bamFile, final ReferenceSource source) throws IOException {
+    private static byte[] cramBytesFromBAMFile(final Path bamFile, final ReferenceSource source) throws IOException {
         try (final SamReader samReader = SamReaderFactory.makeDefault().open(bamFile);
                 final SAMRecordIterator samIterator = samReader.iterator();
                 final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
@@ -348,7 +346,7 @@ public class CRAMFileCRAIIndexTest extends HtsjdkTest {
                     true,
                     source,
                     samReader.getFileHeader(),
-                    bamFile.getName())) {
+                    bamFile.getFileName().toString())) {
                 while (samIterator.hasNext()) {
                     SAMRecord record = samIterator.next();
                     cramWriter.addAlignment(record);

--- a/src/test/java/htsjdk/samtools/CRAMFileReaderTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileReaderTest.java
@@ -27,7 +27,10 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import org.testng.Assert;
@@ -38,11 +41,11 @@ import org.testng.annotations.Test;
  */
 public class CRAMFileReaderTest extends HtsjdkTest {
 
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
-    private static final File CRAM_WITH_CRAI = new File(TEST_DATA_DIR, "cram_with_crai_index.cram");
-    private static final File CRAM_WITHOUT_CRAI = new File(TEST_DATA_DIR, "cram_query_sorted.cram");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
+    private static final Path CRAM_WITH_CRAI = TEST_DATA_DIR.resolve("cram_with_crai_index.cram");
+    private static final Path CRAM_WITHOUT_CRAI = TEST_DATA_DIR.resolve("cram_query_sorted.cram");
     private static final ReferenceSource REFERENCE = createReferenceSource();
-    private static final File INDEX_FILE = new File(TEST_DATA_DIR, "cram_with_crai_index.cram.crai");
+    private static final Path INDEX_FILE = TEST_DATA_DIR.resolve("cram_with_crai_index.cram.crai");
 
     private static ReferenceSource createReferenceSource() {
         final byte[] refBases = new byte[10 * 10];
@@ -52,7 +55,7 @@ public class CRAMFileReaderTest extends HtsjdkTest {
         return new ReferenceSource(rsf);
     }
 
-    // constructor 1: CRAMFileReader(final File cramFile, final InputStream inputStream)
+    // constructor 1: CRAMFileReader(final Path cramFile, final InputStream inputStream)
 
     @Test(description = "Test CRAMReader 1 reference required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader1_ReferenceRequired() {
@@ -62,7 +65,7 @@ public class CRAMFileReaderTest extends HtsjdkTest {
         reader.getIterator().hasNext();
     }
 
-    // constructor 2: CRAMFileReader(final File cramFile, final InputStream inputStream, final ReferenceSource
+    // constructor 2: CRAMFileReader(final Path cramFile, final InputStream inputStream, final ReferenceSource
     // referenceSource)
 
     @Test(description = "Test CRAMReader 2 reference required", expectedExceptions = IllegalArgumentException.class)
@@ -74,9 +77,9 @@ public class CRAMFileReaderTest extends HtsjdkTest {
 
     @Test(description = "Test CRAMReader 2 input required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader2_InputRequired() {
-        final File file = null;
+        final Path path = null;
         final InputStream bis = null;
-        final CRAMFileReader reader = new CRAMFileReader(file, bis, createReferenceSource());
+        final CRAMFileReader reader = new CRAMFileReader(path, bis, createReferenceSource());
         reader.getIterator().hasNext();
     }
 
@@ -95,28 +98,28 @@ public class CRAMFileReaderTest extends HtsjdkTest {
         reader.getIndex();
     }
 
-    // constructor 3: CRAMFileReader(final File cramFile, final File indexFile, final ReferenceSource referenceSource)
+    // constructor 3: CRAMFileReader(final Path cramFile, final Path indexFile, final ReferenceSource referenceSource)
 
     @Test(description = "Test CRAMReader 3 reference required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader3_RequiredReference() {
-        final File indexFile = null;
+        final Path indexPath = null;
         final ReferenceSource refSource = null;
-        final CRAMFileReader reader = new CRAMFileReader(CRAM_WITH_CRAI, indexFile, refSource);
+        final CRAMFileReader reader = new CRAMFileReader(CRAM_WITH_CRAI, indexPath, refSource);
         reader.getIterator().hasNext();
     }
 
     @Test(description = "Test CRAMReader 3 input required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader3_InputRequired() {
-        final File inputFile = null;
-        final File indexFile = null;
+        final Path inputPath = null;
+        final Path indexPath = null;
         ReferenceSource refSource = null;
-        new CRAMFileReader(inputFile, indexFile, refSource);
+        new CRAMFileReader(inputPath, indexPath, refSource);
     }
 
     @Test
     public void testCRAMReader3_ShouldAutomaticallyFindCRAMIndex() {
-        final File indexFile = null;
-        final CRAMFileReader reader = new CRAMFileReader(CRAM_WITH_CRAI, indexFile, REFERENCE);
+        final Path indexPath = null;
+        final CRAMFileReader reader = new CRAMFileReader(CRAM_WITH_CRAI, indexPath, REFERENCE);
         reader.getIndex();
         Assert.assertTrue(reader.hasIndex(), "Can't find CRAM index.");
     }
@@ -130,12 +133,12 @@ public class CRAMFileReaderTest extends HtsjdkTest {
 
     @Test(expectedExceptions = SAMException.class)
     public void testCRAMReader3_WithoutCRAMIndex() {
-        final File indexFile = null;
-        final CRAMFileReader reader = new CRAMFileReader(CRAM_WITHOUT_CRAI, indexFile, REFERENCE);
+        final Path indexPath = null;
+        final CRAMFileReader reader = new CRAMFileReader(CRAM_WITHOUT_CRAI, indexPath, REFERENCE);
         reader.getIndex();
     }
 
-    // constructor 4: CRAMFileReader(final File cramFile, final ReferenceSource referenceSource)
+    // constructor 4: CRAMFileReader(final Path cramFile, final ReferenceSource referenceSource)
 
     @Test(description = "Test CRAMReader 4 reference required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader4_ReferenceRequired() {
@@ -146,8 +149,8 @@ public class CRAMFileReaderTest extends HtsjdkTest {
 
     @Test(description = "Test CRAMReader 4 input required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader4_InputRequired() {
-        final File inputFile = null;
-        new CRAMFileReader(inputFile, createReferenceSource());
+        final Path inputPath = null;
+        new CRAMFileReader(inputPath, createReferenceSource());
     }
 
     @Test
@@ -167,7 +170,7 @@ public class CRAMFileReaderTest extends HtsjdkTest {
     //          final ReferenceSource referenceSource, final ValidationStringency validationStringency)
     @Test(description = "Test CRAMReader 5 reference required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader5_ReferenceRequired() throws IOException {
-        try (final FileInputStream fis = new FileInputStream(CRAM_WITH_CRAI)) {
+        try (final InputStream fis = Files.newInputStream(CRAM_WITH_CRAI)) {
             final SeekableFileStream sfs = null;
             final ReferenceSource refSource = null;
             final CRAMFileReader reader = new CRAMFileReader(fis, sfs, refSource, ValidationStringency.STRICT);
@@ -182,15 +185,15 @@ public class CRAMFileReaderTest extends HtsjdkTest {
         new CRAMFileReader(bis, sfs, createReferenceSource(), ValidationStringency.STRICT);
     }
 
-    // constructor 6: CRAMFileReader(final InputStream stream, final File indexFile, final ReferenceSource
+    // constructor 6: CRAMFileReader(final InputStream stream, final Path indexFile, final ReferenceSource
     // referenceSource,
     //                final ValidationStringency validationStringency)
     @Test(description = "Test CRAMReader 6 reference required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader6_ReferenceRequired() throws IOException {
-        try (final FileInputStream fis = new FileInputStream(CRAM_WITH_CRAI)) {
-            final File file = null;
+        try (final InputStream fis = Files.newInputStream(CRAM_WITH_CRAI)) {
+            final Path indexPath = null;
             final ReferenceSource refSource = null;
-            final CRAMFileReader reader = new CRAMFileReader(fis, file, refSource, ValidationStringency.STRICT);
+            final CRAMFileReader reader = new CRAMFileReader(fis, indexPath, refSource, ValidationStringency.STRICT);
             reader.getIterator().hasNext();
         }
     }
@@ -198,11 +201,11 @@ public class CRAMFileReaderTest extends HtsjdkTest {
     @Test(description = "Test CRAMReader 6 input required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader6_InputRequired() throws IOException {
         InputStream bis = null;
-        File file = null;
-        new CRAMFileReader(bis, file, createReferenceSource(), ValidationStringency.STRICT);
+        Path indexPath = null;
+        new CRAMFileReader(bis, indexPath, createReferenceSource(), ValidationStringency.STRICT);
     }
 
-    // constructor 7: CRAMFileReader(final File cramFile, final File indexFile, final ReferenceSource referenceSource,
+    // constructor 7: CRAMFileReader(final Path cramFile, final Path indexFile, final ReferenceSource referenceSource,
     //                final ValidationStringency validationStringency)
     @Test(description = "Test CRAMReader 7 reference required", expectedExceptions = IllegalArgumentException.class)
     public void testCRAMReader7_ReferenceRequired() throws IOException {
@@ -214,8 +217,8 @@ public class CRAMFileReaderTest extends HtsjdkTest {
 
     @Test
     public void testCRAMReader7_ShouldAutomaticallyFindCRAMIndex() throws IOException {
-        File indexFile = null;
-        CRAMFileReader reader = new CRAMFileReader(CRAM_WITH_CRAI, indexFile, REFERENCE, ValidationStringency.STRICT);
+        Path indexPath = null;
+        CRAMFileReader reader = new CRAMFileReader(CRAM_WITH_CRAI, indexPath, REFERENCE, ValidationStringency.STRICT);
         Assert.assertTrue(reader.hasIndex(), "Can't find existing CRAM index.");
     }
 
@@ -227,9 +230,9 @@ public class CRAMFileReaderTest extends HtsjdkTest {
 
     @Test(expectedExceptions = SAMException.class)
     public void testCRAMReader7_WithoutCRAMIndex() throws IOException {
-        File indexFile = null;
+        Path indexPath = null;
         CRAMFileReader reader =
-                new CRAMFileReader(CRAM_WITHOUT_CRAI, indexFile, REFERENCE, ValidationStringency.STRICT);
+                new CRAMFileReader(CRAM_WITHOUT_CRAI, indexPath, REFERENCE, ValidationStringency.STRICT);
         reader.getIndex();
     }
 

--- a/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMFileWriterTest.java
@@ -33,8 +33,8 @@ import htsjdk.samtools.util.Log.LogLevel;
 import htsjdk.samtools.util.SequenceUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +46,7 @@ import org.testng.annotations.Test;
 public class CRAMFileWriterTest extends HtsjdkTest {
 
     LogLevel globalLogLevel;
-    final File SAM_TOOLS_TEST_DIR = new File("src/test/resources/htsjdk/samtools");
+    final Path SAM_TOOLS_TEST_DIR = Path.of("src/test/resources/htsjdk/samtools");
 
     @Test(description = "Test for lossy CRAM compression invariants.")
     public void lossyCramInvariantsTest() {
@@ -136,7 +136,7 @@ public class CRAMFileWriterTest extends HtsjdkTest {
         // to expected records before comparison
         addMissingNmMd(expectedRecords, referenceSource);
 
-        try (CRAMFileReader cReader = new CRAMFileReader(null, is, referenceSource)) {
+        try (CRAMFileReader cReader = new CRAMFileReader((Path) null, is, referenceSource)) {
 
             SAMRecordIterator iterator2 = cReader.getIterator();
             int index = 0;
@@ -257,11 +257,10 @@ public class CRAMFileWriterTest extends HtsjdkTest {
     @Test
     public void test_roundtrip_tlen_preserved() throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ReferenceSource source = new ReferenceSource(new File(SAM_TOOLS_TEST_DIR, "cram_tlen.fasta"));
+        final ReferenceSource source = new ReferenceSource(SAM_TOOLS_TEST_DIR.resolve("cram_tlen.fasta"));
         final List<SAMRecord> records = new ArrayList<>();
 
-        try (SamReader reader =
-                        SamReaderFactory.make().open(new File(SAM_TOOLS_TEST_DIR, "cram_tlen_reads.sorted.sam"));
+        try (SamReader reader = SamReaderFactory.make().open(SAM_TOOLS_TEST_DIR.resolve("cram_tlen_reads.sorted.sam"));
                 CRAMFileWriter writer = new CRAMFileWriter(baos, source, reader.getFileHeader(), "test.cram")) {
             for (final SAMRecord record : reader) {
                 writer.addAlignment(record);
@@ -273,7 +272,7 @@ public class CRAMFileWriterTest extends HtsjdkTest {
         addMissingNmMd(records, source);
 
         try (CRAMFileReader cramReader = new CRAMFileReader(
-                new ByteArrayInputStream(baos.toByteArray()), (File) null, source, ValidationStringency.STRICT)) {
+                new ByteArrayInputStream(baos.toByteArray()), (Path) null, source, ValidationStringency.STRICT)) {
             final SAMRecordIterator iterator = cramReader.getIterator();
             int i = 0;
             while (iterator.hasNext()) {
@@ -291,10 +290,9 @@ public class CRAMFileWriterTest extends HtsjdkTest {
     public void test_roundtrip_many_reads() throws IOException {
 
         // Create the input file
-        final File outputDir =
-                IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp").toFile();
-        outputDir.deleteOnExit();
-        final Path output = new File(outputDir, "input.cram").toPath();
+        final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp");
+        outputDir.toFile().deleteOnExit();
+        final Path output = outputDir.resolve("input.cram");
         IOUtil.deleteOnExit(output);
         final Path fastaDir = IOUtil.createTempDir("CRAMFileWriterTest");
         IOUtil.deleteOnExit(fastaDir);
@@ -344,9 +342,10 @@ public class CRAMFileWriterTest extends HtsjdkTest {
 
     @Test
     public void testCRAMQuerySort() throws IOException {
-        final File input = new File(SAM_TOOLS_TEST_DIR, "cram_query_sorted.cram");
-        final File reference = new File(SAM_TOOLS_TEST_DIR, "cram_query_sorted.fasta");
-        final File outputFile = File.createTempFile("tmp.", ".cram");
+        final Path input = SAM_TOOLS_TEST_DIR.resolve("cram_query_sorted.cram");
+        final Path reference = SAM_TOOLS_TEST_DIR.resolve("cram_query_sorted.fasta");
+        final Path outputFile = Files.createTempFile("tmp.", ".cram");
+        outputFile.toFile().deleteOnExit();
         final SamReaderFactory samReaderFactory = SamReaderFactory.makeDefault().referenceSequence(reference);
 
         try (final SamReader reader = samReaderFactory.open(input);
@@ -398,7 +397,8 @@ public class CRAMFileWriterTest extends HtsjdkTest {
             writer.addAlignment(record);
         }
 
-        try (CRAMFileReader reader = new CRAMFileReader(null, new ByteArrayInputStream(os.toByteArray()), refSource)) {
+        try (CRAMFileReader reader =
+                new CRAMFileReader((Path) null, new ByteArrayInputStream(os.toByteArray()), refSource)) {
             final SAMRecord decoded = reader.getIterator().next();
             Assert.assertEquals(
                     decoded.getIntegerAttribute(SAMTag.NM),
@@ -439,7 +439,8 @@ public class CRAMFileWriterTest extends HtsjdkTest {
             writer.addAlignment(record);
         }
 
-        try (CRAMFileReader reader = new CRAMFileReader(null, new ByteArrayInputStream(os.toByteArray()), refSource)) {
+        try (CRAMFileReader reader =
+                new CRAMFileReader((Path) null, new ByteArrayInputStream(os.toByteArray()), refSource)) {
             final SAMRecord decoded = reader.getIterator().next();
             Assert.assertEquals(
                     decoded.getIntegerAttribute(SAMTag.NM), Integer.valueOf(0), "NM should be preserved verbatim");

--- a/src/test/java/htsjdk/samtools/CRAMIndexPermutationsTests.java
+++ b/src/test/java/htsjdk/samtools/CRAMIndexPermutationsTests.java
@@ -5,8 +5,8 @@ import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.cram.structure.CRAMEncodingStrategy;
 import htsjdk.samtools.reference.FakeReferenceSequenceFile;
 import htsjdk.samtools.reference.FastaSequenceFile;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -23,14 +23,14 @@ import org.testng.annotations.Test;
  */
 public class CRAMIndexPermutationsTests extends HtsjdkTest {
 
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/cram");
 
     // BAM test file for comparison with CRAM results. This is asubset of NA12878
     // (20:10000000-10004000, 21:10000000-10004000, +2000 unmapped). There is no corresponding
     // reference checked in for this file since its too big, but because we're only using it to validate
     // index query results, we only care that the right the reads are returned, not what the read bases are, so
     // we use a synthetic in-memory fake reference of all 'N's to convert it to CRAM.
-    private static final File truthBAM = new File(TEST_DATA_DIR, "NA12878.20.21.unmapped.orig.bam");
+    private static final Path truthBAM = TEST_DATA_DIR.resolve("NA12878.20.21.unmapped.orig.bam");
 
     // Note that these tests can be REALLY slow because although we don't use the real (huge) reference, we use a fake
     // in-memory reference, but the reference sequences in the dictionary in the test file are large (60 mega-bases),
@@ -43,10 +43,10 @@ public class CRAMIndexPermutationsTests extends HtsjdkTest {
 
     // Caches to avoid rebuilding CRAM files for the same encoding strategy across test methods.
     // Key is the strategy's toString() + index type suffix.
-    private static final ConcurrentMap<String, File> baiCramCache = new ConcurrentHashMap<>();
-    private static final ConcurrentMap<String, File> craiCramCache = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, Path> baiCramCache = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, Path> craiCramCache = new ConcurrentHashMap<>();
 
-    private static File getCachedBAICram(final CRAMEncodingStrategy strategy) {
+    private static Path getCachedBAICram(final CRAMEncodingStrategy strategy) {
         return baiCramCache.computeIfAbsent(strategy.toString(), k -> {
             try {
                 return CRAMIndexTestHelper.createCRAMWithBAIForEncodingStrategy(
@@ -57,7 +57,7 @@ public class CRAMIndexPermutationsTests extends HtsjdkTest {
         });
     }
 
-    private static File getCachedCRAICram(final CRAMEncodingStrategy strategy) {
+    private static Path getCachedCRAICram(final CRAMEncodingStrategy strategy) {
         return craiCramCache.computeIfAbsent(strategy.toString(), k -> {
             try {
                 return CRAMIndexTestHelper.createCRAMWithCRAIForEncodingStrategy(
@@ -187,9 +187,10 @@ public class CRAMIndexPermutationsTests extends HtsjdkTest {
     public void testQueriesWithBAI(
             final CRAMEncodingStrategy cramEncodingStrategy, final QueryInterval[] queryIntervals) throws IOException {
 
-        final File tempCRAM = getCachedBAICram(cramEncodingStrategy);
+        final Path tempCRAM = getCachedBAICram(cramEncodingStrategy);
+        final Path tempIndex = SamFiles.findIndex(tempCRAM);
         final List<String> cramResults = CRAMIndexTestHelper.getCRAMResultsForQueryIntervals(
-                tempCRAM, SamFiles.findIndex(tempCRAM), fakeReferenceSource, queryIntervals);
+                tempCRAM, tempIndex, fakeReferenceSource, queryIntervals);
         final List<String> truthResults = CRAMIndexTestHelper.getBAMResultsForQueryIntervals(truthBAM, queryIntervals);
 
         Assert.assertEquals(cramResults, truthResults);
@@ -199,10 +200,11 @@ public class CRAMIndexPermutationsTests extends HtsjdkTest {
     public void testQueriesWithCRAI(
             final CRAMEncodingStrategy cramEncodingStrategy, final QueryInterval[] queryIntervals) throws IOException {
 
-        final File tempCRAM = getCachedCRAICram(cramEncodingStrategy);
+        final Path tempCRAM = getCachedCRAICram(cramEncodingStrategy);
 
+        final Path tempIndex = SamFiles.findIndex(tempCRAM);
         final List<String> cramResults = CRAMIndexTestHelper.getCRAMResultsForQueryIntervals(
-                tempCRAM, SamFiles.findIndex(tempCRAM), fakeReferenceSource, queryIntervals);
+                tempCRAM, tempIndex, fakeReferenceSource, queryIntervals);
         final List<String> truthResults = CRAMIndexTestHelper.getBAMResultsForQueryIntervals(truthBAM, queryIntervals);
 
         Assert.assertEquals(cramResults, truthResults);
@@ -230,9 +232,10 @@ public class CRAMIndexPermutationsTests extends HtsjdkTest {
 
     @Test(dataProvider = "cramUnmappedTestCases")
     public void testQueryUnmapped(final CRAMEncodingStrategy cramEncodingStrategy) throws IOException {
-        final File tempCRAM = getCachedCRAICram(cramEncodingStrategy);
-        final List<String> cramResults = CRAMIndexTestHelper.getCRAMResultsForUnmapped(
-                tempCRAM, SamFiles.findIndex(tempCRAM), fakeReferenceSource);
+        final Path tempCRAM = getCachedCRAICram(cramEncodingStrategy);
+        final Path tempIndex = SamFiles.findIndex(tempCRAM);
+        final List<String> cramResults =
+                CRAMIndexTestHelper.getCRAMResultsForUnmapped(tempCRAM, tempIndex, fakeReferenceSource);
         final List<String> truthResults = CRAMIndexTestHelper.getBAMResultsForUnmapped(truthBAM);
         Assert.assertEquals(cramResults, truthResults);
     }
@@ -257,15 +260,16 @@ public class CRAMIndexPermutationsTests extends HtsjdkTest {
             throws IOException {
         // queryUnmapped for each encoding strategy on a cram that has ONLY unmapped reads (including 13
         // unmapped/placed)
-        final File tempCRAM = CRAMIndexTestHelper.createCRAMWithCRAIForEncodingStrategy(
-                new File(TEST_DATA_DIR, "NA12878.unmapped.cram"),
-                new ReferenceSource(new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta")),
+        final Path tempCRAM = CRAMIndexTestHelper.createCRAMWithCRAIForEncodingStrategy(
+                TEST_DATA_DIR.resolve("NA12878.unmapped.cram"),
+                new ReferenceSource(TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta")),
                 cramEncodingStrategy);
+        final Path tempIndex = SamFiles.findIndex(tempCRAM);
         final List<String> cramResults = CRAMIndexTestHelper.getCRAMResultsForUnmapped(
                 tempCRAM,
-                SamFiles.findIndex(tempCRAM),
+                tempIndex,
                 new ReferenceSource(
-                        new FastaSequenceFile(new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta"), false)));
+                        new FastaSequenceFile(TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta"), false)));
         // there are 513 unmapped reads, 13 of which are "placed" on reference sequence, and are not returned by htsjdk
         // unmapped query
         Assert.assertEquals(cramResults.size(), 500);

--- a/src/test/java/htsjdk/samtools/CRAMIndexQueryTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMIndexQueryTest.java
@@ -28,12 +28,13 @@ import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloseableIterator;
-import java.io.File;
-import java.io.FileOutputStream;
+import htsjdk.samtools.util.IOUtil;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.function.Function;
 import org.testng.Assert;
@@ -48,20 +49,20 @@ import org.testng.annotations.Test;
  */
 public class CRAMIndexQueryTest extends HtsjdkTest {
 
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
+    private static final Path TEST_DATA_DIR = Paths.get("src/test/resources/htsjdk/samtools/cram");
 
-    private static final File cramQueryWithBAI = new File(TEST_DATA_DIR, "cramQueryWithBAI.cram");
-    private static final File cramQueryWithCRAI = new File(TEST_DATA_DIR, "cramQueryWithCRAI.cram");
-    private static File cramQueryWithLocalCRAI = null; // generated  by @BeforeClass from cramQueryWithCRAI
-    private static final File cramQueryReference = new File(TEST_DATA_DIR, "human_g1k_v37.20.21.10M-10M200k.fasta");
+    private static final Path cramQueryWithBAI = TEST_DATA_DIR.resolve("cramQueryWithBAI.cram");
+    private static final Path cramQueryWithCRAI = TEST_DATA_DIR.resolve("cramQueryWithCRAI.cram");
+    private static Path cramQueryWithLocalCRAI = null; // generated  by @BeforeClass from cramQueryWithCRAI
+    private static final Path cramQueryReference = TEST_DATA_DIR.resolve("human_g1k_v37.20.21.10M-10M200k.fasta");
 
-    private static final File cramQueryReadsWithBAI = new File(TEST_DATA_DIR, "cramQueryTest.cram");
-    private static File cramQueryReadsWithLocalCRAI = null; // generated  by @BeforeClass from cramQueryReadsWithBAI
+    private static final Path cramQueryReadsWithBAI = TEST_DATA_DIR.resolve("cramQueryTest.cram");
+    private static Path cramQueryReadsWithLocalCRAI = null; // generated  by @BeforeClass from cramQueryReadsWithBAI
 
-    private static final File cramQueryTestEmptyWithBAI = new File(TEST_DATA_DIR, "cramQueryTestEmpty.cram");
-    private static File cramQueryTestEmptyWithLocalCRAI =
+    private static final Path cramQueryTestEmptyWithBAI = TEST_DATA_DIR.resolve("cramQueryTestEmpty.cram");
+    private static Path cramQueryTestEmptyWithLocalCRAI =
             null; // generated  by @BeforeClass from cramQueryTestEmptyWithBAI
-    private static final File cramQueryReadsReference = new File(TEST_DATA_DIR, "../hg19mini.fasta");
+    private static final Path cramQueryReadsReference = TEST_DATA_DIR.resolve("../hg19mini.fasta");
 
     // htsjdk currently generates .bai index files instead of .crai due to
     // https://github.com/samtools/htsjdk/issues/531;
@@ -71,29 +72,34 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
     // to run to use as additional test cases
     @BeforeClass
     public void createLocallyGeneratedCRAIFiles() throws IOException {
-        cramQueryWithLocalCRAI = File.createTempFile("cramQueryWithLocalCRAI.", ".cram");
-        cramQueryWithLocalCRAI.deleteOnExit();
-        File tempCRAIOut = new File(cramQueryWithLocalCRAI.getAbsolutePath() + ".crai");
-        tempCRAIOut.deleteOnExit();
+        cramQueryWithLocalCRAI = Files.createTempFile("cramQueryWithLocalCRAI.", ".cram");
+        IOUtil.deleteOnExit(cramQueryWithLocalCRAI);
+        Path tempCRAIOut = craiSibling(cramQueryWithLocalCRAI);
+        IOUtil.deleteOnExit(tempCRAIOut);
         createLocalCRAMAndCRAI(cramQueryWithCRAI, cramQueryWithLocalCRAI, tempCRAIOut);
 
-        cramQueryReadsWithLocalCRAI = File.createTempFile("cramQueryReadsWithLocalCRAI.", ".cram");
-        tempCRAIOut = new File(cramQueryReadsWithLocalCRAI.getAbsolutePath() + ".crai");
-        tempCRAIOut.deleteOnExit();
-        cramQueryReadsWithLocalCRAI.deleteOnExit();
+        cramQueryReadsWithLocalCRAI = Files.createTempFile("cramQueryReadsWithLocalCRAI.", ".cram");
+        tempCRAIOut = craiSibling(cramQueryReadsWithLocalCRAI);
+        IOUtil.deleteOnExit(tempCRAIOut);
+        IOUtil.deleteOnExit(cramQueryReadsWithLocalCRAI);
         createLocalCRAMAndCRAI(cramQueryReadsWithBAI, cramQueryReadsWithLocalCRAI, tempCRAIOut);
 
-        cramQueryTestEmptyWithLocalCRAI = File.createTempFile("cramQueryTestEmptyWithLocalCRAI.", ".cram");
-        tempCRAIOut = new File(cramQueryTestEmptyWithLocalCRAI.getAbsolutePath() + ".crai");
-        tempCRAIOut.deleteOnExit();
-        cramQueryTestEmptyWithLocalCRAI.deleteOnExit();
+        cramQueryTestEmptyWithLocalCRAI = Files.createTempFile("cramQueryTestEmptyWithLocalCRAI.", ".cram");
+        tempCRAIOut = craiSibling(cramQueryTestEmptyWithLocalCRAI);
+        IOUtil.deleteOnExit(tempCRAIOut);
+        IOUtil.deleteOnExit(cramQueryTestEmptyWithLocalCRAI);
         createLocalCRAMAndCRAI(cramQueryTestEmptyWithBAI, cramQueryTestEmptyWithLocalCRAI, tempCRAIOut);
     }
 
-    private void createLocalCRAMAndCRAI(final File inputCRAM, final File outputCRAM, final File outputCRAI)
+    /** Returns the sibling .crai path for a given CRAM path (cramPath + ".crai"). */
+    private static Path craiSibling(final Path cramPath) {
+        return Paths.get(cramPath.toAbsolutePath() + ".crai");
+    }
+
+    private void createLocalCRAMAndCRAI(final Path inputCRAM, final Path outputCRAM, final Path outputCRAI)
             throws IOException {
-        Files.copy(inputCRAM.toPath(), outputCRAM.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        try (FileOutputStream bos = new FileOutputStream(outputCRAI)) {
+        Files.copy(inputCRAM, outputCRAM, StandardCopyOption.REPLACE_EXISTING);
+        try (OutputStream bos = Files.newOutputStream(outputCRAI)) {
             CRAMCRAIIndexer.writeIndex(new SeekableFileStream(outputCRAM), bos);
         }
     }
@@ -182,8 +188,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
             {cramQueryTestEmptyWithBAI, cramQueryReadsReference, new QueryInterval(0, 1, 0), new String[] {}},
             {cramQueryTestEmptyWithLocalCRAI, cramQueryReadsReference, new QueryInterval(0, 1, 0), new String[] {}},
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 new QueryInterval(0, 631, 631),
                 new String[] {
                     "IL29_4505:7:51:11752:16255#2",
@@ -218,8 +224,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleIntervalOverlapping")
     public void testQueryOverlappingSingleInterval(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval interval,
             final String[] expectedNames)
             throws IOException {
@@ -232,8 +238,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleIntervalOverlapping")
     public void testQueryOverlappingSequence(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval interval,
             final String[] expectedNames)
             throws IOException {
@@ -251,8 +257,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleIntervalOverlapping")
     public void testQuerySingleIntervalContainedFalse(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval interval,
             final String[] expectedNames)
             throws IOException {
@@ -265,8 +271,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleIntervalOverlapping")
     public void testQuerySequenceContainedFalse(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval interval,
             final String[] expectedNames)
             throws IOException {
@@ -359,8 +365,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
             {cramQueryTestEmptyWithBAI, cramQueryReadsReference, new QueryInterval(0, 1, 0), new String[] {}},
             {cramQueryTestEmptyWithLocalCRAI, cramQueryReadsReference, new QueryInterval(0, 1, 0), new String[] {}},
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 new QueryInterval(0, 631, 656),
                 new String[] {"IL29_4505:7:88:5383:14756#2"},
             }
@@ -369,8 +375,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleIntervalContained")
     public void testQueryContainedSingleInterval(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval interval,
             final String[] expectedNames)
             throws IOException {
@@ -383,8 +389,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleIntervalContained")
     public void testQueryContainedSequence(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval interval,
             final String[] expectedNames)
             throws IOException {
@@ -402,8 +408,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleIntervalContained")
     public void testQuerySingleIntervalContainedTrue(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval interval,
             final String[] expectedNames)
             throws IOException {
@@ -416,8 +422,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "singleIntervalContained")
     public void testQuerySequenceContainedTrue(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval interval,
             final String[] expectedNames)
             throws IOException {
@@ -570,8 +576,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "multipleIntervalOverlapping")
     public void testQueryOverlappingMultipleIntervals(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval[] intervals,
             final String[] expectedNames)
             throws IOException {
@@ -608,8 +614,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
     // using more than one interval; these tests optimize down to 0 or 1 interval
     @Test(dataProvider = "otherMultipleIntervals")
     public void testOtherMultipleIntervals(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval[] intervals,
             final String[] expectedNames)
             throws IOException {
@@ -756,8 +762,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "multipleIntervalContained")
     public void testQueryContainedMultipleIntervals(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final QueryInterval[] intervals,
             final String[] expectedNames)
             throws IOException {
@@ -780,7 +786,7 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "unmappedQueries")
-    public void testQueryUnmapped(final File cramFileName, final File referenceFileName, final String[] expectedNames)
+    public void testQueryUnmapped(final Path cramFileName, final Path referenceFileName, final String[] expectedNames)
             throws IOException {
         doQueryTest(SamReader::queryUnmapped, cramFileName, referenceFileName, expectedNames);
     }
@@ -796,15 +802,15 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
             // in the same container that don't match the alignment start are properly constrained to only the
             // matching reads
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 "Mito",
                 631,
                 24
             },
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTestGATKGen.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTestGATKGen.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 "Mito",
                 631,
                 24
@@ -814,8 +820,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "alignmentStartQueries")
     public void testQueryAlignmentStart(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final String queryContig,
             final int alignmentStart,
             final int expectedReadCount)
@@ -843,15 +849,15 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
             {cramQueryWithLocalCRAI, cramQueryReference, "20", 100013, "f"},
             {cramQueryWithBAI, cramQueryReference, "20", 100013, "f"},
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 "Mito",
                 631,
                 "IL29_4505:7:30:11521:4492#2"
             },
             {
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTestGATKGen.cram"),
-                new File(TEST_DATA_DIR, "mitoAlignmentStartTest.fa"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTestGATKGen.cram"),
+                TEST_DATA_DIR.resolve("mitoAlignmentStartTest.fa"),
                 "Mito",
                 631,
                 "IL29_4505:7:30:11521:4492#2"
@@ -861,8 +867,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "mateQueries")
     public void testQueryMate(
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final String queryContig,
             final int alignmentStart,
             final String expectedReadName)
@@ -898,8 +904,8 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     private void doQueryTest(
             final Function<SamReader, CloseableIterator<SAMRecord>> getIterator,
-            final File cramFileName,
-            final File referenceFileName,
+            final Path cramFileName,
+            final Path referenceFileName,
             final String[] expectedNames)
             throws IOException {
         SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.LENIENT);
@@ -934,7 +940,7 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
     // (https://github.com/samtools/htsjdk/issues/563), these can be re-enabled.
     //
     @Test(dataProvider = "iteratorStateTests", expectedExceptions = SAMException.class, enabled = false)
-    public void testIteratorState(final File cramFileName, final File referenceFileName) throws IOException {
+    public void testIteratorState(final Path cramFileName, final Path referenceFileName) throws IOException {
         SamReaderFactory factory = SamReaderFactory.makeDefault();
         if (referenceFileName != null) {
             factory = factory.referenceSequence(referenceFileName);
@@ -956,25 +962,25 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
             // reads to be distributed over multiple slices (at least for large numbers of unmapped reads)
             // tests the fix to https://github.com/samtools/htsjdk/issues/562
             {
-                new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.0-unMapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta"),
+                TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.0-unMapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta"),
                 0
             },
             {
-                new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.1-unMapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta"),
+                TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.1-unMapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta"),
                 1
             },
             {
-                new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"),
-                new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta"),
+                TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"),
+                TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta"),
                 500
             },
         };
     }
 
     @Test(dataProvider = "unmappedSliceTest")
-    public void testUnmappedMultiSlice(final File cramFileName, final File referenceFileName, final int expectedCount)
+    public void testUnmappedMultiSlice(final Path cramFileName, final Path referenceFileName, final int expectedCount)
             throws IOException {
         SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT);
         factory = factory.referenceSequence(referenceFileName);
@@ -1014,19 +1020,19 @@ public class CRAMIndexQueryTest extends HtsjdkTest {
 
     @Test(dataProvider = "serialQueries")
     public void testSerialQueriesOnRemoteFile(
-            final File cramFile,
-            final File referenceFile,
+            final Path cramFile,
+            final Path referenceFile,
             final QueryInterval interval,
             final String[] expectedNames,
             final int nUnmapped)
             throws IOException {
-        final Path cramIndex = SamFiles.findIndex(cramFile.toPath());
+        final Path cramIndex = SamFiles.findIndex(cramFile);
 
         try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
             final Path jimfsCRAM = jimfs.getPath("remotecram.cram");
             final Path jimfsCRAI = jimfs.getPath("remotecram.crai");
 
-            Files.copy(cramFile.toPath(), jimfsCRAM);
+            Files.copy(cramFile, jimfsCRAM);
             Files.copy(cramIndex, jimfsCRAI);
 
             SamReaderFactory factory =

--- a/src/test/java/htsjdk/samtools/CRAMIndexTestHelper.java
+++ b/src/test/java/htsjdk/samtools/CRAMIndexTestHelper.java
@@ -6,10 +6,11 @@ import htsjdk.samtools.cram.ref.CRAMReferenceSource;
 import htsjdk.samtools.cram.structure.CRAMEncodingStrategy;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloseableIterator;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import org.testng.Assert;
@@ -23,19 +24,19 @@ public class CRAMIndexTestHelper {
     // Given an input SAM/BAM/CRAM, using the supplied CRAMEncodingStrategy to create and return a temporary CRAM
     // with the same content as the input SAM/BAM/CRAM but created using the supplied CRAMEncodingStrategy, along
     // with an accompanying temporary companion BAI index file.
-    public static File createCRAMWithBAIForEncodingStrategy(
-            final File sourceFile,
+    public static Path createCRAMWithBAIForEncodingStrategy(
+            final Path sourceFile,
             final CRAMReferenceSource referenceSource,
             final CRAMEncodingStrategy cramEncodingStrategy)
             throws IOException {
-        final File temporaryCRAM = createCRAMAndIndexFiles(".bai");
-        final File temporaryBAI = new File(temporaryCRAM.getAbsolutePath() + ".bai");
+        final Path temporaryCRAM = createCRAMAndIndexFiles(".bai");
+        final Path temporaryBAI = temporaryCRAM.resolveSibling(temporaryCRAM.getFileName() + ".bai");
 
         final SamReaderFactory samReadFactory =
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.STRICT);
-        try (final SamReader samReader = samReadFactory.open(sourceFile.toPath());
-                final FileOutputStream cramFileOutputStream = new FileOutputStream(temporaryCRAM);
-                final FileOutputStream cramIndexOutputStream = new FileOutputStream(temporaryBAI);
+        try (final SamReader samReader = samReadFactory.open(sourceFile);
+                final OutputStream cramFileOutputStream = Files.newOutputStream(temporaryCRAM);
+                final OutputStream cramIndexOutputStream = Files.newOutputStream(temporaryBAI);
                 final CRAMFileWriter cramWriter = new CRAMFileWriter(
                         cramEncodingStrategy,
                         cramFileOutputStream,
@@ -43,7 +44,7 @@ public class CRAMIndexTestHelper {
                         true,
                         referenceSource,
                         samReader.getFileHeader(),
-                        temporaryCRAM.getAbsolutePath());
+                        temporaryCRAM.toAbsolutePath().toString());
                 final CloseableIterator<SAMRecord> samIterator = samReader.iterator()) {
             Assert.assertEquals(samReader.getFileHeader().getSortOrder(), SAMFileHeader.SortOrder.coordinate);
             while (samIterator.hasNext()) {
@@ -58,19 +59,19 @@ public class CRAMIndexTestHelper {
 
     // Given an input SAM/BAM/CRAM, using the supplied CRAMEncodingStrategy to create and return a temporary CRAM
     // with the same content as the input, along with an accompanying temporary companion CRAI index file
-    public static File createCRAMWithCRAIForEncodingStrategy(
-            final File sourceFile,
+    public static Path createCRAMWithCRAIForEncodingStrategy(
+            final Path sourceFile,
             final CRAMReferenceSource referenceSource,
             final CRAMEncodingStrategy cramEncodingStrategy)
             throws IOException {
-        final File temporaryCRAM = createCRAMAndIndexFiles(".crai");
-        final File temporaryCRAI = new File(temporaryCRAM.getAbsolutePath() + ".crai");
+        final Path temporaryCRAM = createCRAMAndIndexFiles(".crai");
+        final Path temporaryCRAI = temporaryCRAM.resolveSibling(temporaryCRAM.getFileName() + ".crai");
 
         final SamReaderFactory samReadFactory = SamReaderFactory.makeDefault()
                 .referenceSource(referenceSource)
                 .validationStringency(ValidationStringency.STRICT);
-        try (final SamReader samReader = samReadFactory.open(sourceFile.toPath());
-                final FileOutputStream cramFileOutputStream = new FileOutputStream(temporaryCRAM);
+        try (final SamReader samReader = samReadFactory.open(sourceFile);
+                final OutputStream cramFileOutputStream = Files.newOutputStream(temporaryCRAM);
                 final CRAMFileWriter cramWriter = new CRAMFileWriter(
                         cramEncodingStrategy,
                         cramFileOutputStream,
@@ -78,7 +79,7 @@ public class CRAMIndexTestHelper {
                         true,
                         referenceSource,
                         samReader.getFileHeader(),
-                        temporaryCRAM.getAbsolutePath());
+                        temporaryCRAM.toAbsolutePath().toString());
                 final CloseableIterator<SAMRecord> samIterator = samReader.iterator()) {
             Assert.assertEquals(samReader.getFileHeader().getSortOrder(), SAMFileHeader.SortOrder.coordinate);
             while (samIterator.hasNext()) {
@@ -87,10 +88,10 @@ public class CRAMIndexTestHelper {
         }
         // since CRAMFileWriter creates a BAI by default if an index is requested, make sure some codepath
         // didn't accidentally request one, since we want to ensure we use a .crai
-        Assert.assertFalse(Files.exists(Paths.get(temporaryCRAM.getAbsolutePath() + ".bai")));
+        Assert.assertFalse(Files.exists(temporaryCRAM.resolveSibling(temporaryCRAM.getFileName() + ".bai")));
 
         // now manually create the CRAI
-        try (FileOutputStream bos = new FileOutputStream(temporaryCRAI)) {
+        try (final OutputStream bos = Files.newOutputStream(temporaryCRAI)) {
             CRAMCRAIIndexer.writeIndex(new SeekableFileStream(temporaryCRAM), bos);
         }
 
@@ -99,21 +100,21 @@ public class CRAMIndexTestHelper {
         return temporaryCRAM;
     }
 
-    public static File createCRAMAndIndexFiles(final String indexExtension) throws IOException {
+    public static Path createCRAMAndIndexFiles(final String indexExtension) throws IOException {
         final Path temporaryCRAMDir = Files.createTempDirectory("tempCRAMWithIndex");
         temporaryCRAMDir.toFile().deleteOnExit();
 
-        final File temporaryCRAM = new File(temporaryCRAMDir.toFile(), "tempCRAMWithIndex.cram");
-        temporaryCRAM.deleteOnExit();
-        final File temporaryIndex = new File(temporaryCRAM.getAbsolutePath() + indexExtension);
-        temporaryIndex.deleteOnExit();
+        final Path temporaryCRAM = temporaryCRAMDir.resolve("tempCRAMWithIndex.cram");
+        temporaryCRAM.toFile().deleteOnExit();
+        final Path temporaryIndex = temporaryCRAM.resolveSibling(temporaryCRAM.getFileName() + indexExtension);
+        temporaryIndex.toFile().deleteOnExit();
 
         return temporaryCRAM;
     }
 
     // SamFiles.findIndex(tempCRAM)
-    public static File createBAIForCRAIAsText(
-            final File cramFile, final CRAMReferenceSource referenceSource, final File craiFile) throws IOException {
+    public static Path createBAIForCRAIAsText(
+            final Path cramFile, final CRAMReferenceSource referenceSource, final Path craiFile) throws IOException {
         final SAMSequenceDictionary dictionary = SamReaderFactory.makeDefault()
                 .referenceSource(referenceSource)
                 .open(cramFile)
@@ -122,9 +123,9 @@ public class CRAMIndexTestHelper {
 
         // first, convert the crai to bai and write that out
         final InputStream is = SamIndexes.openIndexFileAsBaiOrNull(craiFile, dictionary);
-        final File baiOutputFile = new File(craiFile.getAbsolutePath() + ".bai");
-        baiOutputFile.deleteOnExit();
-        try (final FileOutputStream fos = new FileOutputStream(baiOutputFile)) {
+        final Path baiOutputFile = craiFile.resolveSibling(craiFile.getFileName() + ".bai");
+        baiOutputFile.toFile().deleteOnExit();
+        try (final OutputStream fos = Files.newOutputStream(baiOutputFile)) {
             byte b[] = new byte[1];
             while (is.read(b, 0, 1) >= 0) {
                 fos.write(b);
@@ -132,22 +133,22 @@ public class CRAMIndexTestHelper {
         }
 
         // now, convert the bai to text and write that out
-        final File baiOutputTextFile = new File(craiFile.getAbsolutePath() + ".bai.txt");
-        baiOutputTextFile.deleteOnExit();
+        final Path baiOutputTextFile = craiFile.resolveSibling(craiFile.getFileName() + ".bai.txt");
+        baiOutputTextFile.toFile().deleteOnExit();
         BAMIndexer.createAndWriteIndex(baiOutputFile, baiOutputTextFile, true);
 
         return baiOutputTextFile;
     }
 
     // SamFiles.findIndex(tempCRAM)
-    public static File createCRAIAsText(final File craiFile) throws IOException {
-        try (final FileInputStream fis = new FileInputStream(craiFile)) {
+    public static Path createCRAIAsText(final Path craiFile) throws IOException {
+        try (final InputStream fis = Files.newInputStream(craiFile)) {
             final CRAIIndex craiIndex = CRAMCRAIIndexer.readIndex(fis);
 
-            final File temporaryCRAIText = new File(craiFile.getAbsolutePath() + ".txt");
-            temporaryCRAIText.deleteOnExit();
+            final Path temporaryCRAIText = craiFile.resolveSibling(craiFile.getFileName() + ".txt");
+            temporaryCRAIText.toFile().deleteOnExit();
 
-            try (final FileOutputStream fos = new FileOutputStream(temporaryCRAIText)) {
+            try (final OutputStream fos = Files.newOutputStream(temporaryCRAIText)) {
                 fos.write("\nSeqId AlignmentStart AlignmentSpan ContainerOffset SliceOffset SliceSize\n".getBytes());
                 for (final CRAIEntry e : craiIndex.getCRAIEntries()) {
                     fos.write(String.format("%s\n", e.toString()).getBytes());
@@ -160,8 +161,8 @@ public class CRAMIndexTestHelper {
     }
 
     public static final List<String> getCRAMResultsForQueryIntervals(
-            final File targetCRAMFile,
-            final File targetIndexFile, // .bai or .crai
+            final Path targetCRAMFile,
+            final Path targetIndexFile, // .bai or .crai
             final CRAMReferenceSource referenceSource,
             final QueryInterval[] queryIntervals)
             throws IOException {
@@ -178,12 +179,12 @@ public class CRAMIndexTestHelper {
     }
 
     public static final List<String> getBAMResultsForQueryIntervals(
-            final File targetBAMFile, final QueryInterval[] queryIntervals) throws IOException {
+            final Path targetBAMFile, final QueryInterval[] queryIntervals) throws IOException {
         final List<String> queryResults = new ArrayList<>(); // might contain duplicates
         final SamReaderFactory samReadFactory =
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.STRICT);
 
-        try (final SamReader samReader = samReadFactory.open(targetBAMFile.toPath());
+        try (final SamReader samReader = samReadFactory.open(targetBAMFile);
                 final CloseableIterator<SAMRecord> samIterator = samReader.query(queryIntervals, true)) {
             Assert.assertEquals(samReader.getFileHeader().getSortOrder(), SAMFileHeader.SortOrder.coordinate);
             while (samIterator.hasNext()) {
@@ -194,8 +195,8 @@ public class CRAMIndexTestHelper {
     }
 
     public static final List<String> getCRAMResultsForUnmapped(
-            final File targetCRAMFile,
-            final File targetIndexFile, // .bai or .crai
+            final Path targetCRAMFile,
+            final Path targetIndexFile, // .bai or .crai
             final CRAMReferenceSource referenceSource)
             throws IOException {
         final List<String> queryResults = new ArrayList<>(); // might contain duplicates
@@ -210,11 +211,11 @@ public class CRAMIndexTestHelper {
         return queryResults;
     }
 
-    public static final List<String> getBAMResultsForUnmapped(final File targetBAMFile) throws IOException {
+    public static final List<String> getBAMResultsForUnmapped(final Path targetBAMFile) throws IOException {
         final List<String> queryResults = new ArrayList<>(); // might contain duplicates
         final SamReaderFactory samReadFactory =
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.STRICT);
-        try (final SamReader samReader = samReadFactory.open(targetBAMFile.toPath());
+        try (final SamReader samReader = samReadFactory.open(targetBAMFile);
                 final CloseableIterator<SAMRecord> samIterator = samReader.queryUnmapped()) {
             Assert.assertEquals(samReader.getFileHeader().getSortOrder(), SAMFileHeader.SortOrder.coordinate);
             while (samIterator.hasNext()) {
@@ -224,16 +225,16 @@ public class CRAMIndexTestHelper {
         return queryResults;
     }
 
-    private static void assertIsCRAIFile(final File indexFile) throws IOException {
+    private static void assertIsCRAIFile(final Path indexFile) throws IOException {
         assertFileStartsWith(indexFile, CRAI_MAGIC);
     }
 
-    private static void assertIsBAIFile(final File indexFile) throws IOException {
+    private static void assertIsBAIFile(final Path indexFile) throws IOException {
         assertFileStartsWith(indexFile, BAI_MAGIC);
     }
 
-    private static void assertFileStartsWith(final File indexFile, final byte[] magicBytes) throws IOException {
-        try (final FileInputStream fis = new FileInputStream(indexFile)) {
+    private static void assertFileStartsWith(final Path indexFile, final byte[] magicBytes) throws IOException {
+        try (final InputStream fis = Files.newInputStream(indexFile)) {
             for (final byte b : magicBytes) {
                 if (fis.read() != (0xFF & b)) {
                     Assert.fail("Unexpected index file header");

--- a/src/test/java/htsjdk/samtools/CRAMIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMIteratorTest.java
@@ -3,7 +3,7 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.seekablestream.SeekableStream;
-import java.io.File;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -31,8 +31,8 @@ public class CRAMIteratorTest extends HtsjdkTest {
     }
 
     private SAMRecordIterator getCramFileIterator(ValidationStringency valStringency) {
-        final File refFile = new File("src/test/resources/htsjdk/samtools/cram/ce.fa");
-        final File cramFile = new File("src/test/resources/htsjdk/samtools/cram/ce#containsInvalidRecords.3.0.cram");
+        final Path refFile = Path.of("src/test/resources/htsjdk/samtools/cram/ce.fa");
+        final Path cramFile = Path.of("src/test/resources/htsjdk/samtools/cram/ce#containsInvalidRecords.3.0.cram");
         final ReferenceSource source = new ReferenceSource(refFile);
 
         final CRAMFileReader cramFileReader = new CRAMFileReader(cramFile, (SeekableStream) null, source);

--- a/src/test/java/htsjdk/samtools/CRAMMergerTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMMergerTest.java
@@ -37,12 +37,12 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.ProgressLoggerInterface;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.utils.ValidationUtils;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.testng.Assert;
@@ -50,11 +50,10 @@ import org.testng.annotations.Test;
 
 public class CRAMMergerTest extends HtsjdkTest {
 
-    private static final Path CRAM_FILE = new File(
-                    "src/test/resources/htsjdk/samtools/cram/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10m-10m100.cram")
-            .toPath();
+    private static final Path CRAM_FILE =
+            Paths.get("src/test/resources/htsjdk/samtools/cram/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.10m-10m100.cram");
     private static final Path CRAM_REF =
-            new File("src/test/resources/htsjdk/samtools/reference/human_g1k_v37.20.21.fasta.gz").toPath();
+            Paths.get("src/test/resources/htsjdk/samtools/reference/human_g1k_v37.20.21.fasta.gz");
 
     /**
      * Writes a <i>partitioned CRAM</i>.
@@ -204,16 +203,14 @@ public class CRAMMergerTest extends HtsjdkTest {
         final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp");
         IOUtil.deleteOnExit(outputDir);
 
-        final Path outputCram = File.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.CRAM)
-                .toPath();
+        final Path outputCram = Files.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.CRAM);
         IOUtil.deleteOnExit(outputCram);
 
         final Path outputCrai = IOUtil.addExtension(outputCram, FileExtensions.CRAM_INDEX);
         IOUtil.deleteOnExit(outputCrai);
 
-        final Path outputCraiMerged = File.createTempFile(
-                        this.getClass().getSimpleName() + ".", FileExtensions.CRAM_INDEX)
-                .toPath();
+        final Path outputCraiMerged =
+                Files.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.CRAM_INDEX);
         IOUtil.deleteOnExit(outputCraiMerged);
 
         // 1. Read an input CRAM and write it out in partitioned form (header, parts, terminator)
@@ -235,8 +232,6 @@ public class CRAMMergerTest extends HtsjdkTest {
         indexCram(outputCram, outputCrai);
 
         // 4. Assert that the merged index is the same as the index produced from the merged file
-        Assert.assertEquals(
-                com.google.common.io.Files.toByteArray(outputCrai.toFile()),
-                com.google.common.io.Files.toByteArray(outputCraiMerged.toFile()));
+        Assert.assertEquals(Files.readAllBytes(outputCrai), Files.readAllBytes(outputCraiMerged));
     }
 }

--- a/src/test/java/htsjdk/samtools/CRAMReferencelessTest.java
+++ b/src/test/java/htsjdk/samtools/CRAMReferencelessTest.java
@@ -2,27 +2,25 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.cram.ref.ReferenceSource;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class CRAMReferencelessTest extends HtsjdkTest {
 
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/cram");
 
     @Test
     public void testReadCRAMWithEmbeddedReference() throws IOException {
         try (final SamReader cramReader = SamReaderFactory.makeDefault()
                         .validationStringency(ValidationStringency.LENIENT)
-                        .referenceSource(
-                                new ReferenceSource(new File(TEST_DATA_DIR, "human_g1k_v37.20.21.1-100.fasta")))
-                        .open(new File(TEST_DATA_DIR, "NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"));
+                        .referenceSource(new ReferenceSource(TEST_DATA_DIR.resolve("human_g1k_v37.20.21.1-100.fasta")))
+                        .open(TEST_DATA_DIR.resolve("NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"));
                 final SamReader cramReaderEmbedded = SamReaderFactory.makeDefault()
                         .validationStringency(ValidationStringency.LENIENT)
-                        .open(new File(
-                                TEST_DATA_DIR,
+                        .open(TEST_DATA_DIR.resolve(
                                 "referenceEmbedded.NA12878.20.21.1-100.100-SeqsPerSlice.500-unMapped.cram"))) {
             final Iterator<SAMRecord> cramIterator = cramReader.iterator();
             final Iterator<SAMRecord> cramEmbeddedIterator = cramReaderEmbedded.iterator();
@@ -43,10 +41,10 @@ public class CRAMReferencelessTest extends HtsjdkTest {
     public void testForNPE() throws IOException {
         try (final SamReader cramReader = SamReaderFactory.makeDefault()
                         .validationStringency(ValidationStringency.LENIENT)
-                        .open(new File(TEST_DATA_DIR, "testIGV1286.sam"));
+                        .open(TEST_DATA_DIR.resolve("testIGV1286.sam"));
                 final SamReader cramReaderEmbedded = SamReaderFactory.makeDefault()
                         .validationStringency(ValidationStringency.LENIENT)
-                        .open(new File(TEST_DATA_DIR, "testIGV1286.cram"))) {
+                        .open(TEST_DATA_DIR.resolve("testIGV1286.cram"))) {
             final Iterator<SAMRecord> cramIterator = cramReader.iterator();
             final Iterator<SAMRecord> cramEmbeddedIterator = cramReaderEmbedded.iterator();
             int count = 0;
@@ -67,7 +65,7 @@ public class CRAMReferencelessTest extends HtsjdkTest {
         // test reading a cram with no reference compression (RR=false in compression header)
         try (final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.LENIENT)
-                .open(new File(TEST_DATA_DIR, "referenceNotRequired.cram"))) {
+                .open(TEST_DATA_DIR.resolve("referenceNotRequired.cram"))) {
             final Iterator<SAMRecord> iterator = samReader.iterator();
             while (iterator.hasNext()) {
                 final SAMRecord samRecord1 = iterator.next();

--- a/src/test/java/htsjdk/samtools/CRAMSliceMD5Test.java
+++ b/src/test/java/htsjdk/samtools/CRAMSliceMD5Test.java
@@ -10,11 +10,12 @@ import htsjdk.samtools.cram.structure.Container;
 import htsjdk.samtools.cram.structure.CramHeader;
 import htsjdk.samtools.cram.structure.Slice;
 import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
+import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.SequenceUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -49,7 +50,7 @@ public class CRAMSliceMD5Test extends HtsjdkTest {
         // check the CRAM file reads:
         final CRAMFileReader reader = new CRAMFileReader(
                 new ByteArrayInputStream(test.cramData),
-                (File) null,
+                (Path) null,
                 test.referenceSourceUpperCased,
                 ValidationStringency.STRICT);
         final SAMRecordIterator iterator = reader.getIterator();
@@ -64,7 +65,7 @@ public class CRAMSliceMD5Test extends HtsjdkTest {
         // try reading the CRAM file with the incorrect ref source that does not upper case bases:
         final CRAMFileReader reader = new CRAMFileReader(
                 new ByteArrayInputStream(test.cramData),
-                (File) null,
+                (SeekableStream) null,
                 test.referenceSourceMixedCase,
                 ValidationStringency.STRICT);
         final SAMRecordIterator iterator = reader.getIterator();

--- a/src/test/java/htsjdk/samtools/CRAMTestUtils.java
+++ b/src/test/java/htsjdk/samtools/CRAMTestUtils.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -20,9 +21,9 @@ public final class CRAMTestUtils {
     // returns the size of the generated file
     public static long writeToCRAMWithEncodingStrategy(
             final CRAMEncodingStrategy cramEncodingStrategy,
-            final File inputFile,
-            final File tempOutputCRAM,
-            final File referenceFile)
+            final Path inputFile,
+            final Path tempOutputCRAM,
+            final Path referenceFile)
             throws IOException {
         return writeToCRAMWithEncodingStrategy(
                 cramEncodingStrategy, inputFile, tempOutputCRAM, new ReferenceSource(referenceFile));
@@ -33,15 +34,15 @@ public final class CRAMTestUtils {
     // returns the size of the generated file
     public static long writeToCRAMWithEncodingStrategy(
             final CRAMEncodingStrategy cramEncodingStrategy,
-            final File inputFile,
-            final File tempOutputCRAM,
+            final Path inputFile,
+            final Path tempOutputCRAM,
             final ReferenceSource referenceSource)
             throws IOException {
         try (final SamReader reader = SamReaderFactory.makeDefault()
                         .referenceSource(referenceSource)
                         .validationStringency((ValidationStringency.SILENT))
                         .open(inputFile);
-                final FileOutputStream fos = new FileOutputStream(tempOutputCRAM)) {
+                final OutputStream fos = Files.newOutputStream(tempOutputCRAM)) {
             final CRAMFileWriter cramWriter = new CRAMFileWriter(
                     cramEncodingStrategy,
                     fos,
@@ -49,14 +50,14 @@ public final class CRAMTestUtils {
                     true,
                     referenceSource,
                     reader.getFileHeader(),
-                    tempOutputCRAM.getName());
+                    tempOutputCRAM.getFileName().toString());
             final SAMRecordIterator inputIterator = reader.iterator();
             while (inputIterator.hasNext()) {
                 cramWriter.addAlignment(inputIterator.next());
             }
             cramWriter.close();
         }
-        return Files.size(tempOutputCRAM.toPath());
+        return Files.size(tempOutputCRAM);
     }
 
     /**

--- a/src/test/java/htsjdk/samtools/CSIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CSIIndexTest.java
@@ -1,9 +1,8 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
@@ -14,7 +13,7 @@ import org.testng.annotations.Test;
 
 public class CSIIndexTest extends HtsjdkTest {
 
-    public static final String TEST_DATA_DIR = "src/test/resources/htsjdk/samtools/BAMFileIndexTest/";
+    public static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/");
     private DiskBasedBAMFileIndex bai;
     private CSIIndex csi;
     private CSIIndex mcsi;
@@ -41,15 +40,15 @@ public class CSIIndexTest extends HtsjdkTest {
 
     @BeforeClass
     public void init() {
-        bai = new DiskBasedBAMFileIndex(new File(TEST_DATA_DIR, "index_test.bam.bai"), null);
-        csi = new CSIIndex(new File(TEST_DATA_DIR, "index_test.bam.csi"), false, null);
-        mcsi = new CSIIndex(new File(TEST_DATA_DIR, "index_test.bam.csi"), true, null);
+        bai = new DiskBasedBAMFileIndex(TEST_DATA_DIR.resolve("index_test.bam.bai"), null);
+        csi = new CSIIndex(TEST_DATA_DIR.resolve("index_test.bam.csi"), false, null);
+        mcsi = new CSIIndex(TEST_DATA_DIR.resolve("index_test.bam.csi"), true, null);
         try {
-            ucsi = new CSIIndex(Paths.get(TEST_DATA_DIR, "uncompressed_index.bam.csi"), null);
+            ucsi = new CSIIndex(TEST_DATA_DIR.resolve("uncompressed_index.bam.csi"), null);
         } catch (IOException e) {
             e.printStackTrace();
         }
-        ubai = new DiskBasedBAMFileIndex(new File(TEST_DATA_DIR, "uncompressed_index.bam.bai"), null);
+        ubai = new DiskBasedBAMFileIndex(TEST_DATA_DIR.resolve("uncompressed_index.bam.bai"), null);
     }
 
     @Test
@@ -411,7 +410,7 @@ public class CSIIndexTest extends HtsjdkTest {
     @Test(dataProvider = "getDataForTestLongReferenceQuery")
     public void testLongReferenceQuery(String chr, int start, int end, int expectedReads) throws IOException {
         final SamReaderFactory samReaderFactory = SamReaderFactory.makeDefault();
-        try (final SamReader read = samReaderFactory.open(new File(TEST_DATA_DIR, "long_references.bam"))) {
+        try (final SamReader read = samReaderFactory.open(TEST_DATA_DIR.resolve("long_references.bam"))) {
             final SAMRecordIterator values = read.query(chr, start, end, false);
             Assert.assertEquals(values.toList().size(), expectedReads);
         }

--- a/src/test/java/htsjdk/samtools/CachingBAMFileIndexTest.java
+++ b/src/test/java/htsjdk/samtools/CachingBAMFileIndexTest.java
@@ -3,8 +3,9 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -42,8 +43,8 @@ public class CachingBAMFileIndexTest extends HtsjdkTest {
         header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
 
         final SAMFileWriterFactory writerFactory = new SAMFileWriterFactory().setCreateIndex(true);
-        final File outBam = File.createTempFile("tmp", ".bam");
-        try (final SAMFileWriter writer = writerFactory.makeWriter(header, true, outBam, null)) {
+        final Path outBam = Files.createTempFile("tmp", ".bam");
+        try (final SAMFileWriter writer = writerFactory.makeWriter(header, true, outBam, (Path) null)) {
             IntStream.range(1, 200)
                     .mapToObj(i -> {
                         final SAMRecord record = new SAMRecord(header);
@@ -57,9 +58,9 @@ public class CachingBAMFileIndexTest extends HtsjdkTest {
                     .forEach(writer::addAlignment);
         }
 
-        final File indexFile = new File(outBam.getParent(), IOUtil.basename(outBam) + FileExtensions.BAI_INDEX);
-        indexFile.deleteOnExit();
-        outBam.deleteOnExit();
+        final Path indexFile = outBam.resolveSibling(IOUtil.basename(outBam) + FileExtensions.BAI_INDEX);
+        indexFile.toFile().deleteOnExit();
+        outBam.toFile().deleteOnExit();
         return new CachingBAMFileIndex(indexFile, dict);
     }
 

--- a/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/CramContainerHeaderIteratorTest.java
@@ -7,8 +7,9 @@ import htsjdk.samtools.cram.structure.Container;
 import htsjdk.samtools.cram.structure.CramHeader;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.Iterables;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -16,7 +17,7 @@ import org.testng.annotations.Test;
 public class CramContainerHeaderIteratorTest extends HtsjdkTest {
     @Test
     public void testContainerHeaderIterator() throws IOException {
-        final File cramFile = new File(
+        final Path cramFile = Paths.get(
                 "src/test/resources/htsjdk/samtools/cram/NA12878.20.21.1-100.100-SeqsPerSlice.0-unMapped.cram");
         CramHeader expectedHeader;
         List<Container> fullContainers;

--- a/src/test/java/htsjdk/samtools/HtsgetBAMFileReaderTest.java
+++ b/src/test/java/htsjdk/samtools/HtsgetBAMFileReaderTest.java
@@ -2,9 +2,9 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloseableIterator;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -18,7 +18,7 @@ public class HtsgetBAMFileReaderTest extends HtsjdkTest {
 
     private static final URI htsgetBAM = URI.create(HTSGET_ENDPOINT + LOCAL_PREFIX + "index_test.bam");
 
-    private static final File bamFile = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private static final Path bamFile = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
 
     private static final int nofMappedReads = 9721;
     private static final int nofUnmappedReads = 279;

--- a/src/test/java/htsjdk/samtools/HtsjdkTestUtils.java
+++ b/src/test/java/htsjdk/samtools/HtsjdkTestUtils.java
@@ -1,10 +1,10 @@
 package htsjdk.samtools;
 
-import java.io.File;
+import java.nio.file.Path;
 
 public class HtsjdkTestUtils {
     public static final String TEST_DATA_DIR = "src/test/resources/htsjdk/samtools/cram/";
-    public static final File NA12878_8000 = new File(TEST_DATA_DIR + "CEUTrio.HiSeq.WGS.b37.NA12878.20.first.8000.bam");
-    public static final File NA12878_20_21 = new File(TEST_DATA_DIR + "NA12878.20.21.unmapped.orig.bam");
-    static final File NA12878_500 = new File(TEST_DATA_DIR + "CEUTrio.HiSeq.WGS.b37.NA12878.20.first.500.bam");
+    public static final Path NA12878_8000 = Path.of(TEST_DATA_DIR + "CEUTrio.HiSeq.WGS.b37.NA12878.20.first.8000.bam");
+    public static final Path NA12878_20_21 = Path.of(TEST_DATA_DIR + "NA12878.20.21.unmapped.orig.bam");
+    static final Path NA12878_500 = Path.of(TEST_DATA_DIR + "CEUTrio.HiSeq.WGS.b37.NA12878.20.first.500.bam");
 }

--- a/src/test/java/htsjdk/samtools/NioSpiCompatibilityTest.java
+++ b/src/test/java/htsjdk/samtools/NioSpiCompatibilityTest.java
@@ -1,0 +1,356 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026 The Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package htsjdk.samtools;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.reference.ReferenceSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
+import htsjdk.samtools.util.CloseableIterator;
+import htsjdk.variant.variantcontext.VariantContext;
+import htsjdk.variant.variantcontext.writer.Options;
+import htsjdk.variant.variantcontext.writer.VariantContextWriter;
+import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
+import htsjdk.variant.vcf.VCFFileReader;
+import htsjdk.variant.vcf.VCFHeader;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Exercises the major htsjdk read/write/index public APIs against a NON-default NIO filesystem (the
+ * in-memory jimfs provider) to prove that the {@link java.nio.file.Path}-based APIs are SPI compatible.
+ *
+ * <p>Every test operates exclusively on jimfs {@link Path} objects through the Path-based public APIs;
+ * none of the deprecated {@link java.io.File} overloads are used. Each test creates an isolated jimfs
+ * {@link FileSystem} in a try-with-resources block, copies any required small checked-in resources into
+ * that filesystem, and cleans up readers/writers as it goes. All resources used are small and record
+ * counts are tiny so the whole class runs in a few seconds.
+ */
+public class NioSpiCompatibilityTest extends HtsjdkTest {
+
+    private static final Path TEST_DATA_DIR = Paths.get("src/test/resources/htsjdk/samtools");
+    private static final Path REFERENCE_FASTA = TEST_DATA_DIR.resolve("hg19mini.fasta");
+    private static final Path REFERENCE_FAI = TEST_DATA_DIR.resolve("hg19mini.fasta.fai");
+    private static final Path REFERENCE_DICT = TEST_DATA_DIR.resolve("hg19mini.dict");
+
+    /** A BAM (issue76.bam) that ships with a co-located .bai index, used for read + query tests. */
+    private static final Path INDEXED_BAM = TEST_DATA_DIR.resolve("issue76.bam");
+
+    private static final Path INDEXED_BAI = TEST_DATA_DIR.resolve("issue76.bam.bai");
+
+    /** A small VCF (with self-describing header) used for the VCF round-trip test. */
+    private static final Path SMALL_VCF = Paths.get("src/test/resources/htsjdk/tribble/test.vcf");
+
+    /** Copies a real (default-filesystem) resource into the supplied jimfs filesystem, returning the jimfs path. */
+    private static Path copyIntoJimfs(final FileSystem jimfs, final Path realPath, final String name)
+            throws IOException {
+        final Path dest = jimfs.getPath(name);
+        Files.copy(realPath, dest);
+        return dest;
+    }
+
+    /** Copies the hg19mini reference (fasta + .fai + .dict) into jimfs and returns the jimfs fasta path. */
+    private static Path copyReferenceIntoJimfs(final FileSystem jimfs) throws IOException {
+        final Path fasta = copyIntoJimfs(jimfs, REFERENCE_FASTA, "hg19mini.fasta");
+        copyIntoJimfs(jimfs, REFERENCE_FAI, "hg19mini.fasta.fai");
+        copyIntoJimfs(jimfs, REFERENCE_DICT, "hg19mini.dict");
+        return fasta;
+    }
+
+    /** Builds a tiny coordinate-sorted header over the hg19mini sequence dictionary loaded from jimfs. */
+    private static SAMFileHeader headerForReference(final Path jimfsFasta) {
+        final SAMSequenceDictionary dict;
+        try (final ReferenceSequenceFile ref = ReferenceSequenceFileFactory.getReferenceSequenceFile(jimfsFasta)) {
+            dict = ref.getSequenceDictionary();
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+        final SAMFileHeader header = new SAMFileHeader(dict);
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        return header;
+    }
+
+    /** Creates a couple of mapped reads on contig "1" using the supplied bases. */
+    private static List<SAMRecord> makeRecords(final SAMFileHeader header) {
+        final List<SAMRecord> records = new ArrayList<>();
+        final String bases = "TAACCCTAACCCTAACCCTAACCCTAACCC"; // 30bp, from contig 1 of hg19mini
+        for (int i = 0; i < 3; i++) {
+            final SAMRecord rec = new SAMRecord(header);
+            rec.setReadName("read" + i);
+            rec.setReferenceName("1");
+            rec.setAlignmentStart(1001 + (i * 50));
+            rec.setReadString(bases);
+            rec.setBaseQualityString("IIIIIIIIIIIIIIIIIIIIIIIIIIIIII");
+            rec.setCigarString(bases.length() + "M");
+            rec.setMappingQuality(60);
+            rec.setReadNegativeStrandFlag(false);
+            records.add(rec);
+        }
+        return records;
+    }
+
+    /** 1. Read a BAM together with its index from jimfs, count records, and run an indexed query. */
+    @Test
+    public void readsIndexedBamFromNonDefaultFilesystem() throws IOException {
+        try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path bam = copyIntoJimfs(jimfs, INDEXED_BAM, "reads.bam");
+            copyIntoJimfs(jimfs, INDEXED_BAI, "reads.bam.bai");
+
+            try (final SamReader reader = SamReaderFactory.makeDefault().open(bam)) {
+                Assert.assertTrue(reader.hasIndex(), "Expected the jimfs BAM to expose its .bai index");
+
+                int total = 0;
+                try (final CloseableIterator<SAMRecord> it = reader.iterator()) {
+                    while (it.hasNext()) {
+                        it.next();
+                        total++;
+                    }
+                }
+                Assert.assertTrue(total > 0, "Expected to read at least one record from the jimfs BAM");
+
+                // An indexed query against the first sequence must succeed and not exceed the full count.
+                final SAMSequenceRecord firstSeq =
+                        reader.getFileHeader().getSequenceDictionary().getSequence(0);
+                int queried = 0;
+                try (final CloseableIterator<SAMRecord> it = reader.query(firstSeq.getSequenceName(), 0, 0, false)) {
+                    while (it.hasNext()) {
+                        it.next();
+                        queried++;
+                    }
+                }
+                Assert.assertTrue(queried <= total);
+            }
+        }
+    }
+
+    /** 2. Write a BAM (with index) to jimfs through the Path API, then read it back and check the count. */
+    @Test
+    public void writesAndReadsBackBamOnNonDefaultFilesystem() throws IOException {
+        try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path fasta = copyReferenceIntoJimfs(jimfs);
+            final SAMFileHeader header = headerForReference(fasta);
+            final List<SAMRecord> records = makeRecords(header);
+
+            final Path bam = jimfs.getPath("out.bam");
+            try (final SAMFileWriter writer =
+                    new SAMFileWriterFactory().setCreateIndex(true).makeBAMWriter(header, true, bam)) {
+                for (final SAMRecord rec : records) {
+                    writer.addAlignment(rec);
+                }
+            }
+            Assert.assertTrue(Files.size(bam) > 0);
+
+            try (final SamReader reader = SamReaderFactory.makeDefault().open(bam)) {
+                int readBack = 0;
+                for (final SAMRecord ignored : reader) {
+                    readBack++;
+                }
+                Assert.assertEquals(readBack, records.size(), "BAM record count did not round-trip on jimfs");
+            }
+        }
+    }
+
+    /** 3. Write and read a CRAM on jimfs using a jimfs-resident reference. */
+    @Test
+    public void writesAndReadsBackCramWithJimfsReference() throws IOException {
+        try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path fasta = copyReferenceIntoJimfs(jimfs);
+            final SAMFileHeader header = headerForReference(fasta);
+            final List<SAMRecord> records = makeRecords(header);
+
+            final Path cram = jimfs.getPath("out.cram");
+            try (final SAMFileWriter writer = new SAMFileWriterFactory().makeCRAMWriter(header, true, cram, fasta)) {
+                for (final SAMRecord rec : records) {
+                    writer.addAlignment(rec);
+                }
+            }
+            Assert.assertTrue(Files.size(cram) > 0);
+
+            final ReferenceSource referenceSource = new ReferenceSource(fasta);
+            try (final SamReader reader = SamReaderFactory.makeDefault()
+                    .referenceSource(referenceSource)
+                    .open(cram)) {
+                int readBack = 0;
+                for (final SAMRecord rec : reader) {
+                    Assert.assertEquals(
+                            rec.getReadString(), records.get(readBack).getReadString());
+                    readBack++;
+                }
+                Assert.assertEquals(readBack, records.size(), "CRAM record count did not round-trip on jimfs");
+            }
+        }
+    }
+
+    /** 4. Read a FASTA reference (fasta + .fai + .dict) from jimfs and fetch sequence data. */
+    @Test
+    public void readsFastaReferenceFromNonDefaultFilesystem() throws IOException {
+        try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path fasta = copyReferenceIntoJimfs(jimfs);
+
+            try (final ReferenceSequenceFile ref = ReferenceSequenceFileFactory.getReferenceSequenceFile(fasta)) {
+                final SAMSequenceDictionary dict = ref.getSequenceDictionary();
+                Assert.assertNotNull(dict, "Expected a sequence dictionary loaded from the jimfs .dict");
+                Assert.assertTrue(dict.size() > 0, "Sequence dictionary should not be empty");
+
+                final String firstContig = dict.getSequence(0).getSequenceName();
+                final ReferenceSequence whole = ref.getSequence(firstContig);
+                Assert.assertTrue(whole.length() > 0, "Expected a non-empty sequence from jimfs");
+
+                final ReferenceSequence sub = ref.getSubsequenceAt(firstContig, 1001, 1030);
+                Assert.assertEquals(sub.getBases().length, 30, "Subsequence length mismatch on jimfs");
+            }
+        }
+    }
+
+    /** 5. Demonstrate BAM index auto-discovery on jimfs via {@link SamFiles#findIndex(Path)}. */
+    @Test
+    public void findsBamIndexOnNonDefaultFilesystem() throws IOException {
+        try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path bam = copyIntoJimfs(jimfs, INDEXED_BAM, "reads.bam");
+            final Path bai = copyIntoJimfs(jimfs, INDEXED_BAI, "reads.bam.bai");
+
+            final Path discovered = SamFiles.findIndex(bam);
+            Assert.assertNotNull(discovered, "SamFiles.findIndex should locate the jimfs .bai");
+            Assert.assertEquals(
+                    discovered.getFileSystem(),
+                    jimfs,
+                    "Discovered index should live on the same (non-default) filesystem");
+            Assert.assertEquals(discovered, bai, "Discovered index path should be the jimfs .bai");
+        }
+    }
+
+    /** 5b. Build a BAM index on jimfs from a BAM that has none, using {@link BAMIndexer#createIndex}. */
+    @Test
+    public void buildsBamIndexOnNonDefaultFilesystem() throws IOException {
+        try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path fasta = copyReferenceIntoJimfs(jimfs);
+            final SAMFileHeader header = headerForReference(fasta);
+
+            // Write a coordinate-sorted BAM with no index alongside it.
+            final Path bam = jimfs.getPath("noindex.bam");
+            try (final SAMFileWriter writer =
+                    new SAMFileWriterFactory().setCreateIndex(false).makeBAMWriter(header, true, bam)) {
+                for (final SAMRecord rec : makeRecords(header)) {
+                    writer.addAlignment(rec);
+                }
+            }
+            Assert.assertNull(SamFiles.findIndex(bam), "BAM should not yet have an index");
+
+            // Indexing requires each record to carry a file source, so enable that when re-opening the BAM.
+            final Path bai = jimfs.getPath("noindex.bam.bai");
+            try (final SamReader reader = SamReaderFactory.makeDefault()
+                    .enable(SamReaderFactory.Option.INCLUDE_SOURCE_IN_RECORDS)
+                    .open(bam)) {
+                BAMIndexer.createIndex(reader, bai);
+            }
+            Assert.assertTrue(Files.size(bai) > 0, "Generated jimfs .bai should be non-empty");
+
+            // The freshly written index should now be discoverable and usable.
+            Assert.assertEquals(SamFiles.findIndex(bam), bai);
+            try (final SamReader reader = SamReaderFactory.makeDefault().open(bam)) {
+                Assert.assertTrue(reader.hasIndex(), "Reader should pick up the jimfs-built index");
+            }
+        }
+    }
+
+    /** 6. Read a VCF from jimfs, write the variants to a new jimfs path, and confirm the count round-trips. */
+    @Test
+    public void writesAndReadsBackVcfOnNonDefaultFilesystem() throws IOException {
+        try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path inVcf = copyIntoJimfs(jimfs, SMALL_VCF, "in.vcf");
+
+            final List<VariantContext> variants = new ArrayList<>();
+            final VCFHeader header;
+            try (final VCFFileReader reader = new VCFFileReader(inVcf, false)) {
+                header = reader.getFileHeader();
+                for (final VariantContext vc : reader) {
+                    variants.add(vc);
+                }
+            }
+            Assert.assertTrue(variants.size() > 0, "Expected to read at least one variant from the jimfs VCF");
+
+            final Path outVcf = jimfs.getPath("out.vcf");
+            try (final VariantContextWriter writer = new VariantContextWriterBuilder()
+                    .setOutputPath(outVcf)
+                    .setReferenceDictionary(header.getSequenceDictionary())
+                    .unsetOption(Options.INDEX_ON_THE_FLY)
+                    .build()) {
+                writer.writeHeader(header);
+                for (final VariantContext vc : variants) {
+                    writer.add(vc);
+                }
+            }
+            Assert.assertTrue(Files.size(outVcf) > 0);
+
+            int readBack = 0;
+            try (final VCFFileReader reader = new VCFFileReader(outVcf, false)) {
+                for (final VariantContext ignored : reader) {
+                    readBack++;
+                }
+            }
+            Assert.assertEquals(readBack, variants.size(), "VCF variant count did not round-trip on jimfs");
+        }
+    }
+
+    /** 7. Write FASTQ records to jimfs and read them back through the Path-based reader/writer. */
+    @Test
+    public void writesAndReadsBackFastqOnNonDefaultFilesystem() throws IOException {
+        try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
+            final Path fastq = jimfs.getPath("reads.fastq");
+
+            final List<htsjdk.samtools.fastq.FastqRecord> written = new ArrayList<>();
+            written.add(new htsjdk.samtools.fastq.FastqRecord("read1", "ACGTACGT", "", "IIIIIIII"));
+            written.add(new htsjdk.samtools.fastq.FastqRecord("read2", "TTTTGGGG", "", "FFFFFFFF"));
+
+            try (final htsjdk.samtools.fastq.BasicFastqWriter writer =
+                    new htsjdk.samtools.fastq.BasicFastqWriter(fastq)) {
+                for (final htsjdk.samtools.fastq.FastqRecord rec : written) {
+                    writer.write(rec);
+                }
+            }
+            Assert.assertTrue(Files.size(fastq) > 0);
+
+            final List<htsjdk.samtools.fastq.FastqRecord> readBack = new ArrayList<>();
+            try (final htsjdk.samtools.fastq.FastqReader reader = new htsjdk.samtools.fastq.FastqReader(fastq)) {
+                while (reader.hasNext()) {
+                    readBack.add(reader.next());
+                }
+            }
+            Assert.assertEquals(readBack.size(), written.size(), "FASTQ record count did not round-trip on jimfs");
+            Assert.assertEquals(readBack.get(0).getReadName(), "read1");
+            Assert.assertEquals(readBack.get(0).getReadString(), "ACGTACGT");
+            Assert.assertEquals(readBack.get(1).getReadString(), "TTTTGGGG");
+        }
+    }
+}

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -33,7 +33,12 @@ import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,29 +50,29 @@ import org.testng.annotations.Test;
 @SuppressWarnings("EmptyTryBlock")
 public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Paths.get("src/test/resources/htsjdk/samtools");
 
     /**
      * PIC-442Confirm that writing to a special file does not cause exception when writing additional files.
      */
     @Test(groups = {"unix"})
     public void specialFileWriterTest() {
-        createSmallBam(new File("/dev/null"));
+        createSmallBam(Paths.get("/dev/null"));
     }
 
     @Test()
     public void ordinaryFileWriterTest() throws Exception {
-        final File outputFile = File.createTempFile("tmp.", FileExtensions.BAM);
-        outputFile.delete();
-        outputFile.deleteOnExit();
-        createSmallBam(outputFile);
-        final File indexFile = SamFiles.findIndex(outputFile);
-        indexFile.deleteOnExit();
-        final File md5File = new File(outputFile.getParent(), outputFile.getName() + ".md5");
-        md5File.deleteOnExit();
-        Assert.assertTrue(outputFile.length() > 0);
-        Assert.assertTrue(indexFile.length() > 0);
-        Assert.assertTrue(md5File.length() > 0);
+        final Path outputPath = Files.createTempFile("tmp.", FileExtensions.BAM);
+        Files.delete(outputPath);
+        outputPath.toFile().deleteOnExit();
+        createSmallBam(outputPath);
+        final Path indexPath = SamFiles.findIndex(outputPath);
+        indexPath.toFile().deleteOnExit();
+        final Path md5Path = outputPath.resolveSibling(outputPath.getFileName().toString() + ".md5");
+        md5Path.toFile().deleteOnExit();
+        Assert.assertTrue(Files.size(outputPath) > 0);
+        Assert.assertTrue(Files.size(indexPath) > 0);
+        Assert.assertTrue(Files.size(md5Path) > 0);
     }
 
     @Test()
@@ -121,27 +126,27 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
             description =
                     "Read and then write SAM to verify header attribute ordering does not change depending on JVM version")
     public void samRoundTrip() throws Exception {
-        final File input = new File(TEST_DATA_DIR, "roundtrip.sam");
+        final Path input = TEST_DATA_DIR.resolve("roundtrip.sam");
 
-        final File outputFile = File.createTempFile("roundtrip-out", ".sam");
-        outputFile.delete();
-        outputFile.deleteOnExit();
+        final Path outputPath = Files.createTempFile("roundtrip-out", ".sam");
+        Files.delete(outputPath);
+        outputPath.toFile().deleteOnExit();
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         try (SamReader reader = SamReaderFactory.makeDefault().open(input);
                 SAMFileWriter writer =
-                        factory.makeSAMWriter(reader.getFileHeader(), false, new FileOutputStream(outputFile))) {
+                        factory.makeSAMWriter(reader.getFileHeader(), false, Files.newOutputStream(outputPath))) {
             for (SAMRecord rec : reader) {
                 writer.addAlignment(rec);
             }
         }
 
         final String originalsam;
-        try (InputStream is = new FileInputStream(input)) {
+        try (InputStream is = Files.newInputStream(input)) {
             originalsam = IOUtil.readFully(is);
         }
 
         final String writtenSam;
-        try (InputStream is = new FileInputStream(outputFile)) {
+        try (InputStream is = Files.newInputStream(outputPath)) {
             writtenSam = IOUtil.readFully(is);
         }
 
@@ -150,15 +155,15 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
     @Test(description = "Write SAM records with null SAMFileHeader")
     public void samNullHeaderRoundTrip() throws Exception {
-        final File input = new File(TEST_DATA_DIR, "roundtrip.sam");
+        final Path input = TEST_DATA_DIR.resolve("roundtrip.sam");
 
-        final File outputFile = File.createTempFile("nullheader-out", ".sam");
-        outputFile.delete();
-        outputFile.deleteOnExit();
+        final Path outputPath = Files.createTempFile("nullheader-out", ".sam");
+        Files.delete(outputPath);
+        outputPath.toFile().deleteOnExit();
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         try (SamReader reader = SamReaderFactory.makeDefault().open(input);
                 SAMFileWriter writer =
-                        factory.makeSAMWriter(reader.getFileHeader(), false, new FileOutputStream(outputFile))) {
+                        factory.makeSAMWriter(reader.getFileHeader(), false, Files.newOutputStream(outputPath))) {
             for (SAMRecord rec : reader) {
                 rec.setHeader(null);
                 writer.addAlignment(rec);
@@ -166,20 +171,16 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
         }
 
         final String originalsam;
-        try (final InputStream is = new FileInputStream(input)) {
+        try (final InputStream is = Files.newInputStream(input)) {
             originalsam = IOUtil.readFully(is);
         }
 
         final String writtenSam;
-        try (final InputStream is = new FileInputStream(outputFile)) {
+        try (final InputStream is = Files.newInputStream(outputPath)) {
             writtenSam = IOUtil.readFully(is);
         }
 
         Assert.assertEquals(writtenSam, originalsam);
-    }
-
-    private void createSmallBam(final File outputFile) {
-        createSmallBam(outputFile.toPath());
     }
 
     private void createSmallBam(final Path outputPath) {
@@ -216,7 +217,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
         final SAMFileWriterFactory factory = new SAMFileWriterFactory();
         factory.setCreateIndex(false);
         factory.setCreateMd5File(false);
-        final File wontBeUsed = new File("wontBeUsed.tmp");
+        final Path wontBeUsed = Paths.get("wontBeUsed.tmp");
         final int maxRecsInRam = 271828;
         factory.setMaxRecordsInRam(maxRecsInRam);
         factory.setTempDirectory(wontBeUsed);
@@ -243,11 +244,11 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
         return numRecs;
     }
 
-    private File prepareOutputFileWithSuffix(final String suffix) throws IOException {
-        final File outputFile = File.createTempFile("tmp.", suffix);
-        outputFile.delete();
-        outputFile.deleteOnExit();
-        return outputFile;
+    private Path prepareOutputFileWithSuffix(final String suffix) throws IOException {
+        final Path outputPath = Files.createTempFile("tmp.", suffix);
+        Files.delete(outputPath);
+        outputPath.toFile().deleteOnExit();
+        return outputPath;
     }
 
     //  Create a writer factory that creates and index and md5 file and set the header to coord sorted
@@ -263,39 +264,40 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
     }
 
     private void verifyWriterOutput(
-            final File outputFile,
+            final Path outputPath,
             final ReferenceSource refSource,
             final int nRecs,
             final boolean verifySupplementalFiles)
             throws IOException {
-        if (outputFile.getName().endsWith(SamReader.Type.CRAM_TYPE.fileExtension())) {
-            Assert.assertTrue(SamStreams.isCRAMFile(new BufferedInputStream(new SeekableFileStream(outputFile))));
+        if (outputPath.getFileName().toString().endsWith(SamReader.Type.CRAM_TYPE.fileExtension())) {
+            Assert.assertTrue(SamStreams.isCRAMFile(new BufferedInputStream(new SeekableFileStream(outputPath))));
         }
 
-        if (outputFile.getName().endsWith(SamReader.Type.BAM_TYPE.fileExtension())) {
-            Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(outputFile))));
+        if (outputPath.getFileName().toString().endsWith(SamReader.Type.BAM_TYPE.fileExtension())) {
+            Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(outputPath))));
         }
 
-        if (outputFile.getName().endsWith(SamReader.Type.SAM_TYPE.fileExtension())) {
+        if (outputPath.getFileName().toString().endsWith(SamReader.Type.SAM_TYPE.fileExtension())) {
             byte[] head = new byte[3];
-            new DataInputStream(new FileInputStream(outputFile)).readFully(head);
+            new DataInputStream(Files.newInputStream(outputPath)).readFully(head);
             Assert.assertEquals("@HD".getBytes(), head);
         }
 
         if (verifySupplementalFiles) {
-            final File indexFile = SamFiles.findIndex(outputFile);
-            indexFile.deleteOnExit();
-            final File md5File = new File(outputFile.getParent(), outputFile.getName() + ".md5");
-            md5File.deleteOnExit();
-            Assert.assertTrue(indexFile.length() > 0);
-            Assert.assertTrue(md5File.length() > 0);
+            final Path indexPath = SamFiles.findIndex(outputPath);
+            indexPath.toFile().deleteOnExit();
+            final Path md5Path =
+                    outputPath.resolveSibling(outputPath.getFileName().toString() + ".md5");
+            md5Path.toFile().deleteOnExit();
+            Assert.assertTrue(Files.size(indexPath) > 0);
+            Assert.assertTrue(Files.size(md5Path) > 0);
         }
 
         SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.LENIENT);
         if (refSource != null) {
             factory.referenceSource(refSource);
         }
-        try (final SamReader reader = factory.open(outputFile)) {
+        try (final SamReader reader = factory.open(outputPath)) {
 
             final SAMRecordIterator it = reader.iterator();
             int count = 0;
@@ -304,29 +306,6 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
             }
             Assert.assertTrue(count == nRecs);
         }
-    }
-
-    private void verifyWriterOutput(Path output, ReferenceSource refSource, int nRecs, boolean verifySupplementalFiles)
-            throws IOException {
-        if (verifySupplementalFiles) {
-            final Path index = SamFiles.findIndex(output);
-            final Path md5File = IOUtil.addExtension(output, ".md5");
-            Assert.assertTrue(Files.size(index) > 0);
-            Assert.assertTrue(Files.size(md5File) > 0);
-        }
-
-        SamReaderFactory factory = SamReaderFactory.makeDefault().validationStringency(ValidationStringency.LENIENT);
-        if (refSource != null) {
-            factory.referenceSource(refSource);
-        }
-        SamReader reader = factory.open(output);
-        SAMRecordIterator it = reader.iterator();
-        int count = 0;
-        for (; it.hasNext(); it.next()) {
-            count++;
-        }
-
-        Assert.assertTrue(count == nRecs);
     }
 
     @DataProvider(name = "bamOrCramWriter")
@@ -344,19 +323,19 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
     @Test(dataProvider = "bamOrCramWriter")
     public void testMakeWriter(final String extension) throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + extension);
+        final Path outputPath = prepareOutputFileWithSuffix("." + extension);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
-        final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
+        final Path referencePath = TEST_DATA_DIR.resolve("hg19mini.fasta");
 
         final int nRecs;
-        try (SAMFileWriter samWriter = factory.makeWriter(header, false, outputFile, referenceFile)) {
+        try (SAMFileWriter samWriter = factory.makeWriter(header, false, outputPath, referencePath)) {
             nRecs = fillSmallBam(samWriter);
         }
 
         verifyWriterOutput(
-                outputFile,
-                new ReferenceSource(referenceFile),
+                outputPath,
+                new ReferenceSource(referencePath),
                 nRecs,
                 !SamReader.Type.SAM_TYPE.fileExtension().equals(extension));
     }
@@ -368,13 +347,13 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
             Files.deleteIfExists(outputPath);
             final SAMFileHeader header = new SAMFileHeader();
             final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
-            final Path referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta").toPath();
+            final Path referencePath = TEST_DATA_DIR.resolve("hg19mini.fasta");
 
             int nRecs;
-            try (SAMFileWriter samWriter = factory.makeWriter(header, false, outputPath, referenceFile)) {
+            try (SAMFileWriter samWriter = factory.makeWriter(header, false, outputPath, referencePath)) {
                 nRecs = fillSmallBam(samWriter);
             }
-            verifyWriterOutput(outputPath, new ReferenceSource(referenceFile), nRecs, true);
+            verifyWriterOutput(outputPath, new ReferenceSource(referencePath), nRecs, true);
         }
     }
 
@@ -387,7 +366,7 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
             final SAMFileHeader header = new SAMFileHeader();
             final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
             final Path referencePath = jimfs.getPath(referenceName);
-            Files.copy(new File(TEST_DATA_DIR, referenceName).toPath(), referencePath);
+            Files.copy(TEST_DATA_DIR.resolve(referenceName), referencePath);
 
             int nRecs;
             try (SAMFileWriter samWriter = factory.makeWriter(header, false, outputPath, referencePath)) {
@@ -399,94 +378,95 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
     @Test
     public void testMakeCRAMWriterWithOptions() throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
+        final Path outputPath = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
-        final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
+        final Path referencePath = TEST_DATA_DIR.resolve("hg19mini.fasta");
 
         final int nRecs;
-        try (SAMFileWriter samWriter = factory.makeCRAMWriter(header, false, outputFile, referenceFile)) {
+        try (SAMFileWriter samWriter = factory.makeCRAMWriter(header, false, outputPath, referencePath)) {
             nRecs = fillSmallBam(samWriter);
         }
 
-        verifyWriterOutput(outputFile, new ReferenceSource(referenceFile), nRecs, true);
+        verifyWriterOutput(outputPath, new ReferenceSource(referencePath), nRecs, true);
     }
 
     @Test
     public void testMakeCRAMWriterWithNoReference() throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
+        final Path outputPath = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
 
-        try (SAMFileWriter samWriter = factory.makeCRAMWriter(header, false, outputFile, null)) {
+        try (SAMFileWriter samWriter = factory.makeCRAMWriter(header, false, outputPath, (Path) null)) {
             fillSmallBam(samWriter);
         }
     }
 
     @Test
     public void testMakeCRAMWriterIgnoresOptions() throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
+        final Path outputPath = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
-        final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
+        final Path referencePath = TEST_DATA_DIR.resolve("hg19mini.fasta");
 
         // Note: does not honor factory settings for CREATE_MD5 or CREATE_INDEX.
         final int nRecs;
         try (SAMFileWriter samWriter =
-                factory.makeCRAMWriter(header, new FileOutputStream(outputFile), referenceFile)) {
+                factory.makeCRAMWriter(header, Files.newOutputStream(outputPath), referencePath)) {
             nRecs = fillSmallBam(samWriter);
         }
 
-        verifyWriterOutput(outputFile, new ReferenceSource(referenceFile), nRecs, false);
+        verifyWriterOutput(outputPath, new ReferenceSource(referencePath), nRecs, false);
     }
 
     @Test
     public void testMakeCRAMWriterPresortedDefault() throws Exception {
-        final File outputFile = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
+        final Path outputPath = prepareOutputFileWithSuffix("." + FileExtensions.CRAM);
         final SAMFileHeader header = new SAMFileHeader();
         final SAMFileWriterFactory factory = createWriterFactoryWithOptions(header);
-        final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
+        final Path referencePath = TEST_DATA_DIR.resolve("hg19mini.fasta");
 
         // Defaults to preSorted==true
         final int nRecs;
-        try (SAMFileWriter samWriter = factory.makeCRAMWriter(header, outputFile, referenceFile)) {
+        try (SAMFileWriter samWriter = factory.makeCRAMWriter(header, true, outputPath, referencePath)) {
             nRecs = fillSmallBam(samWriter);
         }
 
-        verifyWriterOutput(outputFile, new ReferenceSource(referenceFile), nRecs, true);
+        verifyWriterOutput(outputPath, new ReferenceSource(referencePath), nRecs, true);
     }
 
     @Test
     public void testAsync() throws IOException {
         final SAMFileWriterFactory builder = new SAMFileWriterFactory();
 
-        final File outputFile = prepareOutputFileWithSuffix(FileExtensions.BAM);
+        final Path outputPath = prepareOutputFileWithSuffix(FileExtensions.BAM);
         final SAMFileHeader header = new SAMFileHeader();
-        final File referenceFile = new File(TEST_DATA_DIR, "hg19mini.fasta");
+        final Path referencePath = TEST_DATA_DIR.resolve("hg19mini.fasta");
 
-        try (SAMFileWriter writer = builder.makeWriter(header, false, outputFile, referenceFile)) {
+        try (SAMFileWriter writer = builder.makeWriter(header, false, outputPath, referencePath)) {
             Assert.assertEquals(
                     writer instanceof AsyncSAMFileWriter,
                     Defaults.USE_ASYNC_IO_WRITE_FOR_SAMTOOLS,
                     "testAsync default");
         }
 
-        try (SAMFileWriter writer = builder.setUseAsyncIo(true).makeWriter(header, false, outputFile, referenceFile)) {
+        try (SAMFileWriter writer = builder.setUseAsyncIo(true).makeWriter(header, false, outputPath, referencePath)) {
             Assert.assertTrue(writer instanceof AsyncSAMFileWriter, "testAsync option=set");
         }
 
-        try (SAMFileWriter writer = builder.setUseAsyncIo(false).makeWriter(header, false, outputFile, referenceFile)) {
+        try (SAMFileWriter writer = builder.setUseAsyncIo(false).makeWriter(header, false, outputPath, referencePath)) {
             Assert.assertFalse(writer instanceof AsyncSAMFileWriter, "testAsync option=unset");
         }
     }
 
     @Test
     public void testMakeWriterForSamExtension() throws IOException {
-        final File tmpFile = File.createTempFile("testMakeWriterForSamExtension", "." + SAM_TYPE.fileExtension());
-        tmpFile.deleteOnExit();
-        try (SAMFileWriter ignored = new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, tmpFile, null)) {}
+        final Path tmpPath = Files.createTempFile("testMakeWriterForSamExtension", "." + SAM_TYPE.fileExtension());
+        tmpPath.toFile().deleteOnExit();
+        try (SAMFileWriter ignored =
+                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, tmpPath, (Path) null)) {}
 
-        try (FileInputStream fis = new FileInputStream(tmpFile)) {
+        try (InputStream fis = Files.newInputStream(tmpPath)) {
             for (byte b : "@HD\tVN:".getBytes()) {
                 Assert.assertEquals((byte) (fis.read() & 0xFF), b);
             }
@@ -495,69 +475,71 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
 
     @Test
     public void testMakeWriterForBamExtension() throws IOException {
-        final File tmpFile = File.createTempFile("testMakeWriterForBamExtension", "." + BAM_TYPE.fileExtension());
-        tmpFile.deleteOnExit();
+        final Path tmpPath = Files.createTempFile("testMakeWriterForBamExtension", "." + BAM_TYPE.fileExtension());
+        tmpPath.toFile().deleteOnExit();
         try (SAMFileWriter samFileWriter =
-                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, tmpFile, null)) {}
+                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, tmpPath, (Path) null)) {}
 
-        Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(tmpFile))));
+        Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(tmpPath))));
     }
 
     @Test
     public void testMakeWriterForCramExtension() throws IOException {
-        final File cramTmpFile = File.createTempFile("testMakeWriterForCramExtension", "." + CRAM_TYPE.fileExtension());
-        cramTmpFile.deleteOnExit();
-        final File refTmpFile = File.createTempFile("testMakeWriterForCramExtension", ".fa");
-        refTmpFile.deleteOnExit();
+        final Path cramTmpPath =
+                Files.createTempFile("testMakeWriterForCramExtension", "." + CRAM_TYPE.fileExtension());
+        cramTmpPath.toFile().deleteOnExit();
+        final Path refTmpPath = Files.createTempFile("testMakeWriterForCramExtension", ".fa");
+        refTmpPath.toFile().deleteOnExit();
         try (SAMFileWriter ignored =
-                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, cramTmpFile, refTmpFile)) {}
+                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, cramTmpPath, refTmpPath)) {}
 
-        Assert.assertTrue(SamStreams.isCRAMFile(new BufferedInputStream(new SeekableFileStream(cramTmpFile))));
+        Assert.assertTrue(SamStreams.isCRAMFile(new BufferedInputStream(new SeekableFileStream(cramTmpPath))));
     }
 
     @Test(groups = {"defaultReference"})
     public void testMakeWriterForCramExtensionNoReference() throws IOException {
         // NOTE: This requires an environment variable that is set in the gradle file for the defaultReference test
         // group
-        final File cramTmpFile = File.createTempFile("testMakeWriterForCramExtension", "." + CRAM_TYPE.fileExtension());
-        cramTmpFile.deleteOnExit();
+        final Path cramTmpPath =
+                Files.createTempFile("testMakeWriterForCramExtension", "." + CRAM_TYPE.fileExtension());
+        cramTmpPath.toFile().deleteOnExit();
         try (SAMFileWriter samFileWriter =
-                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, cramTmpFile, null)) {
+                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, cramTmpPath, (Path) null)) {
             fillSmallBam(samFileWriter);
         }
-        Assert.assertTrue(SamStreams.isCRAMFile(new BufferedInputStream(new SeekableFileStream(cramTmpFile))));
+        Assert.assertTrue(SamStreams.isCRAMFile(new BufferedInputStream(new SeekableFileStream(cramTmpPath))));
     }
 
     @Test
     public void testMakeWriterForNoExtension() throws IOException {
-        final File tmpFile = File.createTempFile("testMakeWriterForNoExtension", "");
-        Assert.assertFalse(tmpFile.getName().contains("."));
-        tmpFile.deleteOnExit();
+        final Path tmpPath = Files.createTempFile("testMakeWriterForNoExtension", "");
+        Assert.assertFalse(tmpPath.getFileName().toString().contains("."));
+        tmpPath.toFile().deleteOnExit();
         try (SAMFileWriter samFileWriter =
-                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, tmpFile, null)) {}
-        Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(tmpFile))));
+                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, tmpPath, (Path) null)) {}
+        Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(tmpPath))));
     }
 
     @Test
     public void testMakeWriterForUnknownFileExtension() throws IOException {
-        final File tmpFile = File.createTempFile("testMakeWriterForUnknownFileExtension", ".png");
-        Assert.assertFalse(tmpFile.getName().endsWith(SamReader.Type.CRAM_TYPE.fileExtension()));
-        Assert.assertFalse(tmpFile.getName().endsWith(SamReader.Type.SAM_TYPE.fileExtension()));
-        Assert.assertFalse(tmpFile.getName().endsWith(SamReader.Type.BAM_TYPE.fileExtension()));
+        final Path tmpPath = Files.createTempFile("testMakeWriterForUnknownFileExtension", ".png");
+        Assert.assertFalse(tmpPath.getFileName().toString().endsWith(SamReader.Type.CRAM_TYPE.fileExtension()));
+        Assert.assertFalse(tmpPath.getFileName().toString().endsWith(SamReader.Type.SAM_TYPE.fileExtension()));
+        Assert.assertFalse(tmpPath.getFileName().toString().endsWith(SamReader.Type.BAM_TYPE.fileExtension()));
 
-        tmpFile.deleteOnExit();
+        tmpPath.toFile().deleteOnExit();
         try (SAMFileWriter samFileWriter =
-                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, tmpFile, null)) {}
-        Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(tmpFile))));
+                new SAMFileWriterFactory().makeWriter(new SAMFileHeader(), true, tmpPath, (Path) null)) {}
+        Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(tmpPath))));
     }
 
     @Test
     public void testMakeSamOrBamForCramExtension() throws IOException {
-        final File tmpFile = File.createTempFile("testMakeSamOrBamForCramExtension", "." + CRAM_TYPE.fileExtension());
-        tmpFile.deleteOnExit();
+        final Path tmpPath = Files.createTempFile("testMakeSamOrBamForCramExtension", "." + CRAM_TYPE.fileExtension());
+        tmpPath.toFile().deleteOnExit();
         try (SAMFileWriter samFileWriter =
-                new SAMFileWriterFactory().makeSAMOrBAMWriter(new SAMFileHeader(), true, tmpFile)) {}
+                new SAMFileWriterFactory().makeSAMOrBAMWriter(new SAMFileHeader(), true, tmpPath)) {}
 
-        Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(tmpFile))));
+        Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(tmpPath))));
     }
 }

--- a/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterFactoryTest.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -269,26 +270,33 @@ public class SAMFileWriterFactoryTest extends HtsjdkTest {
             final int nRecs,
             final boolean verifySupplementalFiles)
             throws IOException {
-        if (outputPath.getFileName().toString().endsWith(SamReader.Type.CRAM_TYPE.fileExtension())) {
-            Assert.assertTrue(SamStreams.isCRAMFile(new BufferedInputStream(new SeekableFileStream(outputPath))));
-        }
+        // The format-magic checks below open the file with SeekableFileStream, which only supports the
+        // default (local) filesystem, and rely on the file name carrying a proper format extension. The
+        // jimfs-based tests deliberately use bare extension names (no dot), so restrict these checks to
+        // the default filesystem; the reader round-trip and supplemental-file checks below still validate
+        // the non-default-filesystem cases.
+        if (outputPath.getFileSystem() == FileSystems.getDefault()) {
+            if (outputPath.getFileName().toString().endsWith(SamReader.Type.CRAM_TYPE.fileExtension())) {
+                Assert.assertTrue(SamStreams.isCRAMFile(new BufferedInputStream(new SeekableFileStream(outputPath))));
+            }
 
-        if (outputPath.getFileName().toString().endsWith(SamReader.Type.BAM_TYPE.fileExtension())) {
-            Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(outputPath))));
-        }
+            if (outputPath.getFileName().toString().endsWith(SamReader.Type.BAM_TYPE.fileExtension())) {
+                Assert.assertTrue(SamStreams.isBAMFile(new BufferedInputStream(new SeekableFileStream(outputPath))));
+            }
 
-        if (outputPath.getFileName().toString().endsWith(SamReader.Type.SAM_TYPE.fileExtension())) {
-            byte[] head = new byte[3];
-            new DataInputStream(Files.newInputStream(outputPath)).readFully(head);
-            Assert.assertEquals("@HD".getBytes(), head);
+            if (outputPath.getFileName().toString().endsWith(SamReader.Type.SAM_TYPE.fileExtension())) {
+                byte[] head = new byte[3];
+                new DataInputStream(Files.newInputStream(outputPath)).readFully(head);
+                Assert.assertEquals("@HD".getBytes(), head);
+            }
         }
 
         if (verifySupplementalFiles) {
             final Path indexPath = SamFiles.findIndex(outputPath);
-            indexPath.toFile().deleteOnExit();
+            IOUtil.deleteOnExit(indexPath);
             final Path md5Path =
                     outputPath.resolveSibling(outputPath.getFileName().toString() + ".md5");
-            md5Path.toFile().deleteOnExit();
+            IOUtil.deleteOnExit(md5Path);
             Assert.assertTrue(Files.size(indexPath) > 0);
             Assert.assertTrue(Files.size(md5Path) > 0);
         }

--- a/src/test/java/htsjdk/samtools/SAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterTest.java
@@ -3,6 +3,7 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CollectionUtil;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.testng.Assert;
@@ -25,7 +26,7 @@ public class SAMFileWriterTest extends HtsjdkTest {
 
         // First check that it all fails when writing without turning off checking
         for (final String ext : CollectionUtil.makeList(".sam", ".bam")) {
-            final File file = File.createTempFile("test.", ext);
+            final Path file = File.createTempFile("test.", ext).toPath();
             final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), true, file);
 
             try {
@@ -39,7 +40,7 @@ public class SAMFileWriterTest extends HtsjdkTest {
 
         // Then test that it succeeds with checking turned off
         for (final String ext : CollectionUtil.makeList(".sam", ".bam")) {
-            final File file = File.createTempFile("test.", ext);
+            final Path file = File.createTempFile("test.", ext).toPath();
             final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), true, file);
             writer.setSortOrderChecking(false);
             builder.forEach(writer::addAlignment);

--- a/src/test/java/htsjdk/samtools/SAMFileWriterTest.java
+++ b/src/test/java/htsjdk/samtools/SAMFileWriterTest.java
@@ -2,7 +2,7 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CollectionUtil;
-import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,7 +26,7 @@ public class SAMFileWriterTest extends HtsjdkTest {
 
         // First check that it all fails when writing without turning off checking
         for (final String ext : CollectionUtil.makeList(".sam", ".bam")) {
-            final Path file = File.createTempFile("test.", ext).toPath();
+            final Path file = Files.createTempFile("test.", ext);
             final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), true, file);
 
             try {
@@ -40,7 +40,7 @@ public class SAMFileWriterTest extends HtsjdkTest {
 
         // Then test that it succeeds with checking turned off
         for (final String ext : CollectionUtil.makeList(".sam", ".bam")) {
-            final Path file = File.createTempFile("test.", ext).toPath();
+            final Path file = Files.createTempFile("test.", ext);
             final SAMFileWriter writer = new SAMFileWriterFactory().makeSAMOrBAMWriter(builder.getHeader(), true, file);
             writer.setSortOrderChecking(false);
             builder.forEach(writer::addAlignment);

--- a/src/test/java/htsjdk/samtools/SAMIntegerTagTest.java
+++ b/src/test/java/htsjdk/samtools/SAMIntegerTagTest.java
@@ -30,9 +30,10 @@ import htsjdk.samtools.util.BinaryCodec;
 import htsjdk.samtools.util.CloserUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -48,9 +49,9 @@ import org.testng.annotations.Test;
  * @author alecw@broadinstitute.org
  */
 public class SAMIntegerTagTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/SAMIntegerTagTest");
-    private static final File REF_FILE =
-            new File("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/SAMIntegerTagTest");
+    private static final Path REF_FILE =
+            Path.of("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta");
     private SAMSequenceDictionary DICTIONARY_BACKED_BY_REF_FILE;
 
     private static final String BYTE_TAG = "BY";
@@ -221,7 +222,7 @@ public class SAMIntegerTagTest extends HtsjdkTest {
      * @return The same record, after having being written and read back.
      */
     private SAMRecord writeAndReadSamRecord(final String format, SAMRecord rec) throws IOException {
-        final File bamFile = File.createTempFile("htsjdk-writeAndReadSamRecord.", "." + format);
+        final Path bamFile = Files.createTempFile("htsjdk-writeAndReadSamRecord.", "." + format);
         final SAMFileWriter bamWriter =
                 new SAMFileWriterFactory().makeWriter(rec.getHeader(), false, bamFile, REF_FILE);
         bamWriter.addAlignment(rec);
@@ -234,7 +235,7 @@ public class SAMIntegerTagTest extends HtsjdkTest {
             Assert.assertTrue(iterator.hasNext());
             rec = iterator.next();
         }
-        bamFile.delete();
+        Files.delete(bamFile);
         return rec;
     }
 
@@ -322,12 +323,12 @@ public class SAMIntegerTagTest extends HtsjdkTest {
     @DataProvider(name = "legalIntegerAttributesFiles")
     public Object[][] getLegalIntegerAttributesFiles() {
         return new Object[][] {
-            {new File(TEST_DATA_DIR, "variousAttributes.sam")}, {new File(TEST_DATA_DIR, "variousAttributes.bam")}
+            {TEST_DATA_DIR.resolve("variousAttributes.sam")}, {TEST_DATA_DIR.resolve("variousAttributes.bam")}
         };
     }
 
     @Test(dataProvider = "legalIntegerAttributesFiles")
-    public void testLegalIntegerAttributesFilesStrict(final File inputFile) {
+    public void testLegalIntegerAttributesFilesStrict(final Path inputFile) {
         final SamReader reader = SamReaderFactory.makeDefault()
                 .enable(SamReaderFactory.Option.EAGERLY_DECODE)
                 .validationStringency(ValidationStringency.STRICT)
@@ -409,7 +410,7 @@ public class SAMIntegerTagTest extends HtsjdkTest {
                 w = new SAMFileWriterFactory().makeBAMWriter(header, false, baos);
                 break;
             case CRAM:
-                w = new SAMFileWriterFactory().makeCRAMWriter(header, baos, (File) null);
+                w = new SAMFileWriterFactory().makeCRAMWriter(header, baos, (Path) null);
                 break;
             default:
                 throw new RuntimeException("Unknown format: " + format);
@@ -428,7 +429,7 @@ public class SAMIntegerTagTest extends HtsjdkTest {
 
         final SamReader reader = SamReaderFactory.make()
                 .validationStringency(validationStringency)
-                .referenceSource(new ReferenceSource((File) null))
+                .referenceSource(new ReferenceSource((Path) null))
                 .open(SamInputResource.of(new ByteArrayInputStream(baos.toByteArray())));
         final SAMRecordIterator iterator = reader.iterator();
         Assert.assertTrue(iterator.hasNext());

--- a/src/test/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordDuplicateComparatorTest.java
@@ -25,8 +25,9 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloserUtil;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -254,7 +255,7 @@ public class SAMRecordDuplicateComparatorTest extends HtsjdkTest {
         }
 
         // Sort Bam
-        final File sortedBam = File.createTempFile("testOut", ".bam");
+        final Path sortedBam = Files.createTempFile("testOut", ".bam");
         final SamReader reader = randomSetOfRecords.getSamReader();
         // SamReaderFactory.makeDefault().referenceSequence(Defaults.REFERENCE_FASTA).open(input);
         reader.getFileHeader().setSortOrder(SAMFileHeader.SortOrder.duplicate);

--- a/src/test/java/htsjdk/samtools/SAMRecordSetBuilderTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordSetBuilderTest.java
@@ -21,8 +21,7 @@ public class SAMRecordSetBuilderTest extends HtsjdkTest {
 
         SAMRecordSetBuilder samRecords = new SAMRecordSetBuilder(true, SAMFileHeader.SortOrder.coordinate, true, 50000);
 
-        final Path dir = TestUtil.getTempDirectory("SAMRecordSetBuilderTest", "testWriteRandomReference")
-                .toPath();
+        final Path dir = TestUtil.getTempDirectoryAsPath("SAMRecordSetBuilderTest", "testWriteRandomReference");
         final Path fasta = dir.resolve("output.fa");
         final Path dict = dir.resolve("output.dict");
 
@@ -33,10 +32,8 @@ public class SAMRecordSetBuilderTest extends HtsjdkTest {
 
     @Test
     public void testDeterministicWriteRandomReference() throws IOException {
-        final Path dir1 = TestUtil.getTempDirectory("SAMRecordSetBuilderTest", "testWriteRandomReference")
-                .toPath();
-        final Path dir2 = TestUtil.getTempDirectory("SAMRecordSetBuilderTest", "testWriteRandomReference")
-                .toPath();
+        final Path dir1 = TestUtil.getTempDirectoryAsPath("SAMRecordSetBuilderTest", "testWriteRandomReference");
+        final Path dir2 = TestUtil.getTempDirectoryAsPath("SAMRecordSetBuilderTest", "testWriteRandomReference");
 
         try {
             for (final Path dir : CollectionUtil.makeSet(dir1, dir2)) {

--- a/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMRecordUnitTest.java
@@ -30,7 +30,7 @@ import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.TestUtil;
 import htsjdk.utils.TestNGUtils;
-import java.io.*;
+import java.io.IOException;
 import java.lang.reflect.Array;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,13 +46,13 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     @DataProvider(name = "serializationTestData")
     public Object[][] getSerializationTestData() {
         return new Object[][] {
-            {new File("src/test/resources/htsjdk/samtools/serialization_test.sam")},
-            {new File("src/test/resources/htsjdk/samtools/serialization_test.bam")}
+            {Path.of("src/test/resources/htsjdk/samtools/serialization_test.sam")},
+            {Path.of("src/test/resources/htsjdk/samtools/serialization_test.bam")}
         };
     }
 
     @Test(dataProvider = "serializationTestData")
-    public void testSAMRecordSerialization(final File inputFile) throws Exception {
+    public void testSAMRecordSerialization(final Path inputFile) throws Exception {
         final SamReader reader = SamReaderFactory.makeDefault().open(inputFile);
         final SAMRecord initialSAMRecord = reader.iterator().next();
         reader.close();
@@ -761,7 +761,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "serializationTestData")
-    public void testNullHeaderSerialization(final File inputFile) throws Exception {
+    public void testNullHeaderSerialization(final Path inputFile) throws Exception {
         final SamReader reader = SamReaderFactory.makeDefault().open(inputFile);
         final SAMRecord initialSAMRecord = reader.iterator().next();
         reader.close();
@@ -1125,7 +1125,7 @@ public class SAMRecordUnitTest extends HtsjdkTest {
     @DataProvider(name = "attributeAccessTestData")
     private Object[][] hasAttributeTestData() throws IOException {
         final SamReader reader = SamReaderFactory.makeDefault()
-                .open(new File("src/test/resources/htsjdk/samtools/SAMIntegerTagTest/variousAttributes.sam"));
+                .open(Path.of("src/test/resources/htsjdk/samtools/SAMIntegerTagTest/variousAttributes.sam"));
         final SAMRecord samRecordWithAttributes = reader.iterator().next();
         final SAMRecord samRecordWithoutAnyAttributes = new SAMRecord(reader.getFileHeader());
         reader.close();

--- a/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
+++ b/src/test/java/htsjdk/samtools/SAMSequenceRecordTest.java
@@ -25,8 +25,9 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.Interval;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -121,21 +122,22 @@ public class SAMSequenceRecordTest extends HtsjdkTest {
         };
     }
 
-    File AccessFileWithAlternateContigName;
+    Path AccessFileWithAlternateContigName;
 
     @BeforeMethod
     void setup() throws IOException {
-        File input = new File("src/test/resources/htsjdk/samtools/SamSequenceRecordTest/alternate_contig_names.sam");
+        Path input = Path.of("src/test/resources/htsjdk/samtools/SamSequenceRecordTest/alternate_contig_names.sam");
 
-        final File outputFile = File.createTempFile("tmp.", ".bam");
-        outputFile.deleteOnExit();
+        final Path outputFile = Files.createTempFile("tmp.", ".bam");
+        outputFile.toFile().deleteOnExit();
 
         final SamReader samReader = SamReaderFactory.make().open(input);
         final SAMFileHeader fileHeader = samReader.getFileHeader().clone();
         fileHeader.setSortOrder(SAMFileHeader.SortOrder.coordinate);
 
-        try (SAMFileWriter samWriter =
-                new SAMFileWriterFactory().setCreateIndex(true).makeWriter(fileHeader, false, outputFile, null)) {
+        try (SAMFileWriter samWriter = new SAMFileWriterFactory()
+                .setCreateIndex(true)
+                .makeWriter(fileHeader, false, outputFile, (Path) null)) {
             samReader.forEach(samWriter::addAlignment);
         }
         AccessFileWithAlternateContigName = outputFile;

--- a/src/test/java/htsjdk/samtools/SAMTextWriterTest.java
+++ b/src/test/java/htsjdk/samtools/SAMTextWriterTest.java
@@ -24,7 +24,8 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -81,8 +82,8 @@ public class SAMTextWriterTest extends HtsjdkTest {
 
     private void doTest(final SAMRecordSetBuilder recordSetBuilder, final SamFlagField samFlagField) throws Exception {
         SamReader inputSAM = recordSetBuilder.getSamReader();
-        final File samFile = File.createTempFile("tmp.", ".sam");
-        samFile.deleteOnExit();
+        final Path samFile = Files.createTempFile("tmp.", ".sam");
+        samFile.toFile().deleteOnExit();
         final Map<String, Object> tagMap = new HashMap<String, Object>();
         tagMap.put("XC", 'q');
         tagMap.put("XI", 12345);

--- a/src/test/java/htsjdk/samtools/SamFileHeaderMergerTest.java
+++ b/src/test/java/htsjdk/samtools/SamFileHeaderMergerTest.java
@@ -33,9 +33,9 @@ import htsjdk.samtools.util.StringUtil;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -57,17 +57,17 @@ import org.testng.annotations.Test;
  */
 public class SamFileHeaderMergerTest extends HtsjdkTest {
 
-    private static File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
 
     /** tests that if we've set the merging to false, we get a SAMException for bam's with different dictionaries. */
     @Test(expectedExceptions = SequenceUtil.SequenceListsDifferException.class)
     public void testMergedException() {
-        File INPUT[] = {
-            new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/Chromosome1to10.bam"),
-            new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/Chromosome5to9.bam")
+        Path INPUT[] = {
+            TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/Chromosome1to10.bam"),
+            TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/Chromosome5to9.bam")
         };
         final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
-        for (final File inFile : INPUT) {
+        for (final Path inFile : INPUT) {
             IOUtil.assertFileIsReadable(inFile);
             headers.add(SamReaderFactory.makeDefault().getFileHeader(inFile));
         }
@@ -77,13 +77,13 @@ public class SamFileHeaderMergerTest extends HtsjdkTest {
     /** Tests that we can successfully merge two files with */
     @Test
     public void testMerging() {
-        File INPUT[] = {
-            new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/Chromosome1to10.bam"),
-            new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/Chromosome5to9.bam")
+        Path INPUT[] = {
+            TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/Chromosome1to10.bam"),
+            TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/Chromosome5to9.bam")
         };
         final List<SamReader> readers = new ArrayList<SamReader>();
         final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
-        for (final File inFile : INPUT) {
+        for (final Path inFile : INPUT) {
             IOUtil.assertFileIsReadable(inFile);
             // We are now checking for zero-length reads, so suppress complaint about that.
             final SamReader in = SamReaderFactory.makeDefault()
@@ -157,9 +157,9 @@ public class SamFileHeaderMergerTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "data")
-    public void testProgramGroupAndReadGroupMerge(File inputFiles[], File expectedOutputFile) throws IOException {
+    public void testProgramGroupAndReadGroupMerge(Path inputFiles[], Path expectedOutputFile) throws IOException {
 
-        BufferedReader reader = new BufferedReader(new FileReader(expectedOutputFile));
+        BufferedReader reader = new BufferedReader(Files.newBufferedReader(expectedOutputFile));
 
         String line;
         String expected_output = "";
@@ -169,7 +169,7 @@ public class SamFileHeaderMergerTest extends HtsjdkTest {
 
         final List<SamReader> readers = new ArrayList<SamReader>();
         final List<SAMFileHeader> headers = new ArrayList<SAMFileHeader>();
-        for (final File inFile : inputFiles) {
+        for (final Path inFile : inputFiles) {
             IOUtil.assertFileIsReadable(inFile);
 
             // We are now checking for zero-length reads, so suppress complaint about that.
@@ -227,20 +227,20 @@ public class SamFileHeaderMergerTest extends HtsjdkTest {
 
         return new Object[][] {
             {
-                new File[] {
-                    new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/case1/chr11sub_file1.sam"),
-                    new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/case1/chr11sub_file2.sam")
+                new Path[] {
+                    TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/case1/chr11sub_file1.sam"),
+                    TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/case1/chr11sub_file2.sam")
                 },
-                new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/case1/expected_output.sam")
+                TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/case1/expected_output.sam")
             },
             {
-                new File[] {
-                    new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/case2/chr11sub_file1.sam"),
-                    new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/case2/chr11sub_file2.sam"),
-                    new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/case2/chr11sub_file3.sam"),
-                    new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/case2/chr11sub_file4.sam")
+                new Path[] {
+                    TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/case2/chr11sub_file1.sam"),
+                    TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/case2/chr11sub_file2.sam"),
+                    TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/case2/chr11sub_file3.sam"),
+                    TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/case2/chr11sub_file4.sam")
                 },
-                new File(TEST_DATA_DIR, "SamFileHeaderMergerTest/case2/expected_output.sam")
+                TEST_DATA_DIR.resolve("SamFileHeaderMergerTest/case2/expected_output.sam")
             }
         };
     }

--- a/src/test/java/htsjdk/samtools/SamFilesTest.java
+++ b/src/test/java/htsjdk/samtools/SamFilesTest.java
@@ -1,9 +1,8 @@
 package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -15,7 +14,7 @@ import org.testng.annotations.Test;
  */
 public class SamFilesTest extends HtsjdkTest {
     private static final String TEST_DATA = "src/test/resources/htsjdk/samtools/BAMFileIndexTest/";
-    private static final File BAM_FILE = new File(TEST_DATA + "index_test.bam");
+    private static final Path BAM_FILE = Path.of(TEST_DATA + "index_test.bam");
 
     @DataProvider(name = "FindIndexParams")
     public static Object[][] paramsFindIndexForSuffixes() {
@@ -43,52 +42,47 @@ public class SamFilesTest extends HtsjdkTest {
     public void testFindIndexForSuffixes(
             final String dataFileSuffix, final String indexFileSuffix, final String expectIndexSuffix)
             throws IOException {
-        final File dataFile = File.createTempFile("test", dataFileSuffix);
-        dataFile.deleteOnExit();
-        Assert.assertNull(SamFiles.findIndex(dataFile));
-        Assert.assertNull(SamFiles.findIndex(dataFile.toPath()));
+        final Path dataFile = Files.createTempFile("test", dataFileSuffix);
+        Path indexFile = null;
+        try {
+            Assert.assertNull(SamFiles.findIndex(dataFile));
 
-        File indexFile = null;
-        if (indexFileSuffix != null) {
-            indexFile = new File(dataFile.getAbsolutePath().replaceFirst("\\.\\S+$", indexFileSuffix));
-            indexFile.createNewFile();
-            indexFile.deleteOnExit();
-        }
+            if (indexFileSuffix != null) {
+                indexFile = Path.of(dataFile.toAbsolutePath().toString().replaceFirst("\\.\\S+$", indexFileSuffix));
+                Files.createFile(indexFile);
+            }
 
-        final File foundIndexFile = SamFiles.findIndex(dataFile);
-        if (expectIndexSuffix == null) {
-            Assert.assertNull(foundIndexFile);
-        } else {
-            Assert.assertNotNull(foundIndexFile);
-            Assert.assertTrue(foundIndexFile.getName().endsWith(expectIndexSuffix));
-        }
-
-        final Path foundIndexPath = SamFiles.findIndex(dataFile.toPath());
-        if (expectIndexSuffix == null) {
-            Assert.assertNull(foundIndexPath);
-        } else {
-            Assert.assertNotNull(foundIndexPath);
-            Assert.assertTrue(foundIndexPath.getFileName().toString().endsWith(expectIndexSuffix));
+            final Path foundIndexPath = SamFiles.findIndex(dataFile);
+            if (expectIndexSuffix == null) {
+                Assert.assertNull(foundIndexPath);
+            } else {
+                Assert.assertNotNull(foundIndexPath);
+                Assert.assertTrue(foundIndexPath.getFileName().toString().endsWith(expectIndexSuffix));
+            }
+        } finally {
+            Files.deleteIfExists(dataFile);
+            if (indexFile != null) {
+                Files.deleteIfExists(indexFile);
+            }
         }
     }
 
     @DataProvider(name = "filesAndIndicies")
     public Object[][] getFilesAndIndicies() throws IOException {
 
-        final File REAL_INDEX_FILE = new File(BAM_FILE + ".bai"); // test regular file
-        final File SYMLINKED_BAM_WITH_SYMLINKED_INDEX = new File(TEST_DATA, "symlink_with_index.bam");
+        final Path REAL_INDEX_FILE = Path.of(BAM_FILE + ".bai"); // test regular file
+        final Path SYMLINKED_BAM_WITH_SYMLINKED_INDEX = Path.of(TEST_DATA, "symlink_with_index.bam");
 
         return new Object[][] {
             {BAM_FILE, REAL_INDEX_FILE},
-            {SYMLINKED_BAM_WITH_SYMLINKED_INDEX, new File(SYMLINKED_BAM_WITH_SYMLINKED_INDEX + ".bai")},
-            {new File(TEST_DATA, "symlink_without_linked_index.bam"), REAL_INDEX_FILE.getCanonicalFile()},
-            {new File(TEST_DATA, "FileThatDoesntExist"), null}
+            {SYMLINKED_BAM_WITH_SYMLINKED_INDEX, Path.of(SYMLINKED_BAM_WITH_SYMLINKED_INDEX + ".bai")},
+            {Path.of(TEST_DATA, "symlink_without_linked_index.bam"), REAL_INDEX_FILE.toRealPath()},
+            {Path.of(TEST_DATA, "FileThatDoesntExist"), null}
         };
     }
 
     @Test(dataProvider = "filesAndIndicies")
-    public void testIndexSymlinking(File bam, File expected_index) {
+    public void testIndexSymlinking(Path bam, Path expected_index) {
         Assert.assertEquals(SamFiles.findIndex(bam), expected_index);
-        Assert.assertEquals(SamFiles.findIndex(bam.toPath()), IOUtil.toPath(expected_index));
     }
 }

--- a/src/test/java/htsjdk/samtools/SamIndexesTest.java
+++ b/src/test/java/htsjdk/samtools/SamIndexesTest.java
@@ -9,10 +9,12 @@ import htsjdk.samtools.seekablestream.SeekableStreamFactory;
 import htsjdk.samtools.util.IOUtil;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.zip.GZIPOutputStream;
 import org.testng.Assert;
@@ -23,11 +25,11 @@ public class SamIndexesTest extends HtsjdkTest {
 
     @Test
     public void testEmptyBai() throws IOException {
-        final File baiFile = File.createTempFile("test", ".bai");
-        baiFile.deleteOnExit();
-        final FileOutputStream fos = new FileOutputStream(baiFile);
-        fos.write(SamIndexes.BAI.magic);
-        fos.close();
+        final Path baiFile = Files.createTempFile("test", ".bai");
+        baiFile.toFile().deleteOnExit();
+        try (final OutputStream fos = Files.newOutputStream(baiFile)) {
+            fos.write(SamIndexes.BAI.magic);
+        }
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         baos.write(SamIndexes.BAI.magic);
@@ -42,11 +44,11 @@ public class SamIndexesTest extends HtsjdkTest {
 
     @Test
     public void testEmptyCsi() throws IOException {
-        final File csiFile = File.createTempFile("test", ".csi");
-        csiFile.deleteOnExit();
-        final FileOutputStream fos = new FileOutputStream(csiFile);
-        fos.write(SamIndexes.CSI.magic);
-        fos.close();
+        final Path csiFile = Files.createTempFile("test", ".csi");
+        csiFile.toFile().deleteOnExit();
+        try (final OutputStream fos = Files.newOutputStream(csiFile)) {
+            fos.write(SamIndexes.CSI.magic);
+        }
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         baos.write(SamIndexes.CSI.magic);
@@ -116,16 +118,16 @@ public class SamIndexesTest extends HtsjdkTest {
 
     @Test
     public void testCraiFromFile() throws IOException {
-        final File file = File.createTempFile("test", ".crai");
-        file.deleteOnExit();
-        final FileOutputStream fos = new FileOutputStream(file);
+        final Path file = Files.createTempFile("test", ".crai");
+        file.toFile().deleteOnExit();
 
         SAMFileHeader header = new SAMFileHeader();
         header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
         final CRAIEntry entry = new CRAIEntry(0, 1, 2, 5, 3, 4);
-        final CRAMCRAIIndexer indexer = new CRAMCRAIIndexer(fos, header, Collections.singleton(entry));
-        indexer.finish();
-        fos.close();
+        try (final OutputStream fos = Files.newOutputStream(file)) {
+            final CRAMCRAIIndexer indexer = new CRAMCRAIIndexer(fos, header, Collections.singleton(entry));
+            indexer.finish();
+        }
 
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
         dictionary.addSequence(new SAMSequenceRecord("1", 100));
@@ -147,22 +149,22 @@ public class SamIndexesTest extends HtsjdkTest {
     public void testOpenIndexFileAsBaiOrNull_NPE() throws IOException {
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
         dictionary.addSequence(new SAMSequenceRecord("1", 100));
-        Assert.assertNull(SamIndexes.openIndexFileAsBaiOrNull(null, dictionary));
+        Assert.assertNull(SamIndexes.openIndexFileAsBaiOrNull((Path) null, dictionary));
     }
 
     @Test
     public void testOpenIndexFileAsBaiOrNull_ReturnsNull() throws IOException {
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
         dictionary.addSequence(new SAMSequenceRecord("1", 100));
-        File file = File.createTempFile("test", ".notbai");
-        file.deleteOnExit();
+        Path file = Files.createTempFile("test", ".notbai");
+        file.toFile().deleteOnExit();
         Assert.assertNull(SamIndexes.openIndexFileAsBaiOrNull(file, dictionary));
-        file.delete();
+        Files.delete(file);
 
-        file = File.createTempFile("test", ".notcrai");
-        file.deleteOnExit();
+        file = Files.createTempFile("test", ".notcrai");
+        file.toFile().deleteOnExit();
         Assert.assertNull(SamIndexes.openIndexFileAsBaiOrNull(file, dictionary));
-        file.delete();
+        Files.delete(file);
     }
 
     @Test
@@ -170,18 +172,18 @@ public class SamIndexesTest extends HtsjdkTest {
         final SAMSequenceDictionary dictionary = new SAMSequenceDictionary();
         dictionary.addSequence(new SAMSequenceRecord("1", 100));
 
-        final File file = File.createTempFile("test", ".crai");
-        file.deleteOnExit();
-        final FileOutputStream fos = new FileOutputStream(file);
+        final Path file = Files.createTempFile("test", ".crai");
+        file.toFile().deleteOnExit();
         SAMFileHeader header = new SAMFileHeader();
         header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
         final CRAIEntry entry = new CRAIEntry(0, 1, 2, 5, 3, 4);
-        final CRAMCRAIIndexer indexer = new CRAMCRAIIndexer(fos, header, Collections.singleton(entry));
-        indexer.finish();
-        fos.close();
+        try (final OutputStream fos = Files.newOutputStream(file)) {
+            final CRAMCRAIIndexer indexer = new CRAMCRAIIndexer(fos, header, Collections.singleton(entry));
+            indexer.finish();
+        }
 
         final InputStream baiStream =
-                SamIndexes.openIndexUrlAsBaiOrNull(file.toURI().toURL(), dictionary);
+                SamIndexes.openIndexUrlAsBaiOrNull(file.toUri().toURL(), dictionary);
         Assert.assertNotNull(baiStream);
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -200,17 +202,17 @@ public class SamIndexesTest extends HtsjdkTest {
     @DataProvider(name = "getSAMIndexTypeFromStreamTests")
     public Object[][] getSAMIndexTypeFromStreamTests() {
         return new Object[][] {
-            {new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai"), SamIndexes.BAI},
-            {new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.csi"), SamIndexes.CSI},
-            {new File("src/test/resources/htsjdk/samtools/cram/cramQueryWithCRAI.cram.crai"), SamIndexes.CRAI},
+            {Paths.get("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai"), SamIndexes.BAI},
+            {Paths.get("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.csi"), SamIndexes.CSI},
+            {Paths.get("src/test/resources/htsjdk/samtools/cram/cramQueryWithCRAI.cram.crai"), SamIndexes.CRAI},
         };
     }
 
     @Test(dataProvider = "getSAMIndexTypeFromStreamTests")
-    public void testGetSAMIndexTypeFromStream(final File indexFile, final SamIndexes expectedIndexType)
+    public void testGetSAMIndexTypeFromStream(final Path indexFile, final SamIndexes expectedIndexType)
             throws IOException {
         try (final SeekableStream seekableStream =
-                SeekableStreamFactory.getInstance().getStreamFor(indexFile.getPath())) {
+                SeekableStreamFactory.getInstance().getStreamFor(indexFile.toString())) {
             Assert.assertEquals(SamIndexes.getSAMIndexTypeFromStream(seekableStream), expectedIndexType);
             Assert.assertEquals(seekableStream.position(), 0);
         }

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -652,7 +652,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
                         return written;
                     }
                 });
-                final SamInputResource res = usePath ? SamInputResource.of(fifo) : SamInputResource.of(fifo.toFile());
+                final SamInputResource res = SamInputResource.of(fifo);
 
                 int count = 0;
                 try (final SamReader in = SamReaderFactory.make().open(res)) {

--- a/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderFactoryTest.java
@@ -24,7 +24,6 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.BiFunction;
@@ -35,12 +34,12 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class SamReaderFactoryTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
     private static final Log LOG = Log.getInstance(SamReaderFactoryTest.class);
 
     @Test(dataProvider = "variousFormatReaderTestCases")
     public void variousFormatReaderTest(final String inputFile) throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
         final SamReader reader = SamReaderFactory.makeDefault().open(input);
         for (final SAMRecord ignored : reader) {}
         reader.close();
@@ -68,7 +67,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
             }
         };
 
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
         try (final SamReader reader = SamReaderFactory.makeDefault()
                 .inflaterFactory(myInflaterFactory)
                 .open(input)) {
@@ -123,7 +122,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
 
     @Test
     public void testWrap() throws IOException {
-        final Path input = Paths.get(TEST_DATA_DIR.getPath(), "noheader.sam");
+        final Path input = TEST_DATA_DIR.resolve("noheader.sam");
         final SamReader wrappedReader =
                 SamReaderFactory.makeDefault().open(input, SamReaderFactoryTest::addHeader, null);
         int records = countRecords(wrappedReader);
@@ -134,7 +133,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
     @Test(dataProvider = "queryIntervalIssue76TestCases")
     public void queryIntervalIssue76(final String sequenceName, final int start, final int end, final int expectedCount)
             throws IOException {
-        final File input = new File(TEST_DATA_DIR, "issue76.bam");
+        final Path input = TEST_DATA_DIR.resolve("issue76.bam");
         final SamReader reader = SamReaderFactory.makeDefault().open(input);
         final QueryInterval interval = new QueryInterval(
                 reader.getFileHeader().getSequence(sequenceName).getSequenceIndex(), start, end);
@@ -208,7 +207,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
 
     @Test(dataProvider = "variousFormatReaderTestCases")
     public void samRecordFactoryTest(final String inputFile) throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
 
         final SAMRecordFactoryTester recordFactory = new SAMRecordFactoryTester();
         final SamReaderFactory readerFactory = SamReaderFactory.makeDefault().samRecordFactory(recordFactory);
@@ -239,9 +238,9 @@ public class SamReaderFactoryTest extends HtsjdkTest {
     /**
      * Unit tests for asserting all permutations of data and index sources read the same records and header.
      */
-    final File localBam = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    final Path localBam = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
 
-    final File localBamIndex = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai");
+    final Path localBamIndex = Path.of("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai");
 
     final URL bamUrl, bamIndexUrl;
 
@@ -277,26 +276,27 @@ public class SamReaderFactoryTest extends HtsjdkTest {
     }
 
     private InputResource composeInputResourceForType(final InputResource.Type type, final boolean forIndex) {
-        final File f = forIndex ? localBamIndex : localBam;
+        final Path f = forIndex ? localBamIndex : localBam;
         final URL url = forIndex ? bamIndexUrl : bamUrl;
         switch (type) {
             case FILE:
-                return new FileInputResource(f);
+                return new FileInputResource(f.toFile());
             case PATH:
-                return new PathInputResource(f.toPath(), Function.identity());
+                return new PathInputResource(f, Function.identity());
             case URL:
                 return new UrlInputResource(url);
             case SEEKABLE_STREAM:
                 return new SeekableStreamInputResource(new SeekableHTTPStream(url));
             case INPUT_STREAM:
                 try {
-                    return new InputStreamInputResource(new FileInputStream(f));
+                    return new InputStreamInputResource(new FileInputStream(f.toFile()));
                 } catch (final FileNotFoundException e) {
                     throw new RuntimeIOException(e);
                 }
             case HTSGET:
-                return new HtsgetInputResource(URI.create(
-                        HtsgetBAMFileReaderTest.HTSGET_ENDPOINT + HtsgetBAMFileReaderTest.LOCAL_PREFIX + f.getName()));
+                return new HtsgetInputResource(URI.create(HtsgetBAMFileReaderTest.HTSGET_ENDPOINT
+                        + HtsgetBAMFileReaderTest.LOCAL_PREFIX
+                        + f.getFileName().toString()));
             default:
                 throw new IllegalStateException();
         }
@@ -325,7 +325,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
 
     @Test
     public void openPath() throws IOException {
-        final Path path = localBam.toPath();
+        final Path path = localBam;
         final List<SAMRecord> records;
         final SAMFileHeader fileHeader;
         try (final SamReader reader = SamReaderFactory.makeDefault().open(path)) {
@@ -346,9 +346,9 @@ public class SamReaderFactoryTest extends HtsjdkTest {
     public void testOpenIrregularPath() throws IOException {
         // See: htsjdk.samtools.SamInputResource.of(java.nio.file.Path)
         // Related to https://github.com/samtools/htsjdk/issues/1716
-        final File irregularFile = new File("/dev/null");
-        try (final SamReader fileReader = SamReaderFactory.makeDefault().open(irregularFile);
-                final SamReader pathReader = SamReaderFactory.makeDefault().open(irregularFile.toPath())) {
+        final Path irregularPath = Path.of("/dev/null");
+        try (final SamReader fileReader = SamReaderFactory.makeDefault().open(irregularPath);
+                final SamReader pathReader = SamReaderFactory.makeDefault().open(irregularPath)) {
             Assert.assertEquals(fileReader.getResourceDescription(), pathReader.getResourceDescription());
         }
     }
@@ -360,7 +360,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
                 URI.create("htsget://127.0.0.1:3000/reads/htsjdk_test.index_test.bam"), InputResource.Type.HTSGET,
             },
             {
-                localBam.toURI(), InputResource.Type.PATH,
+                localBam.toUri(), InputResource.Type.PATH,
             },
             {
                 URI.create("http://test.url"), InputResource.Type.URL,
@@ -425,8 +425,8 @@ public class SamReaderFactoryTest extends HtsjdkTest {
 
     @Test
     public void checkHasIndexForStreamingPathBamWithFileIndex() throws IOException {
-        InputResource bam = new NeverFilePathInputResource(localBam.toPath());
-        InputResource index = new FileInputResource(localBamIndex);
+        InputResource bam = new NeverFilePathInputResource(localBam);
+        InputResource index = new FileInputResource(localBamIndex.toFile());
 
         // ensure that the index is being used, not checked in queryInputResourcePermutation
         try (final SamReader reader = SamReaderFactory.makeDefault().open(new SamInputResource(bam, index))) {
@@ -436,8 +436,8 @@ public class SamReaderFactoryTest extends HtsjdkTest {
 
     @Test
     public void queryStreamingPathBamWithFileIndex() throws IOException {
-        InputResource bam = new NeverFilePathInputResource(localBam.toPath());
-        InputResource index = new FileInputResource(localBamIndex);
+        InputResource bam = new NeverFilePathInputResource(localBam);
+        InputResource index = new FileInputResource(localBamIndex.toFile());
 
         queryInputResourcePermutation(new SamInputResource(bam, index));
     }
@@ -464,9 +464,9 @@ public class SamReaderFactoryTest extends HtsjdkTest {
     public static class TestReaderFactory implements CustomReaderFactory.ICustomReaderFactory {
         @Override
         public SamReader open(URL url) {
-            final File file = new File(TEST_DATA_DIR, url.getQuery());
-            LOG.info("Opening customr reader for " + file.toString());
-            return SamReaderFactory.makeDefault().open(file);
+            final Path path = TEST_DATA_DIR.resolve(url.getQuery());
+            LOG.info("Opening customr reader for " + path.toString());
+            return SamReaderFactory.makeDefault().open(path);
         }
     }
 
@@ -522,7 +522,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
         // deliberately specify a bad index file to ensure we get an IOException
         getCRAMReaderFromInputResource(
                 (cramURL, indexURL) -> {
-                    return SamInputResource.of(cramURL).index(new File("nonexistent.bai"));
+                    return SamInputResource.of(cramURL).index(Path.of("nonexistent.bai"));
                 },
                 true,
                 3);
@@ -530,16 +530,16 @@ public class SamReaderFactoryTest extends HtsjdkTest {
 
     @Test
     public void testCRAMReaderWithCRAIFromNonFilePath() throws IOException {
-        final File cramFile = new File(TEST_DATA_DIR, "cram/cramQueryWithCRAI.cram");
-        final File cramIndex = new File(TEST_DATA_DIR, "cram/cramQueryWithCRAI.cram.crai");
-        final File referenceFile = new File(TEST_DATA_DIR, "cram/human_g1k_v37.20.21.10M-10M200k.fasta");
+        final Path cramFile = TEST_DATA_DIR.resolve("cram/cramQueryWithCRAI.cram");
+        final Path cramIndex = TEST_DATA_DIR.resolve("cram/cramQueryWithCRAI.cram.crai");
+        final Path referenceFile = TEST_DATA_DIR.resolve("cram/human_g1k_v37.20.21.10M-10M200k.fasta");
 
         try (final FileSystem jimfs = Jimfs.newFileSystem(Configuration.unix())) {
             final Path jimfsCRAM = jimfs.getPath("acram.cram");
             final Path jimfsCRAI = jimfs.getPath("acram.crai");
 
-            Files.copy(cramFile.toPath(), jimfsCRAM);
-            Files.copy(cramIndex.toPath(), jimfsCRAI);
+            Files.copy(cramFile, jimfsCRAM);
+            Files.copy(cramIndex, jimfsCRAI);
 
             final SamReaderFactory factory = SamReaderFactory.makeDefault()
                     .referenceSource(new ReferenceSource(referenceFile))
@@ -560,13 +560,19 @@ public class SamReaderFactoryTest extends HtsjdkTest {
             final boolean hasIndex,
             final int expectedCount)
             throws IOException {
-        final String cramFilePath = new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath();
-        final String cramIndexPath = new File(TEST_DATA_DIR, "cram_with_bai_index.cram.bai").getAbsolutePath();
+        final String cramFilePath = TEST_DATA_DIR
+                .resolve("cram_with_bai_index.cram")
+                .toAbsolutePath()
+                .toString();
+        final String cramIndexPath = TEST_DATA_DIR
+                .resolve("cram_with_bai_index.cram.bai")
+                .toAbsolutePath()
+                .toString();
         final URL cramURL = new URL("file://" + cramFilePath);
         final URL indexURL = new URL("file://" + cramIndexPath);
 
         final SamReaderFactory factory = SamReaderFactory.makeDefault()
-                .referenceSource(new ReferenceSource(new File(TEST_DATA_DIR, "hg19mini.fasta")))
+                .referenceSource(new ReferenceSource(TEST_DATA_DIR.resolve("hg19mini.fasta")))
                 .validationStringency(ValidationStringency.SILENT);
         final SamReader reader = factory.open(getInputResource.apply(cramURL, indexURL));
 
@@ -579,16 +585,17 @@ public class SamReaderFactoryTest extends HtsjdkTest {
     public void testSamReaderFromSeekableStream() throws IOException {
         // even though a SAM isn't indexable, make sure we can open one
         // using a seekable stream
-        final File samFile = new File(TEST_DATA_DIR, "unsorted.sam");
+        final Path samPath = TEST_DATA_DIR.resolve("unsorted.sam");
         final SamReaderFactory factory =
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT);
-        final SamReader reader = factory.open(SamInputResource.of(new SeekableFileStream(samFile)));
+        final SamReader reader = factory.open(SamInputResource.of(new SeekableFileStream(samPath)));
         Assert.assertEquals(countRecords(reader), 10);
     }
 
     @Test
     public void testSamReaderFromURL() throws IOException {
-        final String samFilePath = new File(TEST_DATA_DIR, "unsorted.sam").getAbsolutePath();
+        final String samFilePath =
+                TEST_DATA_DIR.resolve("unsorted.sam").toAbsolutePath().toString();
         final URL samURL = new URL("file://" + samFilePath);
         final SamReaderFactory factory =
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT);
@@ -602,10 +609,10 @@ public class SamReaderFactoryTest extends HtsjdkTest {
         // use a bogus (.bai file) to force SamReaderFactory to fall through to the
         // fallback code that assumes a SAM File when it can't determine the
         // format of the input, to ensure that it results in a SAMFormatException
-        final File samFile = new File(TEST_DATA_DIR, "cram_with_bai_index.cram.bai");
+        final Path samPath = TEST_DATA_DIR.resolve("cram_with_bai_index.cram.bai");
         final SamReaderFactory factory =
                 SamReaderFactory.makeDefault().validationStringency(ValidationStringency.SILENT);
-        try (final SamReader reader = factory.open(SamInputResource.of(new SeekableFileStream(samFile)))) {
+        try (final SamReader reader = factory.open(SamInputResource.of(new SeekableFileStream(samPath)))) {
             countRecords(reader);
         }
     }
@@ -620,10 +627,11 @@ public class SamReaderFactoryTest extends HtsjdkTest {
 
         for (final boolean usePath : CollectionUtil.makeList(true, false)) {
 
-            final File fifo = File.createTempFile("fifo", "");
-            Assert.assertTrue(fifo.delete());
-            fifo.deleteOnExit();
-            final Process exec = new ProcessBuilder("mkfifo", fifo.getAbsolutePath()).start();
+            final Path fifo = Files.createTempFile("fifo", "");
+            Files.delete(fifo);
+            fifo.toFile().deleteOnExit();
+            final Process exec =
+                    new ProcessBuilder("mkfifo", fifo.toAbsolutePath().toString()).start();
             exec.waitFor(1, TimeUnit.MINUTES);
             Assert.assertEquals(exec.exitValue(), 0, "mkfifo failed with exit code " + 0);
 
@@ -644,7 +652,7 @@ public class SamReaderFactoryTest extends HtsjdkTest {
                         return written;
                     }
                 });
-                final SamInputResource res = usePath ? SamInputResource.of(fifo.toPath()) : SamInputResource.of(fifo);
+                final SamInputResource res = usePath ? SamInputResource.of(fifo) : SamInputResource.of(fifo.toFile());
 
                 int count = 0;
                 try (final SamReader in = SamReaderFactory.make().open(res)) {

--- a/src/test/java/htsjdk/samtools/SamReaderSortTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderSortTest.java
@@ -26,7 +26,7 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.cram.ref.ReferenceSource;
-import java.io.File;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -52,7 +52,7 @@ public class SamReaderSortTest extends HtsjdkTest {
     @Test(expectedExceptions = IllegalStateException.class)
     public void testSortsDisagree() throws Exception {
         SAMRecordIterator it = SamReaderFactory.makeDefault()
-                .open(new File(COORDINATE_SORTED_FILE))
+                .open(Path.of(COORDINATE_SORTED_FILE))
                 .iterator();
         try {
             it.assertSorted(SAMFileHeader.SortOrder.queryname);
@@ -68,7 +68,7 @@ public class SamReaderSortTest extends HtsjdkTest {
     @Test(dataProvider = "validSorts")
     public void testSortAssertionValid(String file, SAMFileHeader.SortOrder order) {
         SAMRecordIterator it =
-                SamReaderFactory.makeDefault().open(new File(file)).iterator();
+                SamReaderFactory.makeDefault().open(Path.of(file)).iterator();
         try {
             it.assertSorted(order);
             while (it.hasNext()) {
@@ -92,7 +92,7 @@ public class SamReaderSortTest extends HtsjdkTest {
     @Test(dataProvider = "invalidSorts", expectedExceptions = IllegalStateException.class)
     public void testSortAssertionFails(String file, SAMFileHeader.SortOrder order) throws Exception {
         SAMRecordIterator it =
-                SamReaderFactory.makeDefault().open(new File(file)).iterator();
+                SamReaderFactory.makeDefault().open(Path.of(file)).iterator();
         try {
             it.assertSorted(order);
             while (it.hasNext()) {
@@ -105,8 +105,8 @@ public class SamReaderSortTest extends HtsjdkTest {
     }
 
     private CRAMFileReader getCramFileReader(String file, String fileReference) {
-        final ReferenceSource referenceSource = new ReferenceSource(new File(fileReference));
-        return new CRAMFileReader(new File(file), referenceSource);
+        final ReferenceSource referenceSource = new ReferenceSource(Path.of(fileReference));
+        return new CRAMFileReader(Path.of(file), referenceSource);
     }
 
     @Test(dataProvider = "sortsCramWithoutIndex")

--- a/src/test/java/htsjdk/samtools/SamReaderTest.java
+++ b/src/test/java/htsjdk/samtools/SamReaderTest.java
@@ -26,8 +26,8 @@ package htsjdk.samtools;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.PeekableIterator;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.testng.Assert;
@@ -35,11 +35,11 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class SamReaderTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
 
     @Test(dataProvider = "variousFormatReaderTestCases")
     public void variousFormatReaderTest(final String inputFile) throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
         try (final SamReader reader = SamReaderFactory.makeDefault().open(input)) {
             for (final SAMRecord rec : reader) {
                 // just scan through the lines
@@ -61,8 +61,8 @@ public class SamReaderTest extends HtsjdkTest {
     public void CRAMIndexTest(
             final String inputFile, final String referenceFile, QueryInterval queryInterval, String expectedReadName)
             throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
-        final File reference = new File(TEST_DATA_DIR, referenceFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
+        final Path reference = TEST_DATA_DIR.resolve(referenceFile);
         try (final SamReader reader =
                 SamReaderFactory.makeDefault().referenceSequence(reference).open(input)) {
             Assert.assertTrue(reader.hasIndex());
@@ -86,8 +86,8 @@ public class SamReaderTest extends HtsjdkTest {
 
     @Test(dataProvider = "NoIndexCRAMTest")
     public void CRAMNoIndexTest(final String inputFile, final String referenceFile) throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
-        final File reference = new File(TEST_DATA_DIR, referenceFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
+        final Path reference = TEST_DATA_DIR.resolve(referenceFile);
         try (final SamReader reader =
                 SamReaderFactory.makeDefault().referenceSequence(reference).open(input)) {
             Assert.assertFalse(reader.hasIndex());
@@ -148,7 +148,7 @@ public class SamReaderTest extends HtsjdkTest {
 
     @Test(dataProvider = "variousFormatReaderTestCases")
     public void samRecordFactoryTest(final String inputFile) throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
         final SAMRecordFactoryTester factory = new SAMRecordFactoryTester();
         int i = 0;
         try (final SamReader reader =
@@ -169,7 +169,7 @@ public class SamReaderTest extends HtsjdkTest {
     @Test(dataProvider = "cramTestCases", expectedExceptions = IllegalArgumentException.class)
     public void testReferenceRequiredForCRAM(final String inputFile, final String ignoredReferenceFile)
             throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
         try (final SamReader reader = SamReaderFactory.makeDefault().open(input)) {
             for (final SAMRecord rec : reader) {}
         }
@@ -186,8 +186,8 @@ public class SamReaderTest extends HtsjdkTest {
 
     @Test(dataProvider = "cramTestCases")
     public void testIterateCRAMWithIndex(final String inputFile, final String referenceFile) throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
-        final File reference = new File(TEST_DATA_DIR, referenceFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
+        final Path reference = TEST_DATA_DIR.resolve(referenceFile);
         try (final SamReader reader =
                 SamReaderFactory.makeDefault().referenceSequence(reference).open(input)) {
             for (final SAMRecord rec : reader) {}

--- a/src/test/java/htsjdk/samtools/SamSpecIntTest.java
+++ b/src/test/java/htsjdk/samtools/SamSpecIntTest.java
@@ -26,8 +26,9 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloserUtil;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.testng.Assert;
@@ -35,7 +36,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class SamSpecIntTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
 
     @DataProvider(name = "testSamIntegersTestCases")
     public Object[][] testSamIntegersTestCases() {
@@ -49,7 +50,7 @@ public class SamSpecIntTest extends HtsjdkTest {
 
     @Test(dataProvider = "testSamIntegersTestCases")
     public void testSamIntegers(final String inputFile) throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
         final SamReader samReader = SamReaderFactory.makeDefault().open(input);
 
         tryToWriteToSamAndBam(samReader);
@@ -57,19 +58,19 @@ public class SamSpecIntTest extends HtsjdkTest {
 
     @Test(dataProvider = "testBamIntegersTestCases")
     public void testBamIntegers(final String inputFile) throws IOException {
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
         final SamReader bamReader = SamReaderFactory.makeDefault().open(input);
 
         tryToWriteToSamAndBam(bamReader);
     }
 
     private void tryToWriteToSamAndBam(final SamReader reader) throws IOException {
-        final File bamOutput = File.createTempFile("test", ".bam");
-        final File samOutput = File.createTempFile("test", ".sam");
+        final Path bamOutput = Files.createTempFile("test", ".bam");
+        final Path samOutput = Files.createTempFile("test", ".sam");
         final SAMFileWriter samWriter =
-                new SAMFileWriterFactory().makeWriter(reader.getFileHeader(), true, samOutput, null);
+                new SAMFileWriterFactory().makeWriter(reader.getFileHeader(), true, samOutput, (Path) null);
         final SAMFileWriter bamWriter =
-                new SAMFileWriterFactory().makeWriter(reader.getFileHeader(), true, bamOutput, null);
+                new SAMFileWriterFactory().makeWriter(reader.getFileHeader(), true, bamOutput, (Path) null);
 
         final List<String> errorMessages = new ArrayList<>();
         for (SAMRecord rec : reader) {
@@ -86,7 +87,7 @@ public class SamSpecIntTest extends HtsjdkTest {
         samWriter.close();
         bamWriter.close();
         Assert.assertEquals(errorMessages.size(), 0);
-        bamOutput.deleteOnExit();
-        samOutput.deleteOnExit();
+        bamOutput.toFile().deleteOnExit();
+        samOutput.toFile().deleteOnExit();
     }
 }

--- a/src/test/java/htsjdk/samtools/SamStreamsTest.java
+++ b/src/test/java/htsjdk/samtools/SamStreamsTest.java
@@ -28,24 +28,29 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class SamStreamsTest extends HtsjdkTest {
 
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Paths.get("src/test/resources/htsjdk/samtools");
 
     @Test(dataProvider = "makeData")
     @SuppressWarnings("deprecated") // we're testing a deprecated method here deliberately
     public void testDataFormat(
             final String inputFile, final boolean isGzippedSAMFile, final boolean isBAMFile, final boolean isCRAMFile)
             throws Exception {
-        final File input = new File(TEST_DATA_DIR, inputFile);
+        final Path input = TEST_DATA_DIR.resolve(inputFile);
         try (final InputStream fis = new BufferedInputStream(
-                new FileInputStream(input))) { // must be buffered or the isGzippedSAMFile will blow up
+                Files.newInputStream(input))) { // must be buffered or the isGzippedSAMFile will blow up
             Assert.assertEquals(SamStreams.isGzippedSAMFile(fis), isGzippedSAMFile, "isGzippedSAMFile:" + inputFile);
             Assert.assertEquals(SamStreams.isBAMFile(fis), isBAMFile, "isBAMFile:" + inputFile);
             Assert.assertEquals(SamStreams.isCRAMFile(fis), isCRAMFile, "isCRAMFile:" + inputFile);
@@ -86,7 +91,7 @@ public class SamStreamsTest extends HtsjdkTest {
     public void sourceLikeCram(final String resourceName, final boolean isFile, final boolean expected)
             throws IOException {
         SeekableStream strm = isFile
-                ? new SeekableFileStream(new File(TEST_DATA_DIR, resourceName))
+                ? new SeekableFileStream(TEST_DATA_DIR.resolve(resourceName))
                 : SeekableStreamFactory.getInstance().getStreamFor(new URL(resourceName));
         Assert.assertEquals(SamStreams.sourceLikeCram(strm), expected);
     }
@@ -131,7 +136,7 @@ public class SamStreamsTest extends HtsjdkTest {
     public void sourceLikeBamImpl(final String resourceName, final boolean isFile, final boolean expected)
             throws IOException {
         SeekableStream strm = isFile
-                ? new SeekableFileStream(new File(TEST_DATA_DIR, resourceName))
+                ? new SeekableFileStream(TEST_DATA_DIR.resolve(resourceName))
                 : SeekableStreamFactory.getInstance().getStreamFor(new URL(resourceName));
         Assert.assertEquals(SamStreams.sourceLikeBam(strm), expected);
     }

--- a/src/test/java/htsjdk/samtools/SequenceNameTruncationAndValidationTest.java
+++ b/src/test/java/htsjdk/samtools/SequenceNameTruncationAndValidationTest.java
@@ -25,7 +25,7 @@ package htsjdk.samtools;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.CloserUtil;
-import java.io.File;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
  * @author alecw@broadinstitute.org
  */
 public class SequenceNameTruncationAndValidationTest extends HtsjdkTest {
-    private static File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools");
 
     @Test(
             expectedExceptions = {SAMException.class},
@@ -76,7 +76,7 @@ public class SequenceNameTruncationAndValidationTest extends HtsjdkTest {
 
     @Test(dataProvider = "samFilesWithSpaceInSequenceName")
     public void testSamSequenceTruncation(final String filename) {
-        final SamReader reader = SamReaderFactory.makeDefault().open(new File(TEST_DATA_DIR, filename));
+        final SamReader reader = SamReaderFactory.makeDefault().open(TEST_DATA_DIR.resolve(filename));
         for (final SAMSequenceRecord sequence :
                 reader.getFileHeader().getSequenceDictionary().getSequences()) {
             Assert.assertFalse(sequence.getSequenceName().contains(" "), sequence.getSequenceName());
@@ -94,7 +94,7 @@ public class SequenceNameTruncationAndValidationTest extends HtsjdkTest {
 
     @Test(expectedExceptions = {SAMFormatException.class})
     public void testBadRname() {
-        final SamReader reader = SamReaderFactory.makeDefault().open(new File(TEST_DATA_DIR, "readWithBadRname.sam"));
+        final SamReader reader = SamReaderFactory.makeDefault().open(TEST_DATA_DIR.resolve("readWithBadRname.sam"));
         for (final SAMRecord rec : reader) {}
         Assert.fail("Should not reach here.");
     }

--- a/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
+++ b/src/test/java/htsjdk/samtools/ValidateSamFileTest.java
@@ -34,15 +34,15 @@ import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.util.CloserUtil;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.StringUtil;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.LineNumberReader;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collection;
@@ -59,7 +59,7 @@ import org.testng.annotations.Test;
  * @author Doug Voet
  */
 public class ValidateSamFileTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/ValidateSamFileTest");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/ValidateSamFileTest");
     private static final int TERMINATION_GZIP_BLOCK_SIZE = 28;
     private static final int RANDOM_NUMBER_TRUNC_BYTE = 128;
 
@@ -67,7 +67,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testValidSamFile() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open(new File(TEST_DATA_DIR, "valid.sam"));
+                .open(TEST_DATA_DIR.resolve("valid.sam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertTrue(results.isEmpty());
     }
@@ -78,11 +78,11 @@ public class ValidateSamFileTest extends HtsjdkTest {
         // With current behavior (matching htslib/samtools), NM/MD are regenerated correctly
         // on decode, so validation finds no errors. Previously this test expected MISSING_NM
         // warnings which are no longer produced.
-        final File reference = new File(TEST_DATA_DIR, "nm_tag_validation.fa");
+        final Path reference = TEST_DATA_DIR.resolve("nm_tag_validation.fa");
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
                 .referenceSequence(reference)
-                .open(new File(TEST_DATA_DIR, "nm_tag_validation.cram"));
+                .open(TEST_DATA_DIR.resolve("nm_tag_validation.cram"));
         final Histogram<String> results = executeValidation(
                 samReader, new FastaSequenceFile(reference, true), IndexValidationStringency.EXHAUSTIVE);
         Assert.assertTrue(results.isEmpty());
@@ -92,7 +92,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testSamFileVersion1pt5() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open(new File(TEST_DATA_DIR, "test_samfile_version_1pt5.bam"));
+                .open(TEST_DATA_DIR.resolve("test_samfile_version_1pt5.bam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(results.getCount(), 2.0);
     }
@@ -102,7 +102,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
         Histogram<String> results = executeValidation(
                 SamReaderFactory.makeDefault()
                         .validationStringency(ValidationStringency.SILENT)
-                        .open(new File(TEST_DATA_DIR, "invalid_coord_sort_order.sam")),
+                        .open(TEST_DATA_DIR.resolve("invalid_coord_sort_order.sam")),
                 null,
                 IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(
@@ -112,7 +112,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
         results = executeValidation(
                 SamReaderFactory.makeDefault()
                         .validationStringency(ValidationStringency.SILENT)
-                        .open(new File(TEST_DATA_DIR, "invalid_queryname_sort_order.sam")),
+                        .open(TEST_DATA_DIR.resolve("invalid_queryname_sort_order.sam")),
                 null,
                 IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(
@@ -423,7 +423,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testMateCigarScenarios(
             final String scenario, final String inputFile, final SAMValidationError.Type expectedError)
             throws Exception {
-        final SamReader reader = SamReaderFactory.makeDefault().open(new File(TEST_DATA_DIR, inputFile));
+        final SamReader reader = SamReaderFactory.makeDefault().open(TEST_DATA_DIR.resolve(inputFile));
         final Histogram<String> results = executeValidation(reader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertNotNull(results.get(expectedError.getHistogramString()), scenario);
         Assert.assertEquals(results.get(expectedError.getHistogramString()).getValue(), 1.0, scenario);
@@ -447,7 +447,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
             throws Exception {
         final SamReader reader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open(new File(TEST_DATA_DIR, inputFile));
+                .open(TEST_DATA_DIR.resolve(inputFile));
         final Histogram<String> results = executeValidation(reader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertNotNull(results.get(expectedError.getHistogramString()), scenario);
         Assert.assertEquals(results.get(expectedError.getHistogramString()).getValue(), 1.0, scenario);
@@ -467,7 +467,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
 
     @Test(expectedExceptions = SAMException.class, dataProvider = "testFatalParsingErrors")
     public void testFatalParsingErrors(final String scenario, final String inputFile) throws Exception {
-        final SamReader reader = SamReaderFactory.makeDefault().open(new File(TEST_DATA_DIR, inputFile));
+        final SamReader reader = SamReaderFactory.makeDefault().open(TEST_DATA_DIR.resolve(inputFile));
         executeValidation(reader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.fail("Exception should have been thrown.");
     }
@@ -482,7 +482,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
 
     @Test(dataProvider = "testQualitiesNotStored")
     public void testNotStoredQualitiesFields(final String inputFile, final double expectedValue) throws IOException {
-        try (final SamReader reader = SamReaderFactory.makeDefault().open((new File(TEST_DATA_DIR, inputFile)))) {
+        try (final SamReader reader = SamReaderFactory.makeDefault().open(TEST_DATA_DIR.resolve(inputFile))) {
             final Histogram<String> results = executeValidation(reader, null, IndexValidationStringency.EXHAUSTIVE);
             Assert.assertEquals(
                     results.get(SAMValidationError.Type.QUALITY_NOT_STORED.getHistogramString())
@@ -518,7 +518,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testQualityFormatValidation() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .open(
-                        new File(
+                        Path.of(
                                 "./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/illumina-as-standard.bam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         final Histogram.Bin<String> bin =
@@ -576,8 +576,8 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testHeaderValidation() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open(new File(TEST_DATA_DIR, "buggyHeader.sam"));
-        final File referenceFile = new File(TEST_DATA_DIR, "../hg19mini.fasta");
+                .open(TEST_DATA_DIR.resolve("buggyHeader.sam"));
+        final Path referenceFile = TEST_DATA_DIR.resolve("../hg19mini.fasta");
         final ReferenceSequenceFile reference = new FastaSequenceFile(referenceFile, false);
         final Histogram<String> results = executeValidation(samReader, reference, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(
@@ -598,7 +598,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testSeqQualMismatch() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open(new File(TEST_DATA_DIR, "seq_qual_len_mismatch.sam"));
+                .open(TEST_DATA_DIR.resolve("seq_qual_len_mismatch.sam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(
                 results.get(SAMValidationError.Type.MISMATCH_SEQ_QUAL_LENGTH.getHistogramString())
@@ -610,7 +610,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testPlatformMissing() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open((new File(TEST_DATA_DIR, "missing_platform_unit.sam")));
+                .open(TEST_DATA_DIR.resolve("missing_platform_unit.sam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(
                 results.get(SAMValidationError.Type.MISSING_PLATFORM_VALUE.getHistogramString())
@@ -622,7 +622,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testPlatformInvalid() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open((new File(TEST_DATA_DIR, "invalid_platform_unit.sam")));
+                .open(TEST_DATA_DIR.resolve("invalid_platform_unit.sam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(
                 results.get(SAMValidationError.Type.INVALID_PLATFORM_VALUE.getHistogramString())
@@ -634,7 +634,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void testDuplicateRGIDs() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open((new File(TEST_DATA_DIR, "duplicate_rg.sam")));
+                .open(TEST_DATA_DIR.resolve("duplicate_rg.sam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(
                 results.get(SAMValidationError.Type.DUPLICATE_READ_GROUP_ID.getHistogramString())
@@ -647,7 +647,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
                 .enable(SamReaderFactory.Option.CACHE_FILE_BASED_INDEXES)
-                .open((new File(TEST_DATA_DIR, "bad_index.bam")));
+                .open(TEST_DATA_DIR.resolve("bad_index.bam"));
 
         Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertEquals(
@@ -663,9 +663,9 @@ public class ValidateSamFileTest extends HtsjdkTest {
     }
 
     private void testHeaderVersion(final String version, final boolean expectValid) throws Exception {
-        final File samFile = File.createTempFile("validateHeader.", ".sam");
-        samFile.deleteOnExit();
-        final PrintWriter pw = new PrintWriter(samFile);
+        final Path samFile = Files.createTempFile("validateHeader.", ".sam");
+        samFile.toFile().deleteOnExit();
+        final PrintWriter pw = new PrintWriter(Files.newOutputStream(samFile));
         pw.println("@HD\tVN:" + version);
         pw.close();
         final SamReader reader = SamReaderFactory.makeDefault().open(samFile);
@@ -696,7 +696,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void duplicateReads() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open(new File(TEST_DATA_DIR, "duplicated_reads.sam"));
+                .open(TEST_DATA_DIR.resolve("duplicated_reads.sam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertFalse(results.isEmpty());
         Assert.assertEquals(
@@ -709,7 +709,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
     public void duplicateReadsOutOfOrder() throws Exception {
         final SamReader samReader = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.SILENT)
-                .open(new File(TEST_DATA_DIR, "duplicated_reads_out_of_order.sam"));
+                .open(TEST_DATA_DIR.resolve("duplicated_reads_out_of_order.sam"));
         final Histogram<String> results = executeValidation(samReader, null, IndexValidationStringency.EXHAUSTIVE);
         Assert.assertFalse(results.isEmpty());
         Assert.assertEquals(
@@ -760,7 +760,7 @@ public class ValidateSamFileTest extends HtsjdkTest {
 
     @Test(dataProvider = "validateBamFileTerminationData")
     public void validateBamFileTerminationTest(
-            final File file, final SAMValidationError.Type errorType, final int numWarnings, final int numErrors)
+            final Path file, final SAMValidationError.Type errorType, final int numWarnings, final int numErrors)
             throws IOException {
         final SamFileValidator samFileValidator = new SamFileValidator(new PrintWriter(System.out), 8000);
         samFileValidator.validateBamFileTermination(file);
@@ -784,32 +784,30 @@ public class ValidateSamFileTest extends HtsjdkTest {
             final Collection<SAMValidationError.Type> ignoringError,
             final boolean skipMateValidation)
             throws IOException {
-        final File outFile = File.createTempFile("validation", ".txt");
-        outFile.deleteOnExit();
+        final Path outFile = Files.createTempFile("validation", ".txt");
+        outFile.toFile().deleteOnExit();
 
-        final PrintWriter out = new PrintWriter(outFile);
+        final PrintWriter out = new PrintWriter(Files.newOutputStream(outFile));
         final SamFileValidator samFileValidator = new SamFileValidator(out, 8000);
         samFileValidator.setIndexValidationStringency(stringency).setErrorsToIgnore(ignoringError);
         samFileValidator.setSkipMateValidation(skipMateValidation);
         samFileValidator.validateSamFileSummary(samReader, reference);
 
-        final LineNumberReader reader = new LineNumberReader(new FileReader(outFile));
+        final BufferedReader reader = Files.newBufferedReader(outFile);
         if (reader.readLine().equals("No errors found")) {
             return new Histogram<>();
         }
         final MetricsFile<MetricBase, String> outputFile = new MetricsFile<>();
-        outputFile.read(new FileReader(outFile));
+        outputFile.read(Files.newBufferedReader(outFile));
         Assert.assertNotNull(outputFile.getHistogram());
         return outputFile.getHistogram();
     }
 
-    private File getBrokenFile(int truncByte) throws IOException {
-        final FileChannel stream =
-                FileChannel.open(new File(TEST_DATA_DIR + "/test_samfile_version_1pt5.bam").toPath());
-        final File breakingFile = File.createTempFile("trunc", ".bam");
-        breakingFile.deleteOnExit();
-        FileChannel.open(breakingFile.toPath(), StandardOpenOption.WRITE)
-                .transferFrom(stream, 0, stream.size() - truncByte);
+    private Path getBrokenFile(int truncByte) throws IOException {
+        final FileChannel stream = FileChannel.open(TEST_DATA_DIR.resolve("test_samfile_version_1pt5.bam"));
+        final Path breakingFile = Files.createTempFile("trunc", ".bam");
+        breakingFile.toFile().deleteOnExit();
+        FileChannel.open(breakingFile, StandardOpenOption.WRITE).transferFrom(stream, 0, stream.size() - truncByte);
         return breakingFile;
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/CRAIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAIIndexTest.java
@@ -4,7 +4,13 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.*;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -140,10 +146,10 @@ public class CRAIIndexTest extends HtsjdkTest {
     private SeekableStream getBaiStreamFromFileAsSeekableStream(
             final SAMSequenceDictionary dictionary, final List<CRAIEntry> index) {
         try {
-            final File file = File.createTempFile("test", ".crai");
-            file.deleteOnExit();
+            final Path file = Files.createTempFile("test", ".crai");
+            file.toFile().deleteOnExit();
 
-            try (final FileOutputStream fos = new FileOutputStream(file)) {
+            try (final OutputStream fos = Files.newOutputStream(file)) {
                 doIndexing(index, fos);
             }
 
@@ -159,10 +165,10 @@ public class CRAIIndexTest extends HtsjdkTest {
 
     private SeekableStream getBaiStreamFromFile(final SAMSequenceDictionary dictionary, final List<CRAIEntry> index) {
         try {
-            final File file = File.createTempFile("test", ".crai");
-            file.deleteOnExit();
+            final Path file = Files.createTempFile("test", ".crai");
+            file.toFile().deleteOnExit();
 
-            try (final FileOutputStream fos = new FileOutputStream(file)) {
+            try (final OutputStream fos = Files.newOutputStream(file)) {
                 doIndexing(index, fos);
             }
 

--- a/src/test/java/htsjdk/samtools/cram/CRAMVersionTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAMVersionTest.java
@@ -17,8 +17,8 @@ import htsjdk.samtools.cram.structure.block.Block;
 import htsjdk.samtools.seekablestream.SeekableMemoryStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.zip.CRC32;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -38,7 +38,7 @@ public class CRAMVersionTest extends HtsjdkTest {
     @Test
     public void test_V3_1() throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ReferenceSource source = new ReferenceSource((File) null);
+        ReferenceSource source = new ReferenceSource((Path) null);
         SAMFileHeader samFileHeader = new SAMFileHeader();
         CRAMVersion cramVersion = CramVersions.CRAM_v3_1;
         CRAMFileWriter w = new CRAMFileWriter(baos, source, samFileHeader, null);

--- a/src/test/java/htsjdk/samtools/cram/LosslessRoundTripTest.java
+++ b/src/test/java/htsjdk/samtools/cram/LosslessRoundTripTest.java
@@ -6,6 +6,7 @@ import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
 import htsjdk.samtools.util.SequenceUtil;
 import java.io.*;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.testng.Assert;
@@ -52,7 +53,7 @@ public class LosslessRoundTripTest extends HtsjdkTest {
         }
 
         try (CRAMFileReader reader = new CRAMFileReader(
-                new ByteArrayInputStream(baos.toByteArray()), (File) null, source, ValidationStringency.STRICT)) {
+                new ByteArrayInputStream(baos.toByteArray()), (Path) null, source, ValidationStringency.STRICT)) {
             final SAMRecordIterator iterator = reader.getIterator();
             for (int i = 0; i < records.length; i++) {
                 Assert.assertTrue(iterator.hasNext(), testName + ": too few records returned from CRAM");

--- a/src/test/java/htsjdk/samtools/cram/build/CramIOTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/CramIOTest.java
@@ -10,7 +10,12 @@ import htsjdk.samtools.cram.structure.CramHeader;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.RuntimeIOException;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -27,9 +32,9 @@ public class CramIOTest extends HtsjdkTest {
     @Test(dataProvider = "cramHeaderAndEOF")
     public void testCheckHeaderAndEOF(final CRAMVersion cramVersion) throws IOException {
         final CramHeader cramHeader = new CramHeader(cramVersion, testID);
-        final File file = File.createTempFile("test", ".cram");
-        file.deleteOnExit();
-        try (final FileOutputStream fos = new FileOutputStream(file)) {
+        final Path file = Files.createTempFile("test", ".cram");
+        file.toFile().deleteOnExit();
+        try (final OutputStream fos = Files.newOutputStream(file)) {
             CramIO.writeCramHeader(cramHeader, fos);
             CramIO.writeCramEOF(cramHeader.getCRAMVersion(), fos);
         }
@@ -80,7 +85,7 @@ public class CramIOTest extends HtsjdkTest {
      * @param file the CRAM file to check
      * @return true if the file is a valid CRAM file and is properly terminated with respect to the version.
      */
-    private static boolean checkHeaderAndEOF(final File file) {
+    private static boolean checkHeaderAndEOF(final Path file) {
         try (final SeekableStream seekableStream = new SeekableFileStream(file)) {
             final CramHeader cramHeader = readCramHeader(seekableStream);
             return checkEOF(cramHeader.getCRAMVersion(), seekableStream);

--- a/src/test/java/htsjdk/samtools/cram/compression/CompressorCacheTest.java
+++ b/src/test/java/htsjdk/samtools/cram/compression/CompressorCacheTest.java
@@ -6,14 +6,15 @@ import htsjdk.samtools.cram.compression.range.RangeExternalCompressor;
 import htsjdk.samtools.cram.compression.range.RangeParams;
 import htsjdk.samtools.cram.structure.CompressorCache;
 import htsjdk.samtools.cram.structure.block.BlockCompressionMethod;
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.zip.Deflater;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class CompressorCacheTest extends HtsjdkTest {
-    public static final File BZIP2_FILE = new File("src/test/resources/htsjdk/samtools/cram/io/bzip2-test.bz2");
+    public static final Path BZIP2_FILE = Paths.get("src/test/resources/htsjdk/samtools/cram/io/bzip2-test.bz2");
     public static final byte[] TEST_BYTES = "This is a simple string to test compression".getBytes();
 
     final CompressorCache compressorCache = new CompressorCache();

--- a/src/test/java/htsjdk/samtools/cram/compression/ExternalCompressionTest.java
+++ b/src/test/java/htsjdk/samtools/cram/compression/ExternalCompressionTest.java
@@ -5,16 +5,17 @@ import htsjdk.samtools.Defaults;
 import htsjdk.samtools.cram.compression.range.RangeExternalCompressor;
 import htsjdk.samtools.cram.compression.range.RangeParams;
 import htsjdk.samtools.cram.structure.block.BlockCompressionMethod;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.zip.Deflater;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ExternalCompressionTest extends HtsjdkTest {
-    public static final File BZIP2_FILE = new File("src/test/resources/htsjdk/samtools/cram/io/bzip2-test.bz2");
+    public static final Path BZIP2_FILE = Paths.get("src/test/resources/htsjdk/samtools/cram/io/bzip2-test.bz2");
     public static final byte[] TEST_BYTES = "This is a simple string to test compression".getBytes();
 
     @DataProvider(name = "compressorForMethodPositiveTests")
@@ -123,7 +124,7 @@ public class ExternalCompressionTest extends HtsjdkTest {
     @Test
     public void testBZip2Decompression() throws IOException {
         final BZIP2ExternalCompressor compressor = new BZIP2ExternalCompressor();
-        final byte[] input = Files.readAllBytes(BZIP2_FILE.toPath());
+        final byte[] input = Files.readAllBytes(BZIP2_FILE);
         final byte[] output = compressor.uncompress(input);
         Assert.assertEquals(output, "BZip2 worked".getBytes());
     }

--- a/src/test/java/htsjdk/samtools/cram/spec30/HtsSpecsComplianceTestBase.java
+++ b/src/test/java/htsjdk/samtools/cram/spec30/HtsSpecsComplianceTestBase.java
@@ -21,7 +21,7 @@ public class HtsSpecsComplianceTestBase extends HtsjdkTest {
     protected static final Path SPEC_30_FAILED_DIR =
             Path.of("src/test/resources/htsjdk/hts-specs/test/cram/3.0/failed");
     protected static final Path SPEC_31_DIR = Path.of("src/test/resources/htsjdk/hts-specs/test/cram/3.1/passed");
-    protected static final File REFERENCE = new File("src/test/resources/htsjdk/hts-specs/test/cram/ce.fa");
+    protected static final Path REFERENCE = Path.of("src/test/resources/htsjdk/hts-specs/test/cram/ce.fa");
 
     /**
      * Decode a CRAM file from the 3.0/passed directory and return its records.
@@ -45,13 +45,13 @@ public class HtsSpecsComplianceTestBase extends HtsjdkTest {
      * Read a SAM file from the 3.0/passed directory and return its records.
      */
     protected List<SAMRecord> readSam(final String basename) throws IOException {
-        return readSamFile(SPEC_30_DIR.resolve(basename + ".sam").toFile());
+        return readSamFile(SPEC_30_DIR.resolve(basename + ".sam"));
     }
 
     /**
      * Read a SAM file and return its records.
      */
-    protected List<SAMRecord> readSamFile(final File samFile) throws IOException {
+    protected List<SAMRecord> readSamFile(final Path samFile) throws IOException {
         try (final SamReader reader = SamReaderFactory.makeDefault()
                 .referenceSequence(REFERENCE)
                 .validationStringency(ValidationStringency.SILENT)
@@ -167,7 +167,7 @@ public class HtsSpecsComplianceTestBase extends HtsjdkTest {
      * Round-trip: read SAM → write CRAM → read back → compare against original SAM.
      */
     protected void assertRoundTrip(final String basename) throws IOException {
-        final File samFile = SPEC_30_DIR.resolve(basename + ".sam").toFile();
+        final Path samFile = SPEC_30_DIR.resolve(basename + ".sam");
         final List<SAMRecord> originalRecords = readSamFile(samFile);
         if (originalRecords.isEmpty()) {
             return; // nothing to round-trip

--- a/src/test/java/htsjdk/samtools/cram/spec30/Spec30IndexTest.java
+++ b/src/test/java/htsjdk/samtools/cram/spec30/Spec30IndexTest.java
@@ -4,8 +4,8 @@ import htsjdk.samtools.*;
 import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.CloseableIterator;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -156,9 +156,9 @@ public class Spec30IndexTest extends HtsSpecsComplianceTestBase {
             final boolean contained,
             final int expectedCount)
             throws IOException {
-        final File cramFile = SPEC_30_DIR.resolve(basename + ".cram").toFile();
-        final File craiFile = SPEC_30_DIR.resolve(basename + ".cram.crai").toFile();
-        final ReferenceSource source = new ReferenceSource(REFERENCE);
+        final Path cramFile = SPEC_30_DIR.resolve(basename + ".cram");
+        final Path craiFile = SPEC_30_DIR.resolve(basename + ".cram.crai");
+        final ReferenceSource source = new ReferenceSource(REFERENCE.toPath());
 
         try (final CRAMFileReader reader = new CRAMFileReader(
                 new SeekableFileStream(cramFile),
@@ -176,9 +176,9 @@ public class Spec30IndexTest extends HtsSpecsComplianceTestBase {
     }
 
     private void assertUnmappedCount(final String basename, final int expectedCount) throws IOException {
-        final File cramFile = SPEC_30_DIR.resolve(basename + ".cram").toFile();
-        final File craiFile = SPEC_30_DIR.resolve(basename + ".cram.crai").toFile();
-        final ReferenceSource source = new ReferenceSource(REFERENCE);
+        final Path cramFile = SPEC_30_DIR.resolve(basename + ".cram");
+        final Path craiFile = SPEC_30_DIR.resolve(basename + ".cram.crai");
+        final ReferenceSource source = new ReferenceSource(REFERENCE.toPath());
 
         try (final CRAMFileReader reader = new CRAMFileReader(
                 new SeekableFileStream(cramFile),

--- a/src/test/java/htsjdk/samtools/cram/spec30/Spec30IndexTest.java
+++ b/src/test/java/htsjdk/samtools/cram/spec30/Spec30IndexTest.java
@@ -158,7 +158,7 @@ public class Spec30IndexTest extends HtsSpecsComplianceTestBase {
             throws IOException {
         final Path cramFile = SPEC_30_DIR.resolve(basename + ".cram");
         final Path craiFile = SPEC_30_DIR.resolve(basename + ".cram.crai");
-        final ReferenceSource source = new ReferenceSource(REFERENCE.toPath());
+        final ReferenceSource source = new ReferenceSource(REFERENCE);
 
         try (final CRAMFileReader reader = new CRAMFileReader(
                 new SeekableFileStream(cramFile),
@@ -178,7 +178,7 @@ public class Spec30IndexTest extends HtsSpecsComplianceTestBase {
     private void assertUnmappedCount(final String basename, final int expectedCount) throws IOException {
         final Path cramFile = SPEC_30_DIR.resolve(basename + ".cram");
         final Path craiFile = SPEC_30_DIR.resolve(basename + ".cram.crai");
-        final ReferenceSource source = new ReferenceSource(REFERENCE.toPath());
+        final ReferenceSource source = new ReferenceSource(REFERENCE);
 
         try (final CRAMFileReader reader = new CRAMFileReader(
                 new SeekableFileStream(cramFile),

--- a/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/SliceTests.java
@@ -15,8 +15,8 @@ import htsjdk.samtools.cram.ref.ReferenceSource;
 import htsjdk.samtools.cram.structure.block.Block;
 import htsjdk.samtools.cram.structure.block.BlockCompressionMethod;
 import htsjdk.samtools.util.SequenceUtil;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -105,10 +105,11 @@ public class SliceTests extends HtsjdkTest {
     public void testValidateReferenceMD5Fails() throws IOException {
         // auxf.alteredForMD5test.fa has been altered slightly from the original reference
         // to cause the CRAM md5 check to fail
-        final File CRAMFile = new File("src/test/resources/htsjdk/samtools/cram/auxf#values.3.0.cram");
-        final File refFile = new File("src/test/resources/htsjdk/samtools/cram/auxf.alteredForMD5test.fa");
+        final Path CRAMFile = Path.of("src/test/resources/htsjdk/samtools/cram/auxf#values.3.0.cram");
+        final Path refFile = Path.of("src/test/resources/htsjdk/samtools/cram/auxf.alteredForMD5test.fa");
         final ReferenceSource refSource = new ReferenceSource(refFile);
-        try (final CRAMFileReader reader = new CRAMFileReader(CRAMFile, null, refSource, ValidationStringency.STRICT)) {
+        try (final CRAMFileReader reader =
+                new CRAMFileReader(CRAMFile, (Path) null, refSource, ValidationStringency.STRICT)) {
             final Iterator<SAMRecord> it = reader.getIterator();
             while (it.hasNext()) {
                 it.next();

--- a/src/test/java/htsjdk/samtools/cram/structure/block/CRAMRecordReadFeaturesTest.java
+++ b/src/test/java/htsjdk/samtools/cram/structure/block/CRAMRecordReadFeaturesTest.java
@@ -7,8 +7,8 @@ import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.cram.structure.*;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -67,9 +67,9 @@ public class CRAMRecordReadFeaturesTest extends HtsjdkTest {
         // ensure these are handled correctly on read by comparing the SAMRecords created when reading the
         // CRAM with the SAMRecords from the corresponding truth SAM (see
         // https://github.com/samtools/htsjdk/issues/1379)
-        final File testCRAM = new File(cramFileName);
-        final File testSAM = new File(samFileName);
-        final File referenceFile = referenceFileName == null ? null : new File(referenceFileName);
+        final Path testCRAM = Path.of(cramFileName);
+        final Path testSAM = Path.of(samFileName);
+        final Path referenceFile = referenceFileName == null ? null : Path.of(referenceFileName);
 
         try (final SamReader cramReader =
                         SamReaderFactory.make().referenceSequence(referenceFile).open(testCRAM);

--- a/src/test/java/htsjdk/samtools/filter/IntervalFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/IntervalFilterTest.java
@@ -7,7 +7,7 @@ import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.util.CollectionUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.IntervalList;
-import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -24,7 +24,7 @@ public class IntervalFilterTest extends HtsjdkTest {
         final SAMFileHeader fileHeader;
         final IntervalList list;
 
-        fileHeader = IntervalList.fromFile(new File(
+        fileHeader = IntervalList.fromPath(Path.of(
                         "src/test/resources/htsjdk/samtools/intervallist/IntervalListchr123_empty.interval_list"))
                 .getHeader();
         fileHeader.setSortOrder(SAMFileHeader.SortOrder.unsorted);

--- a/src/test/java/htsjdk/samtools/filter/JavascriptSamRecordFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/JavascriptSamRecordFilterTest.java
@@ -28,11 +28,11 @@ import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.samtools.util.RuntimeScriptException;
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.testng.Assert;
@@ -97,9 +97,9 @@ public class JavascriptSamRecordFilterTest extends HtsjdkTest {
 
     @Test
     public void fileConstructor_compilesAndRuns() throws IOException {
-        File scriptFile = File.createTempFile("filter", ".js");
-        scriptFile.deleteOnExit();
-        Files.writeString(scriptFile.toPath(), "true;", StandardCharsets.UTF_8);
+        Path scriptFile = Files.createTempFile("filter", ".js");
+        scriptFile.toFile().deleteOnExit();
+        Files.writeString(scriptFile, "true;", StandardCharsets.UTF_8);
         SAMFileHeader h = header();
         JavascriptSamRecordFilter f = new JavascriptSamRecordFilter(scriptFile, h);
         Assert.assertFalse(f.filterOut(record(h, "r", 100, "AAAA")));

--- a/src/test/java/htsjdk/samtools/filter/ReadNameFilterTest.java
+++ b/src/test/java/htsjdk/samtools/filter/ReadNameFilterTest.java
@@ -3,7 +3,7 @@ package htsjdk.samtools.filter;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.util.CollectionUtil;
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import org.testng.Assert;
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
  */
 public class ReadNameFilterTest extends HtsjdkTest {
 
-    private static final File TEST_DIR = new File("src/test/resources/htsjdk/samtools/filter");
+    private static final Path TEST_DIR = Path.of("src/test/resources/htsjdk/samtools/filter");
     private static final List<String> names = CollectionUtil.makeList(
             "Read1_filter", "read3_stay", "Read2_filter", "read4_stay", "Hello_filter", "goodbye");
 
@@ -25,7 +25,7 @@ public class ReadNameFilterTest extends HtsjdkTest {
         names.forEach(builder::addUnmappedFragment);
 
         FilteringSamIterator filteringSamIterator = new FilteringSamIterator(
-                builder.getRecords().iterator(), new ReadNameFilter(new File(TEST_DIR, "names.txt"), true));
+                builder.getRecords().iterator(), new ReadNameFilter(TEST_DIR.resolve("names.txt"), true));
 
         Assert.assertEquals(
                 filteringSamIterator.stream()

--- a/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
+++ b/src/test/java/htsjdk/samtools/liftover/LiftOverTest.java
@@ -26,7 +26,12 @@ package htsjdk.samtools.liftover;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.OverlapDetector;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Stream;
 import org.testng.Assert;
@@ -38,8 +43,8 @@ import org.testng.annotations.Test;
  * @author alecw@broadinstitute.org
  */
 public class LiftOverTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/liftover");
-    private static final File CHAIN_FILE = new File(TEST_DATA_DIR, "hg18ToHg19.over.chain");
+    private static final Path TEST_DATA_DIR = Paths.get("src/test/resources/htsjdk/samtools/liftover");
+    private static final Path CHAIN_FILE = TEST_DATA_DIR.resolve("hg18ToHg19.over.chain");
 
     private LiftOver liftOver;
     private Map<String, Set<String>> contigMap;
@@ -52,8 +57,8 @@ public class LiftOverTest extends HtsjdkTest {
     }
 
     @BeforeClass
-    public void initLiftOverFromInputStream() throws FileNotFoundException {
-        InputStream chainFileInputStream = new FileInputStream(CHAIN_FILE);
+    public void initLiftOverFromInputStream() throws IOException {
+        InputStream chainFileInputStream = Files.newInputStream(CHAIN_FILE);
         liftOverFromInputStream = new LiftOver(chainFileInputStream, CHAIN_FILE.toString());
     }
 
@@ -662,9 +667,9 @@ public class LiftOverTest extends HtsjdkTest {
     @Test
     public void testWriteChain() throws Exception {
         final OverlapDetector<Chain> chains = Chain.loadChains(CHAIN_FILE);
-        File outFile = File.createTempFile("test.", ".chain");
-        outFile.deleteOnExit();
-        PrintWriter pw = new PrintWriter(outFile);
+        Path outFile = Files.createTempFile("test.", ".chain");
+        outFile.toFile().deleteOnExit();
+        PrintWriter pw = new PrintWriter(Files.newBufferedWriter(outFile));
         final Map<Integer, Chain> originalChainMap = new TreeMap<>();
         for (final Chain chain : chains.getAll()) {
             chain.write(pw);

--- a/src/test/java/htsjdk/samtools/metrics/MetricsFileTest.java
+++ b/src/test/java/htsjdk/samtools/metrics/MetricsFileTest.java
@@ -29,11 +29,13 @@ import htsjdk.samtools.SAMException;
 import htsjdk.samtools.util.FormatUtil;
 import htsjdk.samtools.util.Histogram;
 import htsjdk.samtools.util.TestUtil;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
 import java.io.Serializable;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Date;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -186,13 +188,13 @@ public class MetricsFileTest extends HtsjdkTest {
 
     @Test
     public void areMetricsFilesEqualTest() {
-        final File TEST_DIR = new File("src/test/resources/htsjdk/samtools/metrics/");
-        final File file1 = new File(TEST_DIR, "metricsOne.metrics");
-        final File file2 = new File(TEST_DIR, "metricsOneCopy.metrics");
-        final File file3 = new File(TEST_DIR, "metricsOneCopyReordered.metrics");
+        final Path TEST_DIR = Paths.get("src/test/resources/htsjdk/samtools/metrics/");
+        final Path file1 = TEST_DIR.resolve("metricsOne.metrics");
+        final Path file2 = TEST_DIR.resolve("metricsOneCopy.metrics");
+        final Path file3 = TEST_DIR.resolve("metricsOneCopyReordered.metrics");
 
-        final File fileModifiedHist = new File(TEST_DIR, "metricsOneModifiedHistogram.metrics");
-        final File fileModifiedMet = new File(TEST_DIR, "metricsOneModifiedMetrics.metrics");
+        final Path fileModifiedHist = TEST_DIR.resolve("metricsOneModifiedHistogram.metrics");
+        final Path fileModifiedMet = TEST_DIR.resolve("metricsOneModifiedMetrics.metrics");
 
         Assert.assertTrue(MetricsFile.areMetricsEqual(file1, file2));
         Assert.assertTrue(MetricsFile.areMetricsEqual(file1, file3));
@@ -206,13 +208,16 @@ public class MetricsFileTest extends HtsjdkTest {
     /** Helper method to persist metrics to file and read them back again. */
     private <METRIC extends MetricBase> MetricsFile<METRIC, Integer> writeThenReadBack(MetricsFile<METRIC, Integer> in)
             throws IOException {
-        File f = File.createTempFile("test", ".metrics");
-        f.deleteOnExit();
-        FileWriter out = new FileWriter(f);
-        in.write(out);
+        Path f = Files.createTempFile("test", ".metrics");
+        f.toFile().deleteOnExit();
+        try (Writer out = Files.newBufferedWriter(f)) {
+            in.write(out);
+        }
 
         MetricsFile<METRIC, Integer> retval = new MetricsFile<METRIC, Integer>();
-        retval.read(new FileReader(f));
+        try (Reader reader = Files.newBufferedReader(f)) {
+            retval.read(reader);
+        }
         return retval;
     }
 }

--- a/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
+++ b/src/test/java/htsjdk/samtools/reference/AbstractIndexedFastaSequenceFileTest.java
@@ -37,8 +37,6 @@ import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.Interval;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.samtools.util.StringUtil;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -53,15 +51,13 @@ import org.testng.annotations.Test;
  * Test the indexed fasta sequence file reader.
  */
 public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/reference");
-    private static final File SEQUENCE_FILE = new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.fasta");
-    private static final File SEQUENCE_FILE_INDEX =
-            new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.fasta.fai");
-    private static final File SEQUENCE_FILE_BGZ = new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.fasta.gz");
-    private static final File SEQUENCE_FILE_GZI =
-            new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.fasta.gz.gzi");
-    private static final File SEQUENCE_FILE_NODICT =
-            new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.nodict.fasta");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/reference");
+    private static final Path SEQUENCE_FILE = TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.fasta");
+    private static final Path SEQUENCE_FILE_INDEX = TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.fasta.fai");
+    private static final Path SEQUENCE_FILE_BGZ = TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.fasta.gz");
+    private static final Path SEQUENCE_FILE_GZI = TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.fasta.gz.gzi");
+    private static final Path SEQUENCE_FILE_NODICT =
+            TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.nodict.fasta");
 
     private final String firstBasesOfChrM = "GATCACAGGTCTATCACCCT";
     private final String extendedBasesOfChrM =
@@ -75,17 +71,15 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
         return new Object[][] {
             new Object[] {new IndexedFastaSequenceFile(SEQUENCE_FILE)},
             {new IndexedFastaSequenceFile(SEQUENCE_FILE_NODICT)},
-            {new IndexedFastaSequenceFile(SEQUENCE_FILE.toPath())},
-            {new IndexedFastaSequenceFile(SEQUENCE_FILE_NODICT.toPath())},
-            {new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ.toPath())}
+            {new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ)}
         };
     }
 
     @DataProvider(name = "comparative")
-    public Object[][] provideOriginalAndNewReaders() throws FileNotFoundException {
+    public Object[][] provideOriginalAndNewReaders() throws FileNotFoundException, IOException {
         GZIIndex gziIndex;
         try {
-            gziIndex = GZIIndex.loadIndex(SEQUENCE_FILE_GZI.toPath());
+            gziIndex = GZIIndex.loadIndex(SEQUENCE_FILE_GZI);
         } catch (IOException e) {
             throw new RuntimeIOException(e);
         }
@@ -99,52 +93,44 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
                 new IndexedFastaSequenceFile(SEQUENCE_FILE)
             },
             new Object[] {
-                ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE.toPath()),
-                new IndexedFastaSequenceFile(SEQUENCE_FILE.toPath())
-            },
-            new Object[] {
-                ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE.toPath(), true),
-                new IndexedFastaSequenceFile(SEQUENCE_FILE.toPath())
-            },
-            new Object[] {
                 ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE_BGZ),
-                new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ.toPath())
+                new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ)
             },
             new Object[] {
                 ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE_BGZ, true),
-                new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ.toPath())
+                new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ)
             },
             new Object[] {
                 ReferenceSequenceFileFactory.getReferenceSequenceFile(SEQUENCE_FILE_BGZ),
                 new BlockCompressedIndexedFastaSequenceFile(
-                        SEQUENCE_FILE_BGZ.getAbsolutePath(),
+                        SEQUENCE_FILE_BGZ.toAbsolutePath().toString(),
                         new SeekableFileStream(SEQUENCE_FILE_BGZ),
-                        new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX)),
+                        new FastaSequenceIndex(Files.newInputStream(SEQUENCE_FILE_INDEX)),
                         null,
                         gziIndex)
             },
             new Object[] {
                 ReferenceSequenceFileFactory.getReferenceSequenceFile(
-                        SEQUENCE_FILE.getAbsolutePath(),
+                        SEQUENCE_FILE.toAbsolutePath().toString(),
                         new SeekableFileStream(SEQUENCE_FILE),
-                        new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX))),
+                        new FastaSequenceIndex(Files.newInputStream(SEQUENCE_FILE_INDEX))),
                 new IndexedFastaSequenceFile(
-                        SEQUENCE_FILE.getAbsolutePath(),
+                        SEQUENCE_FILE.toAbsolutePath().toString(),
                         new SeekableFileStream(SEQUENCE_FILE),
-                        new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX)),
+                        new FastaSequenceIndex(Files.newInputStream(SEQUENCE_FILE_INDEX)),
                         null)
             },
             new Object[] {
                 ReferenceSequenceFileFactory.getReferenceSequenceFile(
-                        SEQUENCE_FILE.getAbsolutePath(),
+                        SEQUENCE_FILE.toAbsolutePath().toString(),
                         new SeekableFileStream(SEQUENCE_FILE),
-                        new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX)),
+                        new FastaSequenceIndex(Files.newInputStream(SEQUENCE_FILE_INDEX)),
                         null,
                         true),
                 new IndexedFastaSequenceFile(
-                        SEQUENCE_FILE.getAbsolutePath(),
+                        SEQUENCE_FILE.toAbsolutePath().toString(),
                         new SeekableFileStream(SEQUENCE_FILE),
-                        new FastaSequenceIndex(new FileInputStream(SEQUENCE_FILE_INDEX)),
+                        new FastaSequenceIndex(Files.newInputStream(SEQUENCE_FILE_INDEX)),
                         null)
             },
         };
@@ -416,7 +402,7 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
 
     @Test(expectedExceptions = FileNotFoundException.class)
     public void testMissingFile() throws Exception {
-        new IndexedFastaSequenceFile(new File(TEST_DATA_DIR, "non-existent.fasta"));
+        new IndexedFastaSequenceFile(TEST_DATA_DIR.resolve("non-existent.fasta"));
         Assert.fail("FileNotFoundException should have been thrown");
     }
 
@@ -427,20 +413,18 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
 
     @Test(expectedExceptions = SAMException.class)
     public void testBadInputForBlockCompressedIndexedFastaSequenceFile() throws Exception {
-        new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE.toPath());
+        new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE);
     }
 
     @Test
     public void testCanCreateBlockCompressedIndexedWithSpecifiedGZIAndDict() throws IOException {
         final Path moved = Files.createTempFile("moved", ".fasta.gz");
-        Files.copy(SEQUENCE_FILE_BGZ.toPath(), moved, StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(SEQUENCE_FILE_BGZ, moved, StandardCopyOption.REPLACE_EXISTING);
         IOUtil.deleteOnExit(moved);
         try (ReferenceSequenceFile withNoAdacentIndex = new BlockCompressedIndexedFastaSequenceFile(
-                        moved,
-                        new FastaSequenceIndex(SEQUENCE_FILE_INDEX),
-                        GZIIndex.loadIndex(SEQUENCE_FILE_GZI.toPath()));
+                        moved, new FastaSequenceIndex(SEQUENCE_FILE_INDEX), GZIIndex.loadIndex(SEQUENCE_FILE_GZI));
                 ReferenceSequenceFile withFilesAdjacent =
-                        new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ.toPath())) {
+                        new BlockCompressedIndexedFastaSequenceFile(SEQUENCE_FILE_BGZ)) {
             Assert.assertEquals(
                     withNoAdacentIndex.getSubsequenceAt("chrM", 100, 1000).getBases(),
                     withFilesAdjacent.getSubsequenceAt("chrM", 100, 1000).getBases());
@@ -450,12 +434,13 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
     // test for IndexedFastaSequenceFile (non-gzipped)
     @Test
     public void testIndexedFastaSequenceFileFromNio() throws IOException {
-        final String dataDir = "src/test/resources/htsjdk/samtools/reference";
-        final IOPath fastaFile =
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta").getAbsolutePath());
-        final IOPath indexFile =
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.fai").getAbsolutePath());
-        ;
+        final Path dataDir = Path.of("src/test/resources/htsjdk/samtools/reference");
+        final IOPath fastaFile = new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta")
+                .toAbsolutePath()
+                .toString());
+        final IOPath indexFile = new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta.fai")
+                .toAbsolutePath()
+                .toString());
 
         // move everything to a jimfs NIO file system so that each file is in a separate directory so it is in
         // a directory by itself, so we can catch any downstream code that makes assumptions that the index
@@ -492,15 +477,16 @@ public class AbstractIndexedFastaSequenceFileTest extends HtsjdkTest {
 
     @Test
     public void testBlockCompressedIndexedFastaSequenceFileFromNio() throws IOException {
-        final String dataDir = "src/test/resources/htsjdk/samtools/reference";
-        final IOPath fastaFile =
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz").getAbsolutePath());
-        final IOPath indexFile =
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.fai").getAbsolutePath());
-        ;
-        final IOPath gziIndexFile =
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz.gzi").getAbsolutePath());
-        ;
+        final Path dataDir = Path.of("src/test/resources/htsjdk/samtools/reference");
+        final IOPath fastaFile = new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta.gz")
+                .toAbsolutePath()
+                .toString());
+        final IOPath indexFile = new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta.fai")
+                .toAbsolutePath()
+                .toString());
+        final IOPath gziIndexFile = new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta.gz.gzi")
+                .toAbsolutePath()
+                .toString());
 
         // move everything to a jimfs NIO file system so that each file is in a separate directory so it is in
         // a directory by iteself, so we can catch any downstream code that makes assumptions that the index

--- a/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaReferenceWriterTest.java
@@ -4,8 +4,10 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.*;
 import htsjdk.samtools.util.*;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
-import java.io.*;
-import java.io.File;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,12 +24,12 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testEmptySequence() throws IOException {
-        final File testOutput = File.createTempFile("fwr-test", ".fasta");
-        Assert.assertTrue(testOutput.delete());
-        testOutput.deleteOnExit();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
+        Files.delete(testOutput);
+        IOUtil.deleteOnExit(testOutput);
 
         try (FastaReferenceWriter writer = new FastaReferenceWriterBuilder()
-                .setFastaFile(testOutput.toPath())
+                .setFastaFile(testOutput)
                 .setMakeFaiOutput(false)
                 .setMakeDictOutput(false)
                 .build()) {
@@ -36,36 +38,36 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
             writer.startSequence("seq2");
             writer.startSequence("seq3");
         } finally {
-            Assert.assertTrue(testOutput.delete());
+            Assert.assertTrue(Files.deleteIfExists(testOutput));
         }
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testEmptyReference() throws IOException {
-        final File testOutput = File.createTempFile("fwr-test", ".fasta");
-        Assert.assertTrue(testOutput.delete());
-        testOutput.deleteOnExit();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
+        Files.delete(testOutput);
+        IOUtil.deleteOnExit(testOutput);
 
         try {
             new FastaReferenceWriterBuilder()
-                    .setFastaFile(testOutput.toPath())
+                    .setFastaFile(testOutput)
                     .setMakeFaiOutput(false)
                     .setMakeDictOutput(false)
                     .build()
                     .close();
         } finally {
-            Assert.assertTrue(testOutput.delete());
+            Assert.assertTrue(Files.deleteIfExists(testOutput));
         }
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testStartSequenceAfterClose() throws IOException {
-        final File testOutput = File.createTempFile("fwr-test", ".fasta");
-        Assert.assertTrue(testOutput.delete());
-        testOutput.deleteOnExit();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
+        Files.delete(testOutput);
+        IOUtil.deleteOnExit(testOutput);
 
         final FastaReferenceWriter writer = new FastaReferenceWriterBuilder()
-                .setFastaFile(testOutput.toPath())
+                .setFastaFile(testOutput)
                 .setMakeFaiOutput(false)
                 .setMakeDictOutput(false)
                 .build();
@@ -74,18 +76,18 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
         try {
             writer.startSequence("seq2");
         } finally {
-            Assert.assertTrue(testOutput.delete());
+            Assert.assertTrue(Files.deleteIfExists(testOutput));
         }
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testAddBasesAfterClose() throws IOException {
-        final File testOutput = File.createTempFile("fwr-test", ".fasta");
-        Assert.assertTrue(testOutput.delete());
-        testOutput.deleteOnExit();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
+        Files.delete(testOutput);
+        IOUtil.deleteOnExit(testOutput);
 
         final FastaReferenceWriter writer = new FastaReferenceWriterBuilder()
-                .setFastaFile(testOutput.toPath())
+                .setFastaFile(testOutput)
                 .setMakeFaiOutput(false)
                 .setMakeDictOutput(false)
                 .build();
@@ -94,13 +96,13 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
         try {
             writer.appendBases(new byte[] {'A', 'A', 'A'});
         } finally {
-            Assert.assertTrue(testOutput.delete());
+            Assert.assertTrue(Files.deleteIfExists(testOutput));
         }
     }
 
     @Test(dataProvider = "invalidBplData", expectedExceptions = IllegalArgumentException.class)
     public void testBadDefaultBasesPerLine(final int invalidBpl) throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
         Files.delete(testOutput);
         IOUtil.deleteOnExit(testOutput);
 
@@ -124,7 +126,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(dataProvider = "invalidBplData", expectedExceptions = IllegalArgumentException.class)
     public void testBadSequenceBasesPerLine(final int invalidBpl) throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
         Files.delete(testOutput);
         IOUtil.deleteOnExit(testOutput);
 
@@ -144,7 +146,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testEmptySequenceAtTheEnd() throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
 
@@ -165,7 +167,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testAppendBasesBeforeStartingSequence() throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
         try (FastaReferenceWriter writer = new FastaReferenceWriterBuilder()
@@ -181,7 +183,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testAddingSameSequenceTwice() throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
         try (FastaReferenceWriter writer = new FastaReferenceWriterBuilder()
@@ -201,7 +203,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testAddingSameSequenceRightAfter() throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
 
@@ -220,7 +222,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, dataProvider = "invalidNameData")
     public void testAddingInvalidSequenceName(final String invalidName) throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
 
@@ -237,8 +239,8 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAddingGziIndexToNonBlockCompressedFile() throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
-        final Path testOutputGZI = File.createTempFile("fwr-test", ".fasta.gzi").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
+        final Path testOutputGZI = Files.createTempFile("fwr-test", ".fasta.gzi");
         IOUtil.deleteOnExit(testOutputGZI);
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
@@ -253,7 +255,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testAddingFaiIndexButNoGziIndex() throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta.gz").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta.gz");
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
 
@@ -267,7 +269,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class, dataProvider = "invalidDescriptionData")
     public void testAddingInvalidDescription(final String invalidDescription) throws IOException {
-        final Path testOutput = File.createTempFile("fwr-test", ".fasta").toPath();
+        final Path testOutput = Files.createTempFile("fwr-test", ".fasta");
         IOUtil.deleteOnExit(testOutput);
         Files.delete(testOutput);
 
@@ -332,8 +334,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
                 new LinkedHashMap<>(dictionary.getSequences().size());
         final Random rdn = new Random(seed);
         generateRandomBasesAndBpls(dictionary, minBpl, maxBpl, bases, bpl, rdn);
-        final Path fastaFile =
-                File.createTempFile("fwr-test", gzipped ? ".fa.gz" : ".fa").toPath();
+        final Path fastaFile = Files.createTempFile("fwr-test", gzipped ? ".fa.gz" : ".fa");
         IOUtil.deleteOnExit(fastaFile);
         Files.delete(fastaFile);
 
@@ -368,8 +369,8 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test
     public void testSingleSequenceStaticWithBpl() throws IOException, GeneralSecurityException, URISyntaxException {
-        final File testOutputFile = File.createTempFile("fwr-test", ".random0.fasta");
-        testOutputFile.deleteOnExit();
+        final Path testOutputFile = Files.createTempFile("fwr-test", ".random0.fasta");
+        IOUtil.deleteOnExit(testOutputFile);
 
         final Map<String, byte[]> seqs =
                 Collections.singletonMap("seqA", SequenceUtil.getRandomBases(new Random(1241), 100));
@@ -377,30 +378,27 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
         final SAMSequenceDictionary dictionary =
                 new SAMSequenceDictionary(Collections.singletonList(new SAMSequenceRecord("seqA", 100)));
         FastaReferenceWriter.writeSingleSequenceReference(
-                testOutputFile.toPath(), 42, true, true, "seqA", null, seqs.get("seqA"));
-        assertOutput(testOutputFile.toPath(), true, true, false, dictionary, 42, seqs, bpls, false);
-        Assert.assertTrue(testOutputFile.delete());
-        Assert.assertTrue(ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(testOutputFile)
-                .delete());
-        Assert.assertTrue(ReferenceSequenceFileFactory.getFastaIndexFileName(testOutputFile.toPath())
-                .toFile()
-                .delete());
+                testOutputFile, 42, true, true, "seqA", null, seqs.get("seqA"));
+        assertOutput(testOutputFile, true, true, false, dictionary, 42, seqs, bpls, false);
+        Assert.assertTrue(Files.deleteIfExists(testOutputFile));
+        Assert.assertTrue(Files.deleteIfExists(
+                ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(testOutputFile)));
+        Assert.assertTrue(Files.deleteIfExists(ReferenceSequenceFileFactory.getFastaIndexFileName(testOutputFile)));
     }
 
     @Test
     public void testSingleSequenceStatic() throws IOException, GeneralSecurityException, URISyntaxException {
-        final File testOutputFile = File.createTempFile("fwr-test", ".random0.fasta");
-        testOutputFile.deleteOnExit();
+        final Path testOutputFile = Files.createTempFile("fwr-test", ".random0.fasta");
+        IOUtil.deleteOnExit(testOutputFile);
 
         final Map<String, byte[]> seqs =
                 Collections.singletonMap("seqA", SequenceUtil.getRandomBases(new Random(1341), 100));
         final Map<String, Integer> bpls = Collections.singletonMap("seqA", FastaReferenceWriter.DEFAULT_BASES_PER_LINE);
         final SAMSequenceDictionary dictionary =
                 new SAMSequenceDictionary(Collections.singletonList(new SAMSequenceRecord("seqA", 100)));
-        FastaReferenceWriter.writeSingleSequenceReference(
-                testOutputFile.toPath(), true, true, "seqA", null, seqs.get("seqA"));
+        FastaReferenceWriter.writeSingleSequenceReference(testOutputFile, true, true, "seqA", null, seqs.get("seqA"));
         assertOutput(
-                testOutputFile.toPath(),
+                testOutputFile,
                 true,
                 true,
                 false,
@@ -409,30 +407,27 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
                 seqs,
                 bpls,
                 false);
-        Assert.assertTrue(testOutputFile.delete());
-        Assert.assertTrue(ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(testOutputFile)
-                .delete());
-        Assert.assertTrue(ReferenceSequenceFileFactory.getFastaIndexFileName(testOutputFile.toPath())
-                .toFile()
-                .delete());
+        Assert.assertTrue(Files.deleteIfExists(testOutputFile));
+        Assert.assertTrue(Files.deleteIfExists(
+                ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(testOutputFile)));
+        Assert.assertTrue(Files.deleteIfExists(ReferenceSequenceFileFactory.getFastaIndexFileName(testOutputFile)));
     }
 
     @Test
     public void testCopyReference() throws IOException, GeneralSecurityException, URISyntaxException {
 
         final int basesPerLine = 80;
-        final Path testOutputFile =
-                File.createTempFile("fwr-test", ".copy0.fasta").toPath();
-        testOutputFile.toFile().deleteOnExit();
+        final Path testOutputFile = Files.createTempFile("fwr-test", ".copy0.fasta");
+        IOUtil.deleteOnExit(testOutputFile);
 
         final Path testIndexOutputFile = ReferenceSequenceFileFactory.getFastaIndexFileName(testOutputFile);
-        testIndexOutputFile.toFile().deleteOnExit();
+        IOUtil.deleteOnExit(testIndexOutputFile);
 
         final Path testDictOutputFile =
                 ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(testOutputFile);
-        testDictOutputFile.toFile().deleteOnExit();
+        IOUtil.deleteOnExit(testDictOutputFile);
 
-        final File source = new File("src/test/resources/htsjdk/samtools/hg19mini.fasta");
+        final Path source = Path.of("src/test/resources/htsjdk/samtools/hg19mini.fasta");
 
         final ReferenceSequenceFile sourceFasta = ReferenceSequenceFileFactory.getReferenceSequenceFile(source);
         final Map<String, byte[]> seqs = new HashMap<>();
@@ -471,16 +466,13 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
     @Test
     public void testAlternativeIndexAndDictFileNames()
             throws IOException, GeneralSecurityException, URISyntaxException {
-        final Path testOutputFile =
-                File.createTempFile("fwr-test", ".random0.fasta").toPath();
+        final Path testOutputFile = Files.createTempFile("fwr-test", ".random0.fasta");
         IOUtil.deleteOnExit(testOutputFile);
 
-        final Path testIndexOutputFile =
-                File.createTempFile("fwr-test", ".random1.fai").toPath();
+        final Path testIndexOutputFile = Files.createTempFile("fwr-test", ".random1.fai");
         IOUtil.deleteOnExit(testIndexOutputFile);
 
-        final Path testDictOutputFile =
-                File.createTempFile("fwr-test", ".random2.dict").toPath();
+        final Path testDictOutputFile = Files.createTempFile("fwr-test", ".random2.dict");
         IOUtil.deleteOnExit(testDictOutputFile);
 
         final SAMSequenceDictionary testDictionary =
@@ -506,21 +498,21 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test
     public void testDirectOutputStreams() throws IOException, GeneralSecurityException, URISyntaxException {
-        final File testOutputFile = File.createTempFile("fwr-test", ".random0.fasta");
-        testOutputFile.deleteOnExit();
+        final Path testOutputFile = Files.createTempFile("fwr-test", ".random0.fasta");
+        IOUtil.deleteOnExit(testOutputFile);
 
-        final File testIndexOutputFile = File.createTempFile("fwr-test", ".random1.fai");
-        testIndexOutputFile.deleteOnExit();
-        final File testDictOutputFile = File.createTempFile("fwr-test", ".random2.dict");
-        testDictOutputFile.deleteOnExit();
+        final Path testIndexOutputFile = Files.createTempFile("fwr-test", ".random1.fai");
+        IOUtil.deleteOnExit(testIndexOutputFile);
+        final Path testDictOutputFile = Files.createTempFile("fwr-test", ".random2.dict");
+        IOUtil.deleteOnExit(testDictOutputFile);
         final SAMSequenceDictionary testDictionary =
                 new SAMSequenceDictionary(Collections.singletonList(new SAMSequenceRecord("seq1", 100)));
         final Map<String, byte[]> seqs =
                 Collections.singletonMap("seq1", SequenceUtil.getRandomBases(new Random(1341), 100));
         final Map<String, Integer> bpls = Collections.singletonMap("seq1", -1);
-        try (OutputStream testOutputStream = new FileOutputStream(testOutputFile);
-                OutputStream testIndexOutputStream = new FileOutputStream(testIndexOutputFile);
-                OutputStream testDictOutputStream = new FileOutputStream(testDictOutputFile)) {
+        try (OutputStream testOutputStream = Files.newOutputStream(testOutputFile);
+                OutputStream testIndexOutputStream = Files.newOutputStream(testIndexOutputFile);
+                OutputStream testDictOutputStream = Files.newOutputStream(testDictOutputFile)) {
             try (FastaReferenceWriter writer = new FastaReferenceWriterBuilder()
                     .setBasesPerLine(50)
                     .setFastaOutput(testOutputStream)
@@ -531,33 +523,33 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
                 writer.appendBases(seqs.get("seq1"));
             }
         }
-        assertFastaContent(testOutputFile.toPath(), false, testDictionary, 50, seqs, bpls, false);
-        assertFastaIndexContent(testOutputFile.toPath(), testIndexOutputFile.toPath(), testDictionary, seqs);
-        assertFastaDictionaryContent(testDictOutputFile.toPath(), testDictionary);
-        Assert.assertTrue(testOutputFile.delete());
-        Assert.assertTrue(testIndexOutputFile.delete());
-        Assert.assertTrue(testDictOutputFile.delete());
+        assertFastaContent(testOutputFile, false, testDictionary, 50, seqs, bpls, false);
+        assertFastaIndexContent(testOutputFile, testIndexOutputFile, testDictionary, seqs);
+        assertFastaDictionaryContent(testDictOutputFile, testDictionary);
+        Assert.assertTrue(Files.deleteIfExists(testOutputFile));
+        Assert.assertTrue(Files.deleteIfExists(testIndexOutputFile));
+        Assert.assertTrue(Files.deleteIfExists(testDictOutputFile));
     }
 
     @Test
     public void testFastaOutputStreams() throws IOException, GeneralSecurityException, URISyntaxException {
-        final File testOutputFile = File.createTempFile("fwr-test", ".random0.fasta");
-        testOutputFile.deleteOnExit();
+        final Path testOutputFile = Files.createTempFile("fwr-test", ".random0.fasta");
+        IOUtil.deleteOnExit(testOutputFile);
 
-        final File testIndexOutputFile =
-                new File(testOutputFile.getParent(), testOutputFile.getName().replaceAll("fasta$", "fai"));
-        testIndexOutputFile.deleteOnExit();
+        final Path testIndexOutputFile = testOutputFile.resolveSibling(
+                testOutputFile.getFileName().toString().replaceAll("fasta$", "fai"));
+        IOUtil.deleteOnExit(testIndexOutputFile);
 
-        final File testDictOutputFile =
-                new File(testOutputFile.getParent(), testOutputFile.getName().replaceAll("fasta$", "dict"));
-        testDictOutputFile.deleteOnExit();
+        final Path testDictOutputFile = testOutputFile.resolveSibling(
+                testOutputFile.getFileName().toString().replaceAll("fasta$", "dict"));
+        IOUtil.deleteOnExit(testDictOutputFile);
 
         final SAMSequenceDictionary testDictionary =
                 new SAMSequenceDictionary(Collections.singletonList(new SAMSequenceRecord("seq1", 100)));
         final Map<String, byte[]> seqs =
                 Collections.singletonMap("seq1", SequenceUtil.getRandomBases(new Random(1341), 100));
         final Map<String, Integer> bpls = Collections.singletonMap("seq1", -1);
-        try (OutputStream testOutputStream = new FileOutputStream(testOutputFile);
+        try (OutputStream testOutputStream = Files.newOutputStream(testOutputFile);
                 FastaReferenceWriter writer = new FastaReferenceWriterBuilder()
                         .setBasesPerLine(50)
                         .setFastaOutput(testOutputStream)
@@ -566,10 +558,10 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
             writer.appendBases(seqs.get("seq1"));
         }
 
-        assertFastaContent(testOutputFile.toPath(), false, testDictionary, 50, seqs, bpls, false);
-        Assert.assertTrue(testOutputFile.delete());
-        Assert.assertFalse(testIndexOutputFile.delete());
-        Assert.assertFalse(testDictOutputFile.delete());
+        assertFastaContent(testOutputFile, false, testDictionary, 50, seqs, bpls, false);
+        Assert.assertTrue(Files.deleteIfExists(testOutputFile));
+        Assert.assertFalse(Files.deleteIfExists(testIndexOutputFile));
+        Assert.assertFalse(Files.deleteIfExists(testDictOutputFile));
     }
 
     private void generateRandomBasesAndBpls(
@@ -857,8 +849,7 @@ public class FastaReferenceWriterTest extends HtsjdkTest {
 
     @Test(dataProvider = "fastaExtensions")
     public void testWriteRandomReference(final String extension) throws IOException {
-        final Path dir = TestUtil.getTempDirectory("SAMRecordSetBuilderTest", "testWriteRandomReference")
-                .toPath();
+        final Path dir = TestUtil.getTempDirectoryAsPath("SAMRecordSetBuilderTest", "testWriteRandomReference");
 
         try {
             final SAMFileHeader header = new SAMFileHeader();

--- a/src/test/java/htsjdk/samtools/reference/FastaSequenceFileTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaSequenceFileTest.java
@@ -27,8 +27,9 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.seekablestream.SeekableStream;
 import htsjdk.samtools.util.StringUtil;
-import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -38,9 +39,9 @@ import org.testng.annotations.Test;
 public class FastaSequenceFileTest extends HtsjdkTest {
     @Test
     public void testTrailingWhitespace() throws Exception {
-        final File fasta = File.createTempFile("test", ".fasta");
-        fasta.deleteOnExit();
-        final PrintWriter writer = new PrintWriter(fasta);
+        final Path fasta = Files.createTempFile("test", ".fasta");
+        fasta.toFile().deleteOnExit();
+        final PrintWriter writer = new PrintWriter(fasta.toFile());
         final String chr1 = "chr1";
         writer.println(">" + chr1);
         final String sequence = "ACGTACGT";
@@ -55,9 +56,9 @@ public class FastaSequenceFileTest extends HtsjdkTest {
 
     @Test
     public void testIntermediateWhitespace() throws Exception {
-        final File fasta = File.createTempFile("test", ".fasta");
-        fasta.deleteOnExit();
-        final PrintWriter writer = new PrintWriter(fasta);
+        final Path fasta = Files.createTempFile("test", ".fasta");
+        fasta.toFile().deleteOnExit();
+        final PrintWriter writer = new PrintWriter(fasta.toFile());
         final String chr1 = "chr1";
         writer.println(">" + chr1 + " extra stuff after sequence name");
         final String sequence = "ACGTACGT";
@@ -74,8 +75,8 @@ public class FastaSequenceFileTest extends HtsjdkTest {
     // There was a bug when reading a fasta with trailing whitespace, only when a sequence dictionary exists.
     @Test
     public void testTrailingWhitespaceWithPreexistingSequenceDictionary() throws Exception {
-        final File fasta =
-                new File("src/test/resources/htsjdk/samtools/reference/reference_with_trailing_whitespace.fasta");
+        final Path fasta =
+                Path.of("src/test/resources/htsjdk/samtools/reference/reference_with_trailing_whitespace.fasta");
         final FastaSequenceFile fastaReader = new FastaSequenceFile(fasta, true);
         ReferenceSequence referenceSequence = fastaReader.nextSequence();
         Assert.assertEquals(referenceSequence.getName(), "chr1");
@@ -87,9 +88,9 @@ public class FastaSequenceFileTest extends HtsjdkTest {
 
     @Test
     public void testStream() throws Exception {
-        final File fasta = File.createTempFile("test", ".fasta");
-        fasta.deleteOnExit();
-        final PrintWriter writer = new PrintWriter(fasta);
+        final Path fasta = Files.createTempFile("test", ".fasta");
+        fasta.toFile().deleteOnExit();
+        final PrintWriter writer = new PrintWriter(fasta.toFile());
         final String chr1 = "chr1";
         writer.println(">" + chr1);
         final String sequence = "ACGTACGT";
@@ -98,7 +99,7 @@ public class FastaSequenceFileTest extends HtsjdkTest {
         writer.close();
         try (SeekableStream seekableStream = new SeekableFileStream(fasta)) {
             final FastaSequenceFile fastaReader =
-                    new FastaSequenceFile(fasta.getAbsolutePath(), seekableStream, null, true);
+                    new FastaSequenceFile(fasta.toAbsolutePath().toString(), seekableStream, null, true);
             final ReferenceSequence referenceSequence1 = fastaReader.nextSequence();
             Assert.assertEquals(referenceSequence1.getName(), chr1);
             Assert.assertEquals(StringUtil.bytesToString(referenceSequence1.getBases()), sequence + sequence);

--- a/src/test/java/htsjdk/samtools/reference/FastaSequenceIndexCreatorTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaSequenceIndexCreatorTest.java
@@ -26,8 +26,8 @@ package htsjdk.samtools.reference;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.IOUtil;
-import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,44 +39,43 @@ import org.testng.annotations.Test;
  * @author Daniel Gomez-Sanchez (magicDGS)
  */
 public class FastaSequenceIndexCreatorTest extends HtsjdkTest {
-    private static File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/reference");
+    private static Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/reference");
 
     @DataProvider(name = "indexedSequences")
     public Object[][] getIndexedSequences() {
         return new Object[][] {
-            {new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.fasta")},
-            {new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.fasta.gz")},
-            {new File(TEST_DATA_DIR, "header_with_white_space.fasta")},
-            {new File(TEST_DATA_DIR, "crlf.fasta")}
+            {TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.fasta")},
+            {TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.fasta.gz")},
+            {TEST_DATA_DIR.resolve("header_with_white_space.fasta")},
+            {TEST_DATA_DIR.resolve("crlf.fasta")}
         };
     }
 
     @Test(dataProvider = "indexedSequences")
-    public void testBuildFromFasta(final File indexedFile) throws Exception {
-        final FastaSequenceIndex original = new FastaSequenceIndex(new File(indexedFile.getAbsolutePath() + ".fai"));
-        final FastaSequenceIndex build = FastaSequenceIndexCreator.buildFromFasta(indexedFile.toPath());
+    public void testBuildFromFasta(final Path indexedFile) throws Exception {
+        final FastaSequenceIndex original = new FastaSequenceIndex(Path.of(indexedFile.toAbsolutePath() + ".fai"));
+        final FastaSequenceIndex build = FastaSequenceIndexCreator.buildFromFasta(indexedFile);
         Assert.assertEquals(original, build);
     }
 
     @Test(dataProvider = "indexedSequences")
-    public void testCreate(final File indexedFile) throws Exception {
+    public void testCreate(final Path indexedFile) throws Exception {
         // copy the file to index
-        final File tempDir =
-                IOUtil.createTempDir("FastaSequenceIndexCreatorTest.testCreate").toFile();
-        final File copied = new File(tempDir, indexedFile.getName());
-        copied.deleteOnExit();
-        Files.copy(indexedFile.toPath(), copied.toPath());
+        final Path tempDir = IOUtil.createTempDir("FastaSequenceIndexCreatorTest.testCreate");
+        final Path copied = tempDir.resolve(indexedFile.getFileName());
+        copied.toFile().deleteOnExit();
+        Files.copy(indexedFile, copied);
 
         // create the index for the copied file
-        FastaSequenceIndexCreator.create(copied.toPath(), false);
+        FastaSequenceIndexCreator.create(copied, false);
 
         // test if the expected .fai and the created one are the same
-        final File expectedFai = new File(indexedFile.getAbsolutePath() + ".fai");
-        final File createdFai = new File(copied.getAbsolutePath() + ".fai");
+        final Path expectedFai = Path.of(indexedFile.toAbsolutePath() + ".fai");
+        final Path createdFai = Path.of(copied.toAbsolutePath() + ".fai");
 
         // read all the files and compare line by line
-        try (final Stream<String> expected = Files.lines(expectedFai.toPath());
-                final Stream<String> created = Files.lines(createdFai.toPath())) {
+        try (final Stream<String> expected = Files.lines(expectedFai);
+                final Stream<String> created = Files.lines(createdFai)) {
             final List<String> expectedLines = expected.filter(String::isEmpty).collect(Collectors.toList());
             final List<String> createdLines = created.filter(String::isEmpty).collect(Collectors.toList());
             Assert.assertEquals(expectedLines, createdLines);

--- a/src/test/java/htsjdk/samtools/reference/FastaSequenceIndexTest.java
+++ b/src/test/java/htsjdk/samtools/reference/FastaSequenceIndexTest.java
@@ -26,10 +26,9 @@ package htsjdk.samtools.reference;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,25 +41,23 @@ import org.testng.annotations.Test;
  * Test the fasta sequence index reader.
  */
 public class FastaSequenceIndexTest extends HtsjdkTest {
-    private static File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/reference");
+    private static Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/reference");
 
     @DataProvider(name = "homosapiens")
-    public Object[][] provideHomoSapiens() throws FileNotFoundException {
-        final File sequenceIndexFile = new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.fasta.fai");
+    public Object[][] provideHomoSapiens() throws IOException {
+        final Path sequenceIndexFile = TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.fasta.fai");
         return new Object[][] {
             new Object[] {new FastaSequenceIndex(sequenceIndexFile)},
-            {new FastaSequenceIndex(sequenceIndexFile.toPath())},
-            {new FastaSequenceIndex(new FileInputStream(sequenceIndexFile))}
+            {new FastaSequenceIndex(Files.newInputStream(sequenceIndexFile))}
         };
     }
 
     @DataProvider(name = "specialcharacters")
-    public Object[][] provideSpecialCharacters() throws FileNotFoundException {
-        final File sequenceIndexFile = new File(TEST_DATA_DIR, "testing.fai");
+    public Object[][] provideSpecialCharacters() throws IOException {
+        final Path sequenceIndexFile = TEST_DATA_DIR.resolve("testing.fai");
         return new Object[][] {
             new Object[] {new FastaSequenceIndex(sequenceIndexFile)},
-            {new FastaSequenceIndex(sequenceIndexFile.toPath())},
-            {new FastaSequenceIndex(new FileInputStream(sequenceIndexFile))}
+            {new FastaSequenceIndex(Files.newInputStream(sequenceIndexFile))}
         };
     }
 
@@ -291,17 +288,17 @@ public class FastaSequenceIndexTest extends HtsjdkTest {
     @Test
     public void testWrite() throws Exception {
         // gets the original file and index
-        final File originalFile = new File(TEST_DATA_DIR, "testing.fai");
+        final Path originalFile = TEST_DATA_DIR.resolve("testing.fai");
         final FastaSequenceIndex originalIndex = new FastaSequenceIndex(originalFile);
 
         // write the index to a temp file and test if files are the same
-        final File fileToWrite = File.createTempFile("testing.toWrite", "fai");
-        fileToWrite.deleteOnExit();
-        originalIndex.write(fileToWrite.toPath());
+        final Path fileToWrite = Files.createTempFile("testing.toWrite", "fai");
+        fileToWrite.toFile().deleteOnExit();
+        originalIndex.write(fileToWrite);
 
         // read all the files and compare line by line
-        try (final Stream<String> original = Files.lines(originalFile.toPath());
-                final Stream<String> written = Files.lines(fileToWrite.toPath())) {
+        try (final Stream<String> original = Files.lines(originalFile);
+                final Stream<String> written = Files.lines(fileToWrite)) {
             final List<String> originalLines =
                     original.filter(s -> !s.isEmpty()).collect(Collectors.toList());
             final List<String> actualLines = written.filter(s -> !s.isEmpty()).collect(Collectors.toList());

--- a/src/test/java/htsjdk/samtools/reference/ReferenceSequenceFileFactoryTests.java
+++ b/src/test/java/htsjdk/samtools/reference/ReferenceSequenceFileFactoryTests.java
@@ -10,7 +10,6 @@ import htsjdk.beta.io.bundle.IOPathResource;
 import htsjdk.io.HtsPath;
 import htsjdk.io.IOPath;
 import htsjdk.samtools.SAMSequenceDictionary;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -23,10 +22,10 @@ import org.testng.annotations.Test;
  * Simple tests for the reference sequence file factory
  */
 public class ReferenceSequenceFileFactoryTests extends HtsjdkTest {
-    public static final File hg18 =
-            new File("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta");
-    public static final File hg18bgzip =
-            new File("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz");
+    public static final Path hg18 =
+            Path.of("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta");
+    public static final Path hg18bgzip =
+            Path.of("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz");
 
     @Test
     public void testPositivePath() {
@@ -72,16 +71,16 @@ public class ReferenceSequenceFileFactoryTests extends HtsjdkTest {
             {hg18, true},
             {hg18bgzip, true},
             {
-                new File("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.noindex.fasta"),
+                Path.of("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.noindex.fasta"),
                 false
             },
             {
-                new File(
+                Path.of(
                         "src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.noindex.fasta.gz"),
                 false
             },
             {
-                new File(
+                Path.of(
                         "src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.nogzindex.fasta.gz"),
                 false
             }
@@ -89,8 +88,8 @@ public class ReferenceSequenceFileFactoryTests extends HtsjdkTest {
     }
 
     @Test(dataProvider = "canCreateIndexedFastaParams")
-    public void testCanCreateIndexedFastaReader(final File path, final boolean indexed) {
-        Assert.assertEquals(ReferenceSequenceFileFactory.canCreateIndexedFastaReader(path.toPath()), indexed);
+    public void testCanCreateIndexedFastaReader(final Path path, final boolean indexed) {
+        Assert.assertEquals(ReferenceSequenceFileFactory.canCreateIndexedFastaReader(path), indexed);
     }
 
     @DataProvider
@@ -109,34 +108,58 @@ public class ReferenceSequenceFileFactoryTests extends HtsjdkTest {
     public void testGetDefaultDictionaryForReferenceSequence(final String fastaFile, final String expectedDict)
             throws Exception {
         Assert.assertEquals(
-                ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(new File(fastaFile)),
-                new File(expectedDict));
+                ReferenceSequenceFileFactory.getDefaultDictionaryForReferenceSequence(Path.of(fastaFile)),
+                Path.of(expectedDict));
     }
 
     @DataProvider
     public Object[][] bundleCases() {
-        final String dataDir = "src/test/resources/htsjdk/samtools/reference";
+        final Path dataDir = Path.of("src/test/resources/htsjdk/samtools/reference");
 
         return new Object[][] {
-            {new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta").getAbsolutePath()), null, null, null
-            },
             {
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.dict").getAbsolutePath()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta")
+                        .toAbsolutePath()
+                        .toString()),
+                null,
                 null,
                 null
             },
             {
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.dict").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.fai").getAbsolutePath()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.dict")
+                        .toAbsolutePath()
+                        .toString()),
+                null,
                 null
             },
             {
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.dict").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz.fai").getAbsolutePath()),
-                new HtsPath(new File(dataDir, "Homo_sapiens_assembly18.trimmed.fasta.gz.gzi").getAbsolutePath()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.dict")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta.fai")
+                        .toAbsolutePath()
+                        .toString()),
+                null
+            },
+            {
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta.gz")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.dict")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta.gz.fai")
+                        .toAbsolutePath()
+                        .toString()),
+                new HtsPath(dataDir.resolve("Homo_sapiens_assembly18.trimmed.fasta.gz.gzi")
+                        .toAbsolutePath()
+                        .toString()),
             },
         };
     }

--- a/src/test/java/htsjdk/samtools/reference/ReferenceSequenceFileWalkerTest.java
+++ b/src/test/java/htsjdk/samtools/reference/ReferenceSequenceFileWalkerTest.java
@@ -3,7 +3,6 @@ package htsjdk.samtools.reference;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMException;
 import htsjdk.samtools.util.CloserUtil;
-import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.testng.Assert;
@@ -39,8 +38,8 @@ public class ReferenceSequenceFileWalkerTest extends HtsjdkTest {
 
     @Test(dataProvider = "TestReference")
     public void testGetFile(final String fileName, final int index1, final int index2) throws SAMException {
-        final File refFile = new File(fileName);
-        final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(refFile);
+        final Path refPath = Paths.get(fileName);
+        final ReferenceSequenceFileWalker refWalker = new ReferenceSequenceFileWalker(refPath);
 
         ReferenceSequence sequence = refWalker.get(index1);
         Assert.assertEquals(sequence.getContigIndex(), index1);

--- a/src/test/java/htsjdk/samtools/reference/ReferenceSequenceTests.java
+++ b/src/test/java/htsjdk/samtools/reference/ReferenceSequenceTests.java
@@ -27,8 +27,8 @@ package htsjdk.samtools.reference;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.TestUtil;
 import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -45,7 +45,7 @@ public class ReferenceSequenceTests extends HtsjdkTest {
 
     @Test(dataProvider = "fastaTestParameters")
     public void testSingleShortSequence(int chroms, int basesPerChrom) throws Exception {
-        File f = makeRandomReference(chroms, basesPerChrom);
+        Path f = makeRandomReference(chroms, basesPerChrom);
         ReferenceSequenceFile ref = ReferenceSequenceFileFactory.getReferenceSequenceFile(f);
 
         for (int i = 1; i <= chroms; ++i) {
@@ -75,10 +75,10 @@ public class ReferenceSequenceTests extends HtsjdkTest {
     }
 
     /** Utility method to write a random reference sequence of specified length. */
-    private File makeRandomReference(int chroms, int basesPerChrom) throws Exception {
-        File file = File.createTempFile("reference.", ".fasta");
-        file.deleteOnExit();
-        BufferedWriter out = new BufferedWriter(new FileWriter(file));
+    private Path makeRandomReference(int chroms, int basesPerChrom) throws Exception {
+        Path file = Files.createTempFile("reference.", ".fasta");
+        file.toFile().deleteOnExit();
+        BufferedWriter out = Files.newBufferedWriter(file);
 
         for (int i = 1; i <= chroms; ++i) {
             out.write("> chr" + i);

--- a/src/test/java/htsjdk/samtools/reference/SamLocusAndReferenceIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/reference/SamLocusAndReferenceIteratorTest.java
@@ -4,18 +4,18 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.util.*;
-import java.io.File;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class SamLocusAndReferenceIteratorTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/reference");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/reference");
 
     @Test
     public void testSamLocusAndReferenceIterator() {
 
-        final File reference = new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.fasta");
-        final File samFile = new File(TEST_DATA_DIR, "simpleSmallFile.sam");
+        final Path reference = TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.fasta");
+        final Path samFile = TEST_DATA_DIR.resolve("simpleSmallFile.sam");
         final ReferenceSequenceFile referenceSequenceFile = new FastaSequenceFile(reference, false);
         final ReferenceSequenceFileWalker referenceSequenceFileWalker =
                 new ReferenceSequenceFileWalker(referenceSequenceFile);
@@ -52,8 +52,8 @@ public class SamLocusAndReferenceIteratorTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSamLocusAndReferenceIteratorMismatch() {
-        final File reference = new File(TEST_DATA_DIR, "reference_with_trailing_whitespace.fasta");
-        final File samFile = new File(TEST_DATA_DIR, "simpleSmallFile.sam");
+        final Path reference = TEST_DATA_DIR.resolve("reference_with_trailing_whitespace.fasta");
+        final Path samFile = TEST_DATA_DIR.resolve("simpleSmallFile.sam");
         final ReferenceSequenceFile referenceSequenceFile = new FastaSequenceFile(reference, false);
         final ReferenceSequenceFileWalker referenceSequenceFileWalker =
                 new ReferenceSequenceFileWalker(referenceSequenceFile);
@@ -65,8 +65,8 @@ public class SamLocusAndReferenceIteratorTest extends HtsjdkTest {
 
     @Test
     public void testSamLocusAndReferenceIteratorLeadingInsertion() {
-        final File reference = new File(TEST_DATA_DIR, "Homo_sapiens_assembly18.trimmed.fasta");
-        final File samFile = new File(TEST_DATA_DIR, "leading_insertion.sam");
+        final Path reference = TEST_DATA_DIR.resolve("Homo_sapiens_assembly18.trimmed.fasta");
+        final Path samFile = TEST_DATA_DIR.resolve("leading_insertion.sam");
         final ReferenceSequenceFile referenceSequenceFile = new FastaSequenceFile(reference, false);
         final ReferenceSequenceFileWalker referenceSequenceFileWalker =
                 new ReferenceSequenceFileWalker(referenceSequenceFile);

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableBufferedStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableBufferedStreamTest.java
@@ -27,19 +27,21 @@ package htsjdk.samtools.seekablestream;
 import static org.testng.Assert.assertEquals;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class SeekableBufferedStreamTest extends HtsjdkTest {
 
-    //    private final File BAM_INDEX_FILE = new File("testdata/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai");
-    private final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    //    private final Path BAM_INDEX_FILE = Paths.get("testdata/htsjdk/samtools/BAMFileIndexTest/index_test.bam.bai");
+    private final Path BAM_FILE = Paths.get("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
     private final String BAM_URL_STRING = "http://broadinstitute.github.io/picard/testdata/index_test.bam";
-    private static File TestFile = new File("src/test/resources/htsjdk/samtools/seekablestream/megabyteZeros.dat");
+    private static Path TestFile = Paths.get("src/test/resources/htsjdk/samtools/seekablestream/megabyteZeros.dat");
 
     /**
      * Test reading across a buffer boundary (buffer size is 512000).   The test first reads a range of
@@ -91,7 +93,7 @@ public class SeekableBufferedStreamTest extends HtsjdkTest {
     public void testEOF() throws IOException {
 
         int remainder = 149;
-        long fileLength = BAM_FILE.length();
+        long fileLength = Files.size(BAM_FILE);
         long startPosition = fileLength - remainder;
         int length = 1000;
 
@@ -143,7 +145,7 @@ public class SeekableBufferedStreamTest extends HtsjdkTest {
         final int length = 5000;
 
         class LimitedSeekableFileStream extends SeekableFileStream {
-            LimitedSeekableFileStream(File file) throws FileNotFoundException {
+            LimitedSeekableFileStream(Path file) throws FileNotFoundException {
                 super(file);
             }
 

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableFileStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableFileStreamTest.java
@@ -25,7 +25,8 @@ package htsjdk.samtools.seekablestream;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.BufferedLineReader;
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -41,7 +42,7 @@ public class SeekableFileStreamTest extends HtsjdkTest {
     @Test
     public void testSeek() throws Exception {
         String expectedLine = "ccccccccc";
-        File testFile = new File("src/test/resources/htsjdk/samtools/seekablestream/seekTest.txt");
+        Path testFile = Paths.get("src/test/resources/htsjdk/samtools/seekablestream/seekTest.txt");
         SeekableFileStream is = new SeekableFileStream(testFile);
         is.seek(20);
         BufferedLineReader reader = new BufferedLineReader(is);

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekablePathStreamTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekablePathStreamTest.java
@@ -24,9 +24,9 @@
 package htsjdk.samtools.seekablestream;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -34,7 +34,7 @@ public class SeekablePathStreamTest extends HtsjdkTest {
 
     @Test
     public void testRead() throws Exception {
-        Path testPath = new File("src/test/resources/htsjdk/samtools/seekablestream/seekTest.txt").toPath();
+        Path testPath = Paths.get("src/test/resources/htsjdk/samtools/seekablestream/seekTest.txt");
         SeekablePathStream is = new SeekablePathStream(testPath);
         Assert.assertEquals(is.position(), 0);
         Assert.assertEquals(is.read(), (int) 'a');

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamFactoryTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamFactoryTest.java
@@ -5,7 +5,6 @@ import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.TestUtil;
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -19,7 +18,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class SeekableStreamFactoryTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools");
+    private static final Path TEST_DATA_DIR = Paths.get("src/test/resources/htsjdk/samtools");
 
     @DataProvider
     public Object[][] getSpecialCasePaths() {
@@ -55,17 +54,35 @@ public class SeekableStreamFactoryTest extends HtsjdkTest {
     public Object[][] getStreamForData() throws MalformedURLException {
         return new Object[][] {
             {
-                new File(TEST_DATA_DIR, "BAMFileIndexTest/index_test.bam").getAbsolutePath(),
-                new File(TEST_DATA_DIR, "BAMFileIndexTest/index_test.bam").getAbsolutePath()
+                TEST_DATA_DIR
+                        .resolve("BAMFileIndexTest/index_test.bam")
+                        .toAbsolutePath()
+                        .toString(),
+                TEST_DATA_DIR
+                        .resolve("BAMFileIndexTest/index_test.bam")
+                        .toAbsolutePath()
+                        .toString()
             },
             {
-                new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath(),
-                new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath()
+                TEST_DATA_DIR
+                        .resolve("cram_with_bai_index.cram")
+                        .toAbsolutePath()
+                        .toString(),
+                TEST_DATA_DIR
+                        .resolve("cram_with_bai_index.cram")
+                        .toAbsolutePath()
+                        .toString()
             },
             {
-                new URL("file://" + new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath())
+                new URL("file://"
+                                + TEST_DATA_DIR
+                                        .resolve("cram_with_bai_index.cram")
+                                        .toAbsolutePath())
                         .toExternalForm(),
-                new File(TEST_DATA_DIR, "cram_with_bai_index.cram").getAbsolutePath()
+                TEST_DATA_DIR
+                        .resolve("cram_with_bai_index.cram")
+                        .toAbsolutePath()
+                        .toString()
             },
             {
                 new URL(TestUtil.BASE_URL_FOR_HTTP_TESTS + "index_test.bam").toExternalForm(),
@@ -86,18 +103,18 @@ public class SeekableStreamFactoryTest extends HtsjdkTest {
 
     @Test
     public void testPathWithEmbeddedSpace() throws IOException {
-        final File testBam = new File(TEST_DATA_DIR, "BAMFileIndexTest/index_test.bam");
+        final Path testBam = TEST_DATA_DIR.resolve("BAMFileIndexTest/index_test.bam");
 
         // create a temp dir with a space in the name and copy the test file there
-        final File tempDir = IOUtil.createTempDir("test spaces").toFile();
-        Assert.assertTrue(tempDir.getAbsolutePath().contains(" "));
-        tempDir.deleteOnExit();
-        final File inputBam = new File(tempDir, "index_test.bam");
-        inputBam.deleteOnExit();
-        IOUtil.copyFile(testBam, inputBam);
+        final Path tempDir = IOUtil.createTempDir("test spaces");
+        Assert.assertTrue(tempDir.toAbsolutePath().toString().contains(" "));
+        IOUtil.deleteOnExit(tempDir);
+        final Path inputBam = tempDir.resolve("index_test.bam");
+        IOUtil.deleteOnExit(inputBam);
+        IOUtil.copyPath(testBam, inputBam);
 
         // make sure the input string we use is URL-encoded
-        final String inputString = Paths.get(inputBam.getAbsolutePath()).toUri().toString();
+        final String inputString = inputBam.toAbsolutePath().toUri().toString();
         Assert.assertFalse(inputString.contains(" "));
         Assert.assertTrue(inputString.contains("%20"));
 

--- a/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamGZIPinputStreamIntegrationTest.java
+++ b/src/test/java/htsjdk/samtools/seekablestream/SeekableStreamGZIPinputStreamIntegrationTest.java
@@ -37,9 +37,9 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
-import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -69,16 +69,16 @@ public class SeekableStreamGZIPinputStreamIntegrationTest extends HtsjdkTest {
     private static Collection<Allele> alleles = Arrays.asList(Allele.create("A", true), Allele.create("C"));
     private static String RANDOM_ATTRIBUTE = "RD";
 
-    private static File createBgzipVcfsWithVariableSize(final int firstRecordAttributeLength, final int nSmallRecords)
+    private static Path createBgzipVcfsWithVariableSize(final int firstRecordAttributeLength, final int nSmallRecords)
             throws Exception {
         final VariantContext longRecord = new VariantContextBuilder("long", TEST_CHR, 1, 1, alleles)
                 .attribute(RANDOM_ATTRIBUTE, generateRandomString(firstRecordAttributeLength))
                 .make();
-        final File tempFile = Files.createTempFile("test" + firstRecordAttributeLength + "_" + nSmallRecords, ".vcf.gz")
-                .toFile();
+        final Path tempFile =
+                Files.createTempFile("test" + firstRecordAttributeLength + "_" + nSmallRecords, ".vcf.gz");
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
                 .setOptions(VariantContextWriterBuilder.NO_OPTIONS)
-                .setOutputFile(tempFile)
+                .setOutputPath(tempFile)
                 .setOutputFileType(VariantContextWriterBuilder.OutputType.BLOCK_COMPRESSED_VCF)
                 .build()) {
             writer.setHeader(createTestHeader()); // do not write the header
@@ -124,7 +124,7 @@ public class SeekableStreamGZIPinputStreamIntegrationTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "compressedVcfsToTest")
-    public void testWrappedSeekableStreamInGZIPinputStream(final File input, final long nLines) throws Exception {
+    public void testWrappedSeekableStreamInGZIPinputStream(final Path input, final long nLines) throws Exception {
         try (final LineReader reader = new BufferedLineReader(new GZIPInputStream(new SeekableFileStream(input)))) {
             for (int i = 0; i < nLines; i++) {
                 Assert.assertNotNull(reader.readLine(), "line #" + reader.getLineNumber());
@@ -135,7 +135,7 @@ public class SeekableStreamGZIPinputStreamIntegrationTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "compressedVcfsToTest")
-    public void testConsistencyWithBgzip(final File input, final long nLines) throws Exception {
+    public void testConsistencyWithBgzip(final Path input, final long nLines) throws Exception {
         try (final InputStream gzIs = new GZIPInputStream(new SeekableFileStream(input));
                 final InputStream bgzIs = new BlockCompressedInputStream(input)) {
             int bgz = bgzIs.read();

--- a/src/test/java/htsjdk/samtools/util/AsyncBlockCompressedInputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/AsyncBlockCompressedInputStreamTest.java
@@ -25,14 +25,15 @@ package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class AsyncBlockCompressedInputStreamTest extends HtsjdkTest {
-    private final File BAM_FILE = new File("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
+    private final Path BAM_FILE = Paths.get("src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam");
 
     @Test
     public void testAsync() throws Exception {

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedInputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedInputStreamTest.java
@@ -5,9 +5,15 @@ import htsjdk.samtools.FileTruncatedException;
 import htsjdk.samtools.cram.io.InputStreamUtils;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.samtools.util.zip.InflaterFactory;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,8 +24,8 @@ import org.testng.annotations.Test;
 
 public class BlockCompressedInputStreamTest extends HtsjdkTest {
     // random data pulled from /dev/random then compressed using bgzip from tabix
-    private static final File BLOCK_UNCOMPRESSED = new File("src/test/resources/htsjdk/samtools/util/random.bin");
-    private static final File BLOCK_COMPRESSED = new File("src/test/resources/htsjdk/samtools/util/random.bin.gz");
+    private static final Path BLOCK_UNCOMPRESSED = Paths.get("src/test/resources/htsjdk/samtools/util/random.bin");
+    private static final Path BLOCK_COMPRESSED = Paths.get("src/test/resources/htsjdk/samtools/util/random.bin.gz");
     private static final long[] BLOCK_COMPRESSED_OFFSETS = new long[] {
         0, 0xfc2e, 0x1004d, 0x1fc7b, 0x2009a,
     };
@@ -27,7 +33,7 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
 
     @Test
     public void testTruncatedStream() throws Exception {
-        byte[] compressed = Files.readAllBytes(BLOCK_COMPRESSED.toPath());
+        byte[] compressed = Files.readAllBytes(BLOCK_COMPRESSED);
         byte[] truncated = Arrays.copyOf(compressed, compressed.length * 2 / 3);
         try (BlockCompressedInputStream stream = new BlockCompressedInputStream(new ByteArrayInputStream(truncated))) {
             Assert.expectThrows(FileTruncatedException.class, () -> InputStreamUtils.readFully(stream));
@@ -36,9 +42,9 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
 
     @Test
     public void stream_should_match_uncompressed_stream() throws Exception {
-        byte[] uncompressed = Files.readAllBytes(BLOCK_UNCOMPRESSED.toPath());
+        byte[] uncompressed = Files.readAllBytes(BLOCK_UNCOMPRESSED);
         try (BlockCompressedInputStream stream =
-                new BlockCompressedInputStream(new FileInputStream(BLOCK_COMPRESSED))) {
+                new BlockCompressedInputStream(Files.newInputStream(BLOCK_COMPRESSED))) {
             for (int i = 0; i < uncompressed.length; i++) {
                 Assert.assertEquals(stream.read(), Byte.toUnsignedInt(uncompressed[i]));
             }
@@ -48,7 +54,7 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
 
     @Test
     public void endOfBlock_should_be_true_only_when_entire_block_is_read() throws Exception {
-        long size = BLOCK_UNCOMPRESSED.length();
+        long size = Files.size(BLOCK_UNCOMPRESSED);
         // input file contains 5 blocks
         List<Long> offsets = new ArrayList<>();
         for (int i = 0; i < BLOCK_UNCOMPRESSED_END_POSITIONS.length; i++) {
@@ -56,7 +62,7 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
         }
         List<Long> endOfBlockTrue = new ArrayList<>();
         try (BlockCompressedInputStream stream =
-                new BlockCompressedInputStream(new FileInputStream(BLOCK_COMPRESSED))) {
+                new BlockCompressedInputStream(Files.newInputStream(BLOCK_COMPRESSED))) {
             for (long i = 0; i < size; i++) {
                 if (stream.endOfBlock()) {
                     endOfBlockTrue.add(i);
@@ -69,9 +75,9 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
 
     @Test
     public void decompression_should_cross_block_boundries() throws Exception {
-        byte[] uncompressed = Files.readAllBytes(BLOCK_UNCOMPRESSED.toPath());
+        byte[] uncompressed = Files.readAllBytes(BLOCK_UNCOMPRESSED);
         try (BlockCompressedInputStream stream =
-                new BlockCompressedInputStream(new FileInputStream(BLOCK_COMPRESSED))) {
+                new BlockCompressedInputStream(Files.newInputStream(BLOCK_COMPRESSED))) {
             byte[] decompressed = new byte[uncompressed.length];
             stream.read(decompressed);
             Assert.assertEquals(decompressed, uncompressed);
@@ -82,7 +88,7 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
 
     @Test
     public void seek_should_read_block() throws Exception {
-        byte[] uncompressed = Files.readAllBytes(BLOCK_UNCOMPRESSED.toPath());
+        byte[] uncompressed = Files.readAllBytes(BLOCK_UNCOMPRESSED);
         try (SeekableFileStream sfs = new SeekableFileStream(BLOCK_COMPRESSED)) {
             try (BlockCompressedInputStream stream = new BlockCompressedInputStream(sfs)) {
                 // seek to the start of the first block
@@ -138,7 +144,7 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
         InputStream get() throws IOException;
     }
 
-    private List<String> writeTempBlockCompressedFileForInflaterTest(final File tempFile) throws IOException {
+    private List<String> writeTempBlockCompressedFileForInflaterTest(final Path tempFile) throws IOException {
         final List<String> linesWritten = new ArrayList<>();
         try (final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(tempFile, 5)) {
             String s = "Hi, Mom!\n";
@@ -162,8 +168,8 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
 
     @DataProvider(name = "customInflaterInput")
     public Object[][] customInflateInput() throws IOException {
-        final File tempFile = File.createTempFile("testCustomInflater.", ".bam");
-        tempFile.deleteOnExit();
+        final Path tempFile = Files.createTempFile("testCustomInflater.", ".bam");
+        IOUtil.deleteOnExit(tempFile);
         final List<String> linesWritten = writeTempBlockCompressedFileForInflaterTest(tempFile);
         // wrap our expected output in a lambda to prevent massive string expansion of the test params during test
         // execution
@@ -174,7 +180,7 @@ public class BlockCompressedInputStreamTest extends HtsjdkTest {
         return new Object[][] {
             {
                 (CheckedExceptionInputStreamSupplier) () ->
-                        new BlockCompressedInputStream(new FileInputStream(tempFile), false, countingInflaterFactory),
+                        new BlockCompressedInputStream(Files.newInputStream(tempFile), false, countingInflaterFactory),
                 expectedOutputSupplier,
                 4
             },

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedOutputStreamTest.java
@@ -27,10 +27,12 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.FileTruncatedException;
 import htsjdk.samtools.util.zip.DeflaterFactory;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -45,8 +47,8 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
 
     @Test
     public void testBasic() throws Exception {
-        final File f = File.createTempFile("BCOST.", ".gz");
-        f.deleteOnExit();
+        final Path f = Files.createTempFile("BCOST.", ".gz");
+        IOUtil.deleteOnExit(f);
         final List<String> linesWritten = new ArrayList<>();
         System.out.println("Creating file " + f);
         final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(f);
@@ -85,8 +87,8 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
 
     @Test
     public void testWriteSingleBytes() throws Exception {
-        final File f = File.createTempFile("BCOST.", ".gz");
-        f.deleteOnExit();
+        final Path f = Files.createTempFile("BCOST.", ".gz");
+        IOUtil.deleteOnExit(f);
         final String s = "Hello, I am a test string, and I will be written out one painful byte at a time.";
         final byte[] bs = s.getBytes();
         final int iterations = BlockCompressedStreamConstants.DEFAULT_UNCOMPRESSED_BLOCK_SIZE * 2 / bs.length;
@@ -180,7 +182,7 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
             throws Exception {
 
         final BlockCompressedInputStream bcis = isFile
-                ? new BlockCompressedInputStream(new File(filePath))
+                ? new BlockCompressedInputStream(Paths.get(filePath))
                 : new BlockCompressedInputStream(new FileInputStream(filePath));
 
         if (isClosed) {
@@ -209,8 +211,8 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
 
     @Test
     public void testOverflow() throws Exception {
-        final File f = File.createTempFile("BCOST.", ".gz");
-        f.deleteOnExit();
+        final Path f = Files.createTempFile("BCOST.", ".gz");
+        IOUtil.deleteOnExit(f);
         System.out.println("Creating file " + f);
         final BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(f);
         Random r = new Random(15555);
@@ -244,8 +246,8 @@ public class BlockCompressedOutputStreamTest extends HtsjdkTest {
 
     @Test
     public void testCustomDeflater() throws Exception {
-        final File f = File.createTempFile("testCustomDeflater.", ".gz");
-        f.deleteOnExit();
+        final Path f = Files.createTempFile("testCustomDeflater.", ".gz");
+        IOUtil.deleteOnExit(f);
         System.out.println("Creating file " + f);
 
         final int[] deflateCalls = {0}; // Note: using and array is a HACK to fool the compiler

--- a/src/test/java/htsjdk/samtools/util/BlockCompressedTerminatorTest.java
+++ b/src/test/java/htsjdk/samtools/util/BlockCompressedTerminatorTest.java
@@ -28,13 +28,13 @@ import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
 import htsjdk.testutil.streams.OneByteAtATimeChannel;
 import java.io.EOFException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -44,9 +44,9 @@ import org.testng.annotations.Test;
  * @author alecw@broadinstitute.org
  */
 public class BlockCompressedTerminatorTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/util");
-    private static final File DEFECTIVE = new File(TEST_DATA_DIR, "defective_bgzf.bam");
-    private static final File NO_TERMINATOR = new File(TEST_DATA_DIR, "no_bgzf_terminator.bam");
+    private static final Path TEST_DATA_DIR = Paths.get("src/test/resources/htsjdk/samtools/util");
+    private static final Path DEFECTIVE = TEST_DATA_DIR.resolve("defective_bgzf.bam");
+    private static final Path NO_TERMINATOR = TEST_DATA_DIR.resolve("no_bgzf_terminator.bam");
 
     @DataProvider
     public Object[][] getFiles() throws IOException {
@@ -58,33 +58,33 @@ public class BlockCompressedTerminatorTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "getFiles")
-    public void testCheckTerminationForFiles(File compressedFile, BlockCompressedInputStream.FileTermination expected)
+    public void testCheckTerminationForFiles(Path compressedFile, BlockCompressedInputStream.FileTermination expected)
             throws IOException {
         Assert.assertEquals(BlockCompressedInputStream.checkTermination(compressedFile), expected);
     }
 
     @Test(dataProvider = "getFiles")
-    public void testCheckTerminationForPaths(File compressedFile, BlockCompressedInputStream.FileTermination expected)
+    public void testCheckTerminationForPaths(Path compressedFile, BlockCompressedInputStream.FileTermination expected)
             throws IOException {
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
-            final Path compressedFileInJimfs = Files.copy(compressedFile.toPath(), fs.getPath("something"));
+            final Path compressedFileInJimfs = Files.copy(compressedFile, fs.getPath("something"));
             Assert.assertEquals(BlockCompressedInputStream.checkTermination(compressedFileInJimfs), expected);
         }
     }
 
     @Test(dataProvider = "getFiles")
     public void testCheckTerminationForSeekableByteChannels(
-            File compressedFile, BlockCompressedInputStream.FileTermination expected) throws IOException {
-        try (SeekableByteChannel channel = Files.newByteChannel(compressedFile.toPath())) {
+            Path compressedFile, BlockCompressedInputStream.FileTermination expected) throws IOException {
+        try (SeekableByteChannel channel = Files.newByteChannel(compressedFile)) {
             Assert.assertEquals(BlockCompressedInputStream.checkTermination(channel), expected);
         }
     }
 
     @Test(dataProvider = "getFiles")
-    public void testChannelPositionIsRestored(File compressedFile, BlockCompressedInputStream.FileTermination expected)
+    public void testChannelPositionIsRestored(Path compressedFile, BlockCompressedInputStream.FileTermination expected)
             throws IOException {
         final long position = 50;
-        try (SeekableByteChannel channel = Files.newByteChannel(compressedFile.toPath())) {
+        try (SeekableByteChannel channel = Files.newByteChannel(compressedFile)) {
             channel.position(position);
             Assert.assertEquals(channel.position(), position);
             Assert.assertEquals(BlockCompressedInputStream.checkTermination(channel), expected);
@@ -92,9 +92,9 @@ public class BlockCompressedTerminatorTest extends HtsjdkTest {
         }
     }
 
-    private static File getValidCompressedFile() throws IOException {
-        final File tmpCompressedFile = File.createTempFile("test.", ".bgzf");
-        tmpCompressedFile.deleteOnExit();
+    private static Path getValidCompressedFile() throws IOException {
+        final Path tmpCompressedFile = Files.createTempFile("test.", ".bgzf");
+        IOUtil.deleteOnExit(tmpCompressedFile);
         final BlockCompressedOutputStream os = new BlockCompressedOutputStream(tmpCompressedFile);
         os.write("Hi, Mom!\n".getBytes());
         os.close();
@@ -103,7 +103,7 @@ public class BlockCompressedTerminatorTest extends HtsjdkTest {
 
     @Test
     public void testReadFullyReadsBytesCorrectly() throws IOException {
-        try (final SeekableByteChannel channel = Files.newByteChannel(DEFECTIVE.toPath())) {
+        try (final SeekableByteChannel channel = Files.newByteChannel(DEFECTIVE)) {
             final ByteBuffer readBuffer = ByteBuffer.allocate(10);
             Assert.assertTrue(channel.size() > readBuffer.capacity());
             BlockCompressedInputStream.readFully(channel, readBuffer);
@@ -116,7 +116,7 @@ public class BlockCompressedTerminatorTest extends HtsjdkTest {
 
     @Test(expectedExceptions = EOFException.class)
     public void testReadFullyThrowWhenItCantReadEnough() throws IOException {
-        try (final SeekableByteChannel channel = Files.newByteChannel(DEFECTIVE.toPath())) {
+        try (final SeekableByteChannel channel = Files.newByteChannel(DEFECTIVE)) {
             final ByteBuffer readBuffer = ByteBuffer.allocate(1000);
             Assert.assertTrue(channel.size() < readBuffer.capacity());
             BlockCompressedInputStream.readFully(channel, readBuffer);

--- a/src/test/java/htsjdk/samtools/util/DiskBackedQueueTest.java
+++ b/src/test/java/htsjdk/samtools/util/DiskBackedQueueTest.java
@@ -96,7 +96,8 @@ public class DiskBackedQueueTest extends SortingCollectionTest {
     }
 
     private DiskBackedQueue<String> makeDiskBackedQueue(final int maxRecordsInRam) {
-        return DiskBackedQueue.newInstance(new StringCodec(), maxRecordsInRam, Collections.singletonList(tmpDir()));
+        return DiskBackedQueue.newInstanceFromPaths(
+                new StringCodec(), maxRecordsInRam, Collections.singletonList(tmpDir()));
     }
 
     @Test

--- a/src/test/java/htsjdk/samtools/util/EdgeReadIteratorTest.java
+++ b/src/test/java/htsjdk/samtools/util/EdgeReadIteratorTest.java
@@ -28,9 +28,9 @@ import static org.testng.Assert.assertEquals;
 import htsjdk.samtools.*;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import org.testng.Assert;
@@ -349,7 +349,7 @@ public class EdgeReadIteratorTest extends AbstractLocusIteratorTestTemplate {
     @Test
     public void testNoGapsInLocusAccumulator() {
         final SamReader reader =
-                SamReaderFactory.make().open(new File("src/test/resources/htsjdk/samtools/util/sliver.sam"));
+                SamReaderFactory.make().open(Path.of("src/test/resources/htsjdk/samtools/util/sliver.sam"));
         final EdgeReadIterator iterator = new EdgeReadIterator(reader, null);
 
         AbstractLocusInfo<EdgingRecordAndOffset> previous = null;

--- a/src/test/java/htsjdk/samtools/util/GZIIndexTest.java
+++ b/src/test/java/htsjdk/samtools/util/GZIIndexTest.java
@@ -25,10 +25,10 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -44,37 +44,38 @@ public class GZIIndexTest extends HtsjdkTest {
     @DataProvider
     public Object[][] indexFiles() {
         return new Object[][] {
-            {new File("src/test/resources/htsjdk/samtools/block_compressed.sam.gz.gzi"), 2},
-            {new File("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz.gzi"), 17}
+            {Paths.get("src/test/resources/htsjdk/samtools/block_compressed.sam.gz.gzi"), 2},
+            {Paths.get("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz.gzi"), 17}
         };
     }
 
     @Test(dataProvider = "indexFiles")
-    public void testLoadIndex(final File indexFile, final int expectedBlocks) throws Exception {
+    public void testLoadIndex(final Path indexFile, final int expectedBlocks) throws Exception {
         // test reading of the input file
-        final GZIIndex index = GZIIndex.loadIndex(indexFile.toPath());
+        final GZIIndex index = GZIIndex.loadIndex(indexFile);
         Assert.assertEquals(index.getNumberOfBlocks(), expectedBlocks);
     }
 
     @Test(dataProvider = "indexFiles")
-    public void testLoadIndexFromStream(final File indexFile, final int expectedBlocks) throws Exception {
-        try (InputStream in = new FileInputStream(indexFile)) {
+    public void testLoadIndexFromStream(final Path indexFile, final int expectedBlocks) throws Exception {
+        try (InputStream in = Files.newInputStream(indexFile)) {
             final GZIIndex index = GZIIndex.loadIndex(indexFile.toString(), in);
             Assert.assertEquals(index.getNumberOfBlocks(), expectedBlocks);
         }
     }
 
     @Test(dataProvider = "indexFiles")
-    public void testWriteIndex(final File indexFile, final int exprectedBlocks) throws Exception {
+    public void testWriteIndex(final Path indexFile, final int exprectedBlocks) throws Exception {
         // load the index and write it down
-        final GZIIndex index = GZIIndex.loadIndex(indexFile.toPath());
-        final File temp = File.createTempFile("testWriteIndex", indexFile.getName());
-        temp.deleteOnExit();
-        index.writeIndex(Files.newOutputStream(temp.toPath()));
+        final GZIIndex index = GZIIndex.loadIndex(indexFile);
+        final Path temp =
+                Files.createTempFile("testWriteIndex", indexFile.getFileName().toString());
+        IOUtil.deleteOnExit(temp);
+        index.writeIndex(temp);
 
         // test equal byte representation on disk
-        final byte[] expected = Files.readAllBytes(indexFile.toPath());
-        final byte[] actual = Files.readAllBytes(temp.toPath());
+        final byte[] expected = Files.readAllBytes(indexFile);
+        final byte[] actual = Files.readAllBytes(temp);
         Assert.assertEquals(expected, actual);
     }
 
@@ -82,22 +83,22 @@ public class GZIIndexTest extends HtsjdkTest {
     public Object[][] filesWithIndex() {
         return new Object[][] {
             {
-                new File("src/test/resources/htsjdk/samtools/block_compressed.sam.gz"),
-                new File("src/test/resources/htsjdk/samtools/block_compressed.sam.gz.gzi")
+                Paths.get("src/test/resources/htsjdk/samtools/block_compressed.sam.gz"),
+                Paths.get("src/test/resources/htsjdk/samtools/block_compressed.sam.gz.gzi")
             },
             {
-                new File("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz"),
-                new File("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz.gzi")
+                Paths.get("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz"),
+                Paths.get("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz.gzi")
             }
         };
     }
 
     @Test(dataProvider = "filesWithIndex")
-    public void testBuildIndex(final File fileToIndex, final File expectedIndex) throws Exception {
+    public void testBuildIndex(final Path fileToIndex, final Path expectedIndex) throws Exception {
         // create the index for the provided file
-        final GZIIndex actual = GZIIndex.buildIndex(fileToIndex.toPath());
+        final GZIIndex actual = GZIIndex.buildIndex(fileToIndex);
         // load the expected index to check for equality
-        final GZIIndex expected = GZIIndex.loadIndex(expectedIndex.toPath());
+        final GZIIndex expected = GZIIndex.loadIndex(expectedIndex);
         Assert.assertEquals(actual, expected);
     }
 
@@ -105,8 +106,7 @@ public class GZIIndexTest extends HtsjdkTest {
     public Iterator<Object[]> virtualOffsetForSeekData() throws Exception {
         // wer use the index from the FASTA file for testing seek
         final GZIIndex index = GZIIndex.loadIndex(
-                new File("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz.gzi")
-                        .toPath());
+                Paths.get("src/test/resources/htsjdk/samtools/reference/Homo_sapiens_assembly18.trimmed.fasta.gz.gzi"));
         final List<Object[]> data = new ArrayList<>(2 * index.getNumberOfBlocks() + 3);
         // position 0
         data.add(new Object[] {0, 0, 0, index});

--- a/src/test/java/htsjdk/samtools/util/IOUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/IOUtilTest.java
@@ -64,7 +64,7 @@ public class IOUtilTest extends HtsjdkTest {
     private static final String[] TEST_FILE_EXTENSIONS = {".txt", ".txt.gz"};
     private static final String TEST_STRING = "bar!";
 
-    private File existingTempFile;
+    private Path existingTempFile;
     private String systemUser;
     private String systemTempDir;
     private FileSystem inMemoryFileSystem;
@@ -72,14 +72,13 @@ public class IOUtilTest extends HtsjdkTest {
 
     @BeforeClass
     public void setUp() throws IOException {
-        existingTempFile = File.createTempFile("FiletypeTest.", ".tmp");
-        existingTempFile.deleteOnExit();
+        existingTempFile = Files.createTempFile("FiletypeTest.", ".tmp");
+        existingTempFile.toFile().deleteOnExit();
         systemTempDir = System.getProperty("java.io.tmpdir");
-        final File tmpDir = new File(systemTempDir);
+        final Path tmpDir = Paths.get(systemTempDir);
         inMemoryFileSystem = Jimfs.newFileSystem(Configuration.unix());
-        ;
-        if (!tmpDir.isDirectory()) tmpDir.mkdir();
-        if (!tmpDir.isDirectory())
+        if (!Files.isDirectory(tmpDir)) Files.createDirectories(tmpDir);
+        if (!Files.isDirectory(tmpDir))
             throw new RuntimeException("java.io.tmpdir (" + systemTempDir + ") is not a directory");
         systemUser = System.getProperty("user.name");
         // build long file of random words for compression testing
@@ -109,8 +108,8 @@ public class IOUtilTest extends HtsjdkTest {
     public void testFileReadingAndWriting() throws IOException {
         String randomizedTestString = TEST_STRING + System.currentTimeMillis();
         for (String ext : TEST_FILE_EXTENSIONS) {
-            File f = File.createTempFile(TEST_FILE_PREFIX, ext);
-            f.deleteOnExit();
+            Path f = Files.createTempFile(TEST_FILE_PREFIX, ext);
+            f.toFile().deleteOnExit();
 
             OutputStream os = IOUtil.openFileForWriting(f);
             BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(os));
@@ -133,26 +132,37 @@ public class IOUtilTest extends HtsjdkTest {
             tmpPath = tmpPath.substring(0, tmpPath.length() - userName.length());
         }
 
-        File tmpDir = new File(tmpPath, userName);
-        tmpDir.mkdir();
-        tmpDir.deleteOnExit();
-        File actual = new File(tmpDir, "actual.txt");
-        actual.deleteOnExit();
-        ProcessExecutor.execute(new String[] {"touch", actual.getAbsolutePath()});
-        File symlink = new File(tmpDir, "symlink.txt");
-        symlink.deleteOnExit();
-        ProcessExecutor.execute(new String[] {"ln", "-s", actual.getAbsolutePath(), symlink.getAbsolutePath()});
-        File lnDir = new File(tmpDir, "symLinkDir");
-        lnDir.deleteOnExit();
-        ProcessExecutor.execute(new String[] {"ln", "-s", tmpDir.getAbsolutePath(), lnDir.getAbsolutePath()});
-        File lnToActual = new File(lnDir, "actual.txt");
-        lnToActual.deleteOnExit();
-        File lnToSymlink = new File(lnDir, "symlink.txt");
-        lnToSymlink.deleteOnExit();
+        final Path tmpDir = Paths.get(tmpPath, userName);
+        Files.createDirectories(tmpDir);
+        tmpDir.toFile().deleteOnExit();
+        final Path actual = tmpDir.resolve("actual.txt");
+        actual.toFile().deleteOnExit();
+        ProcessExecutor.execute(new String[] {"touch", actual.toAbsolutePath().toString()});
+        final Path symlink = tmpDir.resolve("symlink.txt");
+        symlink.toFile().deleteOnExit();
+        ProcessExecutor.execute(new String[] {
+            "ln",
+            "-s",
+            actual.toAbsolutePath().toString(),
+            symlink.toAbsolutePath().toString()
+        });
+        final Path lnDir = tmpDir.resolve("symLinkDir");
+        lnDir.toFile().deleteOnExit();
+        ProcessExecutor.execute(new String[] {
+            "ln",
+            "-s",
+            tmpDir.toAbsolutePath().toString(),
+            lnDir.toAbsolutePath().toString()
+        });
+        final Path lnToActual = lnDir.resolve("actual.txt");
+        lnToActual.toFile().deleteOnExit();
+        final Path lnToSymlink = lnDir.resolve("symlink.txt");
+        lnToSymlink.toFile().deleteOnExit();
 
-        File[] files = {actual, symlink, lnToActual, lnToSymlink};
-        for (File f : files) {
-            Assert.assertEquals(IOUtil.getFullCanonicalPath(f), actual.getCanonicalPath());
+        final Path[] files = {actual, symlink, lnToActual, lnToSymlink};
+        for (final Path f : files) {
+            Assert.assertEquals(
+                    IOUtil.getFullCanonicalPath(f), actual.toRealPath().toString());
         }
     }
 
@@ -161,8 +171,8 @@ public class IOUtilTest extends HtsjdkTest {
         final String utf8 =
                 new StringWriter().append((char) 168).append((char) 197).toString();
         for (String ext : TEST_FILE_EXTENSIONS) {
-            final File f = File.createTempFile(TEST_FILE_PREFIX, ext);
-            f.deleteOnExit();
+            final Path f = Files.createTempFile(TEST_FILE_PREFIX, ext);
+            f.toFile().deleteOnExit();
 
             final BufferedWriter writer = IOUtil.openFileForBufferedUtf8Writing(f);
             writer.write(utf8);
@@ -170,7 +180,7 @@ public class IOUtilTest extends HtsjdkTest {
 
             final BufferedReader reader = IOUtil.openFileForBufferedUtf8Reading(f);
             final String line = reader.readLine();
-            Assert.assertEquals(utf8, line, f.getAbsolutePath());
+            Assert.assertEquals(utf8, line, f.toAbsolutePath().toString());
 
             CloserUtil.close(reader);
         }
@@ -178,40 +188,35 @@ public class IOUtilTest extends HtsjdkTest {
 
     @Test
     public void slurpLinesTest() throws FileNotFoundException {
-        Assert.assertEquals(IOUtil.slurpLines(SLURP_TEST_FILE.toFile()), SLURP_TEST_LINES);
+        Assert.assertEquals(IOUtil.slurpLines(SLURP_TEST_FILE), SLURP_TEST_LINES);
     }
 
     @Test
     public void slurpWhitespaceOnlyFileTest() throws FileNotFoundException {
-        Assert.assertEquals(IOUtil.slurp(FIVE_SPACES_THEN_A_NEWLINE_THEN_FIVE_SPACES_FILE.toFile()), "     \n     ");
+        Assert.assertEquals(IOUtil.slurp(FIVE_SPACES_THEN_A_NEWLINE_THEN_FIVE_SPACES_FILE), "     \n     ");
     }
 
     @Test
     public void slurpEmptyFileTest() throws FileNotFoundException {
-        Assert.assertEquals(IOUtil.slurp(EMPTY_FILE.toFile()), "");
+        Assert.assertEquals(IOUtil.slurp(EMPTY_FILE), "");
     }
 
     @Test
     public void slurpTest() throws FileNotFoundException {
         Assert.assertEquals(
-                IOUtil.slurp(SLURP_TEST_FILE.toFile()),
-                CollectionUtil.join(SLURP_TEST_LINES, SLURP_TEST_LINE_SEPARATOR));
+                IOUtil.slurp(SLURP_TEST_FILE), CollectionUtil.join(SLURP_TEST_LINES, SLURP_TEST_LINE_SEPARATOR));
     }
 
     @Test(dataProvider = "fileTypeTestCases")
     public void testFileType(final String path, boolean expectedIsRegularFile) {
-        final File file = new File(path);
-        Assert.assertEquals(IOUtil.isRegularPath(file), expectedIsRegularFile);
-        Assert.assertEquals(IOUtil.isRegularPath(file.toPath()), expectedIsRegularFile);
+        Assert.assertEquals(IOUtil.isRegularPath(Paths.get(path)), expectedIsRegularFile);
     }
 
     @Test(
             dataProvider = "unixFileTypeTestCases",
             groups = {"unix"})
     public void testFileTypeUnix(final String path, boolean expectedIsRegularFile) {
-        final File file = new File(path);
-        Assert.assertEquals(IOUtil.isRegularPath(file), expectedIsRegularFile);
-        Assert.assertEquals(IOUtil.isRegularPath(file.toPath()), expectedIsRegularFile);
+        Assert.assertEquals(IOUtil.isRegularPath(Paths.get(path)), expectedIsRegularFile);
     }
 
     @Test
@@ -253,7 +258,7 @@ public class IOUtilTest extends HtsjdkTest {
     @DataProvider(name = "fileTypeTestCases")
     private Object[][] fileTypeTestCases() {
         return new Object[][] {
-            {existingTempFile.getAbsolutePath(), Boolean.TRUE},
+            {existingTempFile.toAbsolutePath().toString(), Boolean.TRUE},
             {systemTempDir, Boolean.FALSE}
         };
     }
@@ -293,7 +298,8 @@ public class IOUtilTest extends HtsjdkTest {
         try {
             Path testPath = IOUtil.getDefaultTmpDirPath();
             Assert.assertEquals(
-                    testPath.toFile().getAbsolutePath(), new File(systemTempDir).getAbsolutePath() + "/" + systemUser);
+                    testPath.toAbsolutePath().toString(),
+                    Paths.get(systemTempDir).toAbsolutePath() + "/" + systemUser);
 
             // change the properties to test others
             final String newTempPath =
@@ -303,7 +309,7 @@ public class IOUtilTest extends HtsjdkTest {
             System.setProperty("user.name", newUser);
             testPath = IOUtil.getDefaultTmpDirPath();
             Assert.assertEquals(
-                    testPath.toFile().getAbsolutePath(), new File(newTempPath).getAbsolutePath() + "/" + newUser);
+                    testPath.toAbsolutePath().toString(), Paths.get(newTempPath).toAbsolutePath() + "/" + newUser);
 
         } finally {
             // reset system properties
@@ -415,24 +421,25 @@ public class IOUtilTest extends HtsjdkTest {
 
     @DataProvider
     public Object[][] filesForWritableDirectory() throws Exception {
-        final File nonWritableFile = new File(systemTempDir, "testAssertDirectoryIsWritable_non_writable_dir");
+        final Path nonWritableDir = Paths.get(systemTempDir, "testAssertDirectoryIsWritable_non_writable_dir");
+        final File nonWritableFile = nonWritableDir.toFile();
         nonWritableFile.mkdir();
         nonWritableFile.setWritable(false);
 
         return new Object[][] {
             // non existent
-            {new File("no_exists"), false},
+            {Paths.get("no_exists"), false},
             // non directory
             {existingTempFile, false},
             // non-writable directory
-            {nonWritableFile, false},
+            {nonWritableDir, false},
             // writable directory
-            {new File(systemTempDir), true},
+            {Paths.get(systemTempDir), true},
         };
     }
 
     @Test(dataProvider = "filesForWritableDirectory")
-    public void testAssertDirectoryIsWritableFile(final File file, final boolean writable) {
+    public void testAssertDirectoryIsWritableFile(final Path file, final boolean writable) {
         try {
             IOUtil.assertDirectoryIsWritable(file);
         } catch (SAMException e) {
@@ -498,7 +505,7 @@ public class IOUtilTest extends HtsjdkTest {
 
     @Test(dataProvider = "blockCompressedExtensionExtensionStrings")
     public void testBlockCompressionExtensionFile(final String testString, final boolean expected) {
-        Assert.assertEquals(IOUtil.hasBlockCompressedExtension(new File(testString)), expected);
+        Assert.assertEquals(IOUtil.hasBlockCompressedExtension(Paths.get(testString)), expected);
     }
 
     @DataProvider(name = "blockCompressedExtensionExtensionURIStrings")
@@ -592,7 +599,7 @@ public class IOUtilTest extends HtsjdkTest {
             IOUtil.setCompressionLevel(compressionLevel);
             Assert.assertEquals(IOUtil.getCompressionLevel(), compressionLevel);
             final InputStream inStream = IOUtil.openFileForReading(file);
-            try (final OutputStream outStream = IOUtil.openFileForWriting(outFile.toFile())) {
+            try (final OutputStream outStream = IOUtil.openFileForWriting(outFile)) {
                 IOUtil.transferByStream(inStream, outStream, origSize);
             }
             final long newSize = Files.size(outFile);
@@ -654,7 +661,7 @@ public class IOUtilTest extends HtsjdkTest {
     public void testCopyFile(final Path file) throws IOException {
         final Path outFile = Files.createTempFile("tmp", ".tmp");
         outFile.toFile().deleteOnExit();
-        IOUtil.copyFile(file.toFile(), outFile.toFile());
+        IOUtil.copyPath(file, outFile);
         Assert.assertEquals(
                 Files.lines(file).collect(Collectors.toList()),
                 Files.lines(outFile).collect(Collectors.toList()));
@@ -668,7 +675,7 @@ public class IOUtilTest extends HtsjdkTest {
         outFile.toFile().deleteOnExit();
         file.toFile().setReadable(false);
         try {
-            IOUtil.copyFile(file.toFile(), outFile.toFile());
+            IOUtil.copyPath(file, outFile);
         } finally { // need to set input file permission back to readable so other unit tests can access it
             file.toFile().setReadable(true);
         }
@@ -681,7 +688,7 @@ public class IOUtilTest extends HtsjdkTest {
         final Path outFile = Files.createTempFile("tmp", ".tmp");
         outFile.toFile().deleteOnExit();
         outFile.toFile().setWritable(false);
-        IOUtil.copyFile(file.toFile(), outFile.toFile());
+        IOUtil.copyPath(file, outFile);
     }
 
     @DataProvider
@@ -697,7 +704,7 @@ public class IOUtilTest extends HtsjdkTest {
 
     @Test(dataProvider = "baseNameTests")
     public void testBasename(final Path file, final String expected) {
-        final String result = IOUtil.basename(file.toFile());
+        final String result = IOUtil.basename(file);
         Assert.assertEquals(result, expected);
     }
 
@@ -728,17 +735,17 @@ public class IOUtilTest extends HtsjdkTest {
         final Path regExpDir = Files.createTempDirectory("regExpDir");
         regExpDir.toFile().deleteOnExit();
         final List<String> listExpected = Arrays.asList(expected);
-        final List<File> expectedFiles = new ArrayList<File>();
+        final List<Path> expectedFiles = new ArrayList<Path>();
         for (String name : allNames) {
             final Path file = regExpDir.resolve(name);
             file.toFile().deleteOnExit();
-            file.toFile().createNewFile();
+            Files.createFile(file);
             if (listExpected.contains(name)) {
-                expectedFiles.add(file.toFile());
+                expectedFiles.add(file);
             }
         }
-        final File[] result = IOUtil.getFilesMatchingRegexp(regExpDir.toFile(), regexp);
-        Assert.assertEqualsNoOrder(result, expectedFiles.toArray());
+        final List<Path> result = IOUtil.getPathsMatchingRegexp(regExpDir, regexp);
+        Assert.assertEqualsNoOrder(result.toArray(), expectedFiles.toArray());
     }
 
     @Test()
@@ -757,7 +764,7 @@ public class IOUtilTest extends HtsjdkTest {
             }
         }
         final List<String> retLines = new ArrayList<String>();
-        IOUtil.readLines(file.toFile()).forEachRemaining(retLines::add);
+        IOUtil.readLines(file).forEachRemaining(retLines::add);
         Assert.assertEquals(retLines, lines);
     }
 
@@ -772,7 +779,7 @@ public class IOUtilTest extends HtsjdkTest {
 
     @Test(dataProvider = "fileSuffixTests")
     public void testSuffixTest(final Path file, final String expected) {
-        final String ret = IOUtil.fileSuffix(file.toFile());
+        final String ret = IOUtil.fileSuffix(file);
         Assert.assertEquals(ret, expected);
     }
 
@@ -780,7 +787,7 @@ public class IOUtilTest extends HtsjdkTest {
     public void testCopyDirectoryTree() throws IOException {
         final Path copyToDir = Files.createTempDirectory("copyToDir");
         copyToDir.toFile().deleteOnExit();
-        IOUtil.copyDirectoryTree(TEST_VARIANT_DIR.toFile(), copyToDir.toFile());
+        IOUtil.copyDirectoryTree(TEST_VARIANT_DIR, copyToDir);
         final List<Path> collect = Files.walk(TEST_VARIANT_DIR)
                 .filter(f -> !f.equals(TEST_VARIANT_DIR))
                 .map(p -> p.getFileName())
@@ -835,7 +842,7 @@ public class IOUtilTest extends HtsjdkTest {
 
         try (final OutputStream outputStream = IOUtil.openFileForMd5CalculatingWriting(output)) {
             // tsato: perhaps BamFileIoUtils is a better place for this test
-            BamFileIoUtils.blockCopyBamFile(IOUtil.toPath(HtsjdkTestUtils.NA12878_8000), outputStream, false, false);
+            BamFileIoUtils.blockCopyBamFile(HtsjdkTestUtils.NA12878_8000, outputStream, false, false);
         } catch (IOException e) {
             throw new HtsjdkException("Encountered an IO error", e);
         }

--- a/src/test/java/htsjdk/samtools/util/IntervalListTest.java
+++ b/src/test/java/htsjdk/samtools/util/IntervalListTest.java
@@ -28,9 +28,9 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceRecord;
 import htsjdk.variant.vcf.VCFFileReader;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,7 +48,7 @@ public class IntervalListTest extends HtsjdkTest {
 
     final SAMFileHeader fileHeader;
     final IntervalList list1, list2, list3, empty;
-    public static final Path TEST_DIR = new File("src/test/resources/htsjdk/samtools/intervallist").toPath();
+    public static final Path TEST_DIR = Paths.get("src/test/resources/htsjdk/samtools/intervallist");
 
     public IntervalListTest() {
         fileHeader = IntervalList.fromPath(TEST_DIR.resolve("IntervalListchr123_empty.interval_list"))
@@ -82,7 +82,7 @@ public class IntervalListTest extends HtsjdkTest {
     public void testIntervalListFrom() throws IOException {
         final String testPath =
                 TEST_DIR.resolve("IntervalListFromVCFTestComp.interval_list").toString();
-        final IntervalList fromFileList = IntervalList.fromFile(new File(testPath));
+        final IntervalList fromFileList = IntervalList.fromPath(Paths.get(testPath));
         final IntervalList fromPathList = IntervalList.fromPath(IOUtil.getPath(testPath));
         fromFileList
                 .getHeader()
@@ -732,9 +732,8 @@ public class IntervalListTest extends HtsjdkTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testContigsAbsentInHeader() {
-        String vcf = TEST_DIR.resolve("IntervalListFromVCFNoContigLines.vcf").toString();
-        final File vcfFile = new File(vcf);
-        VCFFileReader.toIntervalList(vcfFile.toPath());
+        final Path vcf = TEST_DIR.resolve("IntervalListFromVCFNoContigLines.vcf");
+        VCFFileReader.toIntervalList(vcf);
     }
 
     @DataProvider

--- a/src/test/java/htsjdk/samtools/util/IntervalListWriterTest.java
+++ b/src/test/java/htsjdk/samtools/util/IntervalListWriterTest.java
@@ -6,7 +6,6 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceDictionary;
 import htsjdk.samtools.SAMSequenceRecord;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -28,9 +27,9 @@ public class IntervalListWriterTest extends HtsjdkTest {
 
     @Test
     public void testEndToEnd() throws IOException {
-        final File tempFile = File.createTempFile("IntervalListWriterTest.", ".interval_list");
-        tempFile.deleteOnExit();
-        testEndToEnd(tempFile.toPath());
+        final Path tempFile = Files.createTempFile("IntervalListWriterTest.", ".interval_list");
+        IOUtil.deleteOnExit(tempFile);
+        testEndToEnd(tempFile);
     }
 
     @Test

--- a/src/test/java/htsjdk/samtools/util/IupacTest.java
+++ b/src/test/java/htsjdk/samtools/util/IupacTest.java
@@ -32,6 +32,7 @@ import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -40,8 +41,9 @@ import org.testng.annotations.Test;
 public class IupacTest extends HtsjdkTest {
     @Test(dataProvider = "basicDataProvider")
     public void basic(final String tempFileExtension) throws Exception {
-        final File outputFile = File.createTempFile("iupacTest.", tempFileExtension);
-        outputFile.deleteOnExit();
+        final Path outputFile =
+                File.createTempFile("iupacTest.", tempFileExtension).toPath();
+        outputFile.toFile().deleteOnExit();
         final SAMFileWriter writer =
                 new SAMFileWriterFactory().makeSAMOrBAMWriter(new SAMFileHeader(), false, outputFile);
         final String bases1 = "=ACMGRSVTWYHKDBNA";

--- a/src/test/java/htsjdk/samtools/util/IupacTest.java
+++ b/src/test/java/htsjdk/samtools/util/IupacTest.java
@@ -31,7 +31,7 @@ import htsjdk.samtools.SAMRecord;
 import htsjdk.samtools.SAMRecordIterator;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
-import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import org.testng.Assert;
@@ -41,9 +41,8 @@ import org.testng.annotations.Test;
 public class IupacTest extends HtsjdkTest {
     @Test(dataProvider = "basicDataProvider")
     public void basic(final String tempFileExtension) throws Exception {
-        final Path outputFile =
-                File.createTempFile("iupacTest.", tempFileExtension).toPath();
-        outputFile.toFile().deleteOnExit();
+        final Path outputFile = Files.createTempFile("iupacTest.", tempFileExtension);
+        IOUtil.deleteOnExit(outputFile);
         final SAMFileWriter writer =
                 new SAMFileWriterFactory().makeSAMOrBAMWriter(new SAMFileHeader(), false, outputFile);
         final String bases1 = "=ACMGRSVTWYHKDBNA";

--- a/src/test/java/htsjdk/samtools/util/LogTest.java
+++ b/src/test/java/htsjdk/samtools/util/LogTest.java
@@ -1,11 +1,11 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -17,18 +17,18 @@ public class LogTest extends HtsjdkTest {
 
     @Test
     public void testLogToFile() throws IOException {
-        final File logFile = File.createTempFile(getClass().getSimpleName(), ".tmp");
-        logFile.deleteOnExit();
+        final Path logFile = Files.createTempFile(getClass().getSimpleName(), ".tmp");
+        IOUtil.deleteOnExit(logFile);
 
         final Log.LogLevel originalLogLevel = Log.getGlobalLogLevel();
         final PrintStream originalStream = Log.getGlobalPrintStream();
 
-        try (final PrintStream stream = new PrintStream(new FileOutputStream(logFile.getPath(), true))) {
+        try (final PrintStream stream = new PrintStream(Files.newOutputStream(logFile, StandardOpenOption.APPEND))) {
             Log.setGlobalPrintStream(stream);
             Log.setGlobalLogLevel(Log.LogLevel.DEBUG);
             final String words = "Hello World";
             log.info(words);
-            final List<String> list = Files.readAllLines(logFile.toPath());
+            final List<String> list = Files.readAllLines(logFile);
             Assert.assertEquals(Log.getGlobalLogLevel(), Log.LogLevel.DEBUG);
             Assert.assertEquals(list.size(), 1);
             Assert.assertTrue(list.get(0).contains(words));
@@ -40,18 +40,18 @@ public class LogTest extends HtsjdkTest {
 
     @Test
     public void testLogToFileWithSupplier() throws IOException {
-        final File logFile = File.createTempFile(getClass().getSimpleName(), ".tmp");
-        logFile.deleteOnExit();
+        final Path logFile = Files.createTempFile(getClass().getSimpleName(), ".tmp");
+        IOUtil.deleteOnExit(logFile);
 
         final Log.LogLevel originalLogLevel = Log.getGlobalLogLevel();
         final PrintStream originalStream = Log.getGlobalPrintStream();
 
-        try (final PrintStream stream = new PrintStream(new FileOutputStream(logFile.getPath(), true))) {
+        try (final PrintStream stream = new PrintStream(Files.newOutputStream(logFile, StandardOpenOption.APPEND))) {
             Log.setGlobalPrintStream(stream);
             Log.setGlobalLogLevel(Log.LogLevel.DEBUG);
             final String words = "Hello World";
             log.info(() -> words);
-            final List<String> list = Files.readAllLines(logFile.toPath());
+            final List<String> list = Files.readAllLines(logFile);
             Assert.assertEquals(Log.getGlobalLogLevel(), Log.LogLevel.DEBUG);
             Assert.assertEquals(list.size(), 1);
             Assert.assertTrue(list.get(0).contains(words));

--- a/src/test/java/htsjdk/samtools/util/Md5CalculatingOutputStreamTest.java
+++ b/src/test/java/htsjdk/samtools/util/Md5CalculatingOutputStreamTest.java
@@ -26,9 +26,9 @@ package htsjdk.samtools.util;
 import com.google.common.base.Charsets;
 import htsjdk.HtsjdkTest;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -47,7 +47,7 @@ public class Md5CalculatingOutputStreamTest extends HtsjdkTest {
     public void testMd5(final String contents, final String expectedMd5) throws IOException {
         byte[] bytes = contents.getBytes(Charsets.US_ASCII);
         OutputStream outputStream = new ByteArrayOutputStream(bytes.length);
-        Md5CalculatingOutputStream md5 = new Md5CalculatingOutputStream(outputStream, (File) null);
+        Md5CalculatingOutputStream md5 = new Md5CalculatingOutputStream(outputStream, (Path) null);
         md5.write(bytes);
         md5.close(); // Cannot use try-with-resources because we need a value after closing the stream
         Assert.assertEquals(md5.md5(), expectedMd5);

--- a/src/test/java/htsjdk/samtools/util/QualityEncodingDetectorTest.java
+++ b/src/test/java/htsjdk/samtools/util/QualityEncodingDetectorTest.java
@@ -6,7 +6,8 @@ import htsjdk.samtools.SAMRecordSetBuilder;
 import htsjdk.samtools.SamReader;
 import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.fastq.FastqReader;
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import org.testng.Assert;
@@ -16,10 +17,10 @@ import org.testng.annotations.Test;
 public class QualityEncodingDetectorTest extends HtsjdkTest {
 
     private static class Testcase {
-        private final File f;
+        private final Path f;
         private final FastqQualityFormat q;
 
-        Testcase(final File file, final FastqQualityFormat qualityFormat) {
+        Testcase(final Path file, final FastqQualityFormat qualityFormat) {
             this.f = file;
             this.q = qualityFormat;
         }
@@ -28,29 +29,29 @@ public class QualityEncodingDetectorTest extends HtsjdkTest {
     static final List<Testcase> FASTQ_TESTCASES = Arrays.asList(
             // Need to use full-range quality here, as Solexa and Illumina are near indistinguishable
             new Testcase(
-                    new File(
+                    Paths.get(
                             "./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/solexa_full_range_as_solexa.fastq"),
                     FastqQualityFormat.Solexa),
             new Testcase(
-                    new File("./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/s_1_sequence.txt"),
+                    Paths.get("./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/s_1_sequence.txt"),
                     FastqQualityFormat.Illumina),
             new Testcase(
-                    new File(
+                    Paths.get(
                             "./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/5k-30BB2AAXX.3.aligned.sam.fastq"),
                     FastqQualityFormat.Standard));
     static final List<Testcase> BAM_TESTCASES = Arrays.asList(
             new Testcase(
-                    new File("./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/unmapped.sam"),
+                    Paths.get("./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/unmapped.sam"),
                     FastqQualityFormat.Standard),
             new Testcase(
-                    new File("./src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam"),
+                    Paths.get("./src/test/resources/htsjdk/samtools/BAMFileIndexTest/index_test.bam"),
                     FastqQualityFormat.Standard),
             new Testcase(
-                    new File(
+                    Paths.get(
                             "./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/solexa-as-standard.bam"),
                     FastqQualityFormat.Solexa),
             new Testcase(
-                    new File(
+                    Paths.get(
                             "./src/test/resources/htsjdk/samtools/util/QualityEncodingDetectorTest/illumina-as-standard.bam"),
                     FastqQualityFormat.Illumina));
 
@@ -76,7 +77,7 @@ public class QualityEncodingDetectorTest extends HtsjdkTest {
     @Test(
             dataProvider = "FASTQ_TESTCASES",
             groups = {"unix"})
-    public void testFastqQualityInference(final File input, final FastqQualityFormat expectedQualityFormat) {
+    public void testFastqQualityInference(final Path input, final FastqQualityFormat expectedQualityFormat) {
         final FastqReader reader = new FastqReader(input);
         Assert.assertEquals(QualityEncodingDetector.detect(reader), expectedQualityFormat);
         reader.close();
@@ -85,7 +86,7 @@ public class QualityEncodingDetectorTest extends HtsjdkTest {
     @Test(
             dataProvider = "BAM_TESTCASES",
             groups = {"unix"})
-    public void testBamQualityInference(final File input, final FastqQualityFormat expectedQualityFormat) {
+    public void testBamQualityInference(final Path input, final FastqQualityFormat expectedQualityFormat) {
         final SamReader reader = SamReaderFactory.makeDefault().open(input);
         Assert.assertEquals(QualityEncodingDetector.detect(reader), expectedQualityFormat);
     }

--- a/src/test/java/htsjdk/samtools/util/SequenceUtilTest.java
+++ b/src/test/java/htsjdk/samtools/util/SequenceUtilTest.java
@@ -27,7 +27,7 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.*;
 import htsjdk.samtools.reference.ReferenceSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequenceFileFactory;
-import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -534,9 +534,9 @@ public class SequenceUtilTest extends HtsjdkTest {
 
     @Test
     public void testCalculateNmTag() {
-        final File TEST_DIR = new File("src/test/resources/htsjdk/samtools/SequenceUtil");
-        final File referenceFile = new File(TEST_DIR, "reference_with_lower_and_uppercase.fasta");
-        final File samFile = new File(TEST_DIR, "upper_and_lowercase_read.sam");
+        final Path TEST_DIR = Path.of("src/test/resources/htsjdk/samtools/SequenceUtil");
+        final Path referenceFile = TEST_DIR.resolve("reference_with_lower_and_uppercase.fasta");
+        final Path samFile = TEST_DIR.resolve("upper_and_lowercase_read.sam");
 
         SamReader reader = SamReaderFactory.makeDefault().open(samFile);
         ReferenceSequenceFile ref = ReferenceSequenceFileFactory.getReferenceSequenceFile(referenceFile);

--- a/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
+++ b/src/test/java/htsjdk/samtools/util/SortingCollectionTest.java
@@ -24,15 +24,19 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Random;
+import java.util.stream.Stream;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -41,10 +45,9 @@ import org.testng.annotations.Test;
 
 public class SortingCollectionTest extends HtsjdkTest {
     // Create a separate directory for files so it is possible to confirm that the directory is emptied
-    protected File tmpDir() {
-        return new File(
-                System.getProperty("java.io.tmpdir") + "/" + System.getProperty("user.name"),
-                getClass().getSimpleName());
+    protected Path tmpDir() {
+        return Paths.get(System.getProperty("java.io.tmpdir") + "/" + System.getProperty("user.name"))
+                .resolve(getClass().getSimpleName());
     }
 
     @BeforeMethod
@@ -61,12 +64,23 @@ public class SortingCollectionTest extends HtsjdkTest {
     void resetTmpDir() {
         System.err.println("Resetting tmpdir");
         IOUtil.deleteDirectoryTree(tmpDir());
-        if (!tmpDir().mkdirs())
-            throw new IllegalStateException("Could not create tmpdir: " + tmpDir().getAbsolutePath());
+        try {
+            Files.createDirectories(tmpDir());
+        } catch (final IOException e) {
+            throw new IllegalStateException("Could not create tmpdir: " + tmpDir().toAbsolutePath(), e);
+        }
     }
 
     protected boolean tmpDirIsEmpty() {
-        return tmpDir().listFiles().length == 0;
+        return countTmpDirEntries() == 0;
+    }
+
+    private long countTmpDirEntries() {
+        try (final Stream<Path> entries = Files.list(tmpDir())) {
+            return entries.count();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @DataProvider(name = "test1")
@@ -106,7 +120,7 @@ public class SortingCollectionTest extends HtsjdkTest {
         assertIteratorEqualsList(strings, sortingCollection.iterator());
 
         sortingCollection.cleanup();
-        Assert.assertEquals(tmpDir().list().length, 0);
+        Assert.assertEquals(countTmpDirEntries(), 0L);
     }
 
     @Test
@@ -118,14 +132,14 @@ public class SortingCollectionTest extends HtsjdkTest {
             sortingCollection.add(str);
         }
 
-        Assert.assertEquals(tmpDir().list().length, 0);
+        Assert.assertEquals(countTmpDirEntries(), 0L);
         sortingCollection.spillToDisk();
-        Assert.assertEquals(tmpDir().list().length, 1);
+        Assert.assertEquals(countTmpDirEntries(), 1L);
 
         assertIteratorEqualsList(strings, sortingCollection.iterator());
 
         sortingCollection.cleanup();
-        Assert.assertEquals(tmpDir().list().length, 0);
+        Assert.assertEquals(countTmpDirEntries(), 0L);
     }
 
     private void assertIteratorEqualsList(final String[] strings, final Iterator<String> sortingCollection) {

--- a/src/test/java/htsjdk/samtools/util/SortingLongCollectionTest.java
+++ b/src/test/java/htsjdk/samtools/util/SortingLongCollectionTest.java
@@ -24,7 +24,12 @@
 package htsjdk.samtools.util;
 
 import htsjdk.HtsjdkTest;
-import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Random;
 import org.testng.Assert;
@@ -35,35 +40,43 @@ import org.testng.annotations.*;
  */
 public class SortingLongCollectionTest extends HtsjdkTest {
     // Create a separate directory for files so it is possible to confirm that the directory is emptied
-    private final File tmpDir = new File(
+    private final Path tmpDir = Paths.get(
             System.getProperty("java.io.tmpdir") + "/" + System.getProperty("user.name"), "SortingLongCollectionTest");
 
     @BeforeMethod
-    void setup() {
+    void setup() throws IOException {
         // Clear out any existing files if the directory exists
-        if (tmpDir.exists()) {
-            for (final File f : tmpDir.listFiles()) {
-                f.delete();
-            }
+        if (Files.exists(tmpDir)) {
+            deleteDirectoryContents();
         }
-        tmpDir.mkdir();
+        Files.createDirectories(tmpDir);
     }
 
     @AfterMethod
-    void tearDown() {
-        if (!tmpDir.exists()) {
+    void tearDown() throws IOException {
+        if (!Files.exists(tmpDir)) {
             // I don't know why it wouldn't exist, but sometimes it doesn't, and it causes the unit test
             // to fail.  AW 20-May-2009
             return;
         }
-        for (final File f : tmpDir.listFiles()) {
-            f.delete();
+        deleteDirectoryContents();
+        Files.delete(tmpDir);
+    }
+
+    private void deleteDirectoryContents() throws IOException {
+        try (final DirectoryStream<Path> stream = Files.newDirectoryStream(tmpDir)) {
+            for (final Path f : stream) {
+                Files.delete(f);
+            }
         }
-        tmpDir.delete();
     }
 
     private boolean tmpDirIsEmpty() {
-        return tmpDir.listFiles().length == 0;
+        try (final DirectoryStream<Path> stream = Files.newDirectoryStream(tmpDir)) {
+            return !stream.iterator().hasNext();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @DataProvider(name = "test1")

--- a/src/test/java/htsjdk/samtools/util/zip/LibdeflateTest.java
+++ b/src/test/java/htsjdk/samtools/util/zip/LibdeflateTest.java
@@ -86,7 +86,7 @@ public class LibdeflateTest extends HtsjdkTest {
 
         // Write with libdeflate (default factory when libdeflate is available)
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (final BlockCompressedOutputStream out = new BlockCompressedOutputStream(baos, (java.io.File) null)) {
+        try (final BlockCompressedOutputStream out = new BlockCompressedOutputStream(baos, (java.nio.file.Path) null)) {
             out.write(original);
         }
 
@@ -110,7 +110,7 @@ public class LibdeflateTest extends HtsjdkTest {
         // Write with JDK deflater
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (final BlockCompressedOutputStream out =
-                new BlockCompressedOutputStream(baos, (java.io.File) null, 5, new DeflaterFactory() {
+                new BlockCompressedOutputStream(baos, (java.nio.file.Path) null, 5, new DeflaterFactory() {
                     @Override
                     public java.util.zip.Deflater makeDeflater(int compressionLevel, boolean gzipCompatible) {
                         return new java.util.zip.Deflater(compressionLevel, gzipCompatible);
@@ -134,8 +134,8 @@ public class LibdeflateTest extends HtsjdkTest {
 
     private byte[] roundTrip(final byte[] data, final int compressionLevel) throws IOException {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (final BlockCompressedOutputStream out =
-                new BlockCompressedOutputStream(baos, (java.io.File) null, compressionLevel, new DeflaterFactory())) {
+        try (final BlockCompressedOutputStream out = new BlockCompressedOutputStream(
+                baos, (java.nio.file.Path) null, compressionLevel, new DeflaterFactory())) {
             out.write(data);
         }
 

--- a/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/AbstractFeatureReaderTest.java
@@ -16,7 +16,6 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderVersion;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.ByteBuffer;
@@ -86,7 +85,7 @@ public class AbstractFeatureReaderTest extends HtsjdkTest {
 
     @Test(dataProvider = "blockCompressedExtensionExtensionStrings", dataProviderClass = IOUtilTest.class)
     public void testBlockCompressionExtensionFile(final String testString, final boolean expected) {
-        Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(new File(testString)), expected);
+        Assert.assertEquals(AbstractFeatureReader.hasBlockCompressedExtension(Path.of(testString)), expected);
     }
 
     @Test(dataProvider = "blockCompressedExtensionExtensionURIStrings", dataProviderClass = IOUtilTest.class)

--- a/src/test/java/htsjdk/tribble/BinaryFeaturesTest.java
+++ b/src/test/java/htsjdk/tribble/BinaryFeaturesTest.java
@@ -4,8 +4,9 @@ import htsjdk.HtsjdkTest;
 import htsjdk.tribble.bed.BEDCodec;
 import htsjdk.tribble.example.ExampleBinaryCodec;
 import htsjdk.tribble.readers.LineIterator;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import org.testng.Assert;
@@ -16,25 +17,25 @@ public class BinaryFeaturesTest extends HtsjdkTest {
     @DataProvider(name = "BinaryFeatureSources")
     public Object[][] createData1() {
         return new Object[][] {
-            {new File(TestUtils.DATA_DIR + "test.bed"), new BEDCodec()},
-            {new File(TestUtils.DATA_DIR + "bed/Unigene.sample.bed"), new BEDCodec()},
+            {Path.of(TestUtils.DATA_DIR + "test.bed"), new BEDCodec()},
+            {Path.of(TestUtils.DATA_DIR + "bed/Unigene.sample.bed"), new BEDCodec()},
             {
-                new File(TestUtils.DATA_DIR + "bed/NA12878.deletions.10kbp.het.gq99.hand_curated.hg19_fixed.bed"),
+                Path.of(TestUtils.DATA_DIR + "bed/NA12878.deletions.10kbp.het.gq99.hand_curated.hg19_fixed.bed"),
                 new BEDCodec()
             },
         };
     }
 
     @Test(enabled = true, dataProvider = "BinaryFeatureSources")
-    public void testBinaryCodec(final File source, final FeatureCodec<Feature, LineIterator> codec) throws IOException {
-        final File tmpFile = File.createTempFile("testBinaryCodec", ".binary.bed");
+    public void testBinaryCodec(final Path source, final FeatureCodec<Feature, LineIterator> codec) throws IOException {
+        final Path tmpFile = Files.createTempFile("testBinaryCodec", ".binary.bed");
         ExampleBinaryCodec.convertToBinaryTest(source, tmpFile, codec);
-        tmpFile.deleteOnExit();
+        tmpFile.toFile().deleteOnExit();
 
         final FeatureReader<Feature> originalReader =
-                AbstractFeatureReader.getFeatureReader(source.getAbsolutePath(), codec, false);
-        final FeatureReader<Feature> binaryReader =
-                AbstractFeatureReader.getFeatureReader(tmpFile.getAbsolutePath(), new ExampleBinaryCodec(), false);
+                AbstractFeatureReader.getFeatureReader(source.toAbsolutePath().toString(), codec, false);
+        final FeatureReader<Feature> binaryReader = AbstractFeatureReader.getFeatureReader(
+                tmpFile.toAbsolutePath().toString(), new ExampleBinaryCodec(), false);
 
         // make sure the header is what we expect
         final List<String> header = (List<String>) binaryReader.getHeader();

--- a/src/test/java/htsjdk/tribble/FeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/FeatureReaderTest.java
@@ -10,8 +10,9 @@ import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
 import htsjdk.tribble.util.ParsingUtils;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -22,20 +23,20 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class FeatureReaderTest extends HtsjdkTest {
-    private static final File asciiBedFile = new File(TestUtils.DATA_DIR + "test.bed");
-    private File binaryBedFile;
-    private static final File tabixBedFile = new File(TestUtils.DATA_DIR + "test.tabix.bed.gz");
+    private static final Path asciiBedFile = Path.of(TestUtils.DATA_DIR + "test.bed");
+    private Path binaryBedFile;
+    private static final Path tabixBedFile = Path.of(TestUtils.DATA_DIR + "test.tabix.bed.gz");
 
     @BeforeClass
     public void setup() throws IOException {
-        binaryBedFile = File.createTempFile("htsjdk-test.featurereader", ".bed");
-        binaryBedFile.deleteOnExit();
+        binaryBedFile = Files.createTempFile("htsjdk-test.featurereader", ".bed");
+        binaryBedFile.toFile().deleteOnExit();
         ExampleBinaryCodec.convertToBinaryTest(asciiBedFile, binaryBedFile, new BEDCodec());
     }
 
     @AfterClass
     public void tearDown() throws Exception {
-        binaryBedFile.delete();
+        Files.deleteIfExists(binaryBedFile);
     }
 
     @DataProvider(name = "indexProvider")
@@ -51,7 +52,7 @@ public class FeatureReaderTest extends HtsjdkTest {
 
     @Test(dataProvider = "indexProvider")
     public void testBedQuery(
-            final File featureFile,
+            final Path featureFile,
             final IndexFactory.IndexType indexType,
             final FeatureCodec<Feature, LocationAware> codec)
             throws IOException {
@@ -80,7 +81,7 @@ public class FeatureReaderTest extends HtsjdkTest {
 
     @Test(dataProvider = "indexProvider")
     public void testLargeNumberOfQueries(
-            final File featureFile,
+            final Path featureFile,
             final IndexFactory.IndexType indexType,
             final FeatureCodec<Feature, LocationAware> codec)
             throws IOException {
@@ -122,7 +123,7 @@ public class FeatureReaderTest extends HtsjdkTest {
 
     @Test(dataProvider = "indexProvider")
     public void testBedNames(
-            final File featureFile,
+            final Path featureFile,
             final IndexFactory.IndexType indexType,
             final FeatureCodec<Feature, LocationAware> codec)
             throws IOException {
@@ -143,31 +144,30 @@ public class FeatureReaderTest extends HtsjdkTest {
 
     private static <FEATURE extends Feature, SOURCE extends LocationAware>
             AbstractFeatureReader<FEATURE, SOURCE> getReader(
-                    final File featureFile,
+                    final Path featureFile,
                     final IndexFactory.IndexType indexType,
                     final FeatureCodec<FEATURE, SOURCE> codec)
                     throws IOException {
         if (indexType.canCreate()) {
             // for types we can create make a new index each time
-            final File idxFile = Tribble.indexFile(featureFile);
+            final Path idxFile = Tribble.indexPath(featureFile);
 
             // delete an already existing index
-            if (idxFile.exists()) {
-                idxFile.delete();
-            }
+            Files.deleteIfExists(idxFile);
             final Index idx = IndexFactory.createIndex(featureFile, codec, indexType);
             idx.write(idxFile);
 
-            idxFile.deleteOnExit();
+            idxFile.toFile().deleteOnExit();
         } // else  let's just hope the index exists, and if so use it
 
-        return AbstractFeatureReader.getFeatureReader(featureFile.getAbsolutePath(), codec);
+        return AbstractFeatureReader.getFeatureReader(
+                featureFile.toAbsolutePath().toString(), codec);
     }
 
     @Test
     public void testReadingBeyondIntSizedBlock() throws IOException {
         final Block block = new Block(0, ((long) Integer.MAX_VALUE) * 2);
-        final SeekableFileStream stream = new SeekableFileStream(new File("/dev/zero"));
+        final SeekableFileStream stream = new SeekableFileStream(Path.of("/dev/zero"));
         final TribbleIndexedFeatureReader.BlockStreamWrapper blockStreamWrapper =
                 new TribbleIndexedFeatureReader.BlockStreamWrapper(stream, block);
         final int chunkSize = 100000; // 10 Mb

--- a/src/test/java/htsjdk/tribble/IntervalList/IntervalListCodecTest.java
+++ b/src/test/java/htsjdk/tribble/IntervalList/IntervalListCodecTest.java
@@ -114,8 +114,8 @@ public class IntervalListCodecTest extends HtsjdkTest {
     public void testDecodeIntervalListFile_bad(Path file) throws Exception {
         IntervalListCodec codec = new IntervalListCodec();
 
-        try (FeatureReader<Interval> intervalListReader = AbstractFeatureReader.getFeatureReader(
-                        file.toAbsolutePath().toString(), codec, false);
+        try (FeatureReader<Interval> intervalListReader =
+                        AbstractFeatureReader.getFeatureReader(file.toRealPath().toString(), codec, false);
                 CloseableTribbleIterator<Interval> iter = intervalListReader.iterator()) {
             for (final Feature unused : iter) {}
         }

--- a/src/test/java/htsjdk/tribble/IntervalList/IntervalListCodecTest.java
+++ b/src/test/java/htsjdk/tribble/IntervalList/IntervalListCodecTest.java
@@ -34,9 +34,9 @@ import htsjdk.samtools.util.IntervalList;
 import htsjdk.samtools.util.IntervalListTest;
 import htsjdk.tribble.*;
 import htsjdk.variant.utils.SAMSequenceDictionaryExtractor;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -68,16 +68,16 @@ public class IntervalListCodecTest extends HtsjdkTest {
     @DataProvider
     Object[][] TribbleDecodeData() {
         return new Object[][] {
-            {new File(TestUtils.DATA_DIR, "interval_list/shortExample.interval_list")},
-            {new File(TestUtils.DATA_DIR, "interval_list/shortExampleWithEmptyLine.interval_list")}
+            {Path.of(TestUtils.DATA_DIR, "interval_list/shortExample.interval_list")},
+            {Path.of(TestUtils.DATA_DIR, "interval_list/shortExampleWithEmptyLine.interval_list")}
         };
     }
 
     @Test(dataProvider = "TribbleDecodeData")
-    public void testTribbleDecode(final File file) throws IOException {
-        final IntervalList intervalListLocal = IntervalList.fromFile(file);
-        try (final FeatureReader<Interval> intervalListReader =
-                        AbstractFeatureReader.getFeatureReader(file.getAbsolutePath(), new IntervalListCodec(), false);
+    public void testTribbleDecode(final Path file) throws IOException {
+        final IntervalList intervalListLocal = IntervalList.fromPath(file);
+        try (final FeatureReader<Interval> intervalListReader = AbstractFeatureReader.getFeatureReader(
+                        file.toAbsolutePath().toString(), new IntervalListCodec(), false);
                 final CloseableTribbleIterator<Interval> iterator = intervalListReader.iterator()) {
             Assert.assertEquals(intervalListLocal.getHeader(), intervalListReader.getHeader());
 
@@ -90,18 +90,18 @@ public class IntervalListCodecTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "TribbleDecodeData")
-    public void testTribbleDecodeCompressed(final File file) throws IOException {
+    public void testTribbleDecodeCompressed(final Path file) throws IOException {
         // compress 'file' to bgzf
-        File tmpGz = File.createTempFile("htsjdk.", FileExtensions.COMPRESSED_INTERVAL_LIST);
+        Path tmpGz = Files.createTempFile("htsjdk.", FileExtensions.COMPRESSED_INTERVAL_LIST);
         try (BlockCompressedOutputStream bgz = new BlockCompressedOutputStream(tmpGz);
-                FileInputStream fis = new FileInputStream(file)) {
+                InputStream fis = Files.newInputStream(file)) {
             IOUtil.copyStream(fis, bgz);
             bgz.flush();
         }
         // test dictonary can be extracted
         Assert.assertNotNull(SAMSequenceDictionaryExtractor.extractDictionary(tmpGz));
         testTribbleDecode(tmpGz);
-        tmpGz.delete();
+        Files.deleteIfExists(tmpGz);
     }
 
     /**
@@ -115,7 +115,7 @@ public class IntervalListCodecTest extends HtsjdkTest {
         IntervalListCodec codec = new IntervalListCodec();
 
         try (FeatureReader<Interval> intervalListReader = AbstractFeatureReader.getFeatureReader(
-                        IOUtil.getFullCanonicalPath(file.toFile()), codec, false);
+                        file.toAbsolutePath().toString(), codec, false);
                 CloseableTribbleIterator<Interval> iter = intervalListReader.iterator()) {
             for (final Feature unused : iter) {}
         }

--- a/src/test/java/htsjdk/tribble/TribbleIndexedFeatureReaderTest.java
+++ b/src/test/java/htsjdk/tribble/TribbleIndexedFeatureReaderTest.java
@@ -8,8 +8,8 @@ import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.readers.LineIterator;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -58,23 +58,23 @@ public class TribbleIndexedFeatureReaderTest extends HtsjdkTest {
 
     @DataProvider()
     public Object[][] createIntervalFileStrings() {
-        return new Object[][] {{new File(TestUtils.DATA_DIR, "interval_list/shortExample.interval_list"), 4}};
+        return new Object[][] {{Path.of(TestUtils.DATA_DIR, "interval_list/shortExample.interval_list"), 4}};
     }
 
     @Test(dataProvider = "createIntervalFileStrings")
-    public void testUnIndexedIntervalList(final File testPath, final int expectedCount) throws IOException {
+    public void testUnIndexedIntervalList(final Path testPath, final int expectedCount) throws IOException {
         final IntervalListCodec codec = new IntervalListCodec();
         try (final TribbleIndexedFeatureReader<Interval, LineIterator> featureReader =
-                new TribbleIndexedFeatureReader<>(testPath.getAbsolutePath(), codec, false)) {
+                new TribbleIndexedFeatureReader<>(testPath.toAbsolutePath().toString(), codec, false)) {
             Assert.assertEquals(featureReader.iterator().stream().count(), expectedCount);
         }
     }
 
     @Test(dataProvider = "createIntervalFileStrings", expectedExceptions = TribbleException.class)
-    public void testUnIndexedIntervalListWithQuery(final File testPath, final int ignored) throws IOException {
+    public void testUnIndexedIntervalListWithQuery(final Path testPath, final int ignored) throws IOException {
         final IntervalListCodec codec = new IntervalListCodec();
         try (final TribbleIndexedFeatureReader<Interval, LineIterator> featureReader =
-                new TribbleIndexedFeatureReader<>(testPath.getAbsolutePath(), codec, false)) {
+                new TribbleIndexedFeatureReader<>(testPath.toAbsolutePath().toString(), codec, false)) {
 
             Assert.assertEquals(
                     featureReader.query("1", 17032814, 17032814).stream().count(), 1);
@@ -84,9 +84,9 @@ public class TribbleIndexedFeatureReaderTest extends HtsjdkTest {
     @Test(expectedExceptions = TribbleException.MalformedFeatureFile.class)
     public void testPoolyFormatedIntervalListWithQuery() throws IOException {
         final IntervalListCodec codec = new IntervalListCodec();
-        final File testPath = new File(TestUtils.DATA_DIR, "interval_list/badExample.interval_list");
+        final Path testPath = Path.of(TestUtils.DATA_DIR, "interval_list/badExample.interval_list");
         try (final TribbleIndexedFeatureReader<Interval, LineIterator> featureReader =
-                new TribbleIndexedFeatureReader<>(testPath.getAbsolutePath(), codec, false)) {
+                new TribbleIndexedFeatureReader<>(testPath.toAbsolutePath().toString(), codec, false)) {
             final CloseableTribbleIterator<Interval> iterator = featureReader.iterator();
             int numberOfRecords = 0;
             while (iterator.hasNext()) {

--- a/src/test/java/htsjdk/tribble/TribbleTest.java
+++ b/src/test/java/htsjdk/tribble/TribbleTest.java
@@ -2,7 +2,7 @@ package htsjdk.tribble;
 
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.FileExtensions;
-import java.io.File;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -16,7 +16,8 @@ public class TribbleTest extends HtsjdkTest {
 
         Assert.assertEquals(Tribble.indexFile(vcf), expectedIndex);
         Assert.assertEquals(
-                Tribble.indexFile(new File(vcf).getAbsolutePath()), new File(expectedIndex).getAbsolutePath());
+                Tribble.indexFile(Path.of(vcf).toAbsolutePath().toString()),
+                Path.of(expectedIndex).toAbsolutePath().toString());
     }
 
     @Test
@@ -27,6 +28,7 @@ public class TribbleTest extends HtsjdkTest {
 
         Assert.assertEquals(Tribble.tabixIndexFile(vcf), expectedIndex);
         Assert.assertEquals(
-                Tribble.tabixIndexFile(new File(vcf).getAbsolutePath()), new File(expectedIndex).getAbsolutePath());
+                Tribble.tabixIndexFile(Path.of(vcf).toAbsolutePath().toString()),
+                Path.of(expectedIndex).toAbsolutePath().toString());
     }
 }

--- a/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
+++ b/src/test/java/htsjdk/tribble/bed/BEDCodecTest.java
@@ -37,9 +37,9 @@ import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.tribble.readers.AsciiLineReaderIterator;
 import htsjdk.tribble.util.ParsingUtils;
 import java.awt.*;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -52,21 +52,21 @@ public class BEDCodecTest extends HtsjdkTest {
         return new Object[][] {
             {
                 // BGZP BED file with no header, 2 features
-                new File(TestUtils.DATA_DIR, "bed/2featuresNoHeader.bed.gz"), 0 // header has length 0
+                Path.of(TestUtils.DATA_DIR, "bed/2featuresNoHeader.bed.gz"), 0 // header has length 0
             },
             {
                 // BGZP BED file with one line header, 2 features
-                new File(TestUtils.DATA_DIR, "bed/2featuresWithHeader.bed.gz"), 10 // header has length 10
+                Path.of(TestUtils.DATA_DIR, "bed/2featuresWithHeader.bed.gz"), 10 // header has length 10
             }
         };
     }
 
     @Test(dataProvider = "gzippedBedTestData")
-    public void testReadActualHeader(final File gzippedBedFile, final int firstFeatureOffset) throws IOException {
+    public void testReadActualHeader(final Path gzippedBedFile, final int firstFeatureOffset) throws IOException {
         // Given an indexable SOURCE on a BED file, test that readActualHeader retains the correct offset
         // of the first feature, whether there is a header or not
         BEDCodec bedCodec = new BEDCodec();
-        try (final InputStream is = ParsingUtils.openInputStream(gzippedBedFile.getPath());
+        try (final InputStream is = ParsingUtils.openInputStream(gzippedBedFile.toString());
                 final BlockCompressedInputStream bcis = new BlockCompressedInputStream(is)) {
             AsciiLineReaderIterator it = (AsciiLineReaderIterator) bedCodec.makeIndexableSourceFromStream(bcis);
             Object header = bedCodec.readActualHeader(it);

--- a/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
+++ b/src/test/java/htsjdk/tribble/gff/Gff3WriterTest.java
@@ -8,7 +8,6 @@ import htsjdk.tribble.TestUtils;
 import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.LineIterator;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Path;
@@ -74,7 +73,7 @@ public class Gff3WriterTest extends HtsjdkTest {
 
             // read temp files back in
 
-            Assert.assertTrue(isGZipped(tempFileGzip.toFile()));
+            Assert.assertTrue(isGZipped(tempFileGzip));
             final List<String> comments2 = new ArrayList<>();
             final HashSet<SequenceRegion> regions2 = new HashSet<>();
             final LinkedHashSet<Gff3Feature> features2 = readFromFile(tempFile, comments2, regions2);
@@ -221,10 +220,10 @@ public class Gff3WriterTest extends HtsjdkTest {
         Assert.assertEquals(encoded, expectedEncoded);
     }
 
-    private static boolean isGZipped(final File f) {
+    private static boolean isGZipped(final Path f) {
         int magic = 0;
         try {
-            RandomAccessFile raf = new RandomAccessFile(f, "r");
+            RandomAccessFile raf = new RandomAccessFile(f.toFile(), "r");
             magic = raf.read() & 0xff | ((raf.read() << 8) & 0xff00);
             raf.close();
         } catch (Throwable e) {

--- a/src/test/java/htsjdk/tribble/index/IndexFactoryTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexFactoryTest.java
@@ -23,7 +23,6 @@
  */
 package htsjdk.tribble.index;
 
-import com.google.common.io.Files;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
@@ -44,9 +43,9 @@ import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFFileReader;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
@@ -64,13 +63,13 @@ public class IndexFactoryTest extends HtsjdkTest {
     @DataProvider(name = "bedDataProvider")
     public Object[][] getLinearIndexFactoryTypes() {
         return new Object[][] {
-            {new File(TestUtils.DATA_DIR, "bed/Unigene.sample.bed")},
-            {new File(TestUtils.DATA_DIR, "bed/Unigene.sample.bed.gz")}
+            {Path.of(TestUtils.DATA_DIR, "bed/Unigene.sample.bed")},
+            {Path.of(TestUtils.DATA_DIR, "bed/Unigene.sample.bed.gz")}
         };
     }
 
     @Test(dataProvider = "bedDataProvider")
-    public void testCreateLinearIndexFromBED(final File inputBEDFIle) {
+    public void testCreateLinearIndexFromBED(final Path inputBEDFIle) {
         Index index = IndexFactory.createLinearIndex(inputBEDFIle, new BEDCodec());
         String chr = "chr2";
 
@@ -86,13 +85,13 @@ public class IndexFactoryTest extends HtsjdkTest {
 
     @Test(expectedExceptions = TribbleException.MalformedFeatureFile.class, dataProvider = "indexFactoryProvider")
     public void testCreateIndexUnsorted(IndexFactory.IndexType type) {
-        final File unsortedBedFile = new File(TestUtils.DATA_DIR, "bed/unsorted.bed");
+        final Path unsortedBedFile = Path.of(TestUtils.DATA_DIR, "bed/unsorted.bed");
         IndexFactory.createIndex(unsortedBedFile, new BEDCodec(), type);
     }
 
     @Test(expectedExceptions = TribbleException.MalformedFeatureFile.class, dataProvider = "indexFactoryProvider")
     public void testCreateIndexDiscontinuousContigs(IndexFactory.IndexType type) throws Exception {
-        final File discontinuousFile = new File(TestUtils.DATA_DIR, "bed/disconcontigs.bed");
+        final Path discontinuousFile = Path.of(TestUtils.DATA_DIR, "bed/disconcontigs.bed");
         IndexFactory.createIndex(discontinuousFile, new BEDCodec(), type);
     }
 
@@ -150,29 +149,30 @@ public class IndexFactoryTest extends HtsjdkTest {
     public Object[][] getVCFIndexData() {
         return new Object[][] {
             new Object[] {
-                new File(TestUtils.DATA_DIR, "tabix/4featuresHG38Header.vcf.gz"),
+                Path.of(TestUtils.DATA_DIR, "tabix/4featuresHG38Header.vcf.gz"),
                 new Interval("chr6", 33414233, 118314029)
             },
             new Object[] {
-                new File(TestUtils.DATA_DIR, "tabix/4featuresHG38Header.vcf"), new Interval("chr6", 33414233, 118314029)
+                Path.of(TestUtils.DATA_DIR, "tabix/4featuresHG38Header.vcf"), new Interval("chr6", 33414233, 118314029)
             },
         };
     }
 
     @Test(dataProvider = "vcfDataProvider")
-    public void testCreateTabixIndexFromVCF(final File inputVCF, final Interval queryInterval) throws IOException {
+    public void testCreateTabixIndexFromVCF(final Path inputVCF, final Interval queryInterval) throws IOException {
         // copy the original file and create the index for the copy
-        final File tempDir = IOUtil.createTempDir("testCreateTabixIndexFromVCF").toFile();
-        tempDir.deleteOnExit();
-        final File tmpVCF = new File(tempDir, inputVCF.getName());
+        final Path tempDir = IOUtil.createTempDir("testCreateTabixIndexFromVCF");
+        tempDir.toFile().deleteOnExit();
+        final Path tmpVCF = tempDir.resolve(inputVCF.getFileName().toString());
         Files.copy(inputVCF, tmpVCF);
-        tmpVCF.deleteOnExit();
+        tmpVCF.toFile().deleteOnExit();
 
         // this test creates a TABIX index (.tbi)
-        final TabixIndex tabixIndexGz = IndexFactory.createTabixIndex(tmpVCF, new VCFCodec(), null);
-        tabixIndexGz.writeBasedOnFeatureFile(tmpVCF);
-        final File tmpIndex = Tribble.tabixIndexFile(tmpVCF);
-        tmpIndex.deleteOnExit();
+        final TabixIndex tabixIndexGz =
+                IndexFactory.createTabixIndex(tmpVCF, new VCFCodec(), (SAMSequenceDictionary) null);
+        tabixIndexGz.writeBasedOnFeaturePath(tmpVCF);
+        final Path tmpIndex = Tribble.tabixIndexPath(tmpVCF);
+        tmpIndex.toFile().deleteOnExit();
 
         try (final VCFFileReader originalReader = new VCFFileReader(inputVCF, false);
                 final VCFFileReader tmpReader = new VCFFileReader(tmpVCF, tmpIndex, true)) {
@@ -196,24 +196,24 @@ public class IndexFactoryTest extends HtsjdkTest {
             // TODO: this needs more test cases, including block compressed and indexed, but bcftools can't
             // generate indices for BCF2.1 files, which is all HTSJDK can read, and htsjdk also can't read/write
             // block compressed BCFs (https://github.com/samtools/htsjdk/issues/946)
-            new Object[] {new File("src/test/resources/htsjdk/variant/serialization_test.bcf")}
+            new Object[] {Path.of("src/test/resources/htsjdk/variant/serialization_test.bcf")}
         };
     }
 
     @Test(dataProvider = "bcfDataFactory")
-    public void testCreateLinearIndexFromBCF(final File inputBCF) throws IOException {
+    public void testCreateLinearIndexFromBCF(final Path inputBCF) throws IOException {
         // copy the original file and create the index for the copy
-        final File tempDir = IOUtil.createTempDir("testCreateIndexFromBCF").toFile();
-        tempDir.deleteOnExit();
-        final File tmpBCF = new File(tempDir, inputBCF.getName());
+        final Path tempDir = IOUtil.createTempDir("testCreateIndexFromBCF");
+        tempDir.toFile().deleteOnExit();
+        final Path tmpBCF = tempDir.resolve(inputBCF.getFileName().toString());
         Files.copy(inputBCF, tmpBCF);
-        tmpBCF.deleteOnExit();
+        tmpBCF.toFile().deleteOnExit();
 
         // NOTE: this test creates a LINEAR index (.idx)
         final Index index = IndexFactory.createIndex(tmpBCF, new BCF2Codec(), IndexFactory.IndexType.LINEAR);
-        index.writeBasedOnFeatureFile(tmpBCF);
-        final File tempIndex = Tribble.indexFile(tmpBCF);
-        tempIndex.deleteOnExit();
+        index.writeBasedOnFeaturePath(tmpBCF);
+        final Path tempIndex = Tribble.indexPath(tmpBCF);
+        tempIndex.toFile().deleteOnExit();
 
         try (final VCFFileReader originalReader = new VCFFileReader(inputBCF, false);
                 final VCFFileReader tmpReader = new VCFFileReader(tmpBCF, tempIndex, true)) {
@@ -246,30 +246,32 @@ public class IndexFactoryTest extends HtsjdkTest {
     @Test(dataProvider = "getRedirectFiles")
     public void testIndexRedirectedFiles(String input, IndexFactory.IndexType type) throws IOException {
         final VCFRedirectCodec codec = new VCFRedirectCodec();
-        final File dir = IOUtil.createTempDir("redirec-test.dir").toFile();
+        final Path dir = IOUtil.createTempDir("redirec-test.dir");
         try {
-            final File tmpInput = new File(dir, new File(input).getName());
-            Files.copy(new File(input), tmpInput);
-            final File tmpDataFile = new File(codec.getPathToDataFile(tmpInput.toString()));
-            Assert.assertTrue(new File(tmpDataFile.getAbsoluteFile().getParent()).mkdir());
-            final File originalDataFile = new File(codec.getPathToDataFile(input));
+            final Path tmpInput = dir.resolve(Path.of(input).getFileName().toString());
+            Files.copy(Path.of(input), tmpInput);
+            final Path tmpDataFile = Path.of(codec.getPathToDataFile(tmpInput.toString()));
+            Files.createDirectories(tmpDataFile.getParent());
+            final Path originalDataFile = Path.of(codec.getPathToDataFile(input));
             Files.copy(originalDataFile, tmpDataFile);
 
             try (final AbstractFeatureReader<VariantContext, LineIterator> featureReader =
-                    AbstractFeatureReader.getFeatureReader(tmpInput.getAbsolutePath(), codec, false)) {
+                    AbstractFeatureReader.getFeatureReader(
+                            tmpInput.toAbsolutePath().toString(), codec, false)) {
                 Assert.assertFalse(featureReader.hasIndex());
             }
             final Index index = IndexFactory.createIndex(tmpInput, codec, type);
-            index.writeBasedOnFeatureFile(tmpDataFile);
+            index.writeBasedOnFeaturePath(tmpDataFile);
 
             try (final AbstractFeatureReader<VariantContext, LineIterator> featureReader =
-                    AbstractFeatureReader.getFeatureReader(tmpInput.getAbsolutePath(), codec)) {
+                    AbstractFeatureReader.getFeatureReader(
+                            tmpInput.toAbsolutePath().toString(), codec)) {
                 Assert.assertTrue(featureReader.hasIndex());
                 Assert.assertEquals(
                         featureReader.query("20", 1110696, 1230237).stream().count(), 2);
             }
         } finally {
-            IOUtil.recursiveDelete(dir.toPath());
+            IOUtil.recursiveDelete(dir);
         }
     }
 }

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -13,7 +13,6 @@ import htsjdk.tribble.index.linear.LinearIndex;
 import htsjdk.tribble.index.tabix.TabixIndex;
 import htsjdk.tribble.util.LittleEndianOutputStream;
 import htsjdk.variant.vcf.VCFCodec;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.FileSystem;
@@ -63,7 +62,7 @@ public class IndexTest extends HtsjdkTest {
     @Test()
     public void testLoadFromStream() throws IOException {
         LinearIndex index = (LinearIndex)
-                IndexFactory.loadIndex(MassiveIndexFile.toString(), new FileInputStream(MassiveIndexFile.toFile()));
+                IndexFactory.loadIndex(MassiveIndexFile.toString(), Files.newInputStream(MassiveIndexFile));
         List<String> sequenceNames = index.getSequenceNames();
         Assert.assertEquals(sequenceNames.size(), 1);
         Assert.assertEquals(sequenceNames.get(0), CHR);

--- a/src/test/java/htsjdk/tribble/index/IndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/IndexTest.java
@@ -13,11 +13,11 @@ import htsjdk.tribble.index.linear.LinearIndex;
 import htsjdk.tribble.index.tabix.TabixIndex;
 import htsjdk.tribble.util.LittleEndianOutputStream;
 import htsjdk.variant.vcf.VCFCodec;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 
 public class IndexTest extends HtsjdkTest {
     private static final String CHR = "1";
-    private static final File MassiveIndexFile = new File(TestUtils.DATA_DIR + "Tb.vcf.idx");
+    private static final Path MassiveIndexFile = Path.of(TestUtils.DATA_DIR + "Tb.vcf.idx");
 
     @DataProvider(name = "StartProvider")
     public Object[][] makeStartProvider() {
@@ -40,7 +40,7 @@ public class IndexTest extends HtsjdkTest {
 
     @Test(dataProvider = "StartProvider")
     public void testMassiveQuery(final int start, final int mid, final int mid2, final int end) throws IOException {
-        LinearIndex index = (LinearIndex) IndexFactory.loadIndex(MassiveIndexFile.getAbsolutePath());
+        LinearIndex index = (LinearIndex) IndexFactory.loadIndex(MassiveIndexFile.toString());
 
         final List<Block> leftBlocks = index.getBlocks(CHR, start, mid);
         final List<Block> rightBlocks = index.getBlocks(CHR, mid2, end); // gap must be big to avoid overlaps
@@ -63,7 +63,7 @@ public class IndexTest extends HtsjdkTest {
     @Test()
     public void testLoadFromStream() throws IOException {
         LinearIndex index = (LinearIndex)
-                IndexFactory.loadIndex(MassiveIndexFile.getAbsolutePath(), new FileInputStream(MassiveIndexFile));
+                IndexFactory.loadIndex(MassiveIndexFile.toString(), new FileInputStream(MassiveIndexFile.toFile()));
         List<String> sequenceNames = index.getSequenceNames();
         Assert.assertEquals(sequenceNames.size(), 1);
         Assert.assertEquals(sequenceNames.get(0), CHR);
@@ -73,16 +73,16 @@ public class IndexTest extends HtsjdkTest {
     public Object[][] writeIndexData() {
         return new Object[][] {
             {
-                new File("src/test/resources/htsjdk/tribble/tabix/testTabixIndex.vcf"),
+                Path.of("src/test/resources/htsjdk/tribble/tabix/testTabixIndex.vcf"),
                 IndexFactory.IndexType.LINEAR,
                 new VCFCodec()
             },
             {
-                new File("src/test/resources/htsjdk/tribble/tabix/testTabixIndex.vcf.gz"),
+                Path.of("src/test/resources/htsjdk/tribble/tabix/testTabixIndex.vcf.gz"),
                 IndexFactory.IndexType.TABIX,
                 new VCFCodec()
             },
-            {new File("src/test/resources/htsjdk/tribble/test.bed"), IndexFactory.IndexType.LINEAR, new BEDCodec()}
+            {Path.of("src/test/resources/htsjdk/tribble/test.bed"), IndexFactory.IndexType.LINEAR, new BEDCodec()}
         };
     }
 
@@ -92,22 +92,22 @@ public class IndexTest extends HtsjdkTest {
     };
 
     @Test(dataProvider = "writeIndexData")
-    public void testWriteIndex(final File inputFile, final IndexFactory.IndexType type, final FeatureCodec codec)
+    public void testWriteIndex(final Path inputFile, final IndexFactory.IndexType type, final FeatureCodec codec)
             throws Exception {
         // temp index file for this test
-        final File tempIndex = File.createTempFile(
+        final Path tempIndex = Files.createTempFile(
                 "index",
                 (type == IndexFactory.IndexType.TABIX) ? FileExtensions.TABIX_INDEX : FileExtensions.TRIBBLE_INDEX);
-        tempIndex.delete();
-        tempIndex.deleteOnExit();
+        Files.delete(tempIndex);
+        tempIndex.toFile().deleteOnExit();
         // create the index
         final Index index = IndexFactory.createIndex(inputFile, codec, type);
-        Assert.assertFalse(tempIndex.exists());
+        Assert.assertFalse(Files.exists(tempIndex));
         // write the index to a file
         index.write(tempIndex);
-        Assert.assertTrue(tempIndex.exists());
+        Assert.assertTrue(Files.exists(tempIndex));
         // load the generated index
-        final Index loadedIndex = IndexFactory.loadIndex(tempIndex.getAbsolutePath());
+        final Index loadedIndex = IndexFactory.loadIndex(tempIndex.toString());
         // TODO: This is just a smoke test; it can pass even if the generated index is unusable for queries.
         // test that the sequences and properties are the same
         Assert.assertEquals(loadedIndex.getSequenceNames(), index.getSequenceNames());
@@ -117,12 +117,12 @@ public class IndexTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "writeIndexData")
-    public void testWritePathIndex(final File inputFile, final IndexFactory.IndexType type, final FeatureCodec codec)
+    public void testWritePathIndex(final Path inputFile, final IndexFactory.IndexType type, final FeatureCodec codec)
             throws Exception {
         try (final FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
             // create the index
             final Index index = IndexFactory.createIndex(inputFile, codec, type);
-            final Path path = fs.getPath(inputFile.getName() + ".index");
+            final Path path = fs.getPath(inputFile.getFileName().toString() + ".index");
             // write the index to a file
             index.write(path);
 
@@ -143,11 +143,11 @@ public class IndexTest extends HtsjdkTest {
 
     @Test(dataProvider = "writeIndexData")
     public void testWriteBasedOnNonRegularFeatureFile(
-            final File inputFile, final IndexFactory.IndexType type, final FeatureCodec codec) throws Exception {
-        final File tmpFolder = IOUtil.createTempDir("NonRegultarFeatureFile").toFile();
+            final Path inputFile, final IndexFactory.IndexType type, final FeatureCodec codec) throws Exception {
+        final Path tmpFolder = IOUtil.createTempDir("NonRegultarFeatureFile");
         // create the index
         final Index index = IndexFactory.createIndex(inputFile, codec, type);
         // try to write based on the tmpFolder
-        Assert.assertThrows(IOException.class, () -> index.writeBasedOnFeatureFile(tmpFolder));
+        Assert.assertThrows(IOException.class, () -> index.writeBasedOnFeaturePath(tmpFolder));
     }
 }

--- a/src/test/java/htsjdk/tribble/index/interval/IntervalTreeTest.java
+++ b/src/test/java/htsjdk/tribble/index/interval/IntervalTreeTest.java
@@ -28,8 +28,8 @@ import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileReader;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -128,7 +128,7 @@ public class IntervalTreeTest extends HtsjdkTest {
 
         // Interval tree index
         int batchSize = 1;
-        Index idx = IndexFactory.createIntervalIndex(new File(bedFile), new BEDCodec(), batchSize);
+        Index idx = IndexFactory.createIntervalIndex(Path.of(bedFile), new BEDCodec(), batchSize);
 
         FeatureReader<BEDFeature> bfr = AbstractFeatureReader.getFeatureReader(bedFile, new BEDCodec(), idx);
         CloseableTribbleIterator<BEDFeature> iter = bfr.query(chr, start, end);

--- a/src/test/java/htsjdk/tribble/index/linear/LinearIndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/linear/LinearIndexTest.java
@@ -28,8 +28,8 @@ import htsjdk.tribble.bed.BEDFeature;
 import htsjdk.tribble.index.Block;
 import htsjdk.tribble.index.Index;
 import htsjdk.tribble.index.IndexFactory;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -39,7 +39,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class LinearIndexTest extends HtsjdkTest {
-    private static final File RANDOM_FILE = new File("notMeaningful");
+    private static final Path RANDOM_FILE = Path.of("notMeaningful");
 
     private static final Block CHR1_B1 = new Block(1, 10);
     private static final Block CHR1_B2 = new Block(10, 20);
@@ -92,7 +92,7 @@ public class LinearIndexTest extends HtsjdkTest {
         Assert.assertTrue(idx.containsChromosome("chr2"));
         Assert.assertFalse(idx.containsChromosome("chr3"));
 
-        Assert.assertEquals(idx.getIndexedFile(), new File(RANDOM_FILE.getAbsolutePath()));
+        Assert.assertEquals(idx.getIndexedPath(), RANDOM_FILE.toAbsolutePath());
 
         Assert.assertNotNull(idx.getBlocks("chr1"));
         Assert.assertEquals(idx.getBlocks("chr1").size(), 3);
@@ -161,14 +161,14 @@ public class LinearIndexTest extends HtsjdkTest {
         for (int i = 0; i < qBlocks.size(); i++) Assert.assertEquals(qBlocks.get(i), eBlocks.get(i));
     }
 
-    File fakeBed = new File(TestUtils.DATA_DIR + "fakeBed.bed");
+    Path fakeBed = Path.of(TestUtils.DATA_DIR + "fakeBed.bed");
 
     @Test
     public void oneEntryFirstChr() {
         final BEDCodec code = new BEDCodec();
         final Index index = IndexFactory.createLinearIndex(fakeBed, code);
         final AbstractFeatureReader reader =
-                AbstractFeatureReader.getFeatureReader(fakeBed.getAbsolutePath(), code, index);
+                AbstractFeatureReader.getFeatureReader(fakeBed.toAbsolutePath().toString(), code, index);
 
         try {
             final CloseableTribbleIterator it = reader.iterator();
@@ -210,7 +210,7 @@ public class LinearIndexTest extends HtsjdkTest {
         // Linear binned index
         LinearIndex.enableAdaptiveIndexing = false;
         final int binSize = 1000;
-        Index idx = IndexFactory.createLinearIndex(new File(bedFile), new BEDCodec(), binSize);
+        Index idx = IndexFactory.createLinearIndex(Path.of(bedFile), new BEDCodec(), binSize);
 
         FeatureReader<BEDFeature> bfr = AbstractFeatureReader.getFeatureReader(bedFile, new BEDCodec(), idx);
         CloseableTribbleIterator<BEDFeature> iter = bfr.query(chr, start, end);
@@ -226,7 +226,7 @@ public class LinearIndexTest extends HtsjdkTest {
 
         // Repeat with adaptive indexing
         LinearIndex.enableAdaptiveIndexing = true;
-        idx = IndexFactory.createLinearIndex(new File(bedFile), new BEDCodec(), binSize);
+        idx = IndexFactory.createLinearIndex(Path.of(bedFile), new BEDCodec(), binSize);
 
         bfr = AbstractFeatureReader.getFeatureReader(bedFile, new BEDCodec(), idx);
         iter = bfr.query(chr, start, end);

--- a/src/test/java/htsjdk/tribble/index/tabix/TabixIndexTest.java
+++ b/src/test/java/htsjdk/tribble/index/tabix/TabixIndexTest.java
@@ -23,7 +23,6 @@
  */
 package htsjdk.tribble.index.tabix;
 
-import com.google.common.io.Files;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import htsjdk.samtools.util.FileExtensions;
@@ -42,8 +41,9 @@ import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFFileReader;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -52,8 +52,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class TabixIndexTest extends HtsjdkTest {
-    private static final File SMALL_TABIX_FILE = new File(TestUtils.DATA_DIR, "tabix/trioDup.vcf.gz.tbi");
-    private static final File BIGGER_TABIX_FILE = new File(TestUtils.DATA_DIR, "tabix/bigger.vcf.gz.tbi");
+    private static final Path SMALL_TABIX_FILE = Path.of(TestUtils.DATA_DIR, "tabix/trioDup.vcf.gz.tbi");
+    private static final Path BIGGER_TABIX_FILE = Path.of(TestUtils.DATA_DIR, "tabix/bigger.vcf.gz.tbi");
 
     /**
      * Read an existing index from disk, write it to a temp file, read that in, and assert that both in-memory
@@ -61,13 +61,14 @@ public class TabixIndexTest extends HtsjdkTest {
      * compression differences.
      */
     @Test(dataProvider = "readWriteTestDataProvider")
-    public void readWriteTest(final File tabixFile) throws Exception {
+    public void readWriteTest(final Path tabixFile) throws Exception {
         final TabixIndex index = new TabixIndex(tabixFile);
-        final File indexFile = File.createTempFile("TabixIndexTest.", FileExtensions.TABIX_INDEX);
-        indexFile.deleteOnExit();
-        final LittleEndianOutputStream los = new LittleEndianOutputStream(new BlockCompressedOutputStream(indexFile));
-        index.write(los);
-        los.close();
+        final Path indexFile = Files.createTempFile("TabixIndexTest.", FileExtensions.TABIX_INDEX);
+        indexFile.toFile().deleteOnExit();
+        try (final LittleEndianOutputStream los = new LittleEndianOutputStream(
+                new BlockCompressedOutputStream(Files.newOutputStream(indexFile), (Path) null))) {
+            index.write(los);
+        }
         final TabixIndex index2 = new TabixIndex(indexFile);
         Assert.assertEquals(index, index2);
         // Unfortunately, can't do byte comparison of original file and temp file, because 1) different compression
@@ -85,12 +86,12 @@ public class TabixIndexTest extends HtsjdkTest {
     public void testQueryProvidedItemsAmount() throws IOException {
         final String VCF = "src/test/resources/htsjdk/tribble/tabix/YRI.trio.2010_07.indel.sites.vcf";
         // Note that we store only compressed files
-        final File plainTextVcfInputFile = new File(VCF);
-        plainTextVcfInputFile.deleteOnExit();
-        final File plainTextVcfIndexFile = new File(VCF + ".tbi");
-        plainTextVcfIndexFile.deleteOnExit();
-        final File compressedVcfInputFile = new File(VCF + ".gz");
-        final File compressedTbiIndexFile = new File(VCF + ".gz.tbi");
+        final Path plainTextVcfInputFile = Path.of(VCF);
+        plainTextVcfInputFile.toFile().deleteOnExit();
+        final Path plainTextVcfIndexFile = Path.of(VCF + ".tbi");
+        plainTextVcfIndexFile.toFile().deleteOnExit();
+        final Path compressedVcfInputFile = Path.of(VCF + ".gz");
+        final Path compressedTbiIndexFile = Path.of(VCF + ".gz.tbi");
         final VCFFileReader compressedVcfReader = new VCFFileReader(compressedVcfInputFile, compressedTbiIndexFile);
 
         // create plain text VCF without "index on the fly" option
@@ -157,46 +158,45 @@ public class TabixIndexTest extends HtsjdkTest {
         return new Object[][] {
             new Object[] {
                 // BGZP BED file with no header, 2 features
-                new File(TestUtils.DATA_DIR, "bed/2featuresNoHeader.bed.gz"),
+                Path.of(TestUtils.DATA_DIR, "bed/2featuresNoHeader.bed.gz"),
                 Arrays.asList(new Interval("chr1", 1, 10), new Interval("chr1", 100, 1000000))
             },
             new Object[] {
                 // BGZP BED file with no header, 3 features; one feature falls in between the query intervals
-                new File(TestUtils.DATA_DIR, "bed/3featuresNoHeader.bed.gz"),
+                Path.of(TestUtils.DATA_DIR, "bed/3featuresNoHeader.bed.gz"),
                 Arrays.asList(new Interval("chr1", 1, 10), new Interval("chr1", 100, 1000000))
             },
             new Object[] {
                 // same file as above (BGZP BED file with no header, 3 features), but change the query to return
                 // only the single interval for the feature that falls in between the other features
-                new File(TestUtils.DATA_DIR, "bed/3featuresNoHeader.bed.gz"),
-                Arrays.asList(new Interval("chr1", 15, 20))
+                Path.of(TestUtils.DATA_DIR, "bed/3featuresNoHeader.bed.gz"), Arrays.asList(new Interval("chr1", 15, 20))
             },
             new Object[] {
                 // BGZP BED file with one line header, 2 features
-                new File(TestUtils.DATA_DIR, "bed/2featuresWithHeader.bed.gz"),
+                Path.of(TestUtils.DATA_DIR, "bed/2featuresWithHeader.bed.gz"),
                 Arrays.asList(new Interval("chr1", 1, 10), new Interval("chr1", 100, 1000000))
             },
         };
     }
 
     @Test(dataProvider = "bedTabixIndexTestData")
-    public void testBedTabixIndex(final File inputBed, final List<Interval> queryIntervals) throws Exception {
+    public void testBedTabixIndex(final Path inputBed, final List<Interval> queryIntervals) throws Exception {
         // copy the input file and create an index for the copy
-        final File tempDir = IOUtil.createTempDir("testBedTabixIndex.tmp").toFile();
-        tempDir.deleteOnExit();
-        final File tmpBed = new File(tempDir, inputBed.getName());
+        final Path tempDir = IOUtil.createTempDir("testBedTabixIndex.tmp");
+        tempDir.toFile().deleteOnExit();
+        final Path tmpBed = tempDir.resolve(inputBed.getFileName().toString());
         Files.copy(inputBed, tmpBed);
-        tmpBed.deleteOnExit();
+        tmpBed.toFile().deleteOnExit();
         final TabixIndex tabixIndexGz = IndexFactory.createTabixIndex(tmpBed, new BEDCodec(), null);
-        tabixIndexGz.writeBasedOnFeatureFile(tmpBed);
-        final File tmpIndex = Tribble.tabixIndexFile(tmpBed);
-        tmpIndex.deleteOnExit();
+        tabixIndexGz.writeBasedOnFeaturePath(tmpBed);
+        final Path tmpIndex = Tribble.tabixIndexPath(tmpBed);
+        tmpIndex.toFile().deleteOnExit();
 
         // iterate over the query intervals and validate the query results
-        try (final FeatureReader<BEDFeature> originalReader =
-                        AbstractFeatureReader.getFeatureReader(inputBed.getAbsolutePath(), new BEDCodec());
-                final FeatureReader<BEDFeature> createdReader =
-                        AbstractFeatureReader.getFeatureReader(tmpBed.getAbsolutePath(), new BEDCodec())) {
+        try (final FeatureReader<BEDFeature> originalReader = AbstractFeatureReader.getFeatureReader(
+                        inputBed.toAbsolutePath().toString(), new BEDCodec());
+                final FeatureReader<BEDFeature> createdReader = AbstractFeatureReader.getFeatureReader(
+                        tmpBed.toAbsolutePath().toString(), new BEDCodec())) {
             for (final Interval interval : queryIntervals) {
                 final Iterator<BEDFeature> originalIt =
                         originalReader.query(interval.getContig(), interval.getStart(), interval.getEnd());

--- a/src/test/java/htsjdk/tribble/index/tabix/TbiEqualityChecker.java
+++ b/src/test/java/htsjdk/tribble/index/tabix/TbiEqualityChecker.java
@@ -60,12 +60,12 @@ public class TbiEqualityChecker {
         this.tbiFile1 = tbiFile1;
         this.tbiFile2 = tbiFile2;
 
-        this.blockStream = new BlockCompressedInputStream(vcfFile.toFile());
+        this.blockStream = new BlockCompressedInputStream(vcfFile);
     }
 
     private void assertEquals(boolean identical) throws IOException {
-        TabixIndex tbi1 = (TabixIndex) IndexFactory.loadIndex(tbiFile1.toFile().getPath());
-        TabixIndex tbi2 = (TabixIndex) IndexFactory.loadIndex(tbiFile2.toFile().getPath());
+        TabixIndex tbi1 = (TabixIndex) IndexFactory.loadIndex(tbiFile1.toString());
+        TabixIndex tbi2 = (TabixIndex) IndexFactory.loadIndex(tbiFile2.toString());
 
         Assert.assertEquals(tbi1.getSequenceNames(), tbi2.getSequenceNames(), "Sequences");
 

--- a/src/test/java/htsjdk/tribble/readers/AsciiLineReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/AsciiLineReaderTest.java
@@ -7,8 +7,9 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.tribble.TestUtils;
 import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -25,8 +26,8 @@ public class AsciiLineReaderTest extends HtsjdkTest {
      */
     @Test
     public void testReadLines() throws Exception {
-        String filePath = TestUtils.DATA_DIR + "gwas/smallp.gwas";
-        InputStream is = new FileInputStream(filePath);
+        Path filePath = Path.of(TestUtils.DATA_DIR, "gwas/smallp.gwas");
+        InputStream is = Files.newInputStream(filePath);
         AsciiLineReader reader = AsciiLineReader.from(is);
         int actualLines = 0;
         int expectedNumber = 20;

--- a/src/test/java/htsjdk/tribble/readers/BlockCompressedAsciiLineReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/BlockCompressedAsciiLineReaderTest.java
@@ -5,8 +5,9 @@ import htsjdk.samtools.util.BlockCompressedFilePointerUtil;
 import htsjdk.samtools.util.BlockCompressedInputStream;
 import htsjdk.samtools.util.BlockCompressedOutputStream;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -16,8 +17,8 @@ public class BlockCompressedAsciiLineReaderTest extends HtsjdkTest {
 
     @Test
     public void testLineReaderPosition() throws IOException {
-        final File multiBlockFile = File.createTempFile("BlockCompressedAsciiLineReaderTest", ".gz");
-        multiBlockFile.deleteOnExit();
+        final Path multiBlockFile = Files.createTempFile("BlockCompressedAsciiLineReaderTest", ".gz");
+        multiBlockFile.toFile().deleteOnExit();
 
         // write a file that has more than a single compressed block
         final long expectedFinalLineOffset = populateMultiBlockCompressedFile(multiBlockFile);
@@ -43,8 +44,8 @@ public class BlockCompressedAsciiLineReaderTest extends HtsjdkTest {
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testRejectPositionalInputStream() throws IOException {
-        final File multiBlockFile = File.createTempFile("BlockCompressedAsciiLineReaderTest", ".gz");
-        multiBlockFile.deleteOnExit();
+        final Path multiBlockFile = Files.createTempFile("BlockCompressedAsciiLineReaderTest", ".gz");
+        multiBlockFile.toFile().deleteOnExit();
         populateMultiBlockCompressedFile(multiBlockFile);
 
         try (final BlockCompressedInputStream bcis = new BlockCompressedInputStream(multiBlockFile);
@@ -54,7 +55,7 @@ public class BlockCompressedAsciiLineReaderTest extends HtsjdkTest {
     }
 
     // Populate a block compressed file so that has more than a single compressed block
-    private long populateMultiBlockCompressedFile(final File tempBlockCompressedFile) throws IOException {
+    private long populateMultiBlockCompressedFile(final Path tempBlockCompressedFile) throws IOException {
         long sentinelLineOffset = -1;
 
         try (BlockCompressedOutputStream bcos = new BlockCompressedOutputStream(tempBlockCompressedFile)) {

--- a/src/test/java/htsjdk/tribble/readers/LongLineBufferedReaderTest.java
+++ b/src/test/java/htsjdk/tribble/readers/LongLineBufferedReaderTest.java
@@ -3,8 +3,9 @@ package htsjdk.tribble.readers;
 import htsjdk.HtsjdkTest;
 import htsjdk.tribble.TestUtils;
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -20,10 +21,10 @@ public class LongLineBufferedReaderTest extends HtsjdkTest {
      */
     @Test
     public void testReadLines() throws Exception {
-        String filePath = TestUtils.DATA_DIR + "large.txt";
-        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(filePath)));
+        Path filePath = Path.of(TestUtils.DATA_DIR, "large.txt");
+        BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(filePath)));
         LongLineBufferedReader testReader =
-                new LongLineBufferedReader(new InputStreamReader(new FileInputStream(filePath)));
+                new LongLineBufferedReader(new InputStreamReader(Files.newInputStream(filePath)));
         String line;
         while ((line = reader.readLine()) != null) {
             Assert.assertEquals(testReader.readLine(), line);

--- a/src/test/java/htsjdk/tribble/readers/PositionalBufferedStreamTest.java
+++ b/src/test/java/htsjdk/tribble/readers/PositionalBufferedStreamTest.java
@@ -3,9 +3,9 @@ package htsjdk.tribble.readers;
 import htsjdk.HtsjdkTest;
 import htsjdk.tribble.TestUtils;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,9 +26,9 @@ public class PositionalBufferedStreamTest extends HtsjdkTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        File fi = new File(TestUtils.DATA_DIR + "test.bed");
-        FileIs = new FileInputStream(fi);
-        expectedBytes = fi.length();
+        Path fi = Path.of(TestUtils.DATA_DIR, "test.bed");
+        FileIs = Files.newInputStream(fi);
+        expectedBytes = Files.size(fi);
     }
 
     @AfterMethod

--- a/src/test/java/htsjdk/tribble/readers/SynchronousLineReaderUnitTest.java
+++ b/src/test/java/htsjdk/tribble/readers/SynchronousLineReaderUnitTest.java
@@ -3,9 +3,10 @@ package htsjdk.tribble.readers;
 import htsjdk.HtsjdkTest;
 import htsjdk.tribble.TestUtils;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -15,10 +16,10 @@ import org.testng.annotations.Test;
 public class SynchronousLineReaderUnitTest extends HtsjdkTest {
     @Test
     public void testLineReaderIterator_streamConstructor() throws Exception {
-        final File filePath = new File(TestUtils.DATA_DIR + "gwas/smallp.gwas");
+        final Path filePath = Paths.get(TestUtils.DATA_DIR + "gwas/smallp.gwas");
         final LineIterator lineIterator = new LineIteratorImpl(
-                new SynchronousLineReader(new PositionalBufferedStream(new FileInputStream(filePath))));
-        final BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filePath)));
+                new SynchronousLineReader(new PositionalBufferedStream(Files.newInputStream(filePath))));
+        final BufferedReader br = new BufferedReader(new InputStreamReader(Files.newInputStream(filePath)));
 
         while (lineIterator.hasNext()) {
             Assert.assertEquals(lineIterator.next(), br.readLine());
@@ -28,10 +29,10 @@ public class SynchronousLineReaderUnitTest extends HtsjdkTest {
 
     @Test
     public void testLineReaderIterator_readerConstructor() throws Exception {
-        final File filePath = new File(TestUtils.DATA_DIR + "gwas/smallp.gwas");
+        final Path filePath = Paths.get(TestUtils.DATA_DIR + "gwas/smallp.gwas");
         final LineIterator lineIterator = new LineIteratorImpl(new SynchronousLineReader(
-                new InputStreamReader(new PositionalBufferedStream(new FileInputStream(filePath)))));
-        final BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(filePath)));
+                new InputStreamReader(new PositionalBufferedStream(Files.newInputStream(filePath)))));
+        final BufferedReader br = new BufferedReader(new InputStreamReader(Files.newInputStream(filePath)));
 
         while (lineIterator.hasNext()) {
             Assert.assertEquals(lineIterator.next(), br.readLine());

--- a/src/test/java/htsjdk/tribble/util/ParsingUtilsTest.java
+++ b/src/test/java/htsjdk/tribble/util/ParsingUtilsTest.java
@@ -3,7 +3,6 @@ package htsjdk.tribble.util;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
-import htsjdk.samtools.util.IOUtil;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
@@ -122,19 +121,19 @@ public class ParsingUtilsTest extends HtsjdkTest {
 
     @Test
     public void testFileDoesExist() throws IOException {
-        File tempFile = File.createTempFile(getClass().getSimpleName(), ".tmp");
-        tempFile.deleteOnExit();
-        testExists(tempFile.getAbsolutePath(), true);
-        testExists(tempFile.toURI().toString(), true);
+        Path tempFile = Files.createTempFile(getClass().getSimpleName(), ".tmp");
+        tempFile.toFile().deleteOnExit();
+        testExists(tempFile.toAbsolutePath().toString(), true);
+        testExists(tempFile.toUri().toString(), true);
         ;
     }
 
     @Test
     public void testFileDoesNotExist() throws IOException {
-        File tempFile = File.createTempFile(getClass().getSimpleName(), ".tmp");
-        tempFile.delete();
-        testExists(tempFile.getAbsolutePath(), false);
-        testExists(tempFile.toURI().toString(), false);
+        Path tempFile = Files.createTempFile(getClass().getSimpleName(), ".tmp");
+        Files.delete(tempFile);
+        testExists(tempFile.toAbsolutePath().toString(), false);
+        testExists(tempFile.toUri().toString(), false);
     }
 
     @Test
@@ -180,13 +179,13 @@ public class ParsingUtilsTest extends HtsjdkTest {
 
     @Test
     public void testFileOpenInputStream() throws IOException {
-        File tempFile = File.createTempFile(getClass().getSimpleName(), ".tmp");
-        tempFile.deleteOnExit();
-        try (Writer writer = new BufferedWriter(new OutputStreamWriter(IOUtil.openFileForWriting(tempFile)))) {
+        Path tempFile = Files.createTempFile(getClass().getSimpleName(), ".tmp");
+        tempFile.toFile().deleteOnExit();
+        try (Writer writer = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(tempFile)))) {
             writer.write("hello");
         }
-        testStream(tempFile.getAbsolutePath());
-        testStream(tempFile.toURI().toString());
+        testStream(tempFile.toAbsolutePath().toString());
+        testStream(tempFile.toUri().toString());
     }
 
     @Test

--- a/src/test/java/htsjdk/utils/SamtoolsTestUtilsTest.java
+++ b/src/test/java/htsjdk/utils/SamtoolsTestUtilsTest.java
@@ -9,8 +9,8 @@ import htsjdk.samtools.SamReaderFactory;
 import htsjdk.samtools.ValidationStringency;
 import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.samtools.util.ProcessExecutor;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -90,14 +90,14 @@ public class SamtoolsTestUtilsTest extends HtsjdkTest {
         }
 
         // Validates CRAM conversion.
-        final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/samtools/cram");
-        final File sourceFile = new File(TEST_DATA_DIR, "cramQueryWithBAI.cram");
-        final File cramReference = new File(TEST_DATA_DIR, "human_g1k_v37.20.21.10M-10M200k.fasta");
+        final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/samtools/cram");
+        final Path sourceFile = TEST_DATA_DIR.resolve("cramQueryWithBAI.cram");
+        final Path cramReference = TEST_DATA_DIR.resolve("human_g1k_v37.20.21.10M-10M200k.fasta");
         // This also validates that any extra command line arguments are passed through to samtools by requesting
         // that NM/MD values are synthesized in the output file (which is required for the output records to match).
         final IOPath tempSamtoolsPath = SamtoolsTestUtils.convertToCRAM(
-                new HtsPath(sourceFile.getAbsolutePath()),
-                new HtsPath(cramReference.getAbsolutePath()),
+                new HtsPath(sourceFile.toAbsolutePath().toString()),
+                new HtsPath(cramReference.toAbsolutePath().toString()),
                 "--input-fmt-option decode_md=1 --output-fmt-option store_md=1 --output-fmt-option store_nm=1");
         final SamReaderFactory factory = SamReaderFactory.makeDefault()
                 .validationStringency(ValidationStringency.LENIENT)

--- a/src/test/java/htsjdk/variant/PrintVariantsExampleTest.java
+++ b/src/test/java/htsjdk/variant/PrintVariantsExampleTest.java
@@ -29,9 +29,9 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.variant.example.PrintVariantsExample;
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.testng.Assert;
@@ -40,19 +40,21 @@ import org.testng.annotations.Test;
 public class PrintVariantsExampleTest extends HtsjdkTest {
     @Test
     public void testExampleWriteFile() throws IOException {
-        final File tempFile = File.createTempFile("example", FileExtensions.VCF);
-        tempFile.deleteOnExit();
-        File f1 = new File(
+        final Path tempFile = Files.createTempFile("example", FileExtensions.VCF);
+        tempFile.toFile().deleteOnExit();
+        Path f1 = Path.of(
                 "src/test/resources/htsjdk/variant/ILLUMINA.wex.broad_phase2_baseline.20111114.both.exome.genotypes.1000.vcf");
-        final String[] args = {f1.getAbsolutePath(), tempFile.getAbsolutePath()};
-        Assert.assertEquals(tempFile.length(), 0);
+        final String[] args = {
+            f1.toAbsolutePath().toString(), tempFile.toAbsolutePath().toString()
+        };
+        Assert.assertEquals(Files.size(tempFile), 0);
         PrintVariantsExample.main(args);
-        Assert.assertNotEquals(tempFile.length(), 0);
+        Assert.assertNotEquals(Files.size(tempFile), 0);
 
         assertFilesEqualSkipHeaders(tempFile, f1);
     }
 
-    private void assertFilesEqualSkipHeaders(File tempFile, File f1) throws FileNotFoundException {
+    private void assertFilesEqualSkipHeaders(Path tempFile, Path f1) {
         final List<String> lines1 = IOUtil.slurpLines(f1);
         final List<String> lines2 = IOUtil.slurpLines(tempFile);
         final int firstNonComment1 = IntStream.range(0, lines1.size())

--- a/src/test/java/htsjdk/variant/VariantBaseTest.java
+++ b/src/test/java/htsjdk/variant/VariantBaseTest.java
@@ -35,8 +35,8 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFConstants;
 import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,19 +52,19 @@ import org.testng.Assert;
 public class VariantBaseTest extends HtsjdkTest {
 
     public static final String variantTestDataRoot =
-            new File("src/test/resources/htsjdk/variant/").getAbsolutePath() + "/";
+            Path.of("src/test/resources/htsjdk/variant/").toAbsolutePath() + "/";
 
     /**
      * Creates a temp file that will be deleted on exit after tests are complete.
      * @param name Prefix of the file.
      * @param extension Extension to concat to the end of the file.
-     * @return A file in the temporary directory starting with name, ending with extension, which will be deleted after the program exits.
+     * @return A Path in the temporary directory starting with name, ending with extension, which will be deleted after the program exits.
      */
-    public static File createTempFile(String name, String extension) {
+    public static Path createTempFile(String name, String extension) {
         try {
-            File file = File.createTempFile(name, extension);
-            file.deleteOnExit();
-            return file;
+            Path path = Files.createTempFile(name, extension);
+            path.toFile().deleteOnExit();
+            return path;
         } catch (IOException ex) {
             throw new RuntimeException("Cannot create temp file: " + ex.getMessage(), ex);
         }

--- a/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCF2WriterUnitTest.java
@@ -39,9 +39,9 @@ import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.variantcontext.VariantContextTestProvider;
 import htsjdk.variant.variantcontext.writer.*;
 import htsjdk.variant.vcf.*;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -63,7 +63,7 @@ import org.testng.annotations.Test;
  */
 public class BCF2WriterUnitTest extends VariantBaseTest {
 
-    private File tempDir;
+    private Path tempDir;
 
     /**
      * create a fake header of known quantity
@@ -88,8 +88,8 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
 
     @BeforeClass
     private void createTemporaryDirectory() {
-        tempDir = TestUtil.getTempDirectory("BCFWriter", "StaleIndex");
-        tempDir.deleteOnExit();
+        tempDir = TestUtil.getTempDirectoryAsPath("BCFWriter", "StaleIndex");
+        tempDir.toFile().deleteOnExit();
     }
 
     /**
@@ -97,11 +97,11 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
      */
     @Test
     public void testWriteAndReadBCF() throws IOException {
-        final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
-        bcfOutputFile.deleteOnExit();
+        final Path bcfOutputFile = Files.createTempFile(tempDir, "testWriteAndReadVCF.", ".bcf");
+        bcfOutputFile.toFile().deleteOnExit();
         final VCFHeader header = createFakeHeader();
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(bcfOutputFile)
+                .setOutputPath(bcfOutputFile)
                 .setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
@@ -125,12 +125,12 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
      */
     @Test
     public void testWriteAndReadBCFWithIndex() throws IOException {
-        final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
-        bcfOutputFile.deleteOnExit();
-        Tribble.indexFile(bcfOutputFile).deleteOnExit();
+        final Path bcfOutputFile = Files.createTempFile(tempDir, "testWriteAndReadVCF.", ".bcf");
+        bcfOutputFile.toFile().deleteOnExit();
+        Tribble.indexPath(bcfOutputFile).toFile().deleteOnExit();
         final VCFHeader header = createFakeHeader();
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(bcfOutputFile)
+                .setOutputPath(bcfOutputFile)
                 .setReferenceDictionary(header.getSequenceDictionary())
                 .setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY))
                 .build()) {
@@ -154,15 +154,15 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
      */
     @Test
     public void testWriteAndReadBCFHeaderless() throws IOException {
-        final File bcfOutputFile = File.createTempFile("testWriteAndReadBCFWithHeader.", ".bcf", tempDir);
-        bcfOutputFile.deleteOnExit();
-        final File bcfOutputHeaderlessFile = File.createTempFile("testWriteAndReadBCFHeaderless.", ".bcf", tempDir);
-        bcfOutputHeaderlessFile.deleteOnExit();
+        final Path bcfOutputFile = Files.createTempFile(tempDir, "testWriteAndReadBCFWithHeader.", ".bcf");
+        bcfOutputFile.toFile().deleteOnExit();
+        final Path bcfOutputHeaderlessFile = Files.createTempFile(tempDir, "testWriteAndReadBCFHeaderless.", ".bcf");
+        bcfOutputHeaderlessFile.toFile().deleteOnExit();
 
         final VCFHeader header = createFakeHeader();
         // we write two files, bcfOutputFile with the header, and bcfOutputHeaderlessFile with just the body
         try (final VariantContextWriter fakeBCFFileWriter = new VariantContextWriterBuilder()
-                .setOutputFile(bcfOutputFile)
+                .setOutputPath(bcfOutputFile)
                 .setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
@@ -170,7 +170,7 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
         }
 
         try (final VariantContextWriter fakeBCFBodyFileWriter = new VariantContextWriterBuilder()
-                .setOutputFile(bcfOutputHeaderlessFile)
+                .setOutputPath(bcfOutputHeaderlessFile)
                 .setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
@@ -182,9 +182,9 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
         VariantContextTestProvider.VariantContextContainer container;
 
         try (final PositionalBufferedStream headerPbs =
-                        new PositionalBufferedStream(new FileInputStream(bcfOutputFile));
+                        new PositionalBufferedStream(Files.newInputStream(bcfOutputFile));
                 final PositionalBufferedStream bodyPbs =
-                        new PositionalBufferedStream(new FileInputStream(bcfOutputHeaderlessFile))) {
+                        new PositionalBufferedStream(Files.newInputStream(bcfOutputHeaderlessFile))) {
 
             BCF2Codec codec = new BCF2Codec();
             codec.readHeader(headerPbs);
@@ -205,13 +205,13 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
      */
     @Test
     public void testReadAndWritePhasedBCF() throws IOException {
-        final File vcfInputFile = new File("src/test/resources/htsjdk/variant/phased.vcf");
-        final File bcfOutputFile = File.createTempFile("testWriteAndReadBCFHeaderless.", ".bcf", tempDir);
-        bcfOutputFile.deleteOnExit();
+        final Path vcfInputFile = Path.of("src/test/resources/htsjdk/variant/phased.vcf");
+        final Path bcfOutputFile = Files.createTempFile(tempDir, "testWriteAndReadBCFHeaderless.", ".bcf");
+        bcfOutputFile.toFile().deleteOnExit();
 
         try (VCFFileReader vcfFile = new VCFFileReader(vcfInputFile);
                 VariantContextWriter bcfWriter = new VariantContextWriterBuilder()
-                        .setOutputFile(bcfOutputFile)
+                        .setOutputPath(bcfOutputFile)
                         .setReferenceDictionary(vcfFile.getFileHeader().getSequenceDictionary())
                         .build(); ) {
             bcfWriter.writeHeader(vcfFile.getFileHeader());
@@ -224,13 +224,13 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
             bcfWriter.close();
 
             // Reading the VCF and writing it to a BCF
-            final File vcfOutputFile = File.createTempFile("testWriteAndReadBCFHeaderless.", ".vcf", tempDir);
-            vcfOutputFile.deleteOnExit();
+            final Path vcfOutputFile = Files.createTempFile(tempDir, "testWriteAndReadBCFHeaderless.", ".vcf");
+            vcfOutputFile.toFile().deleteOnExit();
 
             try (final PositionalBufferedStream headerPbs =
-                            new PositionalBufferedStream(new FileInputStream(bcfOutputFile));
+                            new PositionalBufferedStream(Files.newInputStream(bcfOutputFile));
                     VariantContextWriter vcfWriter = new VariantContextWriterBuilder()
-                            .setOutputFile(vcfOutputFile)
+                            .setOutputPath(vcfOutputFile)
                             .setReferenceDictionary(vcfFile.getFileHeader().getSequenceDictionary())
                             .build(); ) {
                 vcfWriter.writeHeader(vcfFile.getFileHeader());
@@ -266,13 +266,13 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testWriteHeaderTwice() throws IOException {
-        final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
-        bcfOutputFile.deleteOnExit();
+        final Path bcfOutputFile = Files.createTempFile(tempDir, "testWriteAndReadVCF.", ".bcf");
+        bcfOutputFile.toFile().deleteOnExit();
 
         final VCFHeader header = createFakeHeader();
         // prevent writing header twice
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(bcfOutputFile)
+                .setOutputPath(bcfOutputFile)
                 .setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
@@ -283,13 +283,13 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingHeader() throws IOException {
-        final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
-        bcfOutputFile.deleteOnExit();
+        final Path bcfOutputFile = Files.createTempFile(tempDir, "testWriteAndReadVCF.", ".bcf");
+        bcfOutputFile.toFile().deleteOnExit();
 
         final VCFHeader header = createFakeHeader();
         // prevent changing header if it's already written
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(bcfOutputFile)
+                .setOutputPath(bcfOutputFile)
                 .setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {
@@ -300,13 +300,13 @@ public class BCF2WriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingBody() throws IOException {
-        final File bcfOutputFile = File.createTempFile("testWriteAndReadVCF.", ".bcf", tempDir);
-        bcfOutputFile.deleteOnExit();
+        final Path bcfOutputFile = Files.createTempFile(tempDir, "testWriteAndReadVCF.", ".bcf");
+        bcfOutputFile.toFile().deleteOnExit();
 
         final VCFHeader header = createFakeHeader();
         // prevent changing header if part of body is already written
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(bcfOutputFile)
+                .setOutputPath(bcfOutputFile)
                 .setReferenceDictionary(header.getSequenceDictionary())
                 .unsetOption(Options.INDEX_ON_THE_FLY)
                 .build()) {

--- a/src/test/java/htsjdk/variant/bcf2/BCFCodecTest.java
+++ b/src/test/java/htsjdk/variant/bcf2/BCFCodecTest.java
@@ -5,9 +5,9 @@ import htsjdk.tribble.TribbleException;
 import htsjdk.tribble.readers.PositionalBufferedStream;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -18,8 +18,8 @@ public class BCFCodecTest extends VariantBaseTest {
     @Test(expectedExceptions = TribbleException.class)
     private void testRejectBCFVersion22() throws IOException {
         BCF2Codec bcfCodec = new BCF2Codec();
-        try (final FileInputStream fis = new FileInputStream(new File(TEST_DATA_DIR, "BCFVersion22Uncompressed.bcf"));
-                final PositionalBufferedStream pbs = new PositionalBufferedStream(fis)) {
+        try (final PositionalBufferedStream pbs = new PositionalBufferedStream(
+                Files.newInputStream(Path.of(TEST_DATA_DIR, "BCFVersion22Uncompressed.bcf")))) {
             bcfCodec.readHeader(pbs);
         }
     }
@@ -36,8 +36,8 @@ public class BCFCodecTest extends VariantBaseTest {
 
         // the default BCF2Codec version compatibility policy is to reject BCF 2.2 input; but make sure we can
         // provide a codec that implements a more tolerant custom policy that accepts
-        try (final FileInputStream fis = new FileInputStream(new File(TEST_DATA_DIR, "BCFVersion22Uncompressed.bcf"));
-                final PositionalBufferedStream pbs = new PositionalBufferedStream(fis)) {
+        try (final PositionalBufferedStream pbs = new PositionalBufferedStream(
+                Files.newInputStream(Path.of(TEST_DATA_DIR, "BCFVersion22Uncompressed.bcf")))) {
             final FeatureCodecHeader featureCodecHeader = (FeatureCodecHeader) bcfCodec.readHeader(pbs);
             final VCFHeader vcfHeader = (VCFHeader) featureCodecHeader.getHeaderValue();
             Assert.assertNotEquals(vcfHeader.getMetaDataInInputOrder().size(), 0);

--- a/src/test/java/htsjdk/variant/utils/VCFHeaderReaderTest.java
+++ b/src/test/java/htsjdk/variant/utils/VCFHeaderReaderTest.java
@@ -4,8 +4,8 @@ import htsjdk.HtsjdkTest;
 import htsjdk.samtools.seekablestream.SeekableFileStream;
 import htsjdk.tribble.TribbleException;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -25,20 +25,20 @@ public class VCFHeaderReaderTest extends HtsjdkTest {
 
     @Test(dataProvider = "files")
     public void testReadHeaderFrom(final String file) throws IOException {
-        VCFHeader vcfHeader = VCFHeaderReader.readHeaderFrom(new SeekableFileStream(new File(file)));
+        VCFHeader vcfHeader = VCFHeaderReader.readHeaderFrom(new SeekableFileStream(Path.of(file)));
         Assert.assertNotNull(vcfHeader);
     }
 
     @DataProvider
     public Object[][] invalidFiles() {
         return new Object[][] {
-            {new File("src/test/resources/htsjdk/samtools/empty.bam")},
-            {new File("src/test/resources/htsjdk/variant/corrupt_file_that_starts_with_#.vcf")}
+            {Path.of("src/test/resources/htsjdk/samtools/empty.bam")},
+            {Path.of("src/test/resources/htsjdk/variant/corrupt_file_that_starts_with_#.vcf")}
         };
     }
 
     @Test(dataProvider = "invalidFiles", expectedExceptions = TribbleException.InvalidHeader.class)
-    public void testReadHeaderForInvalidFile(File file) throws IOException {
-        VCFHeaderReader.readHeaderFrom(new SeekableFileStream(file));
+    public void testReadHeaderForInvalidFile(Path path) throws IOException {
+        VCFHeaderReader.readHeaderFrom(new SeekableFileStream(path));
     }
 }

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextTestProvider.java
@@ -49,10 +49,9 @@ import htsjdk.variant.vcf.VCFHeaderLineCount;
 import htsjdk.variant.vcf.VCFHeaderLineType;
 import htsjdk.variant.vcf.VCFInfoHeaderLine;
 import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -88,17 +87,17 @@ public class VariantContextTestProvider extends HtsjdkTest {
     private static VariantContext ROOT;
     private static volatile boolean initialized = false;
 
-    private static final List<File> testSourceVCFs = new ArrayList<>();
+    private static final List<Path> testSourceVCFs = new ArrayList<>();
 
     static {
-        testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot
+        testSourceVCFs.add(Path.of(VariantBaseTest.variantTestDataRoot
                 + "ILLUMINA.wex.broad_phase2_baseline.20111114.both.exome.genotypes.1000.vcf"));
-        testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "ex2.vcf"));
-        testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "dbsnp_135.b37.1000.vcf"));
+        testSourceVCFs.add(Path.of(VariantBaseTest.variantTestDataRoot + "ex2.vcf"));
+        testSourceVCFs.add(Path.of(VariantBaseTest.variantTestDataRoot + "dbsnp_135.b37.1000.vcf"));
         if (ENABLE_SYMBOLIC_ALLELE_TESTS) {
-            testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "diagnosis_targets_testfile.vcf"));
-            testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "VQSR.mixedTest.recal"));
-            testSourceVCFs.add(new File(VariantBaseTest.variantTestDataRoot + "breakpoint.vcf"));
+            testSourceVCFs.add(Path.of(VariantBaseTest.variantTestDataRoot + "diagnosis_targets_testfile.vcf"));
+            testSourceVCFs.add(Path.of(VariantBaseTest.variantTestDataRoot + "VQSR.mixedTest.recal"));
+            testSourceVCFs.add(Path.of(VariantBaseTest.variantTestDataRoot + "breakpoint.vcf"));
         }
     }
 
@@ -129,9 +128,9 @@ public class VariantContextTestProvider extends HtsjdkTest {
 
         public abstract CODECTYPE makeCodec();
 
-        public abstract VariantContextWriter makeWriter(final File outputFile, final EnumSet<Options> baseOptions);
+        public abstract VariantContextWriter makeWriter(final Path outputPath, final EnumSet<Options> baseOptions);
 
-        public abstract VariantContextContainer readAllVCs(final File input) throws IOException;
+        public abstract VariantContextContainer readAllVCs(final Path input) throws IOException;
 
         public List<VariantContext> preprocess(final VCFHeader header, List<VariantContext> vcsBeforeIO) {
             return vcsBeforeIO;
@@ -198,9 +197,9 @@ public class VariantContextTestProvider extends HtsjdkTest {
 
     private static void makeEmpiricalTests() throws IOException {
         if (ENABLE_SOURCE_VCF_TESTS) {
-            for (final File file : testSourceVCFs) {
+            for (final Path path : testSourceVCFs) {
                 VCFCodec codec = new VCFCodec();
-                VariantContextContainer x = readAllVCs(file, codec);
+                VariantContextContainer x = readAllVCs(path, codec);
                 List<VariantContext> fullyDecoded = new ArrayList<>();
 
                 for (final VariantContext raw : x.getVCs()) {
@@ -683,9 +682,9 @@ public class VariantContextTestProvider extends HtsjdkTest {
                     // cannot handle symbolic alleles because they may be weird non-call VCFs
                     return;
 
-            final File tmpFile = File.createTempFile("testReaderWriter", tester.getExtension());
-            tmpFile.deleteOnExit();
-            Tribble.indexFile(tmpFile).deleteOnExit();
+            final Path tmpFile = Files.createTempFile("testReaderWriter", tester.getExtension());
+            tmpFile.toFile().deleteOnExit();
+            Tribble.indexPath(tmpFile).toFile().deleteOnExit();
 
             // write expected to disk
             final EnumSet<Options> options = EnumSet.of(Options.INDEX_ON_THE_FLY);
@@ -732,9 +731,9 @@ public class VariantContextTestProvider extends HtsjdkTest {
             final Iterable<VariantContext> vcs,
             final boolean recurse)
             throws IOException {
-        final File tmpFile = File.createTempFile("testReaderWriter", tester.getExtension());
-        tmpFile.deleteOnExit();
-        Tribble.indexFile(tmpFile).deleteOnExit();
+        final Path tmpFile = Files.createTempFile("testReaderWriter", tester.getExtension());
+        tmpFile.toFile().deleteOnExit();
+        Tribble.indexPath(tmpFile).toFile().deleteOnExit();
 
         // write expected to disk
         final EnumSet<Options> options = EnumSet.of(Options.INDEX_ON_THE_FLY);
@@ -794,12 +793,12 @@ public class VariantContextTestProvider extends HtsjdkTest {
         public void remove() {}
     }
 
-    public static VariantContextContainer readAllVCs(final File input, final BCF2Codec codec) throws IOException {
-        PositionalBufferedStream headerPbs = new PositionalBufferedStream(new FileInputStream(input));
+    public static VariantContextContainer readAllVCs(final Path input, final BCF2Codec codec) throws IOException {
+        PositionalBufferedStream headerPbs = new PositionalBufferedStream(Files.newInputStream(input));
         FeatureCodecHeader header = codec.readHeader(headerPbs);
         headerPbs.close();
 
-        final PositionalBufferedStream pbs = new PositionalBufferedStream(new FileInputStream(input));
+        final PositionalBufferedStream pbs = new PositionalBufferedStream(Files.newInputStream(input));
         pbs.skip(header.getHeaderEnd());
 
         final VCFHeader vcfHeader = (VCFHeader) header.getHeaderValue();
@@ -821,10 +820,9 @@ public class VariantContextTestProvider extends HtsjdkTest {
                 });
     }
 
-    public static VariantContextContainer readAllVCs(final File input, final VCFCodec codec)
-            throws FileNotFoundException {
+    public static VariantContextContainer readAllVCs(final Path input, final VCFCodec codec) throws IOException {
         final LineIterator lineIterator =
-                new LineIteratorImpl(new SynchronousLineReader(new BufferedInputStream(new FileInputStream(input))));
+                new LineIteratorImpl(new SynchronousLineReader(new BufferedInputStream(Files.newInputStream(input))));
         final VCFHeader vcfHeader = (VCFHeader) codec.readActualHeader(lineIterator);
         return new VariantContextTestProvider.VariantContextContainer(
                 vcfHeader, new VariantContextTestProvider.VCIterable<LineIterator>(codec, vcfHeader) {
@@ -840,9 +838,9 @@ public class VariantContextTestProvider extends HtsjdkTest {
                 });
     }
 
-    public static void assertVCFandBCFFilesAreTheSame(final File vcfFile, final File bcfFile) throws IOException {
-        final VariantContextContainer vcfData = readAllVCs(vcfFile, new VCFCodec());
-        final VariantContextContainer bcfData = readAllVCs(bcfFile, new BCF2Codec());
+    public static void assertVCFandBCFFilesAreTheSame(final Path vcfPath, final Path bcfPath) throws IOException {
+        final VariantContextContainer vcfData = readAllVCs(vcfPath, new VCFCodec());
+        final VariantContextContainer bcfData = readAllVCs(bcfPath, new BCF2Codec());
         assertEquals(bcfData.getHeader(), vcfData.getHeader());
         assertEquals(bcfData.getVCs(), vcfData.getVCs());
     }
@@ -1046,8 +1044,8 @@ public class VariantContextTestProvider extends HtsjdkTest {
     }
 
     public static void main(String argv[]) {
-        final File variants1 = new File(argv[0]);
-        final File variants2 = new File(argv[1]);
+        final Path variants1 = Path.of(argv[0]);
+        final Path variants2 = Path.of(argv[1]);
         try {
             VariantContextTestProvider.assertVCFandBCFFilesAreTheSame(variants1, variants2);
         } catch (IOException e) {

--- a/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/VariantContextUnitTest.java
@@ -36,7 +36,7 @@ import htsjdk.variant.bcf2.BCF2Codec;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFConstants;
 import htsjdk.variant.vcf.VCFFileReader;
-import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -1688,15 +1688,15 @@ public class VariantContextUnitTest extends VariantBaseTest {
     @DataProvider(name = "serializationTestData")
     public Object[][] getSerializationTestData() {
         return new Object[][] {
-            {new File("src/test/resources/htsjdk/variant/HiSeq.10000.vcf"), new VCFCodec()},
-            {new File("src/test/resources/htsjdk/variant/serialization_test.bcf"), new BCF2Codec()}
+            {Path.of("src/test/resources/htsjdk/variant/HiSeq.10000.vcf"), new VCFCodec()},
+            {Path.of("src/test/resources/htsjdk/variant/serialization_test.bcf"), new BCF2Codec()}
         };
     }
 
     @Test(dataProvider = "serializationTestData")
-    public void testSerialization(final File testFile, final FeatureCodec<VariantContext, ?> codec) throws Exception {
+    public void testSerialization(final Path testPath, final FeatureCodec<VariantContext, ?> codec) throws Exception {
         final AbstractFeatureReader<VariantContext, ?> featureReader =
-                AbstractFeatureReader.getFeatureReader(testFile.getAbsolutePath(), codec, false);
+                AbstractFeatureReader.getFeatureReader(testPath.toAbsolutePath().toString(), codec, false);
         final VariantContext initialVC = featureReader.iterator().next();
 
         final VariantContext vcDeserialized = TestUtil.serializeAndDeserialize(initialVC);
@@ -1781,11 +1781,11 @@ public class VariantContextUnitTest extends VariantBaseTest {
 
     @DataProvider(name = "structuralVariationsTestData")
     public Object[][] getStructuralVariationsTestData() {
-        return new Object[][] {{new File("src/test/resources/htsjdk/variant/structuralvariants.vcf")}};
+        return new Object[][] {{Path.of("src/test/resources/htsjdk/variant/structuralvariants.vcf")}};
     }
 
     @Test(dataProvider = "structuralVariationsTestData")
-    public void testExtractStructuralVariationsData(final File vcfFile) {
+    public void testExtractStructuralVariationsData(final Path vcfFile) {
         VCFFileReader reader = null;
         CloseableIterator<VariantContext> iter = null;
         try {

--- a/src/test/java/htsjdk/variant/variantcontext/filter/FilteringVariantContextIteratorTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/filter/FilteringVariantContextIteratorTest.java
@@ -27,7 +27,7 @@ package htsjdk.variant.variantcontext.filter;
 import htsjdk.HtsjdkTest;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCFFileReader;
-import java.io.File;
+import java.nio.file.Path;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
  * Tests for testing the (VariantContext)FilteringVariantContextIterator, and the HeterozygosityFilter
  */
 public class FilteringVariantContextIteratorTest extends HtsjdkTest {
-    final File testDir = new File("src/test/resources/htsjdk/variant");
+    final Path testDir = Path.of("src/test/resources/htsjdk/variant");
 
     @DataProvider
     public Object[][] filteringIteratorData() {
@@ -54,7 +54,7 @@ public class FilteringVariantContextIteratorTest extends HtsjdkTest {
     @Test(dataProvider = "filteringIteratorData")
     public void testFilteringIterator(final VariantContextFilter filter, final int expectedCount) {
 
-        final File vcf = new File(testDir, "ex2.vcf");
+        final Path vcf = testDir.resolve("ex2.vcf");
         final VCFFileReader vcfReader = new VCFFileReader(vcf, false);
         final FilteringVariantContextIterator filteringIterator =
                 new FilteringVariantContextIterator(vcfReader.iterator(), filter);
@@ -78,7 +78,7 @@ public class FilteringVariantContextIteratorTest extends HtsjdkTest {
     @Test(dataProvider = "badSampleData", expectedExceptions = IllegalArgumentException.class)
     public void testMissingSample(final String file, final String sample) {
 
-        final File vcf = new File(testDir, file);
+        final Path vcf = testDir.resolve(file);
         final VCFFileReader vcfReader = new VCFFileReader(vcf, false);
         final HeterozygosityFilter heterozygosityFilter = new HeterozygosityFilter(true, sample);
 

--- a/src/test/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilterTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/filter/JavascriptVariantFilterTest.java
@@ -30,11 +30,11 @@ import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.vcf.VCFContigHeaderLine;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -103,9 +103,9 @@ public class JavascriptVariantFilterTest extends HtsjdkTest {
 
     @Test
     public void fileConstructor_compilesAndRuns() throws IOException {
-        File scriptFile = File.createTempFile("filter", ".js");
-        scriptFile.deleteOnExit();
-        Files.writeString(scriptFile.toPath(), "true;", StandardCharsets.UTF_8);
+        Path scriptFile = Files.createTempFile("filter", ".js");
+        scriptFile.toFile().deleteOnExit();
+        Files.writeString(scriptFile, "true;", StandardCharsets.UTF_8);
         VCFHeader h = header();
         JavascriptVariantFilter f = new JavascriptVariantFilter(scriptFile, h);
         Assert.assertTrue(f.test(snv("chr1", 100, "A", "C")));

--- a/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/AsyncVariantContextWriterUnitTest.java
@@ -39,9 +39,10 @@ import htsjdk.variant.variantcontext.GenotypesContext;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextBuilder;
 import htsjdk.variant.vcf.*;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -64,24 +65,24 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
 
     @BeforeClass
     private void createTemporaryDirectory() {
-        File tempDir = TestUtil.getTempDirectory("VCFWriter", "StaleIndex");
-        tempDir.deleteOnExit();
+        Path tempDir = TestUtil.getTempDirectoryAsPath("VCFWriter", "StaleIndex");
+        tempDir.toFile().deleteOnExit();
     }
 
     /** test, using the writer and reader, that we can output and input a VCF body without problems */
     @Test
     public void testWriteAndReadAsyncVCFHeaderless() throws IOException {
-        final File fakeVCFFile =
+        final Path fakeVCFPath =
                 VariantBaseTest.createTempFile("testWriteAndReadAsyncVCFHeaderless.", FileExtensions.VCF);
-        fakeVCFFile.deleteOnExit();
+        fakeVCFPath.toFile().deleteOnExit();
 
-        Tribble.indexFile(fakeVCFFile).deleteOnExit();
+        Tribble.indexPath(fakeVCFPath).toFile().deleteOnExit();
         final Set<VCFHeaderLine> metaData = new HashSet<>();
         final Set<String> additionalColumns = new HashSet<>();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(fakeVCFFile)
+                .setOutputPath(fakeVCFPath)
                 .setReferenceDictionary(sequenceDict)
                 .setOptions(EnumSet.of(
                         Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY, Options.USE_ASYNC_IO))
@@ -93,7 +94,7 @@ public class AsyncVariantContextWriterUnitTest extends VariantBaseTest {
         final VCFCodec codec = new VCFCodec();
         codec.setVCFHeader(header, VCFHeaderVersion.VCF4_2);
 
-        try (final FileInputStream fis = new FileInputStream(fakeVCFFile)) {
+        try (final InputStream fis = Files.newInputStream(fakeVCFPath)) {
             final AsciiLineReaderIterator iterator = new AsciiLineReaderIterator(new AsciiLineReader(fis));
             int counter = 0;
             while (iterator.hasNext()) {

--- a/src/test/java/htsjdk/variant/variantcontext/writer/TabixOnTheFlyIndexCreationTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/TabixOnTheFlyIndexCreationTest.java
@@ -32,25 +32,26 @@ import htsjdk.tribble.index.tabix.TabixIndex;
 import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.vcf.VCF3Codec;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.EnumSet;
 import org.testng.annotations.Test;
 
 public class TabixOnTheFlyIndexCreationTest extends HtsjdkTest {
-    private static final File SMALL_VCF = new File("src/test/resources/htsjdk/tribble/tabix/trioDup.vcf.gz");
+    private static final Path SMALL_VCF = Path.of("src/test/resources/htsjdk/tribble/tabix/trioDup.vcf.gz");
 
     @Test
     public void simpleTest() throws Exception {
         final VCF3Codec codec = new VCF3Codec();
-        final FeatureReader<VariantContext> reader =
-                AbstractFeatureReader.getFeatureReader(SMALL_VCF.getAbsolutePath(), codec, false);
+        final FeatureReader<VariantContext> reader = AbstractFeatureReader.getFeatureReader(
+                SMALL_VCF.toAbsolutePath().toString(), codec, false);
         final VCFHeader headerFromFile = (VCFHeader) reader.getHeader();
-        final File vcf = File.createTempFile("TabixOnTheFlyIndexCreationTest.", FileExtensions.COMPRESSED_VCF);
-        final File tabix = new File(vcf.getAbsolutePath() + FileExtensions.TABIX_INDEX);
-        vcf.deleteOnExit();
-        tabix.deleteOnExit();
+        final Path vcf = Files.createTempFile("TabixOnTheFlyIndexCreationTest.", FileExtensions.COMPRESSED_VCF);
+        final Path tabix = Path.of(vcf.toAbsolutePath() + FileExtensions.TABIX_INDEX);
+        vcf.toFile().deleteOnExit();
+        tabix.toFile().deleteOnExit();
         final VariantContextWriter vcfWriter = new VariantContextWriterBuilder()
-                .setOutputFile(vcf)
+                .setOutputPath(vcf)
                 .setReferenceDictionary(headerFromFile.getSequenceDictionary())
                 .setOptions(EnumSet.of(Options.INDEX_ON_THE_FLY, Options.ALLOW_MISSING_FIELDS_IN_HEADER))
                 .build();

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VCFWriterUnitTest.java
@@ -46,10 +46,10 @@ import htsjdk.variant.vcf.VCFFileReader;
 import htsjdk.variant.vcf.VCFHeader;
 import htsjdk.variant.vcf.VCFHeaderLine;
 import htsjdk.variant.vcf.VCFHeaderVersion;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -73,30 +73,30 @@ import org.testng.annotations.Test;
 public class VCFWriterUnitTest extends VariantBaseTest {
     private Set<VCFHeaderLine> metaData;
     private Set<String> additionalColumns;
-    private File tempDir;
+    private Path tempDir;
 
     @BeforeClass
     private void createTemporaryDirectory() {
-        tempDir = TestUtil.getTempDirectory("VCFWriter", "StaleIndex");
-        tempDir.deleteOnExit();
+        tempDir = TestUtil.getTempDirectoryAsPath("VCFWriter", "StaleIndex");
+        tempDir.toFile().deleteOnExit();
     }
 
     /** test, using the writer and reader, that we can output and input a VCF file without problems */
     @Test(dataProvider = "vcfExtensionsDataProvider")
     public void testBasicWriteAndRead(final String extension) throws IOException {
-        final File fakeVCFFile = File.createTempFile("testBasicWriteAndRead.", extension, tempDir);
-        fakeVCFFile.deleteOnExit();
+        final Path fakeVCFPath = Files.createTempFile(tempDir, "testBasicWriteAndRead.", extension);
+        fakeVCFPath.toFile().deleteOnExit();
         if (FileExtensions.COMPRESSED_VCF.equals(extension) || FileExtensions.COMPRESSED_VCF_BGZ.equals(extension)) {
-            new File(fakeVCFFile.getAbsolutePath() + FileExtensions.VCF_INDEX);
+            Path.of(fakeVCFPath.toAbsolutePath() + FileExtensions.VCF_INDEX);
         } else {
-            Tribble.indexFile(fakeVCFFile).deleteOnExit();
+            Tribble.indexPath(fakeVCFPath).toFile().deleteOnExit();
         }
         metaData = new HashSet<>();
         additionalColumns = new HashSet<>();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(fakeVCFFile)
+                .setOutputPath(fakeVCFPath)
                 .setReferenceDictionary(sequenceDict)
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build();
@@ -105,8 +105,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         writer.add(createVC(header));
         writer.close();
         final VCFCodec codec = new VCFCodec();
-        final FeatureReader<VariantContext> reader =
-                AbstractFeatureReader.getFeatureReader(fakeVCFFile.getAbsolutePath(), codec, false);
+        final FeatureReader<VariantContext> reader = AbstractFeatureReader.getFeatureReader(
+                fakeVCFPath.toAbsolutePath().toString(), codec, false);
         final VCFHeader headerFromFile = (VCFHeader) reader.getHeader();
 
         int counter = 0;
@@ -129,19 +129,19 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     /** test, using the writer and reader, that we can output and input a VCF body without problems */
     @Test(dataProvider = "vcfExtensionsDataProvider")
     public void testWriteAndReadVCFHeaderless(final String extension) throws IOException {
-        final File fakeVCFFile = File.createTempFile("testWriteAndReadVCFHeaderless.", extension, tempDir);
-        fakeVCFFile.deleteOnExit();
+        final Path fakeVCFPath = Files.createTempFile(tempDir, "testWriteAndReadVCFHeaderless.", extension);
+        fakeVCFPath.toFile().deleteOnExit();
         if (FileExtensions.COMPRESSED_VCF.equals(extension) || FileExtensions.COMPRESSED_VCF_BGZ.equals(extension)) {
-            new File(fakeVCFFile.getAbsolutePath() + ".tbi");
+            Path.of(fakeVCFPath.toAbsolutePath() + ".tbi");
         } else {
-            Tribble.indexFile(fakeVCFFile).deleteOnExit();
+            Tribble.indexPath(fakeVCFPath).toFile().deleteOnExit();
         }
         metaData = new HashSet<>();
         additionalColumns = new HashSet<>();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(fakeVCFFile)
+                .setOutputPath(fakeVCFPath)
                 .setReferenceDictionary(sequenceDict)
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build()) {
@@ -152,8 +152,8 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         final VCFCodec codec = new VCFCodec();
         codec.setVCFHeader(header, VCFHeaderVersion.VCF4_2);
 
-        try (BlockCompressedInputStream bcis = new BlockCompressedInputStream(fakeVCFFile);
-                FileInputStream fis = new FileInputStream(fakeVCFFile)) {
+        try (BlockCompressedInputStream bcis = new BlockCompressedInputStream(fakeVCFPath);
+                InputStream fis = Files.newInputStream(fakeVCFPath)) {
             AsciiLineReaderIterator iterator = new AsciiLineReaderIterator(new AsciiLineReader(
                     FileExtensions.COMPRESSED_VCF.equals(extension)
                                     || FileExtensions.COMPRESSED_VCF_BGZ.equals(extension)
@@ -170,13 +170,13 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testWriteHeaderTwice() {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
-        fakeVCFFile.deleteOnExit();
+        final Path fakeVCFPath = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
+        fakeVCFPath.toFile().deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         // prevent writing header twice
         try (final VariantContextWriter writer1 = new VariantContextWriterBuilder()
-                .setOutputFile(fakeVCFFile)
+                .setOutputPath(fakeVCFPath)
                 .setReferenceDictionary(sequenceDict)
                 .build()) {
             writer1.writeHeader(header);
@@ -186,13 +186,13 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingHeader() {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
-        fakeVCFFile.deleteOnExit();
+        final Path fakeVCFPath = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
+        fakeVCFPath.toFile().deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         // prevent changing header if it's already written
         try (final VariantContextWriter writer2 = new VariantContextWriterBuilder()
-                .setOutputFile(fakeVCFFile)
+                .setOutputPath(fakeVCFPath)
                 .setReferenceDictionary(sequenceDict)
                 .build()) {
             writer2.writeHeader(header);
@@ -202,13 +202,13 @@ public class VCFWriterUnitTest extends VariantBaseTest {
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testChangeHeaderAfterWritingBody() {
-        final File fakeVCFFile = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
-        fakeVCFFile.deleteOnExit();
+        final Path fakeVCFPath = VariantBaseTest.createTempFile("testBasicWriteAndRead.", FileExtensions.VCF);
+        fakeVCFPath.toFile().deleteOnExit();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         // prevent changing header if part of body is already written
         try (final VariantContextWriter writer3 = new VariantContextWriterBuilder()
-                .setOutputFile(fakeVCFFile)
+                .setOutputPath(fakeVCFPath)
                 .setReferenceDictionary(sequenceDict)
                 .build()) {
             writer3.setHeader(header);
@@ -292,7 +292,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
     }
 
     @Test(dataProvider = "vcfExtensionsDataProvider")
-    public void TestWritingLargeVCF(final String extension) throws FileNotFoundException, InterruptedException {
+    public void TestWritingLargeVCF(final String extension) throws IOException, InterruptedException {
 
         final Set<VCFHeaderLine> metaData = new HashSet<VCFHeaderLine>();
         final Set<String> Columns = new HashSet<String>();
@@ -304,19 +304,19 @@ public class VCFWriterUnitTest extends VariantBaseTest {
         final SAMSequenceDictionary dict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, Columns, dict);
 
-        final File vcf = new File(tempDir, "test" + extension);
+        final Path vcf = tempDir.resolve("test" + extension);
         final String indexExtension;
         if (extension.equals(FileExtensions.COMPRESSED_VCF) || extension.equals(FileExtensions.COMPRESSED_VCF_BGZ)) {
             indexExtension = FileExtensions.TABIX_INDEX;
         } else {
             indexExtension = FileExtensions.TRIBBLE_INDEX;
         }
-        final File vcfIndex = new File(vcf.getAbsolutePath() + indexExtension);
-        vcfIndex.deleteOnExit();
+        final Path vcfIndex = Path.of(vcf.toAbsolutePath() + indexExtension);
+        vcfIndex.toFile().deleteOnExit();
 
         for (int count = 1; count < 2; count++) {
             final VariantContextWriter writer = new VariantContextWriterBuilder()
-                    .setOutputFile(vcf)
+                    .setOutputPath(vcf)
                     .setReferenceDictionary(dict)
                     .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                     .build();
@@ -329,7 +329,7 @@ public class VCFWriterUnitTest extends VariantBaseTest {
             }
             writer.close();
 
-            Assert.assertTrue(vcf.lastModified() <= vcfIndex.lastModified());
+            Assert.assertTrue(vcf.toFile().lastModified() <= vcfIndex.toFile().lastModified());
         }
     }
 
@@ -348,16 +348,16 @@ public class VCFWriterUnitTest extends VariantBaseTest {
      */
     @Test
     public void testModifyHeader() {
-        final File originalVCF = new File("src/test/resources/htsjdk/variant/HiSeq.10000.vcf");
+        final Path originalVCF = Path.of("src/test/resources/htsjdk/variant/HiSeq.10000.vcf");
         final VCFFileReader reader = new VCFFileReader(originalVCF, false);
         final VCFHeader header = reader.getFileHeader();
         reader.close();
 
         header.addMetaDataLine(new VCFHeaderLine("FOOBAR", "foovalue"));
 
-        final File outputVCF = createTempFile("testModifyHeader", FileExtensions.VCF);
+        final Path outputVCF = createTempFile("testModifyHeader", FileExtensions.VCF);
         final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(outputVCF)
+                .setOutputPath(outputVCF)
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER))
                 .build();
         writer.writeHeader(header);
@@ -382,13 +382,13 @@ public class VCFWriterUnitTest extends VariantBaseTest {
      */
     @Test(dataProvider = "vcfExtensionsDataProvider", expectedExceptions = IllegalStateException.class)
     public void testWriteWithEmptyHeader(final String extension) throws IOException {
-        final File fakeVCFFile = File.createTempFile("testWriteAndReadVCFHeaderless.", extension, tempDir);
+        final Path fakeVCFPath = Files.createTempFile(tempDir, "testWriteAndReadVCFHeaderless.", extension);
         metaData = new HashSet<>();
         additionalColumns = new HashSet<>();
         final SAMSequenceDictionary sequenceDict = createArtificialSequenceDictionary();
         final VCFHeader header = createFakeHeader(metaData, additionalColumns, sequenceDict);
         try (final VariantContextWriter writer = new VariantContextWriterBuilder()
-                .setOutputFile(fakeVCFFile)
+                .setOutputPath(fakeVCFPath)
                 .setReferenceDictionary(sequenceDict)
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build()) {

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWriterBuilderUnitTest.java
@@ -35,7 +35,11 @@ import htsjdk.tribble.Tribble;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder.OutputType;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.*;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,41 +63,41 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
     private static final String TEST_BASENAME = "htsjdk-test VariantContextWriterBuilderUnitTest";
     private SAMSequenceDictionary dictionary;
 
-    private File vcf;
-    private File vcfIdx;
-    private File vcfMD5;
-    private File bcf;
-    private File bcfIdx;
-    private File unknown;
+    private Path vcf;
+    private Path vcfIdx;
+    private Path vcfMD5;
+    private Path bcf;
+    private Path bcfIdx;
+    private Path unknown;
 
-    private List<File> blockCompressedVCFs;
-    private List<File> blockCompressedIndices;
+    private List<Path> blockCompressedVCFs;
+    private List<Path> blockCompressedIndices;
 
     @BeforeSuite
     public void before() throws IOException {
         dictionary = createArtificialSequenceDictionary();
-        vcf = File.createTempFile(TEST_BASENAME, FileExtensions.VCF);
-        vcf.deleteOnExit();
-        vcfIdx = Tribble.indexFile(vcf);
-        vcfIdx.deleteOnExit();
-        vcfMD5 = new File(vcf.getAbsolutePath() + ".md5");
-        vcfMD5.deleteOnExit();
-        bcf = File.createTempFile(TEST_BASENAME, FileExtensions.BCF);
-        bcf.deleteOnExit();
-        bcfIdx = Tribble.indexFile(bcf);
-        bcfIdx.deleteOnExit();
-        unknown = File.createTempFile(TEST_BASENAME, ".unknown");
-        unknown.deleteOnExit();
+        vcf = Files.createTempFile(TEST_BASENAME, FileExtensions.VCF);
+        vcf.toFile().deleteOnExit();
+        vcfIdx = Tribble.indexPath(vcf);
+        vcfIdx.toFile().deleteOnExit();
+        vcfMD5 = Path.of(vcf.toAbsolutePath() + ".md5");
+        vcfMD5.toFile().deleteOnExit();
+        bcf = Files.createTempFile(TEST_BASENAME, FileExtensions.BCF);
+        bcf.toFile().deleteOnExit();
+        bcfIdx = Tribble.indexPath(bcf);
+        bcfIdx.toFile().deleteOnExit();
+        unknown = Files.createTempFile(TEST_BASENAME, ".unknown");
+        unknown.toFile().deleteOnExit();
 
-        blockCompressedVCFs = new ArrayList<File>();
-        blockCompressedIndices = new ArrayList<File>();
+        blockCompressedVCFs = new ArrayList<Path>();
+        blockCompressedIndices = new ArrayList<Path>();
         for (final String extension : FileExtensions.BLOCK_COMPRESSED) {
-            final File blockCompressed = File.createTempFile(TEST_BASENAME, FileExtensions.VCF + extension);
-            blockCompressed.deleteOnExit();
+            final Path blockCompressed = Files.createTempFile(TEST_BASENAME, FileExtensions.VCF + extension);
+            blockCompressed.toFile().deleteOnExit();
             blockCompressedVCFs.add(blockCompressed);
 
-            final File index = new File(blockCompressed.getAbsolutePath() + FileExtensions.TABIX_INDEX);
-            index.deleteOnExit();
+            final Path index = Path.of(blockCompressed.toAbsolutePath() + FileExtensions.TABIX_INDEX);
+            index.toFile().deleteOnExit();
             blockCompressedIndices.add(index);
         }
     }
@@ -104,22 +108,22 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
                 new VariantContextWriterBuilder().setReferenceDictionary(dictionary);
 
         VariantContextWriter writer =
-                builder.setOutputFile(vcf.getAbsolutePath()).build();
+                builder.setOutputFile(vcf.toAbsolutePath().toString()).build();
         Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF String");
         Assert.assertFalse(
                 ((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream,
                 "testSetOutputFile VCF String was compressed");
 
-        writer = builder.setOutputFile(vcf).build();
-        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF File");
+        writer = builder.setOutputPath(vcf).build();
+        Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile VCF Path");
         Assert.assertFalse(
                 ((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream,
-                "testSetOutputFile VCF File was compressed");
+                "testSetOutputFile VCF Path was compressed");
 
         for (final String extension : FileExtensions.BLOCK_COMPRESSED) {
-            final File file = File.createTempFile(TEST_BASENAME + ".setoutput", extension);
-            file.deleteOnExit();
-            final String filename = file.getAbsolutePath();
+            final Path file = Files.createTempFile(TEST_BASENAME + ".setoutput", extension);
+            file.toFile().deleteOnExit();
+            final String filename = file.toAbsolutePath().toString();
 
             writer = builder.setOutputFile(filename).build();
             Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile " + extension + " String");
@@ -127,18 +131,18 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
                     ((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream,
                     "testSetOutputFile " + extension + " String was not compressed");
 
-            writer = builder.setOutputFile(file).build();
-            Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile " + extension + " File");
+            writer = builder.setOutputPath(file).build();
+            Assert.assertTrue(writer instanceof VCFWriter, "testSetOutputFile " + extension + " Path");
             Assert.assertTrue(
                     ((VCFWriter) writer).getOutputStream() instanceof BlockCompressedOutputStream,
-                    "testSetOutputFile " + extension + " File was not compressed");
+                    "testSetOutputFile " + extension + " Path was not compressed");
         }
 
-        writer = builder.setOutputFile(bcf).build();
+        writer = builder.setOutputPath(bcf).build();
         Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFile BCF String");
 
-        writer = builder.setOutputFile(bcf.getAbsolutePath()).build();
-        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFile BCF File");
+        writer = builder.setOutputFile(bcf.toAbsolutePath().toString()).build();
+        Assert.assertTrue(writer instanceof BCF2Writer, "testSetOutputFile BCF Path");
     }
 
     @DataProvider
@@ -146,48 +150,48 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
         List<Object[]> cases = new ArrayList<>();
         cases.add(new Object[] {OutputType.VCF, this.vcf});
         cases.add(new Object[] {OutputType.BCF, this.bcf});
-        cases.add(new Object[] {OutputType.VCF_STREAM, new File("/dev/stdout")});
-        for (final File file : this.blockCompressedVCFs) {
+        cases.add(new Object[] {OutputType.VCF_STREAM, Path.of("/dev/stdout")});
+        for (final Path file : this.blockCompressedVCFs) {
             cases.add(new Object[] {OutputType.BLOCK_COMPRESSED_VCF, file});
         }
         return cases.iterator();
     }
 
     @Test(dataProvider = "getFilesAndOutputTypes")
-    public void testDetermineOutputType(OutputType expected, File file) {
-        Assert.assertEquals(VariantContextWriterBuilder.determineOutputTypeFromFile(file), expected);
+    public void testDetermineOutputType(OutputType expected, Path path) {
+        Assert.assertEquals(VariantContextWriterBuilder.determineOutputTypeFromFile(path), expected);
     }
 
     @Test(dataProvider = "getFilesAndOutputTypes")
-    public void testDetermineOutputTypeWithSymlink(OutputType expected, File file) throws IOException {
-        final File link = setUpSymlink(file);
+    public void testDetermineOutputTypeWithSymlink(OutputType expected, Path path) throws IOException {
+        final Path link = setUpSymlink(path);
         Assert.assertEquals(expected, VariantContextWriterBuilder.determineOutputTypeFromFile(link));
     }
 
     @Test(dataProvider = "getFilesAndOutputTypes")
-    public void testDetermineOutputTypeOnPath(OutputType expected, File file) {
-        Assert.assertEquals(VariantContextWriterBuilder.determineOutputTypeFromFile(file.toPath()), expected);
+    public void testDetermineOutputTypeOnPath(OutputType expected, Path path) {
+        Assert.assertEquals(VariantContextWriterBuilder.determineOutputTypeFromFile(path), expected);
     }
 
     @Test(dataProvider = "getFilesAndOutputTypes")
-    public void testDetermineOutputTypeWithSymlinkOnPath(OutputType expected, File file) throws IOException {
-        final File link = setUpSymlink(file);
-        Assert.assertEquals(expected, VariantContextWriterBuilder.determineOutputTypeFromFile(link.toPath()));
+    public void testDetermineOutputTypeWithSymlinkOnPath(OutputType expected, Path path) throws IOException {
+        final Path link = setUpSymlink(path);
+        Assert.assertEquals(expected, VariantContextWriterBuilder.determineOutputTypeFromFile(link));
     }
 
-    private static File setUpSymlink(File target) throws IOException {
+    private static Path setUpSymlink(Path target) throws IOException {
         final Path link = Files.createTempFile("foo.", ".tmp");
         Files.deleteIfExists(link);
-        Files.createSymbolicLink(link, target.toPath());
+        Files.createSymbolicLink(link, target);
         link.toFile().deleteOnExit();
-        return link.toFile();
+        return link;
     }
 
     @Test
     public void testSetOutputFileType() {
         final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                 .setReferenceDictionary(dictionary)
-                .setOutputFile(unknown);
+                .setOutputPath(unknown);
 
         VariantContextWriter writer = builder.setOutputFileType(VariantContextWriterBuilder.OutputType.VCF)
                 .build();
@@ -263,7 +267,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
     public void testAsync() {
         final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                 .setReferenceDictionary(dictionary)
-                .setOutputFile(vcf);
+                .setOutputPath(vcf);
 
         VariantContextWriter writer = builder.build();
         Assert.assertEquals(
@@ -282,7 +286,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
     public void testBuffering() {
         final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                 .setReferenceDictionary(dictionary)
-                .setOutputFile(vcf)
+                .setOutputPath(vcf)
                 .unsetOption(Options.INDEX_ON_THE_FLY); // so the potential BufferedOutputStream is not wrapped in a
         // PositionalOutputStream
 
@@ -303,81 +307,81 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
     }
 
     @Test
-    public void testMD5() {
+    public void testMD5() throws IOException {
         final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                 .setReferenceDictionary(dictionary)
-                .setOutputFile(vcf);
+                .setOutputPath(vcf);
 
         VariantContextWriter writer = builder.build();
         writer.close();
-        Assert.assertEquals(vcfMD5.exists(), Defaults.CREATE_MD5, "MD5 default setting not respected");
+        Assert.assertEquals(Files.exists(vcfMD5), Defaults.CREATE_MD5, "MD5 default setting not respected");
 
-        if (vcfMD5.exists()) vcfMD5.delete();
+        Files.deleteIfExists(vcfMD5);
 
         writer = builder.setCreateMD5().build();
         writer.close();
-        Assert.assertTrue(vcfMD5.exists(), "MD5 not created when requested");
-        vcfMD5.delete();
+        Assert.assertTrue(Files.exists(vcfMD5), "MD5 not created when requested");
+        Files.delete(vcfMD5);
 
         writer = builder.unsetCreateMD5().build();
         writer.close();
-        Assert.assertFalse(vcfMD5.exists(), "MD5 created when not requested");
+        Assert.assertFalse(Files.exists(vcfMD5), "MD5 created when not requested");
 
         writer = builder.setCreateMD5(false).build();
         writer.close();
-        Assert.assertFalse(vcfMD5.exists(), "MD5 created when not requested via boolean parameter");
+        Assert.assertFalse(Files.exists(vcfMD5), "MD5 created when not requested via boolean parameter");
 
         writer = builder.setCreateMD5(true).build();
         writer.close();
-        Assert.assertTrue(vcfMD5.exists(), "MD5 not created when requested via boolean parameter");
-        vcfMD5.delete();
+        Assert.assertTrue(Files.exists(vcfMD5), "MD5 not created when requested via boolean parameter");
+        Files.delete(vcfMD5);
 
-        for (final File blockCompressed : blockCompressedVCFs) {
-            final File md5 = new File(blockCompressed + ".md5");
-            if (md5.exists()) md5.delete();
-            md5.deleteOnExit();
-            writer = builder.setOutputFile(blockCompressed).build();
+        for (final Path blockCompressed : blockCompressedVCFs) {
+            final Path md5 = Path.of(blockCompressed + ".md5");
+            Files.deleteIfExists(md5);
+            md5.toFile().deleteOnExit();
+            writer = builder.setOutputPath(blockCompressed).build();
             writer.close();
-            Assert.assertTrue(md5.exists(), "MD5 digest not created for " + blockCompressed);
+            Assert.assertTrue(Files.exists(md5), "MD5 digest not created for " + blockCompressed);
         }
     }
 
     @Test
-    public void testIndexingOnTheFly() {
+    public void testIndexingOnTheFly() throws IOException {
         final VariantContextWriterBuilder builder = new VariantContextWriterBuilder()
                 .setReferenceDictionary(dictionary)
                 .setOption(Options.INDEX_ON_THE_FLY);
 
-        if (vcfIdx.exists()) vcfIdx.delete();
-        VariantContextWriter writer = builder.setOutputFile(vcf).build();
+        Files.deleteIfExists(vcfIdx);
+        VariantContextWriter writer = builder.setOutputPath(vcf).build();
         writer.close();
-        Assert.assertTrue(vcfIdx.exists(), String.format("VCF index not created for %s / %s", vcf, vcfIdx));
+        Assert.assertTrue(Files.exists(vcfIdx), String.format("VCF index not created for %s / %s", vcf, vcfIdx));
 
-        if (bcfIdx.exists()) bcfIdx.delete();
-        writer = builder.setOutputFile(bcf).build();
+        Files.deleteIfExists(bcfIdx);
+        writer = builder.setOutputPath(bcf).build();
         writer.close();
-        Assert.assertTrue(bcfIdx.exists(), String.format("BCF index not created for %s / %s", bcf, bcfIdx));
+        Assert.assertTrue(Files.exists(bcfIdx), String.format("BCF index not created for %s / %s", bcf, bcfIdx));
 
         for (int i = 0; i < blockCompressedVCFs.size(); i++) {
-            final File blockCompressed = blockCompressedVCFs.get(i);
-            final File index = blockCompressedIndices.get(i);
-            if (index.exists()) index.delete();
-            writer = builder.setOutputFile(blockCompressed)
+            final Path blockCompressed = blockCompressedVCFs.get(i);
+            final Path index = blockCompressedIndices.get(i);
+            Files.deleteIfExists(index);
+            writer = builder.setOutputPath(blockCompressed)
                     .setReferenceDictionary(dictionary)
                     .build();
             writer.close();
             Assert.assertTrue(
-                    index.exists(),
+                    Files.exists(index),
                     String.format("Block-compressed index not created for %s / %s", blockCompressed, index));
 
             // Tabix does not require a reference dictionary.
             // Tribble does: see tests testRefDictRequiredForVCFIndexOnTheFly / testRefDictRequiredForBCFIndexOnTheFly
 
-            index.delete();
+            Files.delete(index);
             writer = builder.setReferenceDictionary(null).build();
             writer.close();
             Assert.assertTrue(
-                    index.exists(),
+                    Files.exists(index),
                     String.format("Block-compressed index not created for %s / %s", blockCompressed, index));
         }
     }
@@ -389,7 +393,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
                 .setOption(Options.INDEX_ON_THE_FLY);
 
         try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
-            final Path vcfPath = fs.getPath(vcf.getName());
+            final Path vcfPath = fs.getPath(vcf.getFileName().toString());
             final Path vcfIdxPath = Tribble.indexPath(vcfPath);
             try (final VariantContextWriter writer =
                     builder.setOutputPath(vcfPath).build()) {
@@ -399,7 +403,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
             Assert.assertTrue(
                     Files.exists(vcfIdxPath), String.format("VCF index not created for %s / %s", vcfPath, vcfIdxPath));
 
-            final Path bcfPath = fs.getPath(bcf.getName());
+            final Path bcfPath = fs.getPath(bcf.getFileName().toString());
             final Path bcfIdxPath = Tribble.indexPath(bcfPath);
             try (final VariantContextWriter writer =
                     builder.setOutputPath(bcfPath).build()) {
@@ -409,11 +413,12 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
                     Files.exists(bcfIdxPath), String.format("BCF index not created for %s / %s", bcfPath, bcfIdxPath));
 
             for (int i = 0; i < blockCompressedVCFs.size(); i++) {
-                final File blockCompressed = blockCompressedVCFs.get(i);
-                final File index = blockCompressedIndices.get(i);
+                final Path blockCompressed = blockCompressedVCFs.get(i);
+                final Path index = blockCompressedIndices.get(i);
 
-                final Path blockCompressedPath = fs.getPath(blockCompressed.getName());
-                final Path indexPath = fs.getPath(index.getName());
+                final Path blockCompressedPath =
+                        fs.getPath(blockCompressed.getFileName().toString());
+                final Path indexPath = fs.getPath(index.getFileName().toString());
 
                 Assert.assertFalse(Files.exists(indexPath));
                 try (VariantContextWriter writer = builder.setOutputPath(blockCompressedPath)
@@ -489,7 +494,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testRefDictRequiredForVCFIndexOnTheFly() {
         new VariantContextWriterBuilder()
-                .setOutputFile(vcf)
+                .setOutputPath(vcf)
                 .setOption(Options.INDEX_ON_THE_FLY)
                 .build();
     }
@@ -497,7 +502,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testRefDictRequiredForBCFIndexOnTheFly() {
         new VariantContextWriterBuilder()
-                .setOutputFile(bcf)
+                .setOutputPath(bcf)
                 .setOption(Options.INDEX_ON_THE_FLY)
                 .build();
     }
@@ -565,14 +570,14 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
      */
     private static long testWriteToPipe(final Consumer<String> codeThatWritesToAFilename)
             throws IOException, InterruptedException, ExecutionException {
-        final File fifo = makeFifo();
+        final Path fifo = makeFifo();
 
         // run the code in a separate thread
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
             final Future<?> writeResult = executor.submit(() -> {
                 try {
-                    codeThatWritesToAFilename.accept(fifo.getAbsolutePath());
+                    codeThatWritesToAFilename.accept(fifo.toAbsolutePath().toString());
                 } catch (Exception x) {
                     // Print to the console to aid debugging, in case the exception doesn't surface.
                     x.printStackTrace();
@@ -582,7 +587,7 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
 
             // drain the pipe with the output.
             final Future<Integer> readResult = executor.submit(() -> {
-                try (final InputStream inputStream = Files.newInputStream(fifo.toPath(), StandardOpenOption.READ)) {
+                try (final InputStream inputStream = Files.newInputStream(fifo, StandardOpenOption.READ)) {
                     int count = 0;
                     while (inputStream.read() >= 0) {
                         count++;
@@ -599,12 +604,12 @@ public class VariantContextWriterBuilderUnitTest extends VariantBaseTest {
         }
     }
 
-    private static File makeFifo() throws IOException, InterruptedException {
+    private static Path makeFifo() throws IOException, InterruptedException {
         // make the fifo
-        final File fifo = File.createTempFile("fifo.for.testWriteToPipe", "");
-        Assert.assertTrue(fifo.delete());
-        fifo.deleteOnExit();
-        final Process exec = new ProcessBuilder("mkfifo", fifo.getAbsolutePath()).start();
+        final Path fifo = Files.createTempFile("fifo.for.testWriteToPipe", "");
+        Files.delete(fifo);
+        fifo.toFile().deleteOnExit();
+        final Process exec = new ProcessBuilder("mkfifo", fifo.toAbsolutePath().toString()).start();
         exec.waitFor(1, TimeUnit.MINUTES);
         Assert.assertEquals(exec.exitValue(), 0, "mkfifo failed with exit code " + 0);
         return fifo;

--- a/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWritersUnitTest.java
+++ b/src/test/java/htsjdk/variant/variantcontext/writer/VariantContextWritersUnitTest.java
@@ -35,9 +35,8 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.VariantContextTestProvider;
 import htsjdk.variant.vcf.VCFCodec;
 import htsjdk.variant.vcf.VCFHeader;
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -92,16 +91,16 @@ public class VariantContextWritersUnitTest extends VariantBaseTest {
         }
 
         @Override
-        public VariantContextWriter makeWriter(final File file, final EnumSet<Options> baseOptions) {
+        public VariantContextWriter makeWriter(final Path path, final EnumSet<Options> baseOptions) {
             return new VariantContextWriterBuilder()
-                    .setOutputFile(file)
+                    .setOutputPath(path)
                     .setReferenceDictionary(dictionary)
                     .setOptions(baseOptions)
                     .build();
         }
 
         @Override
-        public VariantContextTestProvider.VariantContextContainer readAllVCs(File input) throws IOException {
+        public VariantContextTestProvider.VariantContextContainer readAllVCs(Path input) throws IOException {
             final BCF2Codec codec = this.makeCodec();
             return VariantContextTestProvider.readAllVCs(input, codec);
         }
@@ -147,16 +146,16 @@ public class VariantContextWritersUnitTest extends VariantBaseTest {
         }
 
         @Override
-        public VariantContextWriter makeWriter(final File file, final EnumSet<Options> baseOptions) {
+        public VariantContextWriter makeWriter(final Path path, final EnumSet<Options> baseOptions) {
             return new VariantContextWriterBuilder()
-                    .setOutputFile(file)
+                    .setOutputPath(path)
                     .setReferenceDictionary(dictionary)
                     .setOptions(baseOptions)
                     .build();
         }
 
         @Override
-        public VariantContextTestProvider.VariantContextContainer readAllVCs(File input) throws FileNotFoundException {
+        public VariantContextTestProvider.VariantContextContainer readAllVCs(Path input) throws IOException {
             final VCFCodec codec = this.makeCodec();
             return VariantContextTestProvider.readAllVCs(input, codec);
         }

--- a/src/test/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
+++ b/src/test/java/htsjdk/variant/vcf/AbstractVCFCodecTest.java
@@ -5,7 +5,7 @@ import htsjdk.tribble.index.tabix.TabixFormat;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
-import java.io.File;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import org.testng.Assert;
@@ -18,7 +18,7 @@ public class AbstractVCFCodecTest extends VariantBaseTest {
     public void shouldPreserveSymbolicAlleleCase() {
         final VariantContext variant;
         try (final VCFFileReader reader =
-                new VCFFileReader(new File(VariantBaseTest.variantTestDataRoot + "breakpoint.vcf"), false)) {
+                new VCFFileReader(Path.of(VariantBaseTest.variantTestDataRoot + "breakpoint.vcf"), false)) {
             variant = reader.iterator().next();
         }
         // VCF v4.1 s1.4.5
@@ -62,7 +62,7 @@ public class AbstractVCFCodecTest extends VariantBaseTest {
     public void testGLnotOverridePL() {
         final VariantContext variant;
         try (final VCFFileReader reader =
-                new VCFFileReader(new File("src/test/resources/htsjdk/variant/test_withGLandPL.vcf"), false)) {
+                new VCFFileReader(Path.of("src/test/resources/htsjdk/variant/test_withGLandPL.vcf"), false)) {
             variant = reader.iterator().next();
         }
         Assert.assertEquals(variant.getGenotype(0).getPL(), new int[] {45, 0, 50});
@@ -79,7 +79,7 @@ public class AbstractVCFCodecTest extends VariantBaseTest {
 
     @Test(dataProvider = "caseIntolerantDoubles")
     public void testCaseIntolerantDoubles(String vcfInput, double value) {
-        try (final VCFFileReader reader = new VCFFileReader(new File(vcfInput), false)) {
+        try (final VCFFileReader reader = new VCFFileReader(Path.of(vcfInput), false)) {
             try {
                 Iterator<VariantContext> iterator = reader.iterator();
                 final VariantContext baseVariant = iterator.next(); // First row uses Java-style

--- a/src/test/java/htsjdk/variant/vcf/IndexFactoryUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/IndexFactoryUnitTest.java
@@ -37,8 +37,9 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.EnumSet;
 import org.testng.annotations.BeforeMethod;
@@ -49,9 +50,9 @@ import org.testng.annotations.Test;
  */
 public class IndexFactoryUnitTest extends VariantBaseTest {
 
-    File inputFile = new File(variantTestDataRoot + "HiSeq.10000.vcf");
-    File outputFile = createTempFile("onTheFlyOutputTest", FileExtensions.VCF);
-    File outputFileIndex = Tribble.indexFile(outputFile);
+    Path inputFile = Path.of(variantTestDataRoot + "HiSeq.10000.vcf");
+    Path outputFile = createTempFile("onTheFlyOutputTest", FileExtensions.VCF);
+    Path outputFileIndex = Tribble.indexPath(outputFile);
 
     private SAMSequenceDictionary dict;
 
@@ -66,18 +67,18 @@ public class IndexFactoryUnitTest extends VariantBaseTest {
     @Test
     public void testOnTheFlyIndexing1() throws IOException {
         final Index indexFromInputFile = IndexFactory.createDynamicIndex(inputFile, new VCFCodec());
-        if (outputFileIndex.exists()) {
+        if (Files.exists(outputFileIndex)) {
             System.err.println("Deleting " + outputFileIndex);
-            outputFileIndex.delete();
+            Files.delete(outputFileIndex);
         }
 
         for (int maxRecords : Arrays.asList(0, 1, 10, 100, 1000, -1)) {
             final AbstractFeatureReader source = AbstractFeatureReader.getFeatureReader(
-                    inputFile.getAbsolutePath(), new VCFCodec(), indexFromInputFile);
+                    inputFile.toAbsolutePath().toString(), new VCFCodec(), indexFromInputFile);
 
             int counter = 0;
             VariantContextWriter writer = new VariantContextWriterBuilder()
-                    .setOutputFile(outputFile)
+                    .setOutputPath(outputFile)
                     .setReferenceDictionary(dict)
                     .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER))
                     .build();

--- a/src/test/java/htsjdk/variant/vcf/VCFCodec43FeaturesTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFCodec43FeaturesTest.java
@@ -10,7 +10,6 @@ import htsjdk.tribble.index.IndexFactory;
 import htsjdk.variant.VariantBaseTest;
 import htsjdk.variant.variantcontext.Allele;
 import htsjdk.variant.variantcontext.VariantContext;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -151,16 +150,16 @@ public class VCFCodec43FeaturesTest extends VariantBaseTest {
 
     @Test(dataProvider = "all43IndexableFiles")
     public void testVCF43IndexRoundTripQuery(final Path testFile) throws IOException {
-        final File tempDir = TestUtil.getTempDirectory("VCF43Codec", "indextest");
-        tempDir.deleteOnExit();
+        final Path tempDir = TestUtil.getTempDirectoryAsPath("VCF43Codec", "indextest");
+        tempDir.toFile().deleteOnExit();
 
         // copy our input vcf to a temp location, and create a tabix index
-        Files.copy(testFile, (new File(tempDir, testFile.toFile().getName())).toPath());
-        final File vcfFileCopy = new File(tempDir, testFile.toFile().getName());
+        final Path vcfFileCopy = tempDir.resolve(testFile.getFileName().toString());
+        Files.copy(testFile, vcfFileCopy);
         final Index index = IndexFactory.createIndex(vcfFileCopy, new VCFCodec(), IndexFactory.IndexType.TABIX);
-        final File indexFile = new File(tempDir, vcfFileCopy.getName() + FileExtensions.TABIX_INDEX);
-        index.write(indexFile);
-        Assert.assertTrue(indexFile.exists());
+        final Path indexPath = tempDir.resolve(vcfFileCopy.getFileName().toString() + FileExtensions.TABIX_INDEX);
+        index.write(indexPath);
+        Assert.assertTrue(Files.exists(indexPath));
 
         // query for a variant located after any variants containing percent encoded or UTF8 chars
         // 22	327	.	T	C	666.18	GATK_STANDARD;HARD_TO_VALIDATE	AB=0.74;AC=3;AF=0.50;AN=6;DB=0;DP=936;Dels=0

--- a/src/test/java/htsjdk/variant/vcf/VCFFileReaderTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFFileReaderTest.java
@@ -5,11 +5,10 @@ import com.google.common.jimfs.Jimfs;
 import htsjdk.HtsjdkTest;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.tribble.TestUtils;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -21,21 +20,21 @@ import org.testng.annotations.Test;
  * Created by farjoun on 10/12/17.
  */
 public class VCFFileReaderTest extends HtsjdkTest {
-    private static final File TEST_DATA_DIR = new File("src/test/resources/htsjdk/variant/");
+    private static final Path TEST_DATA_DIR = Path.of("src/test/resources/htsjdk/variant/");
 
     @DataProvider(name = "queryableData")
     public Iterator<Object[]> queryableData() throws IOException {
         List<Object[]> tests = new ArrayList<>();
-        tests.add(new Object[] {new File(TEST_DATA_DIR, "NA12891.fp.vcf"), false});
-        tests.add(new Object[] {new File(TEST_DATA_DIR, "NA12891.vcf"), false});
+        tests.add(new Object[] {TEST_DATA_DIR.resolve("NA12891.fp.vcf"), false});
+        tests.add(new Object[] {TEST_DATA_DIR.resolve("NA12891.vcf"), false});
         tests.add(new Object[] {
             VCFUtils.createTemporaryIndexedVcfFromInput(
-                    new File(TEST_DATA_DIR, "NA12891.vcf"), "fingerprintcheckertest.tmp."),
+                    TEST_DATA_DIR.resolve("NA12891.vcf"), "fingerprintcheckertest.tmp."),
             true
         });
         tests.add(new Object[] {
             VCFUtils.createTemporaryIndexedVcfFromInput(
-                    new File(TEST_DATA_DIR, "NA12891.vcf.gz"), "fingerprintcheckertest.tmp."),
+                    TEST_DATA_DIR.resolve("NA12891.vcf.gz"), "fingerprintcheckertest.tmp."),
             true
         });
 
@@ -43,7 +42,7 @@ public class VCFFileReaderTest extends HtsjdkTest {
     }
 
     @Test(dataProvider = "queryableData")
-    public void testIsQueriable(final File vcf, final boolean expectedQueryable) throws Exception {
+    public void testIsQueriable(final Path vcf, final boolean expectedQueryable) throws Exception {
         Assert.assertEquals(new VCFFileReader(vcf, false).isQueryable(), expectedQueryable);
     }
 
@@ -117,8 +116,7 @@ public class VCFFileReaderTest extends HtsjdkTest {
     public void testAcceptOptimisticVCF4_4() {
         // This file is the same as VCF4HeaderTest.vcf, except the header is marked as VCF 4.4
         // This will fail unless the optimistic_vcf_4_4" property isn't set
-        try (final VCFFileReader reader =
-                new VCFFileReader(Paths.get(TEST_DATA_DIR.getAbsolutePath(), "VCF4_4HeaderTest.vcf"), false)) {
+        try (final VCFFileReader reader = new VCFFileReader(TEST_DATA_DIR.resolve("VCF4_4HeaderTest.vcf"), false)) {
             final VCFHeader header = reader.getFileHeader();
             Assert.assertEquals(header.getVCFHeaderVersion(), VCFHeaderVersion.VCF4_3);
         }
@@ -126,21 +124,21 @@ public class VCFFileReaderTest extends HtsjdkTest {
 
     @Test
     public void testTabixFileWithEmbeddedSpaces() throws IOException {
-        final File testVCF = new File(TEST_DATA_DIR, "HiSeq.10000.vcf.bgz");
-        final File testTBI = new File(TEST_DATA_DIR, "HiSeq.10000.vcf.bgz.tbi");
+        final Path testVCF = TEST_DATA_DIR.resolve("HiSeq.10000.vcf.bgz");
+        final Path testTBI = TEST_DATA_DIR.resolve("HiSeq.10000.vcf.bgz.tbi");
 
         // Copy the input files into a temporary directory with embedded spaces in the name.
         // This test needs to include the associated .tbi file because we want to force execution
         // of the tabix code path.
-        final File tempDir = IOUtil.createTempDir("test spaces").toFile();
-        Assert.assertTrue(tempDir.getAbsolutePath().contains(" "));
-        tempDir.deleteOnExit();
-        final File inputVCF = new File(tempDir, "HiSeq.10000.vcf.bgz");
-        inputVCF.deleteOnExit();
-        final File inputTBI = new File(tempDir, "HiSeq.10000.vcf.bgz.tbi");
-        inputTBI.deleteOnExit();
-        IOUtil.copyFile(testVCF, inputVCF);
-        IOUtil.copyFile(testTBI, inputTBI);
+        final Path tempDir = IOUtil.createTempDir("test spaces");
+        Assert.assertTrue(tempDir.toAbsolutePath().toString().contains(" "));
+        tempDir.toFile().deleteOnExit();
+        final Path inputVCF = tempDir.resolve("HiSeq.10000.vcf.bgz");
+        inputVCF.toFile().deleteOnExit();
+        final Path inputTBI = tempDir.resolve("HiSeq.10000.vcf.bgz.tbi");
+        inputTBI.toFile().deleteOnExit();
+        Files.copy(testVCF, inputVCF);
+        Files.copy(testTBI, inputTBI);
 
         try (final VCFFileReader vcfFileReader = new VCFFileReader(inputVCF)) {
             Assert.assertNotNull(vcfFileReader.getFileHeader());

--- a/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFHeaderUnitTest.java
@@ -40,14 +40,19 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringReader;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -63,7 +68,7 @@ import org.testng.annotations.Test;
  */
 public class VCFHeaderUnitTest extends VariantBaseTest {
 
-    private File tempDir;
+    private Path tempDir;
 
     private VCFHeader createHeader(String headerStr) {
         VCFCodec codec = new VCFCodec();
@@ -75,15 +80,17 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
 
     @BeforeClass
     private void createTemporaryDirectory() {
-        tempDir = TestUtil.getTempDirectory("VCFHeader", "VCFHeaderTest");
+        tempDir = TestUtil.getTempDirectoryAsPath("VCFHeader", "VCFHeaderTest");
     }
 
     @AfterClass
-    private void deleteTemporaryDirectory() {
-        for (File f : tempDir.listFiles()) {
-            f.delete();
+    private void deleteTemporaryDirectory() throws IOException {
+        try (final Stream<Path> entries = Files.list(tempDir)) {
+            for (final Path entry : (Iterable<Path>) entries::iterator) {
+                Files.delete(entry);
+            }
         }
-        tempDir.delete();
+        Files.delete(tempDir);
     }
 
     @Test
@@ -103,7 +110,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         final VCFCodec codec = new VCFCodec();
         codec.setRemappedSampleName("FOOSAMPLE");
         final AsciiLineReaderIterator vcfIterator = new AsciiLineReaderIterator(
-                AsciiLineReader.from(new FileInputStream(variantTestDataRoot + "HiSeq.10000.vcf")));
+                AsciiLineReader.from(Files.newInputStream(Path.of(variantTestDataRoot + "HiSeq.10000.vcf"))));
         final VCFHeader header = (VCFHeader) codec.readHeader(vcfIterator).getHeaderValue();
 
         Assert.assertEquals(header.getNGenotypeSamples(), 1, "Wrong number of samples in remapped header");
@@ -135,7 +142,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     @Test(dataProvider = "testVCFHeaderDictionaryMergingData")
     public void testVCFHeaderDictionaryMerging(final String vcfFileName) {
         final VCFHeader headerOne =
-                new VCFFileReader(new File(variantTestDataRoot + vcfFileName), false).getFileHeader();
+                new VCFFileReader(Path.of(variantTestDataRoot + vcfFileName), false).getFileHeader();
         final VCFHeader headerTwo = new VCFHeader(headerOne); // deep copy
         final List<String> sampleList = new ArrayList<String>();
         sampleList.addAll(headerOne.getSampleNamesInOrder());
@@ -155,8 +162,8 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     public void testVCFHeaderSampleRenamingMultiSampleVCF() throws Exception {
         final VCFCodec codec = new VCFCodec();
         codec.setRemappedSampleName("FOOSAMPLE");
-        final AsciiLineReaderIterator vcfIterator =
-                new AsciiLineReaderIterator(AsciiLineReader.from(new FileInputStream(variantTestDataRoot + "ex2.vcf")));
+        final AsciiLineReaderIterator vcfIterator = new AsciiLineReaderIterator(
+                AsciiLineReader.from(Files.newInputStream(Path.of(variantTestDataRoot + "ex2.vcf"))));
         final VCFHeader header = (VCFHeader) codec.readHeader(vcfIterator).getHeaderValue();
     }
 
@@ -165,12 +172,12 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         final VCFCodec codec = new VCFCodec();
         codec.setRemappedSampleName("FOOSAMPLE");
         final AsciiLineReaderIterator vcfIterator = new AsciiLineReaderIterator(
-                AsciiLineReader.from(new FileInputStream(variantTestDataRoot + "dbsnp_135.b37.1000.vcf")));
+                AsciiLineReader.from(Files.newInputStream(Path.of(variantTestDataRoot + "dbsnp_135.b37.1000.vcf"))));
         final VCFHeader header = (VCFHeader) codec.readHeader(vcfIterator).getHeaderValue();
     }
 
     private VCFHeader getHiSeqVCFHeader() {
-        final File vcf = new File("src/test/resources/htsjdk/variant/HiSeq.10000.vcf");
+        final Path vcf = Path.of("src/test/resources/htsjdk/variant/HiSeq.10000.vcf");
         final VCFFileReader reader = new VCFFileReader(vcf, false);
         final VCFHeader header = reader.getFileHeader();
         reader.close();
@@ -315,7 +322,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     @Test
     public void testVCFHeaderHonorContigLineOrder() throws IOException {
         try (final VCFFileReader vcfReader =
-                new VCFFileReader(new File(variantTestDataRoot + "dbsnp_135.b37.1000.vcf"), false)) {
+                new VCFFileReader(Path.of(variantTestDataRoot + "dbsnp_135.b37.1000.vcf"), false)) {
             // start with a header with a bunch of contig lines
             final VCFHeader header = vcfReader.getFileHeader();
             final List<VCFContigHeaderLine> originalHeaderList = header.getContigLines();
@@ -382,7 +389,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
 
     @Test
     public void testVCFHeaderAddMetaDataLineDoesNotDuplicateContigs() {
-        File input = new File("src/test/resources/htsjdk/variant/ex2.vcf");
+        Path input = Path.of("src/test/resources/htsjdk/variant/ex2.vcf");
 
         VCFFileReader reader = new VCFFileReader(input, false);
         VCFHeader header = reader.getFileHeader();
@@ -404,7 +411,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
 
     @Test
     public void testVCFHeaderAddDuplicateContigLine() {
-        File input = new File("src/test/resources/htsjdk/variant/ex2.vcf");
+        Path input = Path.of("src/test/resources/htsjdk/variant/ex2.vcf");
 
         VCFFileReader reader = new VCFFileReader(input, false);
         VCFHeader header = reader.getFileHeader();
@@ -420,7 +427,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
 
     @Test
     public void testVCFHeaderAddDuplicateHeaderLine() {
-        File input = new File("src/test/resources/htsjdk/variant/ex2.vcf");
+        Path input = Path.of("src/test/resources/htsjdk/variant/ex2.vcf");
 
         VCFFileReader reader = new VCFFileReader(input, false);
         VCFHeader header = reader.getFileHeader();
@@ -486,7 +493,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     @Test
     public void testVCFHeaderSerialization() throws Exception {
         final VCFFileReader reader =
-                new VCFFileReader(new File("src/test/resources/htsjdk/variant/HiSeq.10000.vcf"), false);
+                new VCFFileReader(Path.of("src/test/resources/htsjdk/variant/HiSeq.10000.vcf"), false);
         final VCFHeader originalHeader = reader.getFileHeader();
         reader.close();
 
@@ -552,7 +559,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
 
         // read an existing VCF
         final VCFFileReader originalFileReader =
-                new VCFFileReader(new File("src/test/resources/htsjdk/variant/VCF4HeaderTest.vcf"), false);
+                new VCFFileReader(Path.of("src/test/resources/htsjdk/variant/VCF4HeaderTest.vcf"), false);
         final VCFHeader originalHeader = originalFileReader.getFileHeader();
 
         // add a header line with quotes to the header
@@ -597,11 +604,11 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
                 "This other value has a \\n newline in it");
 
         // write the file out into a new copy
-        final File firstCopyVCFFile = File.createTempFile("testEscapeHeaderQuotes1.", FileExtensions.VCF);
-        firstCopyVCFFile.deleteOnExit();
+        final Path firstCopyVCFFile = Files.createTempFile("testEscapeHeaderQuotes1.", FileExtensions.VCF);
+        firstCopyVCFFile.toFile().deleteOnExit();
 
         final VariantContextWriter firstCopyWriter = new VariantContextWriterBuilder()
-                .setOutputFile(firstCopyVCFFile)
+                .setOutputPath(firstCopyVCFFile)
                 .setReferenceDictionary(createArtificialSequenceDictionary())
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build();
@@ -649,10 +656,10 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
                 "This other value has a \\n newline in it");
 
         // write one more copy to make sure things don't get double escaped
-        final File secondCopyVCFFile = File.createTempFile("testEscapeHeaderQuotes2.", FileExtensions.VCF);
-        secondCopyVCFFile.deleteOnExit();
+        final Path secondCopyVCFFile = Files.createTempFile("testEscapeHeaderQuotes2.", FileExtensions.VCF);
+        secondCopyVCFFile.toFile().deleteOnExit();
         final VariantContextWriter secondCopyWriter = new VariantContextWriterBuilder()
-                .setOutputFile(secondCopyVCFFile)
+                .setOutputPath(secondCopyVCFFile)
                 .setReferenceDictionary(createArtificialSequenceDictionary())
                 .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                 .build();
@@ -722,15 +729,15 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         // this test ensures that source/version fields are round-tripped properly
 
         // read an existing VCF
-        File expectedFile = new File("src/test/resources/htsjdk/variant/Vcf4.2WithSourceVersionInfoFields.vcf");
+        Path expectedFile = Path.of("src/test/resources/htsjdk/variant/Vcf4.2WithSourceVersionInfoFields.vcf");
 
         // write the file out into a new copy
-        final File actualFile = File.createTempFile("testVcf4.2roundtrip.", FileExtensions.VCF);
-        actualFile.deleteOnExit();
+        final Path actualFile = Files.createTempFile("testVcf4.2roundtrip.", FileExtensions.VCF);
+        actualFile.toFile().deleteOnExit();
 
         try (final VCFFileReader originalFileReader = new VCFFileReader(expectedFile, false);
                 final VariantContextWriter copyWriter = new VariantContextWriterBuilder()
-                        .setOutputFile(actualFile)
+                        .setOutputPath(actualFile)
                         .setReferenceDictionary(createArtificialSequenceDictionary())
                         .setOptions(EnumSet.of(Options.ALLOW_MISSING_FIELDS_IN_HEADER, Options.INDEX_ON_THE_FLY))
                         .build()) {
@@ -742,8 +749,8 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
             }
         }
 
-        final String actualContents = new String(Files.readAllBytes(actualFile.toPath()), StandardCharsets.UTF_8);
-        final String expectedContents = new String(Files.readAllBytes(expectedFile.toPath()), StandardCharsets.UTF_8);
+        final String actualContents = new String(Files.readAllBytes(actualFile), StandardCharsets.UTF_8);
+        final String expectedContents = new String(Files.readAllBytes(expectedFile), StandardCharsets.UTF_8);
         Assert.assertEquals(actualContents, expectedContents);
     }
 
@@ -756,7 +763,7 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
      * @param file the file
      * @return a string
      */
-    private static String md5SumFile(File file) {
+    private static String md5SumFile(Path file) {
         MessageDigest digest;
         try {
             digest = MessageDigest.getInstance("MD5");
@@ -765,8 +772,8 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
         }
         InputStream is;
         try {
-            is = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
+            is = Files.newInputStream(file);
+        } catch (IOException e) {
             throw new RuntimeException("Unable to open file " + file);
         }
         byte[] buffer = new byte[8192];
@@ -791,12 +798,12 @@ public class VCFHeaderUnitTest extends VariantBaseTest {
     }
 
     private void checkMD5ofHeaderFile(VCFHeader header, String md5sum) {
-        File myTempFile = null;
+        Path myTempFile = null;
         PrintWriter pw = null;
         try {
-            myTempFile = File.createTempFile("VCFHeader", "vcf");
-            myTempFile.deleteOnExit();
-            pw = new PrintWriter(myTempFile);
+            myTempFile = Files.createTempFile("VCFHeader", "vcf");
+            myTempFile.toFile().deleteOnExit();
+            pw = new PrintWriter(Files.newBufferedWriter(myTempFile));
         } catch (IOException e) {
             Assert.fail("Unable to make a temp file!");
         }

--- a/src/test/java/htsjdk/variant/vcf/VCFIteratorTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFIteratorTest.java
@@ -28,14 +28,12 @@ import htsjdk.samtools.util.FileExtensions;
 import htsjdk.samtools.util.IOUtil;
 import htsjdk.samtools.util.RuntimeIOException;
 import htsjdk.variant.VariantBaseTest;
-import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.function.Function;
 import java.util.zip.GZIPOutputStream;
 import org.testng.Assert;
@@ -79,21 +77,21 @@ public class VCFIteratorTest extends VariantBaseTest {
 
     @Test(dataProvider = "VariantFiles")
     public void testUsingFile(final String file, final int nVariants) throws IOException {
-        final VCFIterator r = new VCFIteratorBuilder().open(new File(file));
+        final VCFIterator r = new VCFIteratorBuilder().open(Path.of(file));
         assertExpectedNumberOfVariants(r, nVariants);
     }
 
     private void testUsingZippedInput(
-            final String filepath, final int nVariants, final Function<File, OutputStream> outputStreamProvider)
+            final String filepath, final int nVariants, final Function<Path, OutputStream> outputStreamProvider)
             throws IOException {
-        File tmp = new File(filepath);
+        Path tmp = Path.of(filepath);
         /* TODO fix this when VCFFileReader will support BCF see
          * https://github.com/samtools/htsjdk/pull/837#discussion_r139490218
          * https://github.com/samtools/htsjdk/issues/946
          */
-        if (tmp.getName().endsWith(FileExtensions.VCF)) {
-            tmp = File.createTempFile("tmp", FileExtensions.COMPRESSED_VCF);
-            tmp.deleteOnExit();
+        if (tmp.getFileName().toString().endsWith(FileExtensions.VCF)) {
+            tmp = Files.createTempFile("tmp", FileExtensions.COMPRESSED_VCF);
+            tmp.toFile().deleteOnExit();
             try (FileInputStream in = new FileInputStream(filepath);
                     OutputStream out = outputStreamProvider.apply(tmp); ) {
                 IOUtil.copyStream(in, out);
@@ -109,14 +107,14 @@ public class VCFIteratorTest extends VariantBaseTest {
 
     @Test(dataProvider = "VcfFiles")
     public void testUsingBGZippedInput(final String filepath, final int nVariants) throws IOException {
-        testUsingZippedInput(filepath, nVariants, (F) -> new BlockCompressedOutputStream(F));
+        testUsingZippedInput(filepath, nVariants, (P) -> new BlockCompressedOutputStream(P));
     }
 
     @Test(dataProvider = "VcfFiles")
     public void testUsingGZippedInput(final String filepath, final int nVariants) throws IOException {
-        testUsingZippedInput(filepath, nVariants, (F) -> {
+        testUsingZippedInput(filepath, nVariants, (P) -> {
             try {
-                return new GZIPOutputStream(new FileOutputStream(F));
+                return new GZIPOutputStream(Files.newOutputStream(P));
             } catch (final IOException err) {
                 throw new RuntimeIOException(err);
             }
@@ -133,7 +131,7 @@ public class VCFIteratorTest extends VariantBaseTest {
 
     @Test(dataProvider = "VariantFiles")
     public void testUsingPath(final String path, final int nVariants) throws IOException {
-        final Path a_path = Paths.get(path);
+        final Path a_path = Path.of(path);
         final VCFIterator r = new VCFIteratorBuilder().open(a_path);
         assertExpectedNumberOfVariants(r, nVariants);
     }

--- a/src/test/java/htsjdk/variant/vcf/VCFMergerTest.java
+++ b/src/test/java/htsjdk/variant/vcf/VCFMergerTest.java
@@ -43,7 +43,6 @@ import htsjdk.variant.variantcontext.VariantContext;
 import htsjdk.variant.variantcontext.writer.Options;
 import htsjdk.variant.variantcontext.writer.VariantContextWriter;
 import htsjdk.variant.variantcontext.writer.VariantContextWriterBuilder;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -56,7 +55,7 @@ import org.testng.annotations.Test;
 
 public class VCFMergerTest extends HtsjdkTest {
 
-    private static final Path VCF_FILE = new File("src/test/resources/htsjdk/variant/HiSeq.10000.vcf.bgz").toPath();
+    private static final Path VCF_FILE = Path.of("src/test/resources/htsjdk/variant/HiSeq.10000.vcf.bgz");
 
     /**
      * Writes a <i>partitioned VCF</i>.
@@ -203,7 +202,7 @@ public class VCFMergerTest extends HtsjdkTest {
     }
 
     private static Path indexVcf(Path vcf, Path tbi) throws IOException {
-        TabixIndex tabixIndex = IndexFactory.createTabixIndex(vcf.toFile(), new VCFCodec(), null);
+        TabixIndex tabixIndex = IndexFactory.createTabixIndex(vcf, new VCFCodec(), null);
         tabixIndex.write(tbi);
         return tbi;
     }
@@ -213,16 +212,15 @@ public class VCFMergerTest extends HtsjdkTest {
         final Path outputDir = IOUtil.createTempDir(this.getClass().getSimpleName() + ".tmp");
         IOUtil.deleteOnExit(outputDir);
 
-        final Path outputVcf = File.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.COMPRESSED_VCF)
-                .toPath();
+        final Path outputVcf =
+                Files.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.COMPRESSED_VCF);
         IOUtil.deleteOnExit(outputVcf);
 
         final Path outputTbi = IOUtil.addExtension(outputVcf, FileExtensions.TABIX_INDEX);
         IOUtil.deleteOnExit(outputTbi);
 
-        final Path outputTbiMerged = File.createTempFile(
-                        this.getClass().getSimpleName() + ".", FileExtensions.TABIX_INDEX)
-                .toPath();
+        final Path outputTbiMerged =
+                Files.createTempFile(this.getClass().getSimpleName() + ".", FileExtensions.TABIX_INDEX);
         IOUtil.deleteOnExit(outputTbiMerged);
 
         // 1. Read an input VCF and write it out in partitioned form (header, parts, terminator)


### PR DESCRIPTION
## Summary

Migrates htsjdk from `java.io.File` to `java.nio.file.Path` throughout the public API so the whole library works with any Java NIO `FileSystemProvider` (SPI) — Amazon S3, Google Cloud Storage, HDFS, in-memory filesystems such as [jimfs](https://github.com/google/jimfs), and so on — through the same reader, writer, factory, and index APIs, with no `File`-specific code paths. Targets **6.0.0** (a major, breaking release).

## Credit & basis

This work implements the requirements/design laid out by **@markjschreiber** in **#1783** ("Refactor to universally use `java.nio.file.Path` to promote use of SPIs and async access to HTS files"), and is based heavily on his prior implementation on the [`markjschreiber/use-only-path`](https://github.com/markjschreiber/htsjdk/tree/markjschreiber/use-only-path) branch.

That branch forked from an older `master` (before the whole-codebase Palantir reformat, the SRA excision, and the CRAM 3.1 work), so a direct merge/rebase wasn't practical (213/250 files conflicted, almost entirely on formatting). Instead, this PR re-applies the migration on current `master`, using Mark's branch as the per-file blueprint (`git diff <merge-base> markjschreiber/use-only-path -- <file>`) while adapting to the current tree and a few deliberate design choices below. The bulk of the design and the migration approach are his.

## Approach

Done as a reviewable stack of per-subsystem commits using an **add-then-remove** shape so the tree compiles at every step:

1. Add `Path`/`URI` APIs and deprecate the `File` ones (core I/O → factories → readers → writers → indexes → reference → utilities).
2. Migrate the test suite (~150 files) to `Path`.
3. Delete the deprecated `File` APIs (224 methods/constructors).
4. CHANGELOG + version bump.

## Design choices (differences from the reference branch)

- **Scheme-aware string resolution.** Where an API takes a path as a `String`, it resolves with `IOUtil.getPath` (honours `file:`/`gs:`/`s3:`/custom schemes; falls back to the local filesystem for plain paths, including paths with spaces) rather than raw `Path.of(URI)`. **Existing HTTP/HTTPS and FTP behaviour is unchanged** — those continue to flow through htsjdk's `SeekableStream` machinery, not NIO.
- **Index buffers.** Local index paths keep the memory-mapped / random-access fast path; non-default-filesystem paths fall back to a channel-based stream buffer (`SeekablePathStream`).
- **Retained `File` APIs** (local-only or migration bridges, documented in the CHANGELOG): `IOUtil.newTempFile` / `getDefaultTmpDir` / `createTempDir`, and `IOUtil.toPath(File)` / `filesToPaths(Collection<File>)`.
- Dropped the reference branch's jqwik property tests in favour of TestNG; did not carry over its root migration markdown docs or `.kiro/` specs.

## Testing

- Full offline suite green (**21,957 tests**, 0 failures); `spotlessCheck` and `javadoc` clean.
- New `NioSpiCompatibilityTest` exercises the major read/write/index APIs (BAM/CRAM/VCF/FASTQ, reference access, index discovery + creation) end-to-end against an in-memory **jimfs** filesystem.
- The change set was reviewed by a panel of agents; that pass caught two genuine SPI regressions (a dropped non-local guard in `IOUtil.assertFileIsWritable`, and `SamIndexes.openIndexFileAsBaiOrNull` routing through `java.net.URL.openStream()`), both fixed here.
- Not run locally: the network-gated groups (`ftp`, `http`, `htsget`, `ena`) — worth a CI run.

## Breaking changes

`java.io.File`-based public APIs are removed in favour of `java.nio.file.Path`. See the **6.0.0** section of `CHANGELOG.md` for before/after examples and the full list (including `Defaults.REFERENCE_FASTA`, now a `Path`).

Closes #1783.
