### PR TITLE
Let CRAMContainerStreamWriter callers keep ownership of their stream

### DIFF
--- a/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
+++ b/src/main/java/htsjdk/samtools/CRAMContainerStreamWriter.java
@@ -123,11 +123,30 @@ public class CRAMContainerStreamWriter {
     }
 
     /**
-     * Finish writing to the stream. Flushes the record cache and optionally emits an EOF container.
+     * Finish writing to the stream. Flushes the record cache, optionally emits an EOF container, and then
+     * closes the underlying output stream.
+     *
+     * <p>Note that this closes a stream that was supplied by the caller. Callers that own the lifecycle of
+     * the stream themselves should use {@link #finish(boolean, boolean)} with {@code closeStream} set to
+     * false, and close the stream on their own terms.
+     *
      * @param writeEOFContainer true if an EOF container should be written. Only use false if writing a CRAM file
      *                          fragment which will later be aggregated into a complete CRAM file.
      */
     public void finish(final boolean writeEOFContainer) {
+        finish(writeEOFContainer, true);
+    }
+
+    /**
+     * Finish writing to the stream. Flushes the record cache and optionally emits an EOF container.
+     *
+     * @param writeEOFContainer true if an EOF container should be written. Only use false if writing a CRAM file
+     *                          fragment which will later be aggregated into a complete CRAM file.
+     * @param closeStream true if the underlying output stream should be closed once writing is complete. Pass
+     *                    false when the caller created the stream and is responsible for closing it; the stream
+     *                    is always flushed regardless.
+     */
+    public void finish(final boolean writeEOFContainer, final boolean closeStream) {
         try {
             final Container container = containerFactory.getFinalContainer(streamOffset);
             if (container != null) {
@@ -140,7 +159,9 @@ public class CRAMContainerStreamWriter {
             if (cramIndexer != null) {
                 cramIndexer.finish();
             }
-            outputStream.close();
+            if (closeStream) {
+                outputStream.close();
+            }
         } catch (final IOException e) {
             throw new RuntimeIOException(e);
         }

--- a/src/test/java/htsjdk/samtools/cram/CRAMContainerStreamWriterClosureTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAMContainerStreamWriterClosureTest.java
@@ -21,14 +21,27 @@ public class CRAMContainerStreamWriterClosureTest extends HtsjdkTest {
     private static final String CONTIG = "1";
     private static final int REF_LENGTH = 200;
 
-    /** An output stream that records whether it has been closed. */
+    /**
+     * An output stream that records whether it has been closed and whether it has been flushed.
+     *
+     * <p>Both have to be tracked explicitly. {@link ByteArrayOutputStream} makes writes visible
+     * immediately and inherits a no-op {@code flush()}, so the contents of the stream say nothing about
+     * whether the writer actually flushed it.
+     */
     private static final class CloseRecordingStream extends ByteArrayOutputStream {
         private boolean closed = false;
+        private boolean flushed = false;
 
         @Override
         public void close() throws IOException {
             closed = true;
             super.close();
+        }
+
+        @Override
+        public void flush() throws IOException {
+            flushed = true;
+            super.flush();
         }
     }
 
@@ -64,7 +77,7 @@ public class CRAMContainerStreamWriterClosureTest extends HtsjdkTest {
         writer.finish(true, false);
 
         Assert.assertFalse(stream.closed, "finish(true, false) must not close a stream supplied by the caller");
-        Assert.assertTrue(stream.size() > 0, "expected CRAM bytes to have been flushed to the stream");
+        Assert.assertTrue(stream.flushed, "declining the close must still flush the stream, or data can be lost");
     }
 
     @Test

--- a/src/test/java/htsjdk/samtools/cram/CRAMContainerStreamWriterClosureTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAMContainerStreamWriterClosureTest.java
@@ -1,0 +1,110 @@
+package htsjdk.samtools.cram;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.CRAMContainerStreamWriter;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.cram.ref.ReferenceSource;
+import htsjdk.samtools.reference.InMemoryReferenceSequenceFile;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that {@link CRAMContainerStreamWriter} gives callers control over whether the output stream they
+ * supplied is closed when writing finishes.  See https://github.com/samtools/htsjdk/issues/1092.
+ */
+public class CRAMContainerStreamWriterClosureTest extends HtsjdkTest {
+
+    private static final String CONTIG = "1";
+    private static final int REF_LENGTH = 200;
+
+    /** An output stream that records whether it has been closed. */
+    private static final class CloseRecordingStream extends ByteArrayOutputStream {
+        private boolean closed = false;
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    private static byte[] referenceBases() {
+        final byte[] bases = new byte[REF_LENGTH];
+        final byte[] pattern = "ACGTACGTAC".getBytes();
+        for (int i = 0; i < REF_LENGTH; i++) {
+            bases[i] = pattern[i % pattern.length];
+        }
+        return bases;
+    }
+
+    private static SAMFileHeader makeHeader() {
+        final SAMFileHeader header = new SAMFileHeader();
+        header.addSequence(new SAMSequenceRecord(CONTIG, REF_LENGTH));
+        header.setSortOrder(SAMFileHeader.SortOrder.coordinate);
+        return header;
+    }
+
+    private static CRAMContainerStreamWriter makeWriter(final OutputStream outputStream, final SAMFileHeader header) {
+        final InMemoryReferenceSequenceFile referenceFile = new InMemoryReferenceSequenceFile();
+        referenceFile.add(CONTIG, referenceBases());
+        return new CRAMContainerStreamWriter(outputStream, new ReferenceSource(referenceFile), header, "test", null);
+    }
+
+    @Test
+    public void finish_does_not_close_stream_when_close_stream_is_false() {
+        final SAMFileHeader header = makeHeader();
+        final CloseRecordingStream stream = new CloseRecordingStream();
+
+        final CRAMContainerStreamWriter writer = makeWriter(stream, header);
+        writer.writeHeader(header);
+        writer.finish(true, false);
+
+        Assert.assertFalse(stream.closed, "finish(true, false) must not close a stream supplied by the caller");
+        Assert.assertTrue(stream.size() > 0, "expected CRAM bytes to have been flushed to the stream");
+    }
+
+    @Test
+    public void finish_closes_stream_when_close_stream_is_true() {
+        final SAMFileHeader header = makeHeader();
+        final CloseRecordingStream stream = new CloseRecordingStream();
+
+        final CRAMContainerStreamWriter writer = makeWriter(stream, header);
+        writer.writeHeader(header);
+        writer.finish(true, true);
+
+        Assert.assertTrue(stream.closed, "finish(true, true) should close the stream");
+    }
+
+    /** The single-argument overload must keep its historical behaviour of closing the stream. */
+    @Test
+    public void single_argument_finish_still_closes_stream() {
+        final SAMFileHeader header = makeHeader();
+        final CloseRecordingStream stream = new CloseRecordingStream();
+
+        final CRAMContainerStreamWriter writer = makeWriter(stream, header);
+        writer.writeHeader(header);
+        writer.finish(true);
+
+        Assert.assertTrue(stream.closed, "finish(boolean) must remain backwards compatible and close the stream");
+    }
+
+    /** A caller that keeps ownership of the stream can go on using it after the writer has finished. */
+    @Test
+    public void caller_can_continue_using_stream_after_finish_without_close() throws IOException {
+        final SAMFileHeader header = makeHeader();
+        final CloseRecordingStream stream = new CloseRecordingStream();
+
+        final CRAMContainerStreamWriter writer = makeWriter(stream, header);
+        writer.writeHeader(header);
+        writer.finish(true, false);
+
+        final int sizeAfterFinish = stream.size();
+        stream.write("trailing".getBytes());
+        Assert.assertEquals(stream.size(), sizeAfterFinish + "trailing".length());
+        stream.close();
+    }
+}


### PR DESCRIPTION
Closes #1092.

`CRAMContainerStreamWriter` takes an `OutputStream` created by the caller but unconditionally closed it in `finish()`, so code that manages the stream lifecycle itself had no way to finish writing without having its stream closed underneath it — and a subsequent `close()` by the owner would then fail.

Adds `finish(writeEOFContainer, closeStream)` so callers can opt out of the close. The existing `finish(writeEOFContainer)` overload delegates with `closeStream=true`, so behaviour is unchanged for every current caller, including `CRAMFileWriter`, which relies on it to close the file stream it owns.

The stream is flushed either way, so opting out never loses data.

Tests cover both overloads, that the single-argument form still closes (backwards compatibility), and that a caller can keep using its own stream afterwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overload to CRAM writer finalization that lets callers choose whether the underlying output stream is closed.
  * The original single-argument finalization continues to close the stream by default.

* **Bug Fixes**
  * Finalization now conditionally closes the stream only when requested, allowing callers to keep using the same stream after finalization.
  * Flushing, optional EOF container emission, indexing, and existing error-handling behavior are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->