### PR TITLE
Rename recently added CRAM tests to the house naming convention

### DIFF
--- a/src/test/java/htsjdk/samtools/cram/CRAMContainerStreamWriterClosureTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAMContainerStreamWriterClosureTest.java
@@ -68,7 +68,7 @@ public class CRAMContainerStreamWriterClosureTest extends HtsjdkTest {
     }
 
     @Test
-    public void finish_does_not_close_stream_when_close_stream_is_false() {
+    public void testFinishDoesNotCloseStreamWhenCloseStreamIsFalse() {
         final SAMFileHeader header = makeHeader();
         final CloseRecordingStream stream = new CloseRecordingStream();
 
@@ -81,7 +81,7 @@ public class CRAMContainerStreamWriterClosureTest extends HtsjdkTest {
     }
 
     @Test
-    public void finish_closes_stream_when_close_stream_is_true() {
+    public void testFinishClosesStreamWhenCloseStreamIsTrue() {
         final SAMFileHeader header = makeHeader();
         final CloseRecordingStream stream = new CloseRecordingStream();
 
@@ -94,7 +94,7 @@ public class CRAMContainerStreamWriterClosureTest extends HtsjdkTest {
 
     /** The single-argument overload must keep its historical behaviour of closing the stream. */
     @Test
-    public void single_argument_finish_still_closes_stream() {
+    public void testSingleArgumentFinishStillClosesStream() {
         final SAMFileHeader header = makeHeader();
         final CloseRecordingStream stream = new CloseRecordingStream();
 
@@ -107,7 +107,7 @@ public class CRAMContainerStreamWriterClosureTest extends HtsjdkTest {
 
     /** A caller that keeps ownership of the stream can go on using it after the writer has finished. */
     @Test
-    public void caller_can_continue_using_stream_after_finish_without_close() throws IOException {
+    public void testCallerCanContinueUsingStreamAfterFinishWithoutClose() throws IOException {
         final SAMFileHeader header = makeHeader();
         final CloseRecordingStream stream = new CloseRecordingStream();
 

--- a/src/test/java/htsjdk/samtools/cram/CRAMFileReaderNonSeekableStreamTest.java
+++ b/src/test/java/htsjdk/samtools/cram/CRAMFileReaderNonSeekableStreamTest.java
@@ -90,7 +90,7 @@ public class CRAMFileReaderNonSeekableStreamTest extends HtsjdkTest {
     }
 
     @Test
-    public void query_over_non_seekable_stream_throws_a_descriptive_exception() throws IOException {
+    public void testQueryOverNonSeekableStreamThrowsDescriptiveException() throws IOException {
         try (CRAMFileReader reader = readerOverNonSeekableStream()) {
             try {
                 reader.query(new QueryInterval[] {new QueryInterval(0, 1, 100)}, false);
@@ -108,7 +108,7 @@ public class CRAMFileReaderNonSeekableStreamTest extends HtsjdkTest {
 
     /** Sequential iteration does not require seeking and must keep working. */
     @Test
-    public void sequential_iteration_over_non_seekable_stream_still_works() throws IOException {
+    public void testSequentialIterationOverNonSeekableStreamStillWorks() throws IOException {
         try (CRAMFileReader reader = readerOverNonSeekableStream()) {
             int count = 0;
             final htsjdk.samtools.SAMRecordIterator iterator = reader.getIterator();

--- a/src/test/java/htsjdk/samtools/cram/ref/ReferenceSourceConcurrencyTest.java
+++ b/src/test/java/htsjdk/samtools/cram/ref/ReferenceSourceConcurrencyTest.java
@@ -84,7 +84,7 @@ public class ReferenceSourceConcurrencyTest extends HtsjdkTest {
      * verifies every thread only ever receives bases belonging to the contig it asked for.
      */
     @Test
-    public void concurrent_region_requests_never_return_another_contigs_bases() throws Exception {
+    public void testConcurrentRegionRequestsNeverReturnAnotherContigsBases() throws Exception {
         final ReferenceSource source = new ReferenceSource(new UniformBaseReferenceFile());
 
         final int iterations = 2000;
@@ -123,7 +123,7 @@ public class ReferenceSourceConcurrencyTest extends HtsjdkTest {
 
     /** The single-threaded caching behaviour must be unaffected. */
     @Test
-    public void repeated_requests_for_the_same_contig_return_correct_bases() {
+    public void testRepeatedRequestsForSameContigReturnCorrectBases() {
         final ReferenceSource source = new ReferenceSource(new UniformBaseReferenceFile());
         final SAMSequenceRecord record = new SAMSequenceRecord(contigName(1), CONTIG_LENGTH);
         record.setSequenceIndex(1);
@@ -139,7 +139,7 @@ public class ReferenceSourceConcurrencyTest extends HtsjdkTest {
 
     /** Alternating contigs on one thread must still return the right bases each time. */
     @Test
-    public void alternating_contigs_return_correct_bases() {
+    public void testAlternatingContigsReturnCorrectBases() {
         final ReferenceSource source = new ReferenceSource(new UniformBaseReferenceFile());
 
         for (int i = 0; i < 20; i++) {


### PR DESCRIPTION
Follow-up hygiene on my own recent PRs — no behaviour change.

Three test classes added in #1789, #1791 and #1792 used snake_case method names without the conventional `test` prefix. That is neither idiomatic Java nor what this repo does; measured across `src/test/java`:

- 2020 of 2417 test methods start with `test`
- only 199 of 2417 contain an underscore at all

This renames the nine offending methods in those three classes to `testXxx` camelCase:

| Class | Methods renamed |
|---|---|
| `CRAMContainerStreamWriterClosureTest` | 4 |
| `CRAMFileReaderNonSeekableStreamTest` | 2 |
| `ReferenceSourceConcurrencyTest` | 3 |

The fourth affected class, `CRAMReferenceRegionErrorMessageTest` (from #1790), has its three methods renamed in #1793 instead, since that file is already being modified there.

Test bodies are untouched — naming only. Full CRAM suite green.