### PR TITLE
Publish CRAM reference base cache atomically

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
+++ b/src/main/java/htsjdk/samtools/cram/ref/ReferenceSource.java
@@ -59,11 +59,27 @@ public class ReferenceSource implements CRAMReferenceSource {
 
     private final Map<String, WeakReference<byte[]>> cacheW = new HashMap<>();
 
+    /**
+     * The bases of a single contig together with the index of the contig they belong to. These two values are
+     * only meaningful as a pair, so they are held in one immutable object and published through a single
+     * volatile field. Storing them in two separate mutable fields allowed concurrent callers to interleave
+     * their writes and leave the cache claiming one contig while holding another contig's bases, which was
+     * silently returned as if correct. See https://github.com/samtools/htsjdk/issues/1643.
+     */
+    private static final class CachedContigBases {
+        private final int contigIndex;
+        private final byte[] bases;
+
+        private CachedContigBases(final int contigIndex, final byte[] bases) {
+            this.contigIndex = contigIndex;
+            this.bases = bases;
+        }
+    }
+
     // Optimize for locality of reference by maintaining the backing reference bases for the most recent request.
     // Failure to do this will result in the bases being aggressively GC'd when the only other reference to them
     // is the weak reference hash map above, resulting in much thrashing.
-    private byte[] backingReferenceBases;
-    private int backingContigIndex;
+    private volatile CachedContigBases backingBases;
 
     public ReferenceSource(final File file) {
         this(IOUtil.toPath(file));
@@ -190,9 +206,9 @@ public class ReferenceSource implements CRAMReferenceSource {
         final byte[] bases = getBackingBases(sequenceRecord);
 
         if (bases != null) {
-            // cache the backing bases to prevent thrashing due to aggressive GC
-            backingReferenceBases = bases;
-            backingContigIndex = sequenceRecord.getSequenceIndex();
+            // cache the backing bases to prevent thrashing due to aggressive GC. The contig index and the
+            // bases are published together so that another thread can never observe a mismatched pair.
+            backingBases = new CachedContigBases(sequenceRecord.getSequenceIndex(), bases);
 
             if (zeroBasedStart >= bases.length) {
                 throw new IllegalArgumentException(String.format(
@@ -206,8 +222,10 @@ public class ReferenceSource implements CRAMReferenceSource {
     }
 
     private byte[] getBackingBases(final SAMSequenceRecord sequenceRecord) {
-        if (backingReferenceBases != null && backingContigIndex == sequenceRecord.getSequenceIndex()) {
-            return backingReferenceBases;
+        // read the pair once, so the index check and the bases returned always come from the same snapshot
+        final CachedContigBases cached = backingBases;
+        if (cached != null && cached.contigIndex == sequenceRecord.getSequenceIndex()) {
+            return cached.bases;
         } else {
             return getReferenceBases(sequenceRecord, false);
         }

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceSourceConcurrencyTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceSourceConcurrencyTest.java
@@ -1,0 +1,156 @@
+package htsjdk.samtools.cram.ref;
+
+import htsjdk.HtsjdkTest;
+import htsjdk.samtools.SAMSequenceDictionary;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.reference.ReferenceSequenceFile;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * {@link ReferenceSource} caches the bases of the most recently requested contig alongside that contig's index.
+ * Those two values are only meaningful together, so concurrent callers must never be able to observe bases from
+ * one contig paired with the index of another. See https://github.com/samtools/htsjdk/issues/1643.
+ */
+public class ReferenceSourceConcurrencyTest extends HtsjdkTest {
+
+    private static final int CONTIG_COUNT = 4;
+    private static final int CONTIG_LENGTH = 5000;
+
+    /**
+     * Builds a reference where every contig is filled with a single distinct base, so that bases belonging to
+     * the wrong contig are immediately recognisable.
+     */
+    private static byte[] basesForContig(final int contigIndex) {
+        final byte[] bases = new byte[CONTIG_LENGTH];
+        Arrays.fill(bases, (byte) "ACGT".charAt(contigIndex % 4));
+        return bases;
+    }
+
+    private static String contigName(final int contigIndex) {
+        return "contig" + contigIndex;
+    }
+
+    /** A reference file that serves each contig as a uniform run of one base. */
+    private static final class UniformBaseReferenceFile implements ReferenceSequenceFile {
+        @Override
+        public SAMSequenceDictionary getSequenceDictionary() {
+            return null;
+        }
+
+        @Override
+        public ReferenceSequence nextSequence() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void reset() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isIndexed() {
+            return true;
+        }
+
+        @Override
+        public ReferenceSequence getSequence(final String contig) {
+            final int index = Integer.parseInt(contig.substring("contig".length()));
+            return new ReferenceSequence(contig, index, basesForContig(index));
+        }
+
+        @Override
+        public ReferenceSequence getSubsequenceAt(final String contig, final long start, final long stop) {
+            final int index = Integer.parseInt(contig.substring("contig".length()));
+            final byte[] all = basesForContig(index);
+            return new ReferenceSequence(contig, index, Arrays.copyOfRange(all, (int) start - 1, (int) stop));
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    /**
+     * Hammers a single ReferenceSource from many threads, each repeatedly asking for a different contig, and
+     * verifies every thread only ever receives bases belonging to the contig it asked for.
+     */
+    @Test
+    public void concurrent_region_requests_never_return_another_contigs_bases() throws Exception {
+        final ReferenceSource source = new ReferenceSource(new UniformBaseReferenceFile());
+
+        final int iterations = 2000;
+        final ExecutorService executor = Executors.newFixedThreadPool(CONTIG_COUNT);
+        final List<Callable<String>> tasks = new ArrayList<>();
+
+        for (int contigIndex = 0; contigIndex < CONTIG_COUNT; contigIndex++) {
+            final int index = contigIndex;
+            tasks.add(() -> {
+                final SAMSequenceRecord record = new SAMSequenceRecord(contigName(index), CONTIG_LENGTH);
+                record.setSequenceIndex(index);
+                final byte expected = (byte) "ACGT".charAt(index % 4);
+
+                for (int i = 0; i < iterations; i++) {
+                    final byte[] bases = source.getReferenceBasesByRegion(record, 0, 100);
+                    for (final byte base : bases) {
+                        if (base != expected) {
+                            return String.format(
+                                    "contig %d expected all '%c' but saw '%c'", index, expected, (char) base);
+                        }
+                    }
+                }
+                return null;
+            });
+        }
+
+        final List<Future<String>> results = executor.invokeAll(tasks);
+        executor.shutdown();
+        Assert.assertTrue(executor.awaitTermination(2, TimeUnit.MINUTES), "test threads did not finish in time");
+
+        for (final Future<String> result : results) {
+            final String failure = result.get();
+            Assert.assertNull(failure, "ReferenceSource returned bases for the wrong contig: " + failure);
+        }
+    }
+
+    /** The single-threaded caching behaviour must be unaffected. */
+    @Test
+    public void repeated_requests_for_the_same_contig_return_correct_bases() {
+        final ReferenceSource source = new ReferenceSource(new UniformBaseReferenceFile());
+        final SAMSequenceRecord record = new SAMSequenceRecord(contigName(1), CONTIG_LENGTH);
+        record.setSequenceIndex(1);
+
+        for (int i = 0; i < 5; i++) {
+            final byte[] bases = source.getReferenceBasesByRegion(record, 10, 50);
+            Assert.assertEquals(bases.length, 50);
+            for (final byte base : bases) {
+                Assert.assertEquals((char) base, 'C', "expected contig1 to be all 'C'");
+            }
+        }
+    }
+
+    /** Alternating contigs on one thread must still return the right bases each time. */
+    @Test
+    public void alternating_contigs_return_correct_bases() {
+        final ReferenceSource source = new ReferenceSource(new UniformBaseReferenceFile());
+
+        for (int i = 0; i < 20; i++) {
+            final int index = i % CONTIG_COUNT;
+            final SAMSequenceRecord record = new SAMSequenceRecord(contigName(index), CONTIG_LENGTH);
+            record.setSequenceIndex(index);
+            final byte[] bases = source.getReferenceBasesByRegion(record, 0, 20);
+            for (final byte base : bases) {
+                Assert.assertEquals(
+                        (char) base, "ACGT".charAt(index % 4), "wrong bases returned after switching contigs");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1643.

`ReferenceSource` caches the bases of the most recently used contig to avoid thrashing against the weak-reference map. It kept those bases and the index of the contig they belong to in **two separate mutable fields**, written from `getReferenceBasesByRegion` — which is not synchronized, while the closely related `getReferenceBases` is.

Two threads requesting different contigs can therefore interleave those two writes and leave the cache holding one contig's bases labelled with another contig's index. `getBackingBases` then hands those bases out as a cache hit, so **a caller silently receives reference bases for the wrong contig**. For CRAM that means silently corrupt encoding or decoding, which is how this surfaced in GATK.

The fix holds the pair in one immutable object published through a single volatile field, read once per lookup, so a mismatched pair cannot be observed. This addresses the field-pairing race without adding a lock to the hot path.

The added test drives four threads over four contigs, each filled with a distinct base, and asserts no thread ever sees another contig's bases. It **fails reliably on the current code** (3 out of 3 runs) and passes with this change.