### PR TITLE
Explain why CRAM reference base lookup failed

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/build/CRAMReferenceRegion.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CRAMReferenceRegion.java
@@ -171,8 +171,16 @@ public class CRAMReferenceRegion {
         referenceBases =
                 referenceSource.getReferenceBasesByRegion(sequenceRecord, zeroBasedStart, requestedFragmentLength);
         if (referenceBases == null) {
-            throw new IllegalArgumentException(
-                    String.format("Failure getting reference bases for sequence %s", sequenceRecord.getSequenceName()));
+            // The reference source could not supply bases for a sequence that IS in the sequence dictionary.
+            // In practice this almost always means the reference fasta is missing its companion .fai index (or
+            // .dict, or .gzi for a bgzipped fasta), or that it simply does not contain this sequence, so say so
+            // rather than reporting a bare failure. See https://github.com/samtools/htsjdk/issues/1732.
+            throw new IllegalArgumentException(String.format(
+                    "Failure getting reference bases for sequence '%s'. The reference source did not return any "
+                            + "bases for this sequence. Verify that the reference fasta contains a sequence named "
+                            + "'%s', and that it has been indexed -- a CRAM requires a fasta with a companion .fai "
+                            + "index (plus a .gzi index if the fasta is bgzipped) and a .dict sequence dictionary.",
+                    sequenceRecord.getSequenceName(), sequenceRecord.getSequenceName()));
         } else if (referenceBases.length < requestedFragmentLength) {
             log.warn("The bases of length " + referenceBases.length
                     + " returned by the reference source do not satisfy the requested fragment length "

--- a/src/test/java/htsjdk/samtools/cram/build/CRAMReferenceRegionErrorMessageTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/CRAMReferenceRegionErrorMessageTest.java
@@ -1,0 +1,72 @@
+package htsjdk.samtools.cram.build;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.cram.ref.CRAMReferenceSource;
+import java.util.Collections;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests the diagnostics produced when a reference source cannot supply bases for a sequence that is present
+ * in the sequence dictionary -- most often because the reference fasta has not been indexed.
+ * See https://github.com/samtools/htsjdk/issues/1732.
+ */
+public class CRAMReferenceRegionErrorMessageTest extends HtsjdkTest {
+
+    private static final String SEQUENCE_NAME = "chr1";
+
+    /** A reference source that knows about a sequence but can never supply bases for it. */
+    private static final class NoBasesReferenceSource implements CRAMReferenceSource {
+        @Override
+        public byte[] getReferenceBases(final SAMSequenceRecord sequenceRecord, final boolean tryNameVariants) {
+            return null;
+        }
+
+        @Override
+        public byte[] getReferenceBasesByRegion(
+                final SAMSequenceRecord sequenceRecord, final int zeroBasedStart, final int requestedRegionLength) {
+            return null;
+        }
+    }
+
+    private static CRAMReferenceRegion makeRegion() {
+        final SAMSequenceDictionary dictionary =
+                new SAMSequenceDictionary(Collections.singletonList(new SAMSequenceRecord(SEQUENCE_NAME, 1000)));
+        return new CRAMReferenceRegion(new NoBasesReferenceSource(), dictionary);
+    }
+
+    private static String messageFromFailedFetch() {
+        try {
+            makeRegion().fetchReferenceBasesByRegion(0, 0, 100);
+            Assert.fail("expected an exception when the reference source returns no bases");
+            return null; // unreachable
+        } catch (final IllegalArgumentException e) {
+            return e.getMessage();
+        }
+    }
+
+    @Test
+    public void missing_bases_error_names_the_offending_sequence() {
+        Assert.assertTrue(
+                messageFromFailedFetch().contains(SEQUENCE_NAME),
+                "the error should name the sequence that could not be resolved");
+    }
+
+    @Test
+    public void missing_bases_error_mentions_the_fasta_index() {
+        final String message = messageFromFailedFetch();
+        Assert.assertTrue(
+                message.contains(".fai"),
+                "the error should point at the missing fasta index as the likely cause, but was: " + message);
+    }
+
+    @Test
+    public void missing_bases_error_mentions_the_sequence_dictionary() {
+        final String message = messageFromFailedFetch();
+        Assert.assertTrue(
+                message.contains(".dict"),
+                "the error should mention the required sequence dictionary, but was: " + message);
+    }
+}


### PR DESCRIPTION
Closes #1732.

When a reference source returns no bases for a sequence that *is* present in the sequence dictionary, `CRAMReferenceRegion` threw `Failure getting reference bases for sequence chr1` — which says what went wrong but nothing about why or what to do. In practice the overwhelmingly common cause is a reference fasta that has not been indexed, so users hit this via GATK/Picard with a perfectly good reference and no hint that a missing `.fai` is the problem.

The message now names the sequence and points at the companion `.fai`/`.gzi`/`.dict` files a CRAM needs. Message text only — no change to which inputs are accepted.

Note this does **not** address #998, which is a different misleading message raised from `ReferenceSource` on a separate code path; that one stays open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when reference bases cannot be retrieved.
  * Diagnostics now identify the affected sequence and suggest checking required FASTA indexes and sequence dictionaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->