### PR TITLE
Remove finalize() and other deprecated Java usages (supersedes #1698)

### DIFF
--- a/src/main/java/htsjdk/samtools/CustomReaderFactory.java
+++ b/src/main/java/htsjdk/samtools/CustomReaderFactory.java
@@ -109,7 +109,7 @@ public class CustomReaderFactory {
                     clazz = Class.forName(factoryClassName);
                 }
 
-                factory = (ICustomReaderFactory) clazz.newInstance();
+                factory = (ICustomReaderFactory) clazz.getDeclaredConstructor().newInstance();
                 LOG.info("Created custom factory for " + urlPrefix + " from " + factoryClassName + " loaded from "
                         + (jarFile.isEmpty() ? " this jar" : jarFile));
             } catch (Exception e) {

--- a/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
+++ b/src/main/java/htsjdk/samtools/metrics/MetricsFile.java
@@ -333,7 +333,9 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
                     final String className =
                             line.substring(MAJOR_HEADER_PREFIX.length()).trim();
                     try {
-                        header = (Header) loadClass(className, true).newInstance();
+                        header = (Header) loadClass(className, true)
+                                .getDeclaredConstructor()
+                                .newInstance();
                     } catch (final Exception e) {
                         throw new SAMException("Error load and/or instantiating an instance of " + className, e);
                     }
@@ -390,7 +392,7 @@ public class MetricsFile<BEAN extends MetricBase, HKEY extends Comparable> imple
                             BEAN bean = null;
 
                             try {
-                                bean = (BEAN) type.newInstance();
+                                bean = (BEAN) type.getDeclaredConstructor().newInstance();
                             } catch (final Exception e) {
                                 throw new SAMException("Error instantiating a " + type.getName(), e);
                             }

--- a/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
+++ b/src/main/java/htsjdk/samtools/util/DiskBackedQueue.java
@@ -51,7 +51,7 @@ import java.util.Queue;
  *
  * Created by bradt on 4/28/14.
  */
-public class DiskBackedQueue<E> implements Queue<E> {
+public class DiskBackedQueue<E> implements Queue<E>, AutoCloseable {
     private final int maxRecordsInRamQueue;
     private final Queue<E> ramRecords;
     private Path diskRecords = null;
@@ -93,7 +93,7 @@ public class DiskBackedQueue<E> implements Queue<E> {
         this.maxRecordsInRamQueue = (maxRecordsInRam == 0)
                 ? 0
                 : maxRecordsInRam - 1; // the first of our ram records is stored as headRecord
-        this.ramRecords = new ArrayDeque<E>(this.maxRecordsInRamQueue);
+        this.ramRecords = new ArrayDeque<>(this.maxRecordsInRamQueue);
     }
 
     /**
@@ -230,18 +230,6 @@ public class DiskBackedQueue<E> implements Queue<E> {
         this.inputStream = null;
         this.diskRecords = null;
         this.canAdd = true;
-    }
-
-    /**
-     * Clean up disk resources in case clear() has not been explicitly called (as would be preferable)
-     * Closes the input and output streams associated with this DiskBackedQueue and deletes the temporary file
-     *
-     * @throws Throwable
-     */
-    @Override
-    protected void finalize() throws Throwable {
-        this.closeIOResources();
-        super.finalize(); // NB: intellij wanted me to do this. Need I?  I'm not extending anything
     }
 
     /**
@@ -404,5 +392,14 @@ public class DiskBackedQueue<E> implements Queue<E> {
     @Override
     public <T1> T1[] toArray(final T1[] a) {
         throw new UnsupportedOperationException("DiskBackedQueue does not support toArray(T1[] a)");
+    }
+
+    /**
+     * Clean up disk resources in case clear() has not been explicitly called (as would be preferable).
+     * Closes the input and output streams associated with this DiskBackedQueue and deletes the temporary file.
+     */
+    @Override
+    public void close() {
+        clear();
     }
 }

--- a/src/main/java/htsjdk/samtools/util/FileAppendStreamLRUCache.java
+++ b/src/main/java/htsjdk/samtools/util/FileAppendStreamLRUCache.java
@@ -55,7 +55,6 @@ public class FileAppendStreamLRUCache extends ResourceLimitedMap<Path, OutputStr
                 // In case the file could not be opened because of too many file handles, try to force
                 // file handles to be closed.
                 System.gc();
-                System.runFinalization();
                 try {
                     return IOUtil.maybeBufferOutputStream(
                             Files.newOutputStream(path, StandardOpenOption.CREATE, StandardOpenOption.APPEND));

--- a/src/main/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
+++ b/src/main/java/htsjdk/samtools/util/SamRecordTrackingBuffer.java
@@ -53,7 +53,7 @@ import java.util.NoSuchElementException;
  *
  * @author bradtaylor
  */
-public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
+public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> implements AutoCloseable {
     private int availableRecordsInMemory; // how many more records can we store in memory
     private final int blockSize; // the size of each block
     private final List<Path> tmpDirs; // the list of temporary directories to use
@@ -82,7 +82,7 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
         this.tmpDirs = tmpDirs;
         this.queueHeadRecordIndex = -1;
         this.queueTailRecordIndex = -1;
-        this.blocks = new ArrayDeque<BufferBlock>();
+        this.blocks = new ArrayDeque<>();
         this.header = header;
         this.clazz = clazz;
     }
@@ -203,6 +203,7 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
     /**
      * Close IO resources associated with each underlying BufferBlock
      */
+    @Override
     public void close() {
         while (!blocks.isEmpty()) {
             final BufferBlock block = blocks.pollFirst();
@@ -213,7 +214,7 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
     /**
      * This stores blocks of records, either in memory or on disk, or both!
      */
-    private class BufferBlock {
+    private class BufferBlock implements AutoCloseable {
         private final DiskBackedQueue<SAMRecord> recordsQueue;
         private final int maxBlockSize;
         private long currentStartIndex;
@@ -287,7 +288,7 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
             }
         }
 
-        private int ensureIndexFitsInAnInt(final long value) {
+        private static int ensureIndexFitsInAnInt(final long value) {
             if (value < Integer.MIN_VALUE || Integer.MAX_VALUE < value)
                 throw new SAMException("Error: index out of range: " + value);
             return (int) value;
@@ -325,7 +326,8 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
                 try {
                     // create a wrapped record for the head of the queue, and set the underlying record's examined
                     // information appropriately
-                    final SamRecordWithOrdinal samRecordWithOrdinal = clazz.newInstance();
+                    final SamRecordWithOrdinal samRecordWithOrdinal =
+                            clazz.getDeclaredConstructor().newInstance();
                     samRecordWithOrdinal.setRecord(this.recordsQueue.poll());
                     samRecordWithOrdinal.setRecordOrdinal(this.currentStartIndex);
                     samRecordWithOrdinal.setResultState(this.resultStateIndexes.get(
@@ -359,7 +361,16 @@ public class SamRecordTrackingBuffer<T extends SamRecordWithOrdinal> {
          * This must be called when a block is no longer needed in order to prevent memory leaks.
          */
         public void clear() {
-            this.recordsQueue.clear();
+            this.recordsQueue.close();
+        }
+
+        /**
+         * Close disk IO resources associated with the underlying records queue.
+         * This must be called when a block is no longer needed in order to prevent memory leaks.
+         */
+        @Override
+        public void close() {
+            clear();
         }
     }
 }

--- a/src/main/java/htsjdk/tribble/index/AbstractIndex.java
+++ b/src/main/java/htsjdk/tribble/index/AbstractIndex.java
@@ -382,15 +382,13 @@ public abstract class AbstractIndex implements MutableIndex {
             chrIndices = new LinkedHashMap<String, ChrIndex>(nChromosomes);
 
             while (nChromosomes-- > 0) {
-                final ChrIndex chrIdx = (ChrIndex) getChrIndexClass().newInstance();
+                final ChrIndex chrIdx =
+                        (ChrIndex) getChrIndexClass().getDeclaredConstructor().newInstance();
                 chrIdx.read(dis);
                 chrIndices.put(chrIdx.getName(), chrIdx);
             }
 
-        } catch (final InstantiationException e) {
-            throw new TribbleException.UnableToCreateCorrectIndexType(
-                    "Unable to create class " + getChrIndexClass(), e);
-        } catch (final IllegalAccessException e) {
+        } catch (final ReflectiveOperationException e) {
             throw new TribbleException.UnableToCreateCorrectIndexType(
                     "Unable to create class " + getChrIndexClass(), e);
         } finally {

--- a/src/test/java/htsjdk/TestDataProviders.java
+++ b/src/test/java/htsjdk/TestDataProviders.java
@@ -53,9 +53,9 @@ public class TestDataProviders extends HtsjdkTest {
     // https://github.com/cbeust/testng/blob/master/src/test/java/test/inject/NoInjectionTest.java
     @Test(dataProvider = "DataprovidersThatDontTestThemselves")
     public void testDataProviderswithDP(@NoInjection final Method method, final Class clazz)
-            throws IllegalAccessException, InstantiationException {
+            throws ReflectiveOperationException {
 
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
 
         Assert.assertTrue(
                 HtsjdkTest.class.isAssignableFrom(clazz), "Test Classes must extend HtsJdkTest: " + clazz.getName());

--- a/src/test/java/htsjdk/samtools/SAMBinaryTagAndValueUnitTest.java
+++ b/src/test/java/htsjdk/samtools/SAMBinaryTagAndValueUnitTest.java
@@ -11,7 +11,7 @@ public class SAMBinaryTagAndValueUnitTest extends HtsjdkTest {
     @DataProvider(name = "allowedAttributeTypes")
     public Object[][] allowedTypes() {
         return new Object[][] {
-            {new String("a string")},
+            {"a string"},
             {Byte.valueOf((byte) 7)},
             {Short.valueOf((short) 8)},
             {Integer.valueOf(0)},
@@ -97,17 +97,8 @@ public class SAMBinaryTagAndValueUnitTest extends HtsjdkTest {
     public Object[][] hashCopyEquals() {
         final short tag = SAMTag.makeBinaryTag("UI");
         return new Object[][] {
-            {
-                new SAMBinaryTagAndValue(tag, new String("a string")),
-                new SAMBinaryTagAndValue(tag, new String("a string")),
-                true,
-                true
-            },
-            {
-                new SAMBinaryTagAndValue(tag, new String("a string")),
-                new SAMBinaryTagAndValue(tag, new String("different string")),
-                false,
-                false
+            {new SAMBinaryTagAndValue(tag, "a string"), new SAMBinaryTagAndValue(tag, "a string"), true, true},
+            {new SAMBinaryTagAndValue(tag, "a string"), new SAMBinaryTagAndValue(tag, "different string"), false, false
             },
             {
                 new SAMBinaryTagAndValue(tag, Byte.valueOf((byte) 0)),


### PR DESCRIPTION
Adopts the Java-version-independent cleanups from #1698 (by @lbergelson), rebased onto current `master`. This **supersedes #1698**, which can be closed once this merges.

### What this keeps from #1698

The core motivation is dropping `Object.finalize()`, which is deprecated for removal (since JDK 18): finalization is unreliable for releasing resources and stands in the way of newer JDKs.

- **`DiskBackedQueue`** now implements `AutoCloseable`. The `finalize()` override is removed and replaced with a public `close()` that delegates to `clear()`, so callers can use try-with-resources instead of relying on the GC to reclaim spilled temp files.
- **`SamRecordTrackingBuffer`** (and its inner `BufferBlock`) likewise implement `AutoCloseable`.
- **`FileAppendStreamLRUCache`** drops the deprecated `System.runFinalization()` call.
- Deprecated `Class.newInstance()` → `getDeclaredConstructor().newInstance()` (in `SamRecordTrackingBuffer`, plus the remaining sites in `CustomReaderFactory`, `MetricsFile`, `AbstractIndex`, and `TestDataProviders`).
- Minor tidy-ups: diamond operators, a `static` helper, and redundant `new String("...")` constructors in a test.

### What this intentionally drops from #1698

- **The bump to Java 21.** htsjdk stays on **Java 17** (CI matrix + `build.gradle` toolchain unchanged).
- **The SpotBugs changes** — already superseded on `master` (the plugin is now `6.4.8`, newer than the PR's `6.0.4`, and the `Confidence.valueOf('HIGH')` config already landed). The PR's `effort = MAX` bump is deliberately not brought over.

### Note for downstream consumers

Removing `DiskBackedQueue.finalize()` means there is no longer a GC-triggered safety net that closes IO resources if a caller forgets to. Within htsjdk this is safe (`SamRecordTrackingBuffer` always closes its queues, and spill files are registered via `IOUtil.deleteOnExit`). **External code that constructs `DiskBackedQueue` directly should now use try-with-resources or call `close()`/`clear()` explicitly.**

### Verification

- Full test suite green: **22,076 tests, 0 failures**.
- No JDK removal-track (`-Xlint:removal`) usages remain in the tree after this change.

Co-authored-by: Louis Bergelson <louisb@broadinstitute.org>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit resource-closing support to disk-backed queues and record-tracking buffers, improving predictable cleanup.
* **Bug Fixes**
  * Improved resource cleanup and file-handle retry behavior.
* **Maintenance**
  * Updated reflective object creation for improved compatibility with modern Java.
  * Simplified internal type declarations and test setup without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->