### PR TITLE
Explain why whole-contig CRAM reference lookup failed

### DIFF
--- a/src/main/java/htsjdk/samtools/cram/build/CRAMReferenceRegion.java
+++ b/src/main/java/htsjdk/samtools/cram/build/CRAMReferenceRegion.java
@@ -123,8 +123,7 @@ public class CRAMReferenceRegion {
             setCurrentSequence(referenceIndex);
             referenceBases = referenceSource.getReferenceBases(newSequenceRecord, true);
             if (referenceBases == null) {
-                throw new IllegalArgumentException(String.format(
-                        "A reference must be supplied (reference sequence %s not found).", newSequenceRecord));
+                throw new IllegalArgumentException(noReferenceBasesMessage(newSequenceRecord.getSequenceName()));
             }
             regionStart = 0;
             regionLength = newSequenceRecord.getSequenceLength();
@@ -171,16 +170,7 @@ public class CRAMReferenceRegion {
         referenceBases =
                 referenceSource.getReferenceBasesByRegion(sequenceRecord, zeroBasedStart, requestedFragmentLength);
         if (referenceBases == null) {
-            // The reference source could not supply bases for a sequence that IS in the sequence dictionary.
-            // In practice this almost always means the reference fasta is missing its companion .fai index (or
-            // .dict, or .gzi for a bgzipped fasta), or that it simply does not contain this sequence, so say so
-            // rather than reporting a bare failure. See https://github.com/samtools/htsjdk/issues/1732.
-            throw new IllegalArgumentException(String.format(
-                    "Failure getting reference bases for sequence '%s'. The reference source did not return any "
-                            + "bases for this sequence. Verify that the reference fasta contains a sequence named "
-                            + "'%s', and that it has been indexed -- a CRAM requires a fasta with a companion .fai "
-                            + "index (plus a .gzi index if the fasta is bgzipped) and a .dict sequence dictionary.",
-                    sequenceRecord.getSequenceName(), sequenceRecord.getSequenceName()));
+            throw new IllegalArgumentException(noReferenceBasesMessage(sequenceRecord.getSequenceName()));
         } else if (referenceBases.length < requestedFragmentLength) {
             log.warn("The bases of length " + referenceBases.length
                     + " returned by the reference source do not satisfy the requested fragment length "
@@ -242,5 +232,24 @@ public class CRAMReferenceRegion {
             throw new IllegalArgumentException(String.format("Reference sequence index %d not found", referenceIndex));
         }
         return samSequenceRecord;
+    }
+
+    /**
+     * Describes a failure to obtain reference bases for a sequence that IS present in the sequence dictionary.
+     *
+     * <p>In practice this almost always means the reference fasta has not been indexed, or does not actually
+     * contain the sequence, so name both possibilities rather than reporting a bare failure. Shared by the
+     * whole-contig and by-region lookups so that the two report the same thing.
+     *
+     * @param sequenceName name of the sequence whose bases could not be obtained
+     * @return the exception message to throw
+     */
+    private static String noReferenceBasesMessage(final String sequenceName) {
+        return String.format(
+                "Failure getting reference bases for sequence '%s'. The reference source did not return any "
+                        + "bases for this sequence. Verify that the reference fasta contains a sequence named "
+                        + "'%s', and that it has been indexed -- a CRAM requires a fasta with a companion .fai "
+                        + "index (plus a .gzi index if the fasta is bgzipped) and a .dict sequence dictionary.",
+                sequenceName, sequenceName);
     }
 }

--- a/src/test/java/htsjdk/samtools/cram/build/CRAMReferenceRegionErrorMessageTest.java
+++ b/src/test/java/htsjdk/samtools/cram/build/CRAMReferenceRegionErrorMessageTest.java
@@ -10,8 +10,9 @@ import org.testng.annotations.Test;
 
 /**
  * Tests the diagnostics produced when a reference source cannot supply bases for a sequence that is present
- * in the sequence dictionary -- most often because the reference fasta has not been indexed.
- * See https://github.com/samtools/htsjdk/issues/1732.
+ * in the sequence dictionary -- most often because the reference fasta has not been indexed. Covers both the
+ * by-region and whole-contig lookups, which fail for the same reason and should say the same thing.
+ * See https://github.com/samtools/htsjdk/issues/1732 and https://github.com/samtools/htsjdk/issues/998.
  */
 public class CRAMReferenceRegionErrorMessageTest extends HtsjdkTest {
 
@@ -47,15 +48,26 @@ public class CRAMReferenceRegionErrorMessageTest extends HtsjdkTest {
         }
     }
 
+    /** The whole-contig lookup, as opposed to the by-region one above. */
+    private static String messageFromFailedWholeContigFetch() {
+        try {
+            makeRegion().fetchReferenceBases(0);
+            Assert.fail("expected an exception when the reference source returns no bases");
+            return null; // unreachable
+        } catch (final IllegalArgumentException e) {
+            return e.getMessage();
+        }
+    }
+
     @Test
-    public void missing_bases_error_names_the_offending_sequence() {
+    public void testMissingBasesErrorNamesOffendingSequence() {
         Assert.assertTrue(
                 messageFromFailedFetch().contains(SEQUENCE_NAME),
                 "the error should name the sequence that could not be resolved");
     }
 
     @Test
-    public void missing_bases_error_mentions_the_fasta_index() {
+    public void testMissingBasesErrorMentionsFastaIndex() {
         final String message = messageFromFailedFetch();
         Assert.assertTrue(
                 message.contains(".fai"),
@@ -63,10 +75,45 @@ public class CRAMReferenceRegionErrorMessageTest extends HtsjdkTest {
     }
 
     @Test
-    public void missing_bases_error_mentions_the_sequence_dictionary() {
+    public void testMissingBasesErrorMentionsSequenceDictionary() {
         final String message = messageFromFailedFetch();
         Assert.assertTrue(
                 message.contains(".dict"),
                 "the error should mention the required sequence dictionary, but was: " + message);
+    }
+
+    /**
+     * The whole-contig lookup used to report "A reference must be supplied (reference sequence ... not found)",
+     * which is misleading when a reference was supplied but simply was not indexed, and which dumped the whole
+     * SAMSequenceRecord into the message. See https://github.com/samtools/htsjdk/issues/998.
+     */
+    @Test
+    public void testWholeContigFetchExplainsLikelyCause() {
+        final String message = messageFromFailedWholeContigFetch();
+        Assert.assertTrue(message.contains(SEQUENCE_NAME), "the error should name the sequence, but was: " + message);
+        Assert.assertTrue(
+                message.contains(".fai"),
+                "the error should point at the missing fasta index as the likely cause, but was: " + message);
+        Assert.assertTrue(
+                message.contains(".dict"),
+                "the error should mention the required sequence dictionary, but was: " + message);
+    }
+
+    /** Both lookup paths fail for the same reason, so they should say the same thing. */
+    @Test
+    public void testBothLookupPathsReportSameDiagnostic() {
+        Assert.assertEquals(
+                messageFromFailedWholeContigFetch(),
+                messageFromFailedFetch(),
+                "the whole-contig and by-region lookups should report an identical diagnostic");
+    }
+
+    /** The message should not dump the raw SAMSequenceRecord toString() at the user. */
+    @Test
+    public void testMessageDoesNotDumpRawSequenceRecord() {
+        final String message = messageFromFailedWholeContigFetch();
+        Assert.assertFalse(
+                message.contains("SAMSequenceRecord("),
+                "the error should name the sequence, not dump the record, but was: " + message);
     }
 }


### PR DESCRIPTION
Closes #998.

The whole-contig reference lookup reported:

```
A reference must be supplied (reference sequence SAMSequenceRecord(name=1,
length=200,dict_index=0,assembly=null,alternate_names=[]) not found).
```

which is misleading in the common case — a reference *was* supplied, it just had not been indexed — and it dumped the entire `SAMSequenceRecord` at the user.

This is the sibling of the by-region lookup fixed in #1790 (for #1732). Both fail for the same reason, so I factored the diagnostic into one private helper used by both, rather than letting two copies of the same message drift apart. It names the sequence and points at the companion `.fai`/`.gzi`/`.dict` files a CRAM needs.

Message text only — no change to which inputs are accepted.

Tests cover the whole-contig path, assert the two paths report an identical diagnostic, and assert the message no longer contains a raw `SAMSequenceRecord(` dump.

Test methods follow the house `testXxx` camelCase convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error messages when reference bases cannot be retrieved through whole-contig or regional lookups.
  * Diagnostics now consistently identify the affected sequence and provide guidance about missing FASTA indexes or sequence dictionaries.
  * Error messages no longer include unnecessary raw sequence-record details.

* **Tests**
  * Added coverage confirming consistent diagnostics across both lookup methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->